### PR TITLE
Resource monitor shows app process CPU/memory instead of system-wide

### DIFF
--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 use serde::Serialize;
-use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 
 static SYS: Mutex<Option<System>> = Mutex::new(None);
 
@@ -13,24 +13,24 @@ pub struct ResourceUsage {
 #[tauri::command]
 pub fn get_resource_usage() -> ResourceUsage {
     let mut guard = SYS.lock().unwrap_or_else(|p| p.into_inner());
-    // Initialize with only CPU and memory subsystems to avoid loading
-    // processes, disks, and network data we don't need.
-    let sys = guard.get_or_insert_with(|| {
-        System::new_with_specifics(
-            RefreshKind::new()
-                .with_cpu(CpuRefreshKind::new().with_cpu_usage())
-                .with_memory(MemoryRefreshKind::new().with_ram()),
-        )
-    });
-    // Note: the first call to refresh_cpu_usage() yields ~0% because
-    // System::new_with_specifics() establishes a baseline snapshot and
-    // global_cpu_usage() measures the delta since the last refresh.
-    // The persistent static SYS ensures subsequent 1-second polls are accurate;
-    // the initial ~0% reading is expected and harmless.
-    sys.refresh_cpu_usage();
-    sys.refresh_memory();
-    ResourceUsage {
-        cpu_percent: sys.global_cpu_usage(),
-        memory_mb: sys.used_memory() / 1_048_576,
+    let sys = guard.get_or_insert_with(System::new);
+    let pid = sysinfo::get_current_pid().expect("failed to get PID");
+    let refresh = ProcessRefreshKind::new()
+        .with_cpu()
+        .with_memory();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        refresh,
+    );
+    match sys.process(pid) {
+        Some(proc_) => ResourceUsage {
+            cpu_percent: proc_.cpu_usage(),
+            memory_mb: proc_.memory() / 1_048_576,
+        },
+        None => ResourceUsage {
+            cpu_percent: 0.0,
+            memory_mb: 0,
+        },
     }
 }


### PR DESCRIPTION
## Summary
- Switches `resource_monitor.rs` from system-wide metrics (`global_cpu_usage()` / `used_memory()`) to per-process metrics using `sysinfo::get_current_pid()` and `refresh_processes_specifics()`
- The RESOURCES panel now displays Murmur's own CPU usage and RSS memory instead of totals across all system processes
- No frontend changes needed -- the `ResourceUsage` struct shape is unchanged

## Test plan
- [ ] Run `cargo check` -- passes
- [ ] Run `npx tsc --noEmit` -- passes
- [ ] Open dev window, expand RESOURCES panel, verify CPU% and Memory MB reflect app-level values (should be much lower than previous system-wide numbers)

Closes #72