### PR TITLE
feat: add pre-VAD RMS logging and VAD sensitivity slider

### DIFF
--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -25,6 +25,7 @@ pub struct DictationState {
     pub language: String,
     pub auto_paste: bool,
     pub auto_paste_delay_ms: u64,
+    pub vad_sensitivity: u32,
 }
 
 impl Default for DictationState {
@@ -35,6 +36,7 @@ impl Default for DictationState {
             language: "en".to_string(),
             auto_paste: false,
             auto_paste_delay_ms: 50,
+            vad_sensitivity: 50,
         }
     }
 }

--- a/app/src-tauri/src/vad.rs
+++ b/app/src-tauri/src/vad.rs
@@ -27,7 +27,7 @@ pub enum VadResult {
 /// `model_path` must point to a valid Silero VAD GGML model file.
 /// This function creates a `WhisperVadContext` which is `!Send`, so it must
 /// run entirely within a single thread (use `spawn_blocking`).
-pub fn filter_speech(model_path: &str, samples: &[f32]) -> Result<VadResult, String> {
+pub fn filter_speech(model_path: &str, samples: &[f32], threshold: f32) -> Result<VadResult, String> {
     let mut ctx_params = WhisperVadContextParams::default();
     ctx_params.set_n_threads(1);
     ctx_params.set_use_gpu(false);
@@ -35,10 +35,8 @@ pub fn filter_speech(model_path: &str, samples: &[f32]) -> Result<VadResult, Str
     let mut ctx = WhisperVadContext::new(model_path, ctx_params)
         .map_err(|e| format!("Failed to create VAD context: {}", e))?;
 
-    let vad_params = WhisperVadParams::default();
-    // Default params already match our desired values:
-    //   threshold: 0.5, min_speech_duration: 250ms,
-    //   min_silence_duration: 100ms, speech_pad: 30ms
+    let mut vad_params = WhisperVadParams::default();
+    vad_params.set_threshold(threshold);
 
     let segments = ctx
         .segments_from_samples(vad_params, samples)

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -41,6 +41,37 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
   );
 }
 
+function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v: number) => void }) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => { setDraft(value); }, [value]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-xs text-stone-600 dark:text-stone-400">
+          Sensitivity
+        </label>
+        <span className="text-xs font-medium text-stone-700 dark:text-stone-300">
+          {draft}%
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={5}
+        value={draft}
+        onChange={(e) => setDraft(Number(e.target.value))}
+        onPointerUp={() => onCommit(draft)}
+        className="w-full h-1.5 bg-stone-200 dark:bg-stone-600 rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
+      />
+      <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+        Higher = keeps more audio. Lower = trims silence more aggressively.
+      </p>
+    </div>
+  );
+}
+
 interface SettingsPanelProps {
   isOpen: boolean;
   onClose: () => void;
@@ -294,6 +325,17 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               <span>Selected device not found — will use System Default</span>
             </div>
           )}
+        </div>
+
+        {/* Voice Detection */}
+        <div>
+          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+            Voice Detection
+          </label>
+          <VadSensitivitySlider
+            value={settings.vadSensitivity}
+            onCommit={(value) => onUpdateSettings({ vadSensitivity: value })}
+          />
         </div>
 
         {/* Recording Trigger */}

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -57,6 +57,7 @@ export interface ConfigureOptions {
   language?: string;
   autoPaste?: boolean;
   autoPasteDelayMs?: number;
+  vadSensitivity?: number;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -47,9 +47,9 @@ export function useSettings() {
       });
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates) {
       const version = ++configureVersionRef.current;
-      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs })
+      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity })
         .catch((err) => {
           console.error('Failed to configure:', err);
           if (configureVersionRef.current === version) {
@@ -59,6 +59,7 @@ export function useSettings() {
               language: previousSettings.language,
               autoPaste: previousSettings.autoPaste,
               autoPasteDelayMs: previousSettings.autoPasteDelayMs,
+              vadSensitivity: previousSettings.vadSensitivity,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   recordingMode: RecordingMode;
   microphone: string;
   launchAtLogin: boolean;
+  vadSensitivity: number;
 }
 
 export type ModelOption =
@@ -58,6 +59,7 @@ export const DEFAULT_SETTINGS: Settings = {
   recordingMode: 'hold_down',
   microphone: 'system_default',
   launchAtLogin: false,
+  vadSensitivity: 50,
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
## Summary
- Log audio signal level (RMS, peak, device name) before VAD to diagnose dead-mic vs aggressive-trim from logs alone
- Add user-facing Voice Detection sensitivity slider (0–100, default 50) so users can tune VAD threshold without code changes
- Wire `vad_sensitivity` through Rust state → VAD → frontend settings with full revert-on-error support

Closes #104

## Log output
```
pipeline: audio rms=0.0171 peak=0.1307 (device=Anker PowerConf C200)
pipeline: VAD trimmed 247125 → 109920 samples (44% speech, 28ms)
```

## Files changed
| File | Change |
|------|--------|
| `audio.rs` | Public `compute_rms`, new `compute_peak` + tests, device name tracking + getter |
| `commands/recording.rs` | Pre-VAD log line, read/pass sensitivity, handle in `configure_dictation` |
| `vad.rs` | Add `threshold` param to `filter_speech` |
| `state.rs` | Add `vad_sensitivity` to `DictationState` |
| `settings.ts` | Add `vadSensitivity` to types + defaults |
| `dictation.ts` | Add `vadSensitivity` to `ConfigureOptions` |
| `useSettings.ts` | Sync `vadSensitivity` to Rust |
| `SettingsPanel.tsx` | `VadSensitivitySlider` component |

## Test plan
- [x] `cargo test --lib -- --test-threads=1` — 63/63 pass (including 4 new `compute_peak` tests)
- [x] `npx tsc --noEmit` — clean
- [x] Manual: confirmed `rms=0.0000` on wrong mic (MacBook Pro Microphone), healthy signal on correct mic (Anker PowerConf C200)
- [x] Manual: VAD trimming works end-to-end with Anker mic (88% and 44% speech kept)
- [x] Manual: VAD sensitivity slider confirmed working — sensitivity=0 (threshold 1.0) correctly rejects all audio; sensitivity=55 (threshold 0.45) keeps 56% speech; slider changes logged in configure_dictation calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)