### PR TITLE
fix: cache WhisperState to eliminate swap pressure (#109)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -374,6 +374,7 @@ pub fn set_processing(processing: bool) {
 }
 
 /// Returns whether the app is currently in the processing state.
+#[cfg(test)]
 pub fn is_processing() -> bool {
     IS_PROCESSING.load(Ordering::SeqCst)
 }


### PR DESCRIPTION
## Summary

- **Cache `WhisperState` across transcriptions** instead of creating/destroying it on every `transcribe()` call. Each cycle was allocating/freeing ~500MB of ggml buffers that macOS marked `MADV_FREE` but never reclaimed, accumulating 5.8GB in swap after ~300 transcriptions.
- **Add lifecycle logging** to `whisper.rs` — logs state creation at model load, reuse on each transcription, and cleanup on reset.
- **Fix dead_code warning** — gate `is_processing()` behind `#[cfg(test)]` since it's only used in tests.

## Test plan

- [x] `cargo test --lib -- --test-threads=1` — all 63 unit tests pass
- [x] Manual testing: confirmed logs show `state cached for reuse` on first transcription, `reusing cached state` on subsequent ones
- [x] Verified correct drop order (state before context) on model switch via `releasing cached state and model` log

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized transcription engine by implementing intelligent state caching, eliminating redundant computational operations during repeated transcription tasks and improving overall system responsiveness.

* **Bug Fixes**
  * Enhanced transcription reset functionality to ensure complete cleanup of internal state resources.

* **Tests**
  * Added keyboard processing state verification utilities for test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->