### PR TITLE
feat: transcription performance metrics UI

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
   const { historyEntries, addEntry, clearHistory } = useHistoryManagement();
   const {
     status, recordingDuration, error: recordingError,
-    handleStart, handleStop, toggleRecording, statsVersion,
+    handleStart, handleStop, toggleRecording, statsVersion, metricsVersion,
   } = useRecordingState({ addEntry, microphone: settings.microphone });
   const [statsResetVersion, setStatsResetVersion] = useState(0);
   const combinedStatsVersion = statsVersion + statsResetVersion;
@@ -167,6 +167,7 @@ function App() {
           accessibilityGranted={accessibilityGranted}
           onCheckForUpdate={checkForUpdate}
           updateStatus={updateStatus}
+          metricsVersion={metricsVersion}
         />
       </div>
 

--- a/app/src/components/PerformanceMetrics.tsx
+++ b/app/src/components/PerformanceMetrics.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { loadMetrics, clearMetrics } from '../lib/metrics';
+import type { TranscriptionMetric } from '../lib/metrics';
+
+interface PerformanceMetricsProps {
+  metricsVersion: number;
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function computeRollingAverage(metrics: TranscriptionMetric[]): number {
+  if (metrics.length === 0) return 0;
+  const sum = metrics.reduce((acc, m) => acc + m.inferenceMs, 0);
+  return sum / metrics.length;
+}
+
+export function PerformanceMetrics({ metricsVersion }: PerformanceMetricsProps) {
+  const [metrics, setMetrics] = useState<TranscriptionMetric[]>(() => loadMetrics());
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  useEffect(() => { setMetrics(loadMetrics()); }, [metricsVersion]);
+
+  const handleClear = () => {
+    if (confirmClear) {
+      clearMetrics();
+      setMetrics([]);
+      setConfirmClear(false);
+    } else {
+      setConfirmClear(true);
+      setTimeout(() => setConfirmClear(false), 3000);
+    }
+  };
+
+  // Show last 20, newest first
+  const recent = [...metrics].reverse().slice(0, 20);
+  const rollingAvg = computeRollingAverage(metrics);
+
+  if (recent.length === 0) {
+    return (
+      <div className="text-xs text-stone-500 dark:text-stone-400">
+        No performance data yet. Metrics will appear after your first transcription.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Summary */}
+      <div className="flex gap-2 text-xs">
+        <div className="flex-1 px-2 py-1.5 rounded bg-stone-100 dark:bg-stone-700 text-center">
+          <div className="font-semibold text-stone-800 dark:text-stone-100 tabular-nums">
+            {Math.round(rollingAvg)}ms
+          </div>
+          <div className="text-[10px] text-stone-500 dark:text-stone-400 leading-none mt-0.5">
+            Avg Inference
+          </div>
+        </div>
+        <div className="flex-1 px-2 py-1.5 rounded bg-stone-100 dark:bg-stone-700 text-center">
+          <div className="font-semibold text-stone-800 dark:text-stone-100 tabular-nums">
+            {metrics.length}
+          </div>
+          <div className="text-[10px] text-stone-500 dark:text-stone-400 leading-none mt-0.5">
+            Total Runs
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-stone-500 dark:text-stone-400 border-b border-stone-200 dark:border-stone-600">
+              <th className="text-left py-1 pr-2 font-medium">Time</th>
+              <th className="text-right py-1 px-2 font-medium">Rec</th>
+              <th className="text-right py-1 px-2 font-medium">Inference</th>
+              <th className="text-right py-1 px-2 font-medium">Words</th>
+              <th className="text-left py-1 pl-2 font-medium">Model</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recent.map((m) => {
+              const isOutlier = rollingAvg > 0 && m.inferenceMs > rollingAvg * 2;
+              return (
+                <tr
+                  key={m.id}
+                  className={`border-b border-stone-100 dark:border-stone-700 ${
+                    isOutlier ? 'bg-amber-50 dark:bg-amber-900/20' : ''
+                  }`}
+                >
+                  <td className="py-1 pr-2 text-stone-600 dark:text-stone-300 tabular-nums">
+                    {formatTime(m.timestamp)}
+                  </td>
+                  <td className="py-1 px-2 text-right text-stone-600 dark:text-stone-300 tabular-nums">
+                    {m.recordingDurationSecs}s
+                  </td>
+                  <td className={`py-1 px-2 text-right tabular-nums ${
+                    isOutlier
+                      ? 'text-amber-700 dark:text-amber-400 font-semibold'
+                      : 'text-stone-600 dark:text-stone-300'
+                  }`}>
+                    {m.inferenceMs}ms
+                  </td>
+                  <td className="py-1 px-2 text-right text-stone-600 dark:text-stone-300 tabular-nums">
+                    {m.wordCount}
+                  </td>
+                  <td className="py-1 pl-2 text-stone-500 dark:text-stone-400 truncate max-w-[80px]">
+                    {m.model}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Clear button */}
+      <button
+        onClick={handleClear}
+        className={`w-full px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
+          confirmClear
+            ? 'border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40'
+            : 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600'
+        }`}
+      >
+        {confirmClear ? 'Confirm Clear' : 'Clear Metrics'}
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   MODEL_OPTIONS, MOONSHINE_MODELS, WHISPER_MODELS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
+import { PerformanceMetrics } from '../PerformanceMetrics';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
 
@@ -52,9 +53,10 @@ interface SettingsPanelProps {
   accessibilityGranted: boolean | null;
   onCheckForUpdate: () => Promise<void>;
   updateStatus: UpdateStatus;
+  metricsVersion: number;
 }
 
-export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, accessibilityGranted, onCheckForUpdate, updateStatus }: SettingsPanelProps) {
+export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, accessibilityGranted, onCheckForUpdate, updateStatus, metricsVersion }: SettingsPanelProps) {
   const [confirmReset, setConfirmReset] = useState(false);
   const [version, setVersion] = useState('');
 
@@ -475,6 +477,14 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           >
             {confirmReset ? 'Confirm Reset' : 'Reset Stats'}
           </button>
+        </div>
+
+        {/* Performance Metrics */}
+        <div className="pt-4 border-t border-stone-200 dark:border-stone-700">
+          <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+            Performance
+          </h3>
+          <PerformanceMetrics metricsVersion={metricsVersion} />
         </div>
 
         {/* Logs */}

--- a/app/src/lib/metrics.ts
+++ b/app/src/lib/metrics.ts
@@ -1,0 +1,52 @@
+export interface TranscriptionMetric {
+  id: string;
+  timestamp: number;
+  recordingDurationSecs: number;
+  inferenceMs: number;
+  wordCount: number;
+  model: string;
+}
+
+const STORAGE_KEY = 'transcription-metrics';
+const MAX_ENTRIES = 100;
+
+export function loadMetrics(): TranscriptionMetric[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (e) {
+    console.error('Failed to load metrics:', e);
+  }
+  return [];
+}
+
+export function saveMetrics(entries: TranscriptionMetric[]): void {
+  try {
+    const trimmed = entries.slice(-MAX_ENTRIES);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch (e) {
+    console.error('Failed to save metrics:', e);
+  }
+}
+
+export function addMetric(entry: Omit<TranscriptionMetric, 'id' | 'timestamp'>): TranscriptionMetric[] {
+  const metrics = loadMetrics();
+  const newEntry: TranscriptionMetric = {
+    id: Date.now().toString(),
+    timestamp: Date.now(),
+    ...entry,
+  };
+  const updated = [...metrics, newEntry].slice(-MAX_ENTRIES);
+  saveMetrics(updated);
+  return updated;
+}
+
+export function clearMetrics(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.error('Failed to clear metrics:', e);
+  }
+}


### PR DESCRIPTION
## Summary

- Enrich the `transcription-complete` Tauri event with `inference_ms`, `word_count`, and `model` fields from the Rust transcription pipeline
- Add a `metrics.ts` localStorage-backed store for per-transcription timing data (bounded to 100 entries)
- Display a performance metrics table in the settings panel showing the last 20 transcriptions with recording duration, inference time, word count, and model
- Highlight outlier transcriptions (inference > 2x rolling average) in amber

Closes #41

## Test plan

- [ ] Run a transcription and verify the Performance section in Settings populates with a new row
- [ ] Confirm inference_ms, word_count, model, and recording duration are all present
- [ ] Run multiple transcriptions and verify outlier highlighting (amber) when inference time exceeds 2x the average
- [ ] Click "Clear Metrics" and confirm all data is removed
- [ ] Verify TypeScript check passes: `cd app && npx tsc --noEmit`
- [ ] Verify Rust check passes: `cd app/src-tauri && cargo check`