### PR TITLE
Add log verbosity setting to reduce noise from heartbeat/keyboard spam

### DIFF
--- a/app/src-tauri/src/commands/keyboard.rs
+++ b/app/src-tauri/src/commands/keyboard.rs
@@ -38,3 +38,8 @@ pub fn update_keyboard_key(app_handle: tauri::AppHandle, hotkey: String) {
 pub fn set_keyboard_recording(recording: bool) {
     keyboard::set_recording_state(recording);
 }
+
+#[tauri::command]
+pub fn set_verbose_logging(verbose: bool) {
+    keyboard::set_verbose_logging(verbose);
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ pub fn run() {
             commands::keyboard::stop_keyboard_listener,
             commands::keyboard::update_keyboard_key,
             commands::keyboard::set_keyboard_recording,
+            commands::keyboard::set_verbose_logging,
             commands::logging::get_log_contents,
             commands::logging::clear_logs,
             commands::logging::log_frontend,

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -482,6 +482,32 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
             Logs
           </h3>
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+                Verbose Logs
+              </label>
+              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                Log keyboard heartbeats and event details
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.verboseLogs}
+              aria-label="Verbose logs"
+              onClick={() => onUpdateSettings({ verboseLogs: !settings.verboseLogs })}
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                settings.verboseLogs ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  settings.verboseLogs ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
           <button
             onClick={onViewLogs}
             className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   recordingMode: RecordingMode;
   microphone: string;
   launchAtLogin: boolean;
+  verboseLogs: boolean;
 }
 
 export type ModelOption =
@@ -58,6 +59,7 @@ export const DEFAULT_SETTINGS: Settings = {
   recordingMode: 'hold_down',
   microphone: 'system_default',
   launchAtLogin: false,
+  verboseLogs: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
Closes #95

## Summary
- Adds a **Verbose Logs** toggle (off by default) in Settings > Logs section
- Gates 5 diagnostic log lines behind the toggle: the 60s keyboard heartbeat and all Both-mode key event detail logs
- Uses an `AtomicBool` flag in the keyboard module (matches existing `LISTENER_ACTIVE` / `IS_PROCESSING` pattern)
- Setting persists in localStorage and syncs to the Rust backend on mount and on change

## Test plan
- [ ] Open Settings > Logs — verify "Verbose Logs" toggle appears above "View Logs" button
- [ ] With toggle OFF, use the app normally — verify heartbeat and BOTH-mode event lines do not appear in logs
- [ ] With toggle ON, verify heartbeat lines appear every ~60s and BOTH-mode event lines appear on key events
- [ ] Toggle setting, close and reopen app — verify setting persists