### PR TITLE
Log accessibility permission status in keyboard listener events

### DIFF
--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -396,14 +396,14 @@ fn start_keyboard_listener(app_handle: tauri::AppHandle, hotkey: String, mode: S
         return Err("Accessibility permission is required. Please grant it in System Settings.".to_string());
     }
     keyboard::start_listener(app_handle, &hotkey, &mode);
-    log_info!("Keyboard listener started: mode={}, key={}", mode, hotkey);
+    log_info!("Keyboard listener started: mode={}, key={}, accessibility={}", mode, hotkey, injector::is_accessibility_enabled());
     Ok(())
 }
 
 #[tauri::command]
 fn stop_keyboard_listener() {
     keyboard::stop_listener();
-    log_info!("Keyboard listener stopped");
+    log_info!("Keyboard listener stopped: accessibility={}", injector::is_accessibility_enabled());
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- Added accessibility permission status to `log_info!` calls in `start_keyboard_listener` and `stop_keyboard_listener`
- Makes logs self-documenting by including `accessibility=true/false` alongside existing mode and key info

## Test plan
- [x] `cargo test -- --test-threads=1` — all 52 unit tests + 2 integration tests pass
- [ ] Run app, start/stop keyboard listener, verify log entries include `accessibility=` field

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging output with additional diagnostic information for improved system monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->