### PR TITLE
feat: replace native select dropdowns with custom styled components

### DIFF
--- a/ui/src/components/settings/SettingsPanel.tsx
+++ b/ui/src/components/settings/SettingsPanel.tsx
@@ -3,9 +3,10 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getVersion } from '@tauri-apps/api/app';
 import {
-  Settings, ModelOption, DoubleTapKey, RecordingMode, DEFAULT_SETTINGS,
+  Settings, RecordingMode, DEFAULT_SETTINGS,
   MODEL_OPTIONS, MOONSHINE_MODELS, WHISPER_MODELS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
 } from '../../lib/settings';
+import { Select } from '../ui/Select';
 import type { DictationStatus } from '../../lib/types';
 
 interface SettingsPanelProps {
@@ -159,27 +160,21 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
             Transcription Model
           </label>
-          <select
+          <Select
             value={settings.model}
-            onChange={(e) => onUpdateSettings({ model: e.target.value as ModelOption })}
+            onChange={(value) => onUpdateSettings({ model: value })}
             disabled={isRecording}
-            className={`w-full px-3 py-2 rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 focus:ring-2 focus:ring-stone-500 focus:border-transparent text-sm ${isRecording ? 'opacity-50 cursor-not-allowed' : ''}`}
-          >
-            <optgroup label="Moonshine (Fast, CPU)">
-              {MOONSHINE_MODELS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label} ({option.size})
-                </option>
-              ))}
-            </optgroup>
-            <optgroup label="Whisper (Metal GPU)">
-              {WHISPER_MODELS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label} ({option.size})
-                </option>
-              ))}
-            </optgroup>
-          </select>
+            items={[
+              {
+                label: 'Moonshine (Fast, CPU)',
+                options: MOONSHINE_MODELS.map((m) => ({ value: m.value, label: `${m.label} (${m.size})` })),
+              },
+              {
+                label: 'Whisper (Metal GPU)',
+                options: WHISPER_MODELS.map((m) => ({ value: m.value, label: `${m.label} (${m.size})` })),
+              },
+            ]}
+          />
           <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
             Moonshine runs on CPU; Whisper uses Metal GPU. Larger models are more accurate but slower.
           </p>
@@ -247,17 +242,15 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
             Microphone
           </label>
-          <select
+          <Select
             value={settings.microphone}
-            onChange={(e) => onUpdateSettings({ microphone: e.target.value })}
+            onChange={(value) => onUpdateSettings({ microphone: value })}
             disabled={isRecording}
