### PR TITLE
fix: restart double-tap listener when accessibility permission granted

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,23 @@
+# Known Bugs & Backlog
+
+---
+
+## Control key does not trigger recording
+
+**Status:** Open
+**Affects:** Key Combo recording mode
+**Symptom:** Selecting a Control key combo as the recording hotkey does not trigger recording. Shift and Alt combos work fine.
+**Likely cause:** The `global-shortcut` plugin or macOS intercepts Control key combos before the app receives them.
+**Entry point:** `ui/src/lib/hooks/useHotkeyToggle.ts`, `ui/src/lib/hotkey.ts`
+
+---
+
+## Double-tap listener start/stop events are not logged
+
+**Status:** Backlog
+**Affects:** Observability / debugging
+**Description:** When `start_double_tap_listener` and `stop_double_tap_listener` are called, nothing is written to `app.log`. This makes it hard to diagnose issues like the accessibility-permission restart bug without adding console logs manually.
+**Proposed fix:** Add `log_info!` calls in `lib.rs` at the start and stop of the rdev listener, including the hotkey key name and whether accessibility permission was granted at the time.
+**Entry point:** `ui/src-tauri/src/lib.rs` — `start_double_tap_listener`, `stop_double_tap_listener` commands
+
+---

--- a/ui/src/lib/hooks/useDoubleTapToggle.ts
+++ b/ui/src/lib/hooks/useDoubleTapToggle.ts
@@ -6,12 +6,13 @@ import type { DictationStatus } from '../types';
 interface UseDoubleTapToggleProps {
   enabled: boolean;
   initialized: boolean;
+  accessibilityGranted: boolean;
   doubleTapKey: string;
   status: DictationStatus;
   onToggle: () => void;
 }
 
-export function useDoubleTapToggle({ enabled, initialized, doubleTapKey, status, onToggle }: UseDoubleTapToggleProps) {
+export function useDoubleTapToggle({ enabled, initialized, accessibilityGranted, doubleTapKey, status, onToggle }: UseDoubleTapToggleProps) {
   const onToggleRef = useRef(onToggle);
   useEffect(() => { onToggleRef.current = onToggle; }, [onToggle]);
 
@@ -22,7 +23,7 @@ export function useDoubleTapToggle({ enabled, initialized, doubleTapKey, status,
   }, [enabled, status]);
 
   useEffect(() => {
-    if (!enabled || !initialized) return;
+    if (!enabled || !initialized || !accessibilityGranted) return;
 
     let unlisten: (() => void) | null = null;
     let cancelled = false;
@@ -58,5 +59,5 @@ export function useDoubleTapToggle({ enabled, initialized, doubleTapKey, status,
         console.warn('Failed to stop double-tap listener on cleanup:', err);
       });
     };
-  }, [enabled, initialized, doubleTapKey]);
+  }, [enabled, initialized, accessibilityGranted, doubleTapKey]);
 }


### PR DESCRIPTION
## Problem

After granting Accessibility permission, double-tap recording didn't work until the user switched the keybind away and back. Root cause: rdev's `listen()` silently starts doing nothing if Accessibility isn't granted yet. The only thing that previously triggered a restart was a `doubleTapKey` change re-running the `useEffect`.

## Fix

`App.tsx` now polls `check_accessibility_permission` on mount and on window focus. The boolean is passed to `useDoubleTapToggle` as a new `accessibilityGranted` prop and added to the `useEffect` dependency array. When the user grants permission and returns focus to the app, the listener automatically stops and restarts — no keybind toggle needed.

## Also

- Adds `docs/bugs.md` with:
  - Existing Control key combo bug
  - Backlog item: log double-tap listener start/stop events to `app.log`

## Test plan

- [ ] Launch app in double-tap mode with Accessibility NOT granted
- [ ] Grant Accessibility permission in System Settings, return to app
- [ ] Double-tap Shift — recording starts without touching the keybind setting
- [ ] `npx tsc --noEmit` — no type errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added known bugs and backlog section documenting current issues.

* **Bug Fixes**
  * Fixed double-tap listener to properly detect and respond to accessibility permission changes.
  * Double-tap functionality now restarts when accessibility permission is granted.

* **New Features**
  * Added automatic accessibility permission status monitoring on app focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->