### PR TITLE
fix(ci): skip directories when uploading release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
           ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
           echo "Artifacts: $ARTIFACTS"
           echo "$ARTIFACTS" | jq -r '.[]' | while read -r artifact; do
+            if [ ! -f "$artifact" ]; then
+              echo "Skipping (not a file): $artifact"
+              continue
+            fi
             echo "Uploading: $artifact"
             gh release upload "${{ github.ref_name }}" "$artifact" \
               --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

- Adds a file check (`[ ! -f "$artifact" ]`) to skip directory entries in the release upload step
- `tauri-action` includes the `.app` bundle (a directory) in `artifactPaths`, which causes `gh release upload` to fail

## Context

v0.5.0 release workflow failed at the upload step because of this. The smoke test passed but the upload choked on the `.app` directory. This was identified in #58 (closed without merge) — this PR lands the fix.

## Test plan

- [ ] Tag a release → upload step skips `.app` directory, uploads `.dmg` successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chore
* Improved release process robustness by enhancing artifact handling to skip non-file artifacts during release deployments, ensuring more reliable releases without affecting valid file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->