-            className={`w-full px-3 py-2 rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 focus:ring-2 focus:ring-stone-500 focus:border-transparent text-sm ${isRecording ? 'opacity-50 cursor-not-allowed' : ''}`}
-          >
-            <option value="system_default">System Default</option>
-            {audioDevices.map((name) => (
-              <option key={name} value={name}>{name}</option>
-            ))}
-          </select>
+            items={[
+              { value: 'system_default', label: 'System Default' },
+              ...audioDevices.map((name) => ({ value: name, label: name })),
+            ]}
+          />
           {savedDeviceMissing && (
             <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
               <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
@@ -313,18 +306,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
             {keyLabel}
           </label>
-          <select
+          <Select
             value={settings.doubleTapKey}
-            onChange={(e) => onUpdateSettings({ doubleTapKey: e.target.value as DoubleTapKey })}
+            onChange={(value) => onUpdateSettings({ doubleTapKey: value })}
             disabled={isRecording}
-            className={`w-full px-3 py-2 rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 focus:ring-2 focus:ring-stone-500 focus:border-transparent text-sm ${isRecording ? 'opacity-50 cursor-not-allowed' : ''}`}
-          >
-            {DOUBLE_TAP_KEY_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            items={DOUBLE_TAP_KEY_OPTIONS}
+          />
           <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
             {keyHelpText}
           </p>

--- a/ui/src/components/settings/SettingsPanel.tsx
+++ b/ui/src/components/settings/SettingsPanel.tsx
@@ -330,6 +330,9 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </div>
             <button
               type="button"
+              role="switch"
+              aria-checked={settings.autoPaste}
+              aria-label="Auto paste"
               onClick={() => onUpdateSettings({ autoPaste: !settings.autoPaste })}
               className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
                 settings.autoPaste ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -1,0 +1,277 @@
+import { useState, useRef, useEffect, useId } from 'react';
+
+export interface SelectOption<T extends string = string> {
+  value: T;
+  label: string;
+}
+
+export interface SelectGroup<T extends string = string> {
+  label: string;
+  options: SelectOption<T>[];
+}
+
+export type SelectItems<T extends string = string> =
+  | SelectOption<T>[]
+  | SelectGroup<T>[];
+
+export interface SelectProps<T extends string = string> {
+  value: T;
+  onChange: (value: T) => void;
+  items: SelectItems<T>;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+function isGrouped<T extends string>(
+  items: SelectItems<T>,
+): items is SelectGroup<T>[] {
+  return items.length > 0 && 'options' in items[0];
+}
+
+export function Select<T extends string = string>({
+  value,
+  onChange,
+  items,
+  disabled,
+  placeholder,
+}: SelectProps<T>) {
+  const id = useId();
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+
+  const flatOptions: SelectOption<T>[] = isGrouped(items)
+    ? items.flatMap((g) => g.options)
+    : items;
+
+  const selectedOption = flatOptions.find((o) => o.value === value);
+  const displayLabel = selectedOption?.label ?? placeholder ?? '';
+
+  // Click-outside handler
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        triggerRef.current?.contains(e.target as Node) ||
+        listboxRef.current?.contains(e.target as Node)
+      ) {
+        return;
+      }
+      setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen]);
+
+  // Scroll highlighted option into view
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listboxRef.current) return;
+    const el = listboxRef.current.querySelector(
+      `[data-index="${highlightedIndex}"]`,
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const open = () => {
+    if (disabled) return;
+    setIsOpen(true);
+    const idx = flatOptions.findIndex((o) => o.value === value);
+    setHighlightedIndex(idx >= 0 ? idx : 0);
+  };
+
+  const close = () => {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+    triggerRef.current?.focus();
+  };
+
+  const selectOption = (option: SelectOption<T>) => {
+    onChange(option.value);
+    close();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+
+    switch (e.key) {
+      case 'Enter':
+      case ' ': {
+        e.preventDefault();
+        if (!isOpen) {
+          open();
+        } else if (highlightedIndex >= 0 && highlightedIndex < flatOptions.length) {
+          selectOption(flatOptions[highlightedIndex]);
+        }
+        break;
+      }
+      case 'ArrowDown': {
+        e.preventDefault();
+        if (!isOpen) {
+          open();
+        } else {
+          setHighlightedIndex((prev) =>
+            prev < flatOptions.length - 1 ? prev + 1 : 0,
+          );
+        }
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        if (!isOpen) {
+          open();
+          setHighlightedIndex(flatOptions.length - 1);
+        } else {
+          setHighlightedIndex((prev) =>
+            prev > 0 ? prev - 1 : flatOptions.length - 1,
+          );
+        }
+        break;
+      }
+      case 'Home': {
+        if (isOpen) {
+          e.preventDefault();
+          setHighlightedIndex(0);
+        }
+        break;
+      }
+      case 'End': {
+        if (isOpen) {
+          e.preventDefault();
+          setHighlightedIndex(flatOptions.length - 1);
+        }
+        break;
+      }
+      case 'Escape': {
+        if (isOpen) {
+          e.preventDefault();
+          close();
+        }
+        break;
+      }
+      case 'Tab': {
+        if (isOpen) {
+          setIsOpen(false);
+          setHighlightedIndex(-1);
+        }
+        break;
+      }
+    }
+  };
+
+  function renderOption(option: SelectOption<T>, index: number) {
+    const isSelected = option.value === value;
+    const isHighlighted = index === highlightedIndex;
+    return (
+      <li
+        key={option.value}
+        role="option"
+        id={`${id}-option-${index}`}
+        data-index={index}
+        aria-selected={isSelected}
+        onClick={() => selectOption(option)}
+        onMouseEnter={() => setHighlightedIndex(index)}
+        className={`px-3 py-2 text-sm cursor-pointer flex items-center justify-between ${
+          isHighlighted ? 'bg-stone-100 dark:bg-stone-600' : ''
+        } ${isSelected ? 'font-medium' : ''} text-stone-900 dark:text-stone-100`}
+      >
+        <span className="truncate">{option.label}</span>
+        {isSelected && (
+          <svg
+            className="w-4 h-4 text-stone-500 dark:text-stone-400 shrink-0 ml-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        )}
+      </li>
+    );
+  }
+
+  // Build a flat index offset for grouped items
+  let flatIndex = 0;
+
+  return (
+    <div className="relative w-full" onKeyDown={handleKeyDown}>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-controls={`${id}-listbox`}
+        aria-activedescendant={
+          isOpen && highlightedIndex >= 0
+            ? `${id}-option-${highlightedIndex}`
+            : undefined
+        }
+        disabled={disabled}
+        onClick={() => (isOpen ? close() : open())}
+        className={`w-full px-3 py-2 rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 text-sm text-left focus:ring-2 focus:ring-stone-500 focus:border-transparent transition-colors flex items-center justify-between ${
+          disabled ? 'opacity-50 cursor-not-allowed' : ''
+        }`}
+      >
+        <span className="truncate">{displayLabel}</span>
+        <svg
+          className={`w-4 h-4 text-stone-400 shrink-0 ml-2 transition-transform ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <ul
+          ref={listboxRef}
+          role="listbox"
+          id={`${id}-listbox`}
+          className="absolute z-10 mt-1 w-full max-h-60 overflow-auto rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 shadow-lg py-1"
+        >
+          {isGrouped(items)
+            ? items.map((group, gi) => {
+                const startIndex = flatIndex;
+                flatIndex += group.options.length;
+                return (
+                  <li
+                    key={gi}
+                    role="group"
+                    aria-labelledby={`${id}-group-${gi}`}
+                  >
+                    <span
+                      id={`${id}-group-${gi}`}
+                      className="block px-3 py-1.5 text-xs font-semibold text-stone-500 dark:text-stone-400 uppercase tracking-wider select-none"
+                    >
+                      {group.label}
+                    </span>
+                    <ul role="none">
+                      {group.options.map((option, oi) =>
+                        renderOption(option, startIndex + oi),
+                      )}
+                    </ul>
+                  </li>
+                );
+              })
+            : flatOptions.map((option, idx) => renderOption(option, idx))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces all 3 native `<select>` elements (Transcription Model, Microphone, Double-Tap Key) with a reusable custom `Select` component that matches the app's flat, dark Tailwind UI
- Supports both flat option lists and grouped options (Moonshine/Whisper section headers replace native `<optgroup>`)
- Includes keyboard navigation (arrow keys, Enter/Space, Escape, Home/End), click-outside-to-close, and full ARIA accessibility (`combobox`/`listbox`/`option` roles)

## Test plan
- [ ] Open settings panel — all 3 dropdowns render with custom styling matching the rest of the UI
- [ ] Verify Model selector shows grouped sections (Moonshine / Whisper) with styled headers
- [ ] Verify Microphone selector shows "System Default" + enumerated devices
- [ ] Verify Double-Tap Key selector shows Shift, Option, Control
- [ ] Test keyboard navigation: arrow keys, Enter to select, Escape to close
- [ ] Test click-outside-to-close
- [ ] Test disabled state while recording (grayed out, non-interactive)
- [ ] Verify light and dark mode styling
- [ ] Verify selected item shows checkmark and bold text
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (7 tests)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New accessible dropdown component with full keyboard navigation support (arrow keys, Enter/Space, Escape, Tab).
  * Enhanced settings panel with unified dropdown selectors for transcription model, microphone, and double-tap key configuration, providing a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->