### PR TITLE
fix: statically link sherpa-rs to fix launch crash

### DIFF
--- a/ui/src-tauri/Cargo.lock
+++ b/ui/src-tauri/Cargo.lock
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -6109,12 +6109,6 @@ dependencies = [
  "libc",
  "rustix 1.1.3",
 ]
-
-[[package]]
-name = "xkeysym"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ rdev = { git = "https://github.com/Narsil/rdev", branch = "main" }
 sysinfo = "0.32"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-sherpa-rs = { version = "0.6", default-features = false, features = ["download-binaries"] }
+sherpa-rs = { version = "0.6", default-features = false, features = ["download-binaries", "static"] }
 tar = "0.4"
 bzip2 = "0.5"
 


### PR DESCRIPTION
## Summary

- Adds `static` feature to `sherpa-rs` dependency, eliminating the runtime dependency on `libonnxruntime.1.17.1.dylib`
- Fixes launch crash in the bundled `.app` where the dylib was missing (no `LC_RPATH` set, no dylib in `Contents/Frameworks/`)

## Context

The build succeeded because the linker found the dylib in `target/release/` at compile time. But Tauri's bundler didn't copy it into the `.app`, so the app crashed before `main()` on every launch from `/Applications`.

Static linking is consistent with how `whisper-rs` already works. Binary grows from ~5.7 MB to ~20 MB.

## Test plan

- [ ] `otool -L` on bundled binary shows no `libonnxruntime` reference
- [ ] App launches from `/Applications` without crashing
- [ ] Moonshine model download + transcription works
- [ ] Whisper transcription still works (regression check)

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for binary compilation and linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->