### PR TITLE
fix: eliminate auto-paste toggle race conditions and silent failures

### DIFF
--- a/ui/src/lib/hooks/useInitialization.ts
+++ b/ui/src/lib/hooks/useInitialization.ts
@@ -7,12 +7,15 @@ export function useInitialization(settings: Settings) {
   const [error, setError] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
     initDictation()
-      .then(() =>
-        configure({ model: settings.model, language: settings.language, autoPaste: settings.autoPaste })
-      )
-      .then(() => setInitialized(true))
-      .catch((err) => setError(String(err)));
+      .then(() => {
+        if (cancelled) return;
+        return configure({ model: settings.model, language: settings.language, autoPaste: settings.autoPaste });
+      })
+      .then(() => { if (!cancelled) setInitialized(true); })
+      .catch((err) => { if (!cancelled) setError(String(err)); });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount — settings are loaded synchronously before this runs
 


### PR DESCRIPTION
## Summary

- **`useInitialization`**: Add a `cancelled` flag with a cleanup function so that stale in-flight `configure()` calls are dropped when the effect unmounts (React 18 Strict Mode runs effects twice; without this, the first run's configure arrives _after_ the user's own toggle configure and silently resets `auto_paste` in Rust)
- **`useSettings`**: Remove `async` from `updateSettings`, add a `configureVersionRef` counter so that configure failures revert React state/localStorage only when no newer configure has been requested — prevents a superseded stale failure from clobbering valid newer state

## Test plan

- [ ] Toggle auto-paste ON → verify it stays ON after the animation settles
- [ ] Toggle auto-paste OFF → verify it stays OFF
- [ ] Toggle rapidly several times → verify final state matches last click
- [ ] Record and transcribe with auto-paste ON → text is pasted automatically
- [ ] Record and transcribe with auto-paste OFF → text goes to clipboard only
- [ ] Open settings panel immediately on app launch and toggle — verify no flicker/reset

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)