### PR TITLE
fix: allow scrolling within long transcription history entries

### DIFF
--- a/ui/src/components/history/HistoryPanel.tsx
+++ b/ui/src/components/history/HistoryPanel.tsx
@@ -105,7 +105,7 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
               </div>
             </div>
             {/* Text content */}
-            <p className="text-sm text-stone-900 dark:text-stone-100 line-clamp-3">
+            <p className="text-sm text-stone-900 dark:text-stone-100 overflow-y-auto max-h-32">
               {entry.text}
             </p>
           </button>


### PR DESCRIPTION
## Summary
- Replace `line-clamp-3` with `overflow-y-auto max-h-32` on the transcription text `<p>` in `HistoryPanel.tsx`
- Long transcription entries now scroll vertically within their box instead of being truncated at 3 lines

## Test plan
- [ ] Record a long voice memo (30s+) and verify the transcription entry shows a scrollbar when text overflows
- [ ] Verify short entries still display normally without a scrollbar
- [ ] Verify clicking an entry still copies text to clipboard

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * History entries with lengthy text are now scrollable instead of being truncated. This allows users to view complete content within the history panel, improving readability and access to full entry text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->