### PR TITLE
feat: simultaneous hold-down + double-tap recording mode

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,7 @@ import { useHistoryManagement } from './lib/hooks/useHistoryManagement';
 import { useRecordingState } from './lib/hooks/useRecordingState';
 import { useHoldDownToggle } from './lib/hooks/useHoldDownToggle';
 import { useDoubleTapToggle } from './lib/hooks/useDoubleTapToggle';
+import { useCombinedToggle } from './lib/hooks/useCombinedToggle';
 import { useShowAboutListener } from './lib/hooks/useShowAboutListener';
 import { useAutoUpdater } from './lib/hooks/useAutoUpdater';
 import { UpdateModal } from './components/UpdateModal';
@@ -76,6 +77,7 @@ function App() {
   const handleResetStats = () => { resetStats(); setStatsResetVersion(v => v + 1); };
   useHoldDownToggle({ enabled: settings.recordingMode === 'hold_down', initialized, accessibilityGranted, holdDownKey: settings.doubleTapKey, onStart: handleStart, onStop: handleStop });
   useDoubleTapToggle({ enabled: settings.recordingMode === 'double_tap', initialized, accessibilityGranted, doubleTapKey: settings.doubleTapKey, status, onToggle: toggleRecording });
+  useCombinedToggle({ enabled: settings.recordingMode === 'both', initialized, accessibilityGranted, triggerKey: settings.doubleTapKey, status, onStart: handleStart, onStop: handleStop, onToggle: toggleRecording });
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 

--- a/ui/src/components/settings/SettingsPanel.tsx
+++ b/ui/src/components/settings/SettingsPanel.tsx
@@ -126,10 +126,13 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     !audioDevices.includes(settings.microphone);
 
   const isDoubleTap = settings.recordingMode === 'double_tap';
-  const keyLabel = isDoubleTap ? 'Double-Tap Key' : 'Hold Key';
-  const keyHelpText = isDoubleTap
-    ? 'Double-tap to start recording, single tap to stop'
-    : 'Hold to start recording, release to stop';
+  const isBoth = settings.recordingMode === 'both';
+  const keyLabel = isBoth ? 'Trigger Key' : isDoubleTap ? 'Double-Tap Key' : 'Hold Key';
+  const keyHelpText = isBoth
+    ? 'Hold to record, or double-tap to start and single tap to stop'
+    : isDoubleTap
+      ? 'Double-tap to start recording, single tap to stop'
+      : 'Hold to start recording, release to stop';
   const isRecording = status !== 'idle';
   const selectedModel = MODEL_OPTIONS.find(m => m.value === settings.model);
   const downloadProgressPercent =

--- a/ui/src/lib/hooks/useCombinedToggle.ts
+++ b/ui/src/lib/hooks/useCombinedToggle.ts
@@ -73,7 +73,8 @@ export function useCombinedToggle({ enabled, initialized, accessibilityGranted, 
       });
       if (cancelled) { unlistenStart(); unlistenStop(); unlistenCancel(); unlistenToggle(); return; }
 
-      unlistenError = await listen<string>('keyboard-listener-error', async () => {
+      unlistenError = await listen<string>('keyboard-listener-error', async (event) => {
+        console.error('Keyboard listener error:', event.payload);
         if (cancelled) return;
         await new Promise<void>((r) => setTimeout(r, 2000));
         if (!cancelled) {

--- a/ui/src/lib/hooks/useCombinedToggle.ts
+++ b/ui/src/lib/hooks/useCombinedToggle.ts
@@ -1,0 +1,112 @@
+import { useEffect, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import type { DictationStatus } from '../types';
+
+interface UseCombinedToggleProps {
+  enabled: boolean;
+  initialized: boolean;
+  accessibilityGranted: boolean | null;
+  triggerKey: string;
+  status: DictationStatus;
+  onStart: () => void;
+  onStop: () => void;
+  onToggle: () => void;
+}
+
+export function useCombinedToggle({ enabled, initialized, accessibilityGranted, triggerKey, status, onStart, onStop, onToggle }: UseCombinedToggleProps) {
+  const onStartRef = useRef(onStart);
+  const onStopRef = useRef(onStop);
+  const onToggleRef = useRef(onToggle);
+  useEffect(() => { onStartRef.current = onStart; }, [onStart]);
+  useEffect(() => { onStopRef.current = onStop; }, [onStop]);
+  useEffect(() => { onToggleRef.current = onToggle; }, [onToggle]);
+
+  // Track whether a hold-down press is currently active. When true, we skip
+  // syncing recording state to the backend double-tap detector — otherwise
+  // the eager hold-start would set dtap.recording=true, causing the first
+  // release of a double-tap to fire as "single tap to stop" instead of
+  // advancing to WaitingSecondDown.
+  const holdActiveRef = useRef(false);
+
+  // Keep the backend double-tap detector in sync with recording state,
+  // but ONLY for double-tap-initiated recordings (not eager hold presses).
+  useEffect(() => {
+    if (!enabled) return;
+    if (holdActiveRef.current) return;
+    invoke('set_keyboard_recording', { recording: status === 'recording' }).catch(() => {});
+  }, [enabled, status]);
+
+  useEffect(() => {
+    if (!enabled || !initialized || !accessibilityGranted) return;
+
+    let unlistenStart: (() => void) | null = null;
+    let unlistenStop: (() => void) | null = null;
+    let unlistenCancel: (() => void) | null = null;
+    let unlistenToggle: (() => void) | null = null;
+    let unlistenError: (() => void) | null = null;
+    let cancelled = false;
+
+    const setup = async () => {
+      unlistenStart = await listen('hold-down-start', () => {
+        holdActiveRef.current = true;
+        onStartRef.current();
+      });
+      if (cancelled) { unlistenStart(); return; }
+
+      unlistenStop = await listen('hold-down-stop', () => {
+        holdActiveRef.current = false;
+        onStopRef.current();
+      });
+      if (cancelled) { unlistenStart(); unlistenStop(); return; }
+
+      // Cancel: discard speculative recording from a short tap (no transcription)
+      unlistenCancel = await listen('hold-down-cancel', () => {
+        holdActiveRef.current = false;
+        invoke('cancel_native_recording').catch(() => {});
+      });
+      if (cancelled) { unlistenStart(); unlistenStop(); unlistenCancel(); return; }
+
+      unlistenToggle = await listen('double-tap-toggle', () => {
+        holdActiveRef.current = false;
+        onToggleRef.current();
+      });
+      if (cancelled) { unlistenStart(); unlistenStop(); unlistenCancel(); unlistenToggle(); return; }
+
+      unlistenError = await listen<string>('keyboard-listener-error', async () => {
+        if (cancelled) return;
+        await new Promise<void>((r) => setTimeout(r, 2000));
+        if (!cancelled) {
+          try {
+            await invoke('start_keyboard_listener', { hotkey: triggerKey, mode: 'both' });
+          } catch (err) {
+            console.error('Failed to restart combined listener after error:', err);
+          }
+        }
+      });
+      if (cancelled) { unlistenStart(); unlistenStop(); unlistenCancel(); unlistenToggle(); unlistenError(); return; }
+
+      try {
+        await invoke('start_keyboard_listener', { hotkey: triggerKey, mode: 'both' });
+        if (cancelled) {
+          invoke('stop_keyboard_listener').catch(() => {});
+        }
+      } catch (err) {
+        console.error('Failed to start combined listener:', err);
+      }
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      holdActiveRef.current = false;
+      unlistenStart?.();
+      unlistenStop?.();
+      unlistenCancel?.();
+      unlistenToggle?.();
+      unlistenError?.();
+      invoke('stop_keyboard_listener').catch(() => {});
+    };
+  }, [enabled, initialized, accessibilityGranted, triggerKey]);
+}

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -1,4 +1,4 @@
-export type RecordingMode = 'hold_down' | 'double_tap';
+export type RecordingMode = 'hold_down' | 'double_tap' | 'both';
 
 export type DoubleTapKey = 'shift_l' | 'alt_l' | 'ctrl_r';
 
@@ -45,6 +45,7 @@ export const DOUBLE_TAP_KEY_OPTIONS: { value: DoubleTapKey; label: string }[] = 
 export const RECORDING_MODE_OPTIONS: { value: RecordingMode; label: string }[] = [
   { value: 'hold_down', label: 'Hold Down' },
   { value: 'double_tap', label: 'Double-Tap' },
+  { value: 'both', label: 'Both' },
 ];
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -66,7 +67,7 @@ export function loadSettings(): Settings {
       const parsed = JSON.parse(stored) as Partial<Settings> & { hotkey?: string; recordingMode?: string };
 
       // Migrate: 'hotkey' mode no longer exists → default to 'hold_down'
-      const validModes: RecordingMode[] = ['hold_down', 'double_tap'];
+      const validModes: RecordingMode[] = ['hold_down', 'double_tap', 'both'];
       if (!parsed.recordingMode || !validModes.includes(parsed.recordingMode as RecordingMode)) {
         parsed.recordingMode = DEFAULT_SETTINGS.recordingMode;
       }


### PR DESCRIPTION
## Summary
- Adds a new **"Both"** recording mode that lets users hold the trigger key to record (release to stop) OR double-tap to toggle recording, using the same key
- Uses deferred hold emission — a 200ms background timer distinguishes taps from holds, eliminating state thrash during double-tap sequences
- Ignores keyboard events during the transcription processing phase, preventing spam from corrupting state

## Changes
- **keyboard.rs**: `Both` variant in `DetectorMode`, deferred hold via timer thread, second-phase suppression for double-tap, `IS_PROCESSING` flag, tuned timing (200ms tap/hold threshold, 50ms cooldowns, 400ms dtap window)
- **lib.rs**: `cancel_native_recording` command, `set_processing()` calls around pipeline, `"both"` in `VALID_MODES`
- **useCombinedToggle.ts**: New hook listening for `hold-down-start`, `hold-down-stop`, `hold-down-cancel`, and `double-tap-toggle` events
- **settings.ts**: `'both'` added to `RecordingMode` type, options, and migration
- **App.tsx**: Wire `useCombinedToggle` hook
- **SettingsPanel.tsx**: UI labels for Both mode

## How it works
```
Press key:
  └─ Start 200ms timer (no state change yet)
  └─ If still held after 200ms → emit hold-down-start → recording begins
  └─ If released before 200ms → it was a tap (no recording started)

Double-tap (tap-release-tap-release):
  └─ First tap: no state change
  └─ Second tap: emit double-tap-toggle → recording toggles

During transcription processing:
  └─ All key events ignored
  └─ Detectors reset with cooldown when processing ends
```

## Test plan
- [x] Rust unit tests pass (56 tests)
- [x] TypeScript compiles
- [x] Hold-down: press and hold → recording starts after 200ms, release → transcribes
- [x] Double-tap: quick tap-tap → toggles recording on/off
- [x] Short single tap: no state change (no flash)
- [x] Spam during processing: events ignored, clean state after
- [x] Existing hold-down and double-tap single modes unaffected

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Both" recording mode: hold the trigger key to record continuously or double‑tap to toggle recording on/off
  * Added ability to cancel in‑progress recordings without transcription

* **Improvements**
  * Updated trigger key labels and help text to explain combined behavior
  * Improved responsiveness and reliability of the combined mode (better coordination between hold and double‑tap)
  * Keyboard listener now recovers and restarts automatically on errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->