### PR TITLE
feat: collapsible accordion sections for settings panel

### DIFF
--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   MODEL_OPTIONS, MOONSHINE_MODELS, WHISPER_MODELS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
+import { SettingsSection } from './SettingsSection';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
 
@@ -191,7 +192,8 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
       </div>
 
       {/* Content */}
-      <div className="p-4 space-y-6">
+      <div className="px-4 pt-1">
+        <SettingsSection title="Transcription" subtitle="Model, microphone">
         {/* Model Selector */}
         <div>
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
@@ -295,7 +297,9 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </div>
           )}
         </div>
+        </SettingsSection>
 
+        <SettingsSection title="Recording" subtitle="Trigger mode, shortcut key">
         {/* Recording Trigger */}
         <div>
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
@@ -353,7 +357,9 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             {keyHelpText}
           </p>
         </div>
+        </SettingsSection>
 
+        <SettingsSection title="Output" subtitle="Auto-paste, launch at login">
         {/* Auto-Paste Toggle */}
         <div>
           <div className="flex items-center justify-between">
@@ -443,12 +449,11 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </button>
           </div>
         </div>
+        </SettingsSection>
 
+        <SettingsSection title="About" subtitle="Stats, logs, updates" defaultExpanded={false}>
         {/* Model Info */}
-        <div className="pt-4 border-t border-stone-200 dark:border-stone-700">
-          <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
-            Current Model
-          </h3>
+        <div>
           <div className="text-sm text-stone-600 dark:text-stone-400">
             <p><strong>Model:</strong> {selectedModel?.label}</p>
             <p><strong>Backend:</strong> {selectedModel
@@ -460,10 +465,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         </div>
 
         {/* Reset Stats */}
-        <div className="pt-4 border-t border-stone-200 dark:border-stone-700">
-          <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
-            Statistics
-          </h3>
+        <div>
           <button
             onClick={handleResetClick}
             aria-label={confirmReset ? 'Confirm reset statistics' : 'Reset statistics'}
@@ -478,10 +480,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         </div>
 
         {/* Logs */}
-        <div className="pt-4 border-t border-stone-200 dark:border-stone-700">
-          <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
-            Logs
-          </h3>
+        <div>
           <button
             onClick={onViewLogs}
             className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"
@@ -491,10 +490,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         </div>
 
         {/* Updates */}
-        <div className="pt-4 border-t border-stone-200 dark:border-stone-700">
-          <h3 className="text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
-            Updates
-          </h3>
+        <div>
           <button
             onClick={onCheckForUpdate}
             disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'}
@@ -518,14 +514,15 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </p>
           )}
         </div>
-      </div>
 
-      {/* Footer */}
-      {version && (
-        <div className="px-4 py-3 border-t border-stone-200 dark:border-stone-700 text-center">
-          <span className="text-xs text-stone-400 dark:text-stone-500">v{version}</span>
-        </div>
-      )}
+        {/* Version */}
+        {version && (
+          <div className="text-center">
+            <span className="text-xs text-stone-400 dark:text-stone-500">v{version}</span>
+          </div>
+        )}
+        </SettingsSection>
+      </div>
     </aside>
   );
 }

--- a/app/src/components/settings/SettingsSection.tsx
+++ b/app/src/components/settings/SettingsSection.tsx
@@ -1,0 +1,69 @@
+import { useState, useId, useCallback } from 'react';
+
+interface SettingsSectionProps {
+  title: string;
+  subtitle?: string;
+  defaultExpanded?: boolean;
+  children: React.ReactNode;
+}
+
+export function SettingsSection({ title, subtitle, defaultExpanded = true, children }: SettingsSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [overflowVisible, setOverflowVisible] = useState(defaultExpanded);
+  const contentId = useId();
+
+  const handleToggle = useCallback(() => {
+    setExpanded((prev) => {
+      if (prev) setOverflowVisible(false);
+      return !prev;
+    });
+  }, []);
+
+  const handleTransitionEnd = useCallback(() => {
+    if (expanded) setOverflowVisible(true);
+  }, [expanded]);
+
+  return (
+    <div className="border-b border-stone-200 dark:border-stone-700">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={handleToggle}
+        className="flex w-full items-center justify-between py-3 text-sm font-semibold text-stone-900 dark:text-stone-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-1 rounded-sm"
+      >
+        <span className="text-left">
+          {title}
+          {subtitle && !expanded && (
+            <span className="block text-xs font-normal text-stone-400 dark:text-stone-500">{subtitle}</span>
+          )}
+        </span>
+        <svg
+          className={`w-4 h-4 text-stone-400 shrink-0 transition-transform duration-200 ${
+            expanded ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        id={contentId}
+        role="region"
+        aria-labelledby={undefined}
+        className={`grid transition-[grid-template-rows] duration-200 ${
+          expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+        onTransitionEnd={handleTransitionEnd}
+      >
+        <div className={overflowVisible ? 'overflow-visible' : 'overflow-hidden'}>
+          <div className="pb-4 space-y-4">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/settings/SettingsSection.tsx
+++ b/app/src/components/settings/SettingsSection.tsx
@@ -11,6 +11,7 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [overflowVisible, setOverflowVisible] = useState(defaultExpanded);
   const contentId = useId();
+  const headerId = useId();
 
   const handleToggle = useCallback(() => {
     setExpanded((prev) => {
@@ -27,6 +28,7 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
     <div className="border-b border-stone-200 dark:border-stone-700">
       <button
         type="button"
+        id={headerId}
         aria-expanded={expanded}
         aria-controls={contentId}
         onClick={handleToggle}
@@ -52,7 +54,7 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
       <div
         id={contentId}
         role="region"
-        aria-labelledby={undefined}
+        aria-labelledby={headerId}
         className={`grid transition-[grid-template-rows] duration-200 ${
           expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
         }`}


### PR DESCRIPTION
## Summary
- Groups 11+ flat settings into 4 collapsible accordion sections: **Transcription**, **Recording**, **Output**, and **About**
- Less-used items (model info, stats, logs, updates, version) moved into **About** which starts collapsed — directly addressing the crowding complaint
- Each collapsed section shows a subtitle hint (e.g. "Stats, logs, updates") so users know what's inside without expanding
- New `SettingsSection` component with smooth CSS grid animation, overflow handling for Select dropdowns, and ARIA disclosure pattern

## Test plan
- [ ] Sections 1–3 expanded, section 4 collapsed on open
- [ ] Click headers to toggle with smooth animation
- [ ] Select dropdowns (Model, Mic, Key) open without clipping
- [ ] Collapsed sections show subtitle hints
- [ ] Dark mode renders correctly
- [ ] Tab/Enter/Space keyboard navigation works on section headers
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (26/26)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings sections are now collapsible with smooth animations, allowing users to expand/collapse configuration groups as needed

* **Refactor**
  * Settings panel layout restructured with improved visual organization and grouping
  * Configuration reorganized into clear sections: Transcription, Recording, Output, and About
  * Version information relocated to the About section for better information organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->