### PR TITLE
fix: app stuck in processing after VAD model downloads on first run

### DIFF
--- a/app/src-tauri/src/commands/models.rs
+++ b/app/src-tauri/src/commands/models.rs
@@ -173,27 +173,19 @@ pub(crate) async fn ensure_vad_model(app_handle: &tauri::AppHandle) -> Result<()
         .map_err(|e| format!("Failed to create models directory: {}", e))?;
 
     tracing::info!(target: "system", "VAD model not found, downloading...");
-    let _ = app_handle.emit("recording-status-changed", "downloading-vad");
 
-    let result = async {
-        let temp_path = models_dir.join(format!("{}.tmp", vad::VAD_MODEL_FILENAME));
-        let received = stream_download(app_handle, vad::VAD_MODEL_URL, &temp_path).await?;
+    let temp_path = models_dir.join(format!("{}.tmp", vad::VAD_MODEL_FILENAME));
+    let received = stream_download(app_handle, vad::VAD_MODEL_URL, &temp_path).await?;
 
-        tokio::fs::rename(&temp_path, &model_path)
-            .await
-            .map_err(|e| {
-                let _ = std::fs::remove_file(&temp_path);
-                format!("Failed to finalize VAD model download: {}", e)
-            })?;
+    tokio::fs::rename(&temp_path, &model_path)
+        .await
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&temp_path);
+            format!("Failed to finalize VAD model download: {}", e)
+        })?;
 
-        tracing::info!(target: "system", "VAD model downloaded: {} ({} bytes)", vad::VAD_MODEL_FILENAME, received);
-        Ok::<(), String>(())
-    }
-    .await;
-
-    // Always restore status so the UI doesn't get stuck at "downloading-vad"
-    let _ = app_handle.emit("recording-status-changed", "processing");
-    result
+    tracing::info!(target: "system", "VAD model downloaded: {} ({} bytes)", vad::VAD_MODEL_FILENAME, received);
+    Ok(())
 }
 
 /// Stream a file download with progress events. Returns total bytes received.


### PR DESCRIPTION
## Summary

- Removes two `recording-status-changed` Tauri event emissions from `ensure_vad_model` that were causing the app to get stuck in `processing` state after the first transcription on a fresh install
- `ensure_vad_model` is now a silent background utility with no UI side effects

## Root Cause

`ensure_vad_model` emitted `"downloading-vad"` on start and `"processing"` on completion. The intent was to prevent the UI getting stuck on a `downloading-vad` status. This worked in the model download UI context, but the function is also called as a fire-and-forget `tokio::spawn` from the recording pipeline when the VAD model is absent.

In that path, the pipeline completes and `IdleGuard` resets status to idle *before* the download finishes. The `"processing"` emission then fires ~400ms later and stomps idle with no transition out — leaving the app non-functional until restart.

`"downloading-vad"` had no frontend handler (confirmed by grep), so that emission was always a no-op.

## Change

`commands/models.rs` — removed `app_handle.emit("recording-status-changed", "downloading-vad")` and `app_handle.emit("recording-status-changed", "processing")` from `ensure_vad_model`. The function now just downloads the file and logs.

## Testing

- 63 unit tests pass
- The pre-existing `moonshine_backend_roundtrip` integration test failure is unrelated (Moonshine model not installed on this machine)

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VAD model download performance and streamlined the download process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->