### PR TITLE
docs: comprehensive documentation rewrite for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,157 @@
 # Changelog
 
-All notable changes to Local Dictation will be documented in this file.
+All notable changes to Murmur will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
+
+## [0.8.0] - 2026-03-02
+
 ### Added
-- **Double-tap modifier key recording mode** — double-tap Shift/Option/Control to start recording, single tap to stop. Uses rdev for low-level keyboard event listening with a state machine that rejects held keys, modifier+letter combos, slow taps, and triple-tap spam.
-- **Recording mode setting** — choose between "Key Combo" (Shift+Space etc.) and "Double-Tap" modes in Settings.
-- **Unit tests** — 23 tests for the DoubleTapDetector state machine covering all edge cases (held keys, combos, cooldowns, single-tap-to-stop).
-- `keyboard.rs` module for double-tap detection and rdev listener management.
+- **Structured event system** with `TauriEmitterLayer`, ring buffer, JSONL export, and privacy stripping (`telemetry.rs`)
+- **Log viewer window** with Events and Metrics tabs for real-time structured event inspection
+
+## [0.7.8] - 2026-03-01
 
 ### Fixed
-- Settings help text incorrectly said "Hold this key to record, release to transcribe" — corrected to reflect toggle/double-tap behavior.
-- rdev macOS crash: switched from crates.io v0.5 to git `main` branch and added `set_is_main_thread(false)` to prevent TIS/TSM thread-safety segfaults.
+- Cache `WhisperState` to eliminate per-transcription alloc/free cycles, improving latency
+
+## [0.7.7] - 2026-03-01
+
+### Added
+- **Collapsible accordion sections** for the settings panel
+- **Pre-VAD RMS logging** and VAD sensitivity slider for tuning speech detection
+
+## [0.7.6] - 2026-02-28
+
+### Fixed
+- CI: set `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` to fix `std::filesystem` errors with Xcode 16.4
+- CI: add ARM i8mm flags to rust check job
+
+## [0.7.5] - 2026-02-28
+
+### Added
+- **Silero VAD pre-processing** to filter silence and prevent whisper hallucination loops (`vad.rs`)
+- **Configurable auto-paste delay** with retry logic and failure notification
+
+### Fixed
+- Discard phantom recordings and add transcription logging
+- Reposition overlay on display configuration change
 
 ### Changed
-- Accessibility permission is now also required for double-tap recording mode (rdev needs it for global keyboard event listening).
+- Split `lib.rs` into focused single-responsibility modules (`state.rs`, `audio.rs`, etc.)
+- Split `keyboard.rs` into focused submodules
+- Rename `ui/` to `app/` at repo root
 
-## [0.2.0] - 2025-XX-XX
+## [0.7.0] - 2026-02-27
+
+### Added
+- **"Both" recording mode** — simultaneous hold-down + double-tap (`useCombinedToggle.ts`)
+
+### Fixed
+- Allow scrolling within long transcription history entries
+- Restore tray icon and fix overlay click surfacing main window
+
+## [0.6.7] - 2026-02-27
+
+### Changed
+- **Rebrand to Murmur** — app rename with new icon
+
+## [0.6.5] - 2026-02-26
+
+### Added
+- **OTA auto-updater** with min-version enforcement (`useAutoUpdater.ts`, `lib/updater.ts`)
+- Custom styled select dropdowns replacing native selects
+
+### Fixed
+- Log accessibility permission status in keyboard listener start/stop
+
+## [0.6.2] - 2026-02-26
+
+### Added
+- **Microphone device selection** in settings
+- **Launch at login** toggle
+
+## [0.6.0] - 2026-02-26
+
+### Added
+- **Interactive overlay** with Dynamic Island notch integration (`OverlayWidget.tsx`, `commands/overlay.rs`)
+
+## [0.5.3] - 2026-02-24
+
+### Added
+- Group model selector by backend (Moonshine / Whisper)
+- CI: Rust tests and settings migration tests in CI pipeline
+- CI: post-build smoke test in release workflow
+
+### Fixed
+- Statically link sherpa-rs to fix launch crash
+
+## [0.5.0] - 2026-02-23
+
+### Added
+- **Moonshine transcription backend** via sherpa-rs as an alternative to Whisper
+- **Hold-Down recording mode** replacing Key Combo mode (press to start, release to stop)
+- `TranscriptionBackend` trait extracted from `transcriber.rs` for backend abstraction
+
+### Fixed
+- Eliminate auto-paste toggle race conditions and silent failures
+- Surface Control shortcut failures and warn in settings
+
+## [0.4.0] - 2026-02-20
+
+### Added
+- **In-app model downloader** for first-launch onboarding
+- Per-phase timing instrumentation for the transcription pipeline
+
+### Fixed
+- Surface rdev listener failures and add heartbeat logging
+
+## [0.3.2] - 2026-02-19
+
+### Fixed
+- Auto-paste toggle shrinks and loses track in dark mode
+- Set `signingIdentity` so local builds use Developer ID cert
+- Use draft-then-publish pattern in release workflow
+
+## [0.3.0] - 2026-02-19
+
+### Added
+- **Live resource monitor** with CPU/memory chart (`resource_monitor.rs`, `useResourceMonitor.ts`)
+- **Logging viewer** for inspecting app logs in real time
+- **Double-tap modifier key recording mode** — double-tap Shift/Option/Control to start recording, single tap to stop
+- **Recording mode setting** — choose between "Key Combo" and "Double-Tap" modes in Settings
+- Unit tests (23 tests) for the `DoubleTapDetector` state machine
+- `keyboard.rs` module for double-tap detection and rdev listener management
+
+### Fixed
+- Settings help text incorrectly described recording behavior
+- rdev macOS crash: switched to git `main` branch and added `set_is_main_thread(false)` to prevent TIS/TSM segfaults
+
+### Changed
+- Accessibility permission now also required for double-tap recording mode
+
+## [0.2.0] - 2026-02-19
 
 ### Added
 - Native audio capture via cpal (replaced Web Audio + Python sidecar)
 - Pure Rust transcription pipeline via whisper-rs with Metal GPU acceleration
 - Auto-paste toggle with osascript Cmd+V simulation
 - File-based logging with rotation (`~/Library/Application Support/local-dictation/logs/`)
+- Word statistics with stats bar and localStorage persistence
+- Custom hotkey binding
+- Status widget — tray icon, overlay pill, audio waveform
+- Warm neutral UI redesign
 
 ### Removed
 - Python sidecar dependency — all processing is now pure Rust
 - Web Audio capture module (`audioCapture.ts`)
 
-## [0.1.0] - 2024-XX-XX
+## [0.1.0] - 2026-02-19
 
 ### Added
 - Tauri desktop app with React/TypeScript frontend
@@ -41,13 +163,7 @@ All notable changes to Local Dictation will be documented in this file.
 - macOS permissions guidance
 - About window with version info
 - Production build with DMG installer
-
-### Backend
 - Python sidecar for transcription (whisper.cpp)
 - JSON-based communication protocol
 - Support for multiple Whisper models (tiny.en to large-v3-turbo)
-
-### Technical
-- Built with Tauri 2, React 18, TypeScript, Tailwind CSS
-- ~1.5MB DMG, ~25MB installed app size
-- Local processing - no cloud dependencies
+- Local processing with no cloud dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ Read these before working on a feature:
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript
+- **[docs/features/vad.md](docs/features/vad.md)** — VAD speech filtering
+- **[docs/features/overlay.md](docs/features/overlay.md)** — Dynamic Island overlay
+- **[docs/features/log-viewer.md](docs/features/log-viewer.md)** — Structured event system and log viewer
+- **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
+- **[docs/features/models.md](docs/features/models.md)** — Model management and download
 
 ## File Map
 
@@ -28,10 +33,10 @@ Read these before working on a feature:
 |------|---------|
 | `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
-| `commands/recording.rs` | `IdleGuard`, transcription pipeline, 7 recording/status commands |
+| `commands/recording.rs` | `IdleGuard`, transcription pipeline with VAD, 7 recording/status commands |
 | `commands/permissions.rs` | 6 permission and audio device commands |
 | `commands/keyboard.rs` | 4 keyboard listener commands |
-| `commands/logging.rs` | 3 logging commands |
+| `commands/logging.rs` | 4 logging commands, delegates to telemetry.rs |
 | `commands/models.rs` | Model download pipeline and existence checks |
 | `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
 | `commands/overlay.rs` | Notch detection, overlay positioning, show/hide commands |
@@ -40,7 +45,9 @@ Read these before working on a feature:
 | `transcriber/` | whisper-rs and moonshine model loading and inference |
 | `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
 | `state.rs` | `DictationState`, `AppState` with mutex-wrapped state |
-| `logging.rs` | File-based logging with rotation |
+| `telemetry.rs` | Structured event system: TauriEmitterLayer, ring buffer, JSONL, privacy stripping |
+| `vad.rs` | Silero VAD speech filtering via whisper-rs |
+| `resource_monitor.rs` | System CPU/memory monitoring via sysinfo |
 
 ### Frontend (`app/src/`)
 
@@ -48,10 +55,25 @@ Read these before working on a feature:
 |------|---------|
 | `App.tsx` | Main orchestrator, wires hooks together |
 | `lib/settings.ts` | Settings types, defaults, localStorage persistence |
+| `lib/events.ts` | Event types, stream/level definitions, color constants |
+| `lib/history.ts` | History entry types and localStorage persistence |
+| `lib/stats.ts` | Usage metrics: words, WPM, recordings, tokens |
+| `lib/dictation.ts` | Tauri command wrappers for dictation pipeline |
+| `lib/updater.ts` | Semver parsing, min-version checking, update utilities |
+| `lib/log.ts` | Frontend logging via Rust tracing (flog utility) |
 | `lib/hooks/useHoldDownToggle.ts` | Hold-down mode (rdev press/release events) |
 | `lib/hooks/useDoubleTapToggle.ts` | Double-tap mode (rdev events) |
+| `lib/hooks/useCombinedToggle.ts` | Both mode (hold-down + double-tap simultaneous) |
 | `lib/hooks/useRecordingState.ts` | Recording status, transcription, toggle logic |
+| `lib/hooks/useAutoUpdater.ts` | OTA updates, min-version enforcement |
+| `lib/hooks/useHistoryManagement.ts` | Transcription history with localStorage persistence |
+| `lib/hooks/useInitialization.ts` | One-time init sequence (initDictation + configure) |
+| `lib/hooks/useShowAboutListener.ts` | Listens for show-about tray event |
+| `lib/hooks/useEventStore.ts` | Structured event log buffer with live streaming |
+| `lib/hooks/useResourceMonitor.ts` | CPU/memory polling with rolling buffer |
 | `components/settings/SettingsPanel.tsx` | Settings UI with mode switching |
+| `components/log-viewer/LogViewerApp.tsx` | Structured event viewer with Events + Metrics tabs |
+| `components/OverlayWidget.tsx` | Dynamic Island notch overlay |
 
 ## Key Patterns
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Murmur is a privacy-first, local-only voice dictation app for macOS. You speak, it transcribes — no cloud, no API keys, no internet. All inference runs on-device using Apple Silicon's GPU (or CPU for the Moonshine backend).
+Murmur is a privacy-first, local-only voice dictation app for macOS. You speak, it transcribes -- no cloud, no API keys, no internet. All inference runs on-device using Apple Silicon's GPU (Whisper) or CPU (Moonshine).
 
 Built with **Tauri 2** (Rust backend + React frontend). ~25MB installed, no Python, no sidecar.
 
@@ -15,10 +15,13 @@ Built with **Tauri 2** (Rust backend + React frontend). ~25MB installed, no Pyth
 | Desktop framework | Tauri 2 | Rust backend, React frontend, smaller than Electron |
 | UI | React 18 + TypeScript + Tailwind CSS 4 | Vite 6 build |
 | Audio capture | cpal | Native multi-channel input, mono mix, 16kHz resample |
-| Transcription (primary) | whisper-rs → whisper.cpp | Metal GPU-accelerated on Apple Silicon |
+| VAD | Silero v5.1.2 via whisper-rs | Filters silence before transcription; prevents Whisper hallucination loops |
+| Transcription (primary) | whisper-rs -> whisper.cpp | Metal GPU-accelerated on Apple Silicon |
 | Transcription (alt) | Moonshine via sherpa-rs / ONNX | CPU-only, int8-quantized, ~16ms for 3s audio |
 | Text injection | arboard + osascript | Clipboard-first; osascript for auto-paste |
 | Keyboard listening | rdev (git main branch) | Global key events; single background thread |
+| Telemetry | tracing + tracing-subscriber | Structured events: ring buffer, JSONL file, real-time frontend emission |
+| System info | sysinfo | CPU and memory monitoring for resource panel |
 | Release | GitHub Actions + Apple notarization | Signed DMG, auto-updater via `latest.json` |
 
 ---
@@ -27,44 +30,63 @@ Built with **Tauri 2** (Rust backend + React frontend). ~25MB installed, no Pyth
 
 ```
 Hotkey event (rdev listener thread)
-    ↓
+    |
 Frontend hook (useHoldDownToggle / useDoubleTapToggle / useCombinedToggle)
-    ↓
-invoke('start_native_recording') → cpal captures audio
-    ↓
-invoke('stop_native_recording') → audio thread joins, samples resampled to 16kHz mono
-    ↓
-TranscriptionBackend::transcribe() → whisper.cpp (Metal GPU) or Moonshine (ONNX CPU)
-    ↓
-injector::inject_text() → arboard writes to clipboard
-    ↓
-[optional] osascript simulates Cmd+V → text appears in focused app
-    ↓
-'transcription-complete' event → frontend history + stats update
+    |
+invoke('start_native_recording') --> cpal captures audio
+    |
+invoke('stop_native_recording') --> audio thread joins, samples resampled to 16kHz mono
+    |
+Silero VAD filters silence (configurable sensitivity 0-100)
+    |
+TranscriptionBackend::transcribe() --> whisper.cpp (Metal GPU) or Moonshine (ONNX CPU)
+    |
+injector::inject_text() --> arboard writes to clipboard
+    |
+[optional] osascript simulates Cmd+V --> text appears in focused app
+    |
+'transcription-complete' event --> all windows: history + stats update
 ```
+
+---
+
+## Three-Window Architecture
+
+Murmur runs three distinct webview windows, each with separate Tauri capabilities following the principle of least privilege:
+
+| Window | Label | Entry Point | Purpose |
+|--------|-------|-------------|---------|
+| Main | `main` | `index.html` | Settings, recording controls, transcription history, stats, resource monitor, permissions, model download, about/update modals |
+| Overlay | `overlay` | `overlay.html` | Dynamic Island-style notch widget with waveform visualization. Always-on-top, transparent, not focusable |
+| Log Viewer | `log-viewer` | `log-viewer.html` | Structured event browser with Events tab (stream/level filtering) and Metrics tab (transcription timing charts) |
+
+All three windows intercept close requests and hide instead of being destroyed, preserving state. The overlay reads settings from localStorage directly (no shared React context across windows).
 
 ---
 
 ## Rust Backend (`app/src-tauri/src/`)
 
-### `lib.rs` — App Wiring
+### `lib.rs` -- App Wiring
 
-- Declares all modules, registers 25+ Tauri commands via `invoke_handler!`
+- Declares all modules, registers 30 Tauri commands via `invoke_handler!`
 - Defines `State` (top-level Tauri state): holds `AppState` + cached notch dimensions
-- Defines `MutexExt` trait with `lock_or_recover()`: recovers poisoned mutexes after panics instead of propagating the panic — keeps the app alive if any thread panics while holding a lock
-- Hides window on close (keeps app alive in tray), suppresses default "Reopen" behavior
+- Defines `MutexExt` trait with `lock_or_recover()`: recovers poisoned mutexes after panics instead of propagating the panic -- keeps the app alive if any thread panics while holding a lock
+- Hides window on close (keeps app alive in tray), suppresses default "Reopen" behavior -- dock icon click only shows the main window when no windows are visible (prevents overlay clicks from unhiding the main window)
 - Caches notch info on the main thread during setup (NSScreen APIs are main-thread-only)
+- Registers 5 Tauri plugins: opener, autostart (LaunchAgent), updater, notification, process
 
-### `state.rs` — Shared State
+### `state.rs` -- Shared State
 
 ```rust
 enum DictationStatus { Idle, Recording, Processing }
 
 struct DictationState {
     status: DictationStatus,
-    model_name: String,   // e.g. "base.en", "moonshine-tiny"
+    model_name: String,        // e.g. "base.en", "moonshine-tiny"
     language: String,
     auto_paste: bool,
+    auto_paste_delay_ms: u64,  // 10-500, default 50
+    vad_sensitivity: u32,      // 0-100, default 50
 }
 
 struct AppState {
@@ -73,15 +95,20 @@ struct AppState {
 }
 ```
 
-### `audio.rs` — Audio Capture
+Note: `DictationState::default()` sets `model_name` to `"base.en"`, but the frontend default is `"moonshine-tiny"`. The frontend always calls `configure_dictation` before `initialized` becomes true, so the Rust default is effectively overwritten before any recording can occur. New users start with `moonshine-tiny`.
+
+### `audio.rs` -- Audio Capture
 
 - cpal opens the input device and builds a stream; multi-channel interleaved samples are averaged to mono
-- RMS computed per chunk → `audio-level` events emitted at ~60fps (throttled via `AtomicU64`) → waveform animation in UI
-- Each recording gets a fresh `Arc<Mutex<Vec<f32>>>` buffer — prevents stale data from previous recordings
+- RMS computed per chunk -> `audio-level` events emitted at ~60fps (throttled via `AtomicU64` to 16ms minimum gap) -> waveform animation in UI
+- Each recording gets a fresh `Arc<Mutex<Vec<f32>>>` buffer -- prevents stale data from previous recordings
 - Stop command sent via channel; thread joins before samples are consumed
 - Linear interpolation resamples captured audio to 16kHz (what Whisper and Moonshine expect)
+- Recording state stored in a global `OnceLock<Mutex<RecordingState>>` with command sender, thread handle, shared buffer, sample rate, start timestamp, and device name
+- Initialization handshake: `start_recording` waits up to 5 seconds for the audio thread to signal ready
+- Device name redacted in release build logs
 
-### `keyboard.rs` — Keyboard Detection
+### `keyboard.rs` -- Keyboard Detection
 
 All keyboard detection runs through a **single persistent rdev background thread** shared by two detectors.
 
@@ -89,19 +116,21 @@ All keyboard detection runs through a **single persistent rdev background thread
 
 Simple 2-state machine:
 ```
-Idle → [key press] → Held (emit 'hold-down-start')
-Held → [key release] → Idle (emit 'hold-down-stop')
+Idle --> [key press] --> Held (emit 'hold-down-start')
+Held --> [key release] --> Idle (emit 'hold-down-stop')
 ```
 Rejects combos (e.g. Shift+A while Shift is the trigger key cancels hold and emits Stop).
+
+In hold-down-only mode, there is no minimum hold duration: a key press immediately emits `hold-down-start` and a key release immediately emits `hold-down-stop`. The 0.3-second minimum recording threshold in `stop_native_recording` handles discarding phantom triggers.
 
 #### Double-Tap Detector
 
 4-state machine:
 ```
-Idle → [press] → WaitingFirstUp
-     → [release <200ms] → WaitingSecondDown
-     → [press, gap <400ms] → WaitingSecondUp
-     → [release <200ms] → FIRE → Idle
+Idle --> [press] --> WaitingFirstUp
+     --> [release <200ms] --> WaitingSecondDown
+     --> [press, gap <400ms] --> WaitingSecondUp
+     --> [release <200ms] --> FIRE --> Idle
 ```
 Rejects: taps held >200ms, modifier+letter combos, gaps >400ms, triple-tap spam.
 When `recording=true`, a single tap fires immediately (to stop, not start).
@@ -113,97 +142,199 @@ The interesting one. The problem: a key press could be the start of a double-tap
 Solution: **deferred hold promotion via a background timer thread + atomic invalidation counter.**
 
 1. On key press, a timer thread is spawned for 200ms
-2. If the key is released before 200ms — it was a tap. Timer fires but is invalidated by `HOLD_PRESS_COUNTER` (atomically incremented on release)
-3. If the key is still held after 200ms — timer fires `hold-down-start`. Now we're in hold mode
-4. Double-tap has priority during the second-press window; hold only wins after 200ms of uninterrupted hold
+2. If the key is released before 200ms -- it was a tap. Timer fires but is invalidated by `HOLD_PRESS_COUNTER` (atomically incremented on release)
+3. If the key is still held after 200ms -- timer fires, sets `HOLD_PROMOTED` to true, and emits `hold-down-start`. Now we're in hold mode
+4. The hold-down detector is suppressed when the double-tap detector is in its second phase (WaitingSecondDown or WaitingSecondUp), preventing false hold events during double-tap sequences
+5. On key release: if promoted, emits `hold-down-stop`. If not promoted but double-tap fired, emits `double-tap-toggle`. Otherwise (short single tap with no double-tap), nothing is emitted -- no recording was ever started
 
-#### macOS Thread Safety — The rdev Segfault Fix
+#### Processing State Management
+
+When entering the transcription pipeline, `set_processing(true)` is called:
+- Both-mode callback ignores all key events
+- Pending hold-promotion timers are invalidated via `HOLD_PRESS_COUNTER`
+- Both detectors are reset
+- On exit from processing, cooldowns are applied to prevent accidental re-triggers
+
+#### macOS Thread Safety -- The rdev Segfault Fix
 
 rdev's keyboard translation uses macOS **TIS/TSM** (Text Input Sources) APIs to map raw key codes to characters. These APIs **must run on the main thread**. rdev listens on a background thread. Without intervention, this silently segfaults.
 
-Fix — one line, called before `rdev::listen()`:
+Fix -- one line, called before `rdev::listen()`:
 ```rust
 rdev::set_is_main_thread(false);
 ```
-This tells rdev it is *not* on the main thread, which causes it to wrap TIS/TSM calls in `dispatch_sync(dispatch_get_main_queue(), ...)` — marshaling only those calls to main, while the listener loop stays on the background thread.
+This tells rdev it is *not* on the main thread, which causes it to wrap TIS/TSM calls in `dispatch_sync(dispatch_get_main_queue(), ...)` -- marshaling only those calls to main, while the listener loop stays on the background thread.
 
-### `transcriber/` — Inference Backends
+A heartbeat monitor thread logs trace-level messages every 60 seconds while the listener is active.
+
+### `vad.rs` -- Voice Activity Detection
+
+- Uses **Silero VAD v5.1.2** via whisper-rs `WhisperVadContext`
+- Filters out silence before transcription to prevent Whisper hallucination loops on quiet recordings
+- VAD threshold computed from user-configurable sensitivity: `threshold = 1.0 - (vad_sensitivity / 100.0)` (0-100 scale, default 50)
+- Configured: 1 thread, GPU disabled
+- Returns speech segments as centisecond timestamps, converted to sample indices
+- Three outcomes: `NoSpeech` (skip transcription entirely), `Speech` (trimmed samples), `Error` (fallback to unfiltered audio)
+- `filter_speech` is `!Send` (WhisperVadContext constraint), must run via `spawn_blocking`
+- VAD context is created and destroyed per transcription (not cached like WhisperState)
+
+### `transcriber/` -- Inference Backends
 
 Both backends implement a shared trait:
 
 ```rust
 trait TranscriptionBackend: Send + Sync {
+    fn name(&self) -> &str;
     fn load_model(&mut self, model_name: &str) -> Result<(), String>;
     fn transcribe(&mut self, samples: &[f32], language: &str) -> Result<String, String>;
     fn model_exists(&self) -> bool;
+    fn models_dir(&self) -> PathBuf;
     fn reset(&mut self);
 }
 ```
 
+Backend selection is determined by model name prefix: names starting with `"moonshine-"` use MoonshineBackend, everything else uses WhisperBackend. When the model changes across the whisper/moonshine boundary, the entire `Box<dyn TranscriptionBackend>` is replaced. When the model changes within the same backend type, `reset()` is called to force a reload.
+
 **Whisper (`whisper.rs`)**
-- wraps whisper.cpp via `whisper-rs` with the Metal GPU backend enabled by default
-- single `.bin` file per model (GGML format), sourced from Hugging Face
-- model context created lazily on first transcription (fast startup)
-- scans 6 standard paths to find existing model files
-- suppresses whisper.cpp's verbose stdout via log trampoline
+- Wraps whisper.cpp via `whisper-rs` with the Metal GPU backend enabled by default
+- Single `.bin` file per model (GGML format), sourced from Hugging Face
+- **WhisperState caching (v0.7.8)**: The `WhisperBackend` struct holds `context: Option<WhisperContext>`, `state: Option<WhisperState>`, and `loaded_model_name: Option<String>`. On first `load_model()`, a `WhisperContext` is created from the model file and `ctx.create_state()` allocates GPU/Metal buffers exactly once. The `WhisperState` is stored and reused across all subsequent transcriptions (`state.full(params, samples)`). Only a model name change triggers `reset()` and reallocation. Previously, `create_state()` was called per-transcription, causing expensive alloc/free cycles
+- Uses greedy sampling (best_of=1), single segment mode, timestamps/progress/special tokens suppressed, blank suppression enabled
+- Scans 6 standard paths to find existing model files
+- Suppresses whisper.cpp's verbose stdout via log trampoline (`install_logging_hooks()` called once via `std::sync::Once`)
 
 **Moonshine (`moonshine.rs`)**
-- wraps sherpa-rs (ONNX runtime), CPU-only, int8-quantized
-- requires a directory of 5 ONNX files: `preprocess`, `encode`, `uncached_decode`, `cached_decode`, `tokens`
-- downloaded as `.tar.bz2`, extracted in-process using pure Rust (`bzip2` + `tar` crates)
+- Wraps sherpa-rs (ONNX runtime), CPU-only, int8-quantized
+- Requires a directory of 5 ONNX files: `preprocess.onnx`, `encode.int8.onnx`, `uncached_decode.int8.onnx`, `cached_decode.int8.onnx`, `tokens.txt`
+- Downloaded as `.tar.bz2` from sherpa-onnx GitHub releases, extracted in-process using pure Rust (`bzip2` + `tar` crates). Partial extractions are cleaned up on failure
 - English-only; ignores the `language` parameter
 - ~16ms latency for 3 seconds of audio on Apple Silicon
 
-### `injector.rs` — Text Injection
+**Available Models (7 total)**
 
-1. **Clipboard** (always): `arboard` writes text to the system clipboard
-2. **Auto-paste** (optional): waits 150ms (clipboard sync + window focus), then:
+| Model | Backend | Size |
+|-------|---------|------|
+| `moonshine-tiny` | Moonshine (CPU) | ~124 MB |
+| `moonshine-base` | Moonshine (CPU) | ~286 MB |
+| `tiny.en` | Whisper (Metal GPU) | ~75 MB |
+| `base.en` | Whisper (Metal GPU) | ~150 MB |
+| `small.en` | Whisper (Metal GPU) | ~500 MB |
+| `medium.en` | Whisper (Metal GPU) | ~1.5 GB |
+| `large-v3-turbo` | Whisper (Metal GPU) | ~3 GB |
+
+The initial model downloader screen shows a curated subset of 4 models: `moonshine-tiny`, `moonshine-base`, `large-v3-turbo`, `base.en`. Default selection: `moonshine-tiny`.
+
+### `injector.rs` -- Text Injection
+
+1. **Clipboard** (always): `arboard` writes text to the system clipboard. Empty/whitespace-only text is silently skipped.
+2. **Auto-paste** (optional): waits a configurable delay (10-500ms, default 50ms), then:
    ```
    osascript -e 'tell application "System Events" to keystroke "v" using command down'
    ```
-   The 150ms delay is intentional — without it, the target window hasn't regained focus yet.
+   The delay allows the target window to regain focus.
+   Retries once on failure with 100ms backoff. 2-second timeout on the entire operation.
+   On failure, emits `auto-paste-failed` with a hint message ("press Cmd+V to paste manually").
+   Requires Accessibility permission -- if not granted, text stays in clipboard with a warning log.
    Previous approaches (`engio`, rdev simulate) broke on Sonoma/Sequoia. osascript is the reliable path.
-   Requires Accessibility permission.
 
-### `commands/recording.rs` — Transcription Pipeline & RAII Guard
+### `commands/recording.rs` -- Transcription Pipeline & RAII Guard
 
-**`IdleGuard`** — RAII guard wrapping the transcription pipeline:
+**`IdleGuard`** -- RAII guard wrapping the transcription pipeline:
 - On drop (if not disarmed), resets status to `Idle` and clears the "processing" keyboard flag
 - Guarantees the UI never gets stuck in "Processing" on any error path
-- Disarmed when handing off successfully to prevent double-reset
+- Both the outer command and inner pipeline have their own guards with a disarm handoff pattern
 
 **`run_transcription_pipeline()`**:
-1. Load model (lazy; no-op if already loaded)
-2. Run inference, timed
-3. Inject text via `app_handle.run_on_main_thread()` (osascript requires main thread)
+1. Read state -- model name, language, auto-paste settings, paste delay, VAD sensitivity in a single lock acquisition
+2. Pre-VAD diagnostics -- compute RMS and peak amplitude of raw audio, log device name
+3. VAD phase -- if VAD model exists, run Silero VAD on a blocking thread. Three outcomes: NoSpeech (skip), Speech (trimmed), Error (fallback). If VAD model missing, spawn background download for next time
+4. Transcription phase -- lock backend mutex, call `load_model()` (lazy), then `transcribe()`
+5. Text injection -- dispatched to main thread via `run_on_main_thread()` (osascript requires main thread). Clipboard write + optional paste with 2-second timeout
+6. Structured logging -- emits `vad_ms`, `inference_ms`, `paste_ms`, `total_ms`, `audio_secs`, `word_count`, `char_count`, `model`, `backend` as tracing fields
 
-### `commands/overlay.rs` — Notch Overlay
+**`cancel_native_recording`**: Transitions Recording -> Idle without transcription. Used by "both" mode to discard speculative recordings from short taps.
 
-- `detect_notch_info()`: reads `NSScreen.mainScreen().safeAreaInsets()` via `objc2`; uses `auxiliaryTopLeftArea` + `auxiliaryTopRightArea` to compute notch width. Main-thread only.
+**Minimum recording threshold**: Recordings shorter than 0.3 seconds (4,800 samples at 16kHz) are silently discarded as phantom triggers.
+
+### `commands/overlay.rs` -- Notch Overlay
+
+- `detect_notch_info()`: reads `NSScreen.mainScreen().safeAreaInsets()` via `objc2`; uses `auxiliaryTopLeftArea` + `auxiliaryTopRightArea` to compute notch width. Main-thread only. Fallback: 200px wide, 37px tall.
 - `raise_window_above_menubar()`: sets NSWindow level to **25** (NSMainMenuWindowLevel = 24). Calls private API `_setPreventsActivation(true)` to prevent focus-stealing on click; guarded with `respondsToSelector()` for forward compatibility.
-- `register_screen_change_observer()`: subscribes to `NSApplicationDidChangeScreenParametersNotification` — repositions overlay automatically when displays are plugged/unplugged or lid opens. Observer intentionally leaked (app lifetime).
+- `register_screen_change_observer()`: subscribes to `NSApplicationDidChangeScreenParametersNotification` -- repositions overlay automatically when displays are plugged/unplugged or lid opens. Emits `notch-info-changed` to frontend. Observer intentionally leaked (app lifetime).
+- Overlay width = notch_width + 120px (60px expansion per side). Mouse events explicitly re-enabled (`setIgnoreCursorEvents(false)`) because `focusable:false` disables them on macOS.
 
-### `logging.rs` — File Logging
+### `commands/tray.rs` -- Tray Icon
 
-- Writes to `~/Library/Application Support/local-dictation/logs/app.log`
-- Rotates to `app.log.1` at 5MB
-- ISO 8601 timestamps implemented without external libraries (Howard Hinnant algorithm)
-- Separate `frontend.log` for JS-side log calls
-- `LOG_MUX` static mutex ensures thread-safe appends
+- Static 66x66 RGBA icon (3x resolution for 22pt Retina menu bar) showing 5 vertical capsule bars in an equalizer style, rendered as white with anti-aliased edges
+- `update_tray_icon` is a registered no-op command -- the tray icon is always static white. Command kept to avoid breaking the registered handler
+- Tray menu: "Show Murmur" (shows and focuses main window) and "Quit Murmur" (exits app). Left-click on tray icon also shows the main window
+
+### `commands/models.rs` -- Model Downloads
+
+- `check_model_exists`: checks both the currently configured backend AND the other backend type, so the download screen does not appear if any model is installed
+- `check_specific_model_exists`: verifies a named model exists on disk. Includes path traversal protection (rejects `..`, `/`, `\` in model names)
+- `download_model`: streaming download with progress events. Whisper models download as single `.bin` files from Hugging Face. Moonshine models download as `.tar.bz2` archives from sherpa-onnx GitHub releases, extracted via `bzip2` + `tar` on a blocking thread
+- **VAD model co-download**: when downloading any transcription model, the Silero VAD model (`ggml-silero-v5.1.2.bin`, ~1.8MB) is automatically co-downloaded if not already present. VAD download failure is non-fatal
+- **Lazy VAD download**: `ensure_vad_model` is a fallback for users who upgrade from a pre-VAD version. If the VAD model is missing at transcription time, a background download is kicked off for next time. Emits `recording-status-changed` with value `"downloading-vad"` during explicit download
+- All downloads use a temp-file-then-rename pattern for atomicity. Partial downloads never appear as valid models
+
+### `telemetry.rs` -- Structured Event System
+
+Replaces the former `logging.rs`. All application logging goes through `tracing` with two output layers:
+
+```
+tracing event
+    |
+    +--> Pretty-printed text file (app.log / app.dev.log) via tracing_appender
+    |
+    +--> TauriEmitterLayer
+             |
+             +--> In-memory ring buffer (500 events, FIFO eviction)
+             |
+             +--> JSONL file (events.jsonl / events.dev.jsonl)
+             |
+             +--> 'app-event' emission to all frontend windows
+```
+
+**TauriEmitterLayer**: A custom `tracing_subscriber::Layer` that intercepts all tracing events and:
+1. Collects fields via `JsonVisitor` into serde_json values
+2. Builds an `AppEvent` struct (timestamp, stream/target, level, summary/message, data/fields)
+3. Pushes to ring buffer (capped at 500, evicts oldest)
+4. Writes as JSONL line to persistent file
+5. Emits `app-event` to all Tauri windows
+
+**Tracing targets (streams)**: `pipeline`, `audio`, `system`, `keyboard`.
+
+**Privacy stripping**: In release builds, all string fields from `pipeline` target events are stripped from the data object. Only numeric fields survive. The summary (message) is not stripped.
+
+**JSONL rotation**: File is rotated (renamed to `.jsonl.1`) when it exceeds 5MB.
+
+**Buffer seeding**: On startup, the ring buffer is pre-populated with up to 500 events from the existing JSONL file.
+
+**Log files**: Separate filenames for dev (`app.dev.log`, `events.dev.jsonl`) vs release builds.
+
+**Frontend logging**: The `log_frontend` command routes frontend log messages through the Rust tracing system at INFO/WARN/ERROR levels with `source="frontend"`.
+
+### `resource_monitor.rs` -- System Resource Monitoring
+
+- Reports CPU usage percentage and used memory (MB) via `sysinfo` crate
+- Uses a persistent `System` instance stored in a `static Mutex<Option<System>>`, initialized on first call
+- First call returns ~0% CPU (baseline measurement behavior of sysinfo)
+- Polled every 1 second by the frontend when the resource panel is expanded
 
 ---
 
 ## Frontend (`app/src/`)
 
-### `App.tsx` — Main Orchestrator
+### `App.tsx` -- Main Orchestrator
 
 Wires all hooks together. Key state:
-- `modelReady` — null (checking) | false (needs download) | true (ready)
-- `initialized` — backend init complete
-- `accessibilityGranted` — macOS Accessibility permission
-- `status` — `'idle' | 'recording' | 'processing'`
+- `modelReady` -- null (checking) | false (needs download) | true (ready)
+- `initialized` -- backend init complete
+- `accessibilityGranted` -- macOS Accessibility permission
+- `status` -- `'idle' | 'recording' | 'processing'`
 
-**Dual-mode hook pattern** — all three hooks always called (Rules of Hooks); gated by `enabled`:
+**Dual-mode hook pattern** -- all three hooks always called (Rules of Hooks); gated by `enabled`:
 ```tsx
 useHoldDownToggle({ enabled: settings.recordingMode === 'hold_down', ... });
 useDoubleTapToggle({ enabled: settings.recordingMode === 'double_tap', ... });
@@ -214,30 +345,150 @@ useCombinedToggle({ enabled: settings.recordingMode === 'both', ... });
 
 | Hook | Responsibility |
 |------|---------------|
-| `useRecordingState` | Recording/transcription state machine, event listeners |
-| `useHoldDownToggle` | Hold-down mode, error recovery + auto-restart |
-| `useDoubleTapToggle` | Double-tap mode, syncs `recording` state to backend |
-| `useCombinedToggle` | Both modes; `holdActiveRef` prevents double-tap firing on hold release |
-| `useSettings` | localStorage persistence, OS autostart sync |
-| `useAutoUpdater` | OTA updates, min-version enforcement, semver comparison |
+| `useRecordingState` | Recording/transcription state machine, event listeners, audio level tracking, locked mode, stats integration |
+| `useHoldDownToggle` | Hold-down mode (rdev press/release events), error recovery + auto-restart |
+| `useDoubleTapToggle` | Double-tap mode (rdev events), syncs `recording` state to backend |
+| `useCombinedToggle` | Both modes; `holdActiveRef` prevents double-tap firing on hold release. Calls `cancel_native_recording` for speculative recording discard |
+| `useSettings` | localStorage persistence, OS autostart sync, backend configuration pushes |
+| `useAutoUpdater` | OTA updates, min-version enforcement, semver comparison, forced updates, macOS notifications |
+| `useInitialization` | One-time init sequence (initDictation + configure) on mount |
+| `useHistoryManagement` | Transcription history array with localStorage persistence (max 50 entries) |
+| `useEventStore` | Structured event log buffer: backend hydration, live `app-event` streaming, batched rendering via rAF, filter/clear |
+| `useResourceMonitor` | CPU/memory polling every 1 second, rolling 60-reading buffer |
+| `useShowAboutListener` | Listens for `show-about` tray event, manages about modal state |
 
-**`transcription-complete` as single source of truth** — history entries are added *only* via the Rust event, never in `handleStop()`. Prevents duplicates when the overlay initiates recording independently.
+**`transcription-complete` as single source of truth** -- history entries are added *only* via the Rust event, never in `handleStop()`. Prevents duplicates when the overlay initiates recording independently.
 
-**Ref-based state in callbacks** — `statusRef` stays in sync with `status` state so hotkey callbacks always read current status without stale closure captures.
+**Ref-based state in callbacks** -- `statusRef` stays in sync with `status` state so hotkey callbacks always read current status without stale closure captures. Callbacks stored in refs prevent listener setup from re-running on identity changes.
 
-### `lib/stats.ts` — Usage Metrics
+### `lib/settings.ts` -- Settings & Model Configuration
+
+```typescript
+interface Settings {
+    model: ModelOption;         // default: 'moonshine-tiny'
+    doubleTapKey: DoubleTapKey; // default: 'shift_l'
+    language: string;           // default: 'en'
+    autoPaste: boolean;         // default: false
+    autoPasteDelayMs: number;   // default: 50 (range: 10-500)
+    recordingMode: RecordingMode; // default: 'hold_down'
+    microphone: string;         // default: 'system_default'
+    launchAtLogin: boolean;     // default: false
+    vadSensitivity: number;     // default: 50 (range: 0-100)
+}
+```
+
+Settings persisted to localStorage under key `"dictation-settings"`. Migration handles legacy `hotkey` recording mode -> `hold_down`.
+
+### `lib/stats.ts` -- Usage Metrics
 
 Persisted to localStorage:
 - `totalWords`, `totalRecordings`, `totalDurationSeconds`
-- `wpmSamples: number[]` — rolling 100-sample history (outlier-resistant)
-- Approx tokens = `totalWords × 1.3`
+- `wpmSamples: number[]` -- rolling 100-sample history (outlier-resistant)
+- Approx tokens = `totalWords * 1.3`
 
-### `OverlayWidget.tsx` — Notch Widget
+### `lib/events.ts` -- Event System Types
 
-- Rendered in a separate Tauri window (`overlay.html`), always-on-top, transparent, no decorations
-- 7-bar waveform driven by `requestAnimationFrame` + direct DOM refs — bypasses React reconciliation for 60fps
+```typescript
+interface AppEvent {
+    timestamp: string;
+    stream: StreamName;   // 'pipeline' | 'audio' | 'keyboard' | 'system'
+    level: LevelName;     // 'trace' | 'debug' | 'info' | 'warn' | 'error'
+    summary: string;
+    data: Record<string, unknown>;
+}
+```
+
+Color constants map each stream and level to Tailwind classes (bg, text, dot) for the log viewer UI.
+
+### `OverlayWidget.tsx` -- Notch Widget
+
+- Rendered in the overlay window, always-on-top, transparent, no decorations
+- **Three visual states**: Idle (small mic icon, dimmed), Recording (expanded, red pulsing dot + animated waveform), Processing (expanded, spinning circle + dimmed waveform)
+- **7-bar waveform** driven by `requestAnimationFrame` + direct DOM refs -- bypasses React reconciliation for 60fps. Center bars are taller (envelope shaping), random jitter for organic feel
+- Spring-like expand/collapse transition (`cubic-bezier(0.34, 1.56, 0.64, 1)` over 500ms)
 - Single click: stop recording (250ms debounce). Double-click: toggle locked mode (keeps recording across single clicks)
 - Reads microphone setting from localStorage (no Tauri IPC needed)
+
+### Log Viewer (`components/log-viewer/`)
+
+**Events tab**:
+- Stream filter chips -- toggle which event streams to show (default active: `pipeline`, `audio`, `system`)
+- Level filter -- toggle info/warn/error visibility
+- Event list with auto-scroll (disengages on manual scroll up, re-engages within 40px of bottom)
+- Expandable rows: timestamp, colored stream chip, level label, summary text. Click to reveal JSON data
+- Copy All and Clear buttons
+
+**Metrics tab**:
+- Extracts transcription timing from pipeline events where `summary === 'transcription complete'`
+- Last 20 transcriptions displayed
+- Four toggleable series: Total, Inference, VAD, Paste
+- Stat cards with latest value, average, trend indicator (up/down/flat, 10% threshold)
+- Two SVG line charts: Total + Inference (upper, 150px), VAD + Paste (lower, 120px)
+- Auto-scaled Y-axis with round tick marks
+
+### Resource Monitor
+
+- Collapsible panel in the main window; collapse state persisted to localStorage
+- Header always shows current CPU% and memory MB
+- Expanded view: SVG polyline chart with CPU and memory lines, grid at 25/50/75%, legend
+- Only polls when expanded (performance optimization)
+- Rolling window of 60 readings (1 minute of data)
+
+---
+
+## Tauri Commands (30)
+
+| Module | Command | Description |
+|--------|---------|-------------|
+| recording | `init_dictation` | Returns initialized/idle response (no-op marker) |
+| recording | `process_audio` | Accepts base64-encoded WAV, runs full pipeline |
+| recording | `get_status` | Returns status, model name, language |
+| recording | `configure_dictation` | Updates model, language, autoPaste, autoPasteDelayMs, vadSensitivity |
+| recording | `start_native_recording` | Begins cpal audio capture; Idle -> Recording |
+| recording | `stop_native_recording` | Stops capture, runs VAD + transcription + injection pipeline |
+| recording | `cancel_native_recording` | Discards recording without transcribing (speculative hold-down) |
+| permissions | `open_system_preferences` | Opens macOS System Settings to Microphone pane |
+| permissions | `check_accessibility_permission` | Returns boolean for Accessibility status |
+| permissions | `request_accessibility_permission` | Triggers Accessibility prompt + opens Settings |
+| permissions | `request_microphone_permission` | Opens Microphone privacy pane |
+| permissions | `list_audio_devices` | Returns Vec of input device names |
+| keyboard | `start_keyboard_listener` | Starts rdev listener with hotkey and mode |
+| keyboard | `stop_keyboard_listener` | Stops processing keyboard events (thread stays alive) |
+| keyboard | `update_keyboard_key` | Changes hotkey at runtime; emits stop if held |
+| keyboard | `set_keyboard_recording` | Syncs recording state to double-tap detector |
+| logging | `get_log_contents` | Returns last N lines of pretty-printed log file |
+| logging | `clear_logs` | Deletes all log files + clears event ring buffer |
+| logging | `log_frontend` | Routes frontend message through Rust tracing |
+| logging | `open_log_viewer` | Shows and focuses the log-viewer window |
+| models | `check_model_exists` | Checks if any model exists (either backend) |
+| models | `check_specific_model_exists` | Checks named model on disk (path traversal protected) |
+| models | `download_model` | Streaming download + VAD co-download |
+| tray | `update_tray_icon` | No-op (static white icon). Kept for API compat |
+| overlay | `show_overlay` | Positions and shows the overlay window |
+| overlay | `hide_overlay` | Hides the overlay window |
+| overlay | `get_notch_info` | Returns cached notch dimensions or None |
+| telemetry | `get_event_history` | Returns ring buffer (up to 500 events) |
+| telemetry | `clear_event_history` | Clears the event ring buffer |
+| resource_monitor | `get_resource_usage` | Returns CPU% and memory MB |
+
+---
+
+## Events (Rust -> Frontend)
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `audio-level` | f32 (RMS 0.0-1.0) | Real-time audio level during recording, ~60fps |
+| `recording-status-changed` | String | Status transitions: `"idle"`, `"recording"`, `"processing"`, `"downloading-vad"` |
+| `transcription-complete` | `{text, duration}` | Broadcast to all windows after non-empty transcription |
+| `auto-paste-failed` | String (hint) | Paste failed; text is in clipboard |
+| `download-progress` | `{received, total}` | Streaming download progress (bytes) |
+| `double-tap-toggle` | `()` | Double-tap detected |
+| `hold-down-start` | `()` | Hold key pressed (or promoted in both mode) |
+| `hold-down-stop` | `()` | Hold key released |
+| `keyboard-listener-error` | String | rdev thread error; frontend retries after 2s |
+| `notch-info-changed` | `Option<{notch_width, notch_height}>` | Display config changed |
+| `app-event` | `AppEvent` | Every tracing event, powers log viewer |
+| `show-about` | `()` | Tray menu "About" click |
 
 ---
 
@@ -252,15 +503,67 @@ Accessibility is checked via `AXIsProcessTrusted()` FFI. If not granted, a syste
 
 ---
 
-## Release Pipeline
+## Data Directory
+
+All models, logs, and event data are stored under:
+```
+~/Library/Application Support/local-dictation/
+```
+
+This is a legacy name from before the app was renamed to Murmur. Contents:
+- `models/` -- Whisper GGML `.bin` files, Moonshine ONNX directories, Silero VAD model
+- `logs/` -- `app.log` / `app.dev.log` (pretty-printed), `events.jsonl` / `events.dev.jsonl` (structured)
+
+---
+
+## Build & Release
+
+### Dev Configuration
+
+```bash
+cd app && npm run tauri dev        # Dev with hot reload
+cd app && npm run tauri build      # Production .app and .dmg
+cd app/src-tauri && cargo test -- --test-threads=1  # Rust tests (single-threaded)
+cd app && npx tsc --noEmit         # TypeScript check
+```
+
+`tauri.dev.conf.json` overrides only two fields from production config: `identifier` -> `"com.localdictation.dev"` and `productName` -> `"Local Dictation Dev"`. This ensures the dev build installs as a separate app.
+
+### Release Pipeline
 
 1. `git tag vX.Y.Z && git push --tags`
 2. GitHub Actions: TypeScript check + `cargo test`
-3. macOS: `tauri-action` → Developer ID signing → Apple notarization
+3. macOS: `tauri-action` -> Developer ID signing -> Apple notarization
 4. Smoke test: launch built `.app`, verify alive for 5 seconds
-5. Publish: `.dmg`, `.app.tar.gz`, `.sig`, `latest.json` → GitHub Release
+5. Publish: `.dmg`, `.app.tar.gz`, `.sig`, `latest.json` -> GitHub Release
 
 **Auto-updater**: Tauri updater plugin checks `latest.json` on GitHub Releases. Updates are signed (ed25519). Min-version enforcement removes "Skip"/"Later" for required updates.
+
+### Release Profile
+
+```toml
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+```
+
+---
+
+## Thread Model
+
+The app uses at least 4 persistent background threads plus short-lived workers:
+
+| Thread | Lifetime | Purpose |
+|--------|----------|---------|
+| rdev keyboard listener | App lifetime (spawned once) | Global key event loop |
+| Keyboard heartbeat | App lifetime | Trace-level heartbeat every 60s |
+| Audio capture | Per-recording session | cpal stream + mono mix |
+| Hold-promotion timer | Per key press (both mode) | 200ms sleep, atomic check |
+
+Plus Tokio async tasks for VAD (`spawn_blocking`), downloads, and text injection dispatch.
 
 ---
 
@@ -270,7 +573,8 @@ Accessibility is checked via `AXIsProcessTrusted()` FFI. If not granted, a syste
 |----------|-----------|
 | Pure Rust backend | No Python subprocess; faster startup, smaller bundle, no dependency hell |
 | Pluggable `TranscriptionBackend` trait | Whisper and Moonshine swap cleanly; same pipeline code |
-| Lazy model loading | Fast app startup; model context created on first transcription |
+| Lazy model loading + WhisperState caching | Fast app startup; GPU buffers allocated once, reused across transcriptions |
+| VAD pre-filtering | Prevents Whisper hallucination loops on silence; skips unnecessary inference |
 | Clipboard-first injection | Reliable across all apps; auto-paste layered on top |
 | osascript for auto-paste | `engio` and rdev simulate broke on Sonoma/Sequoia |
 | Single rdev thread, two detectors | Avoids multiple listeners; both detectors share one event stream |
@@ -279,3 +583,7 @@ Accessibility is checked via `AXIsProcessTrusted()` FFI. If not granted, a syste
 | `IdleGuard` RAII | Guarantees status reset on any error path in the transcription pipeline |
 | Atomic timer invalidation (Both mode) | Stale hold-timers can't fire after key is released and re-pressed |
 | `_setPreventsActivation` + `respondsToSelector` | Overlay never steals focus; forward-compatible with future macOS |
+| tracing-based telemetry | Unified observability: every backend event captured, persisted, and streamed to frontend |
+| Privacy stripping in release builds | Pipeline string fields stripped from structured events; only numerics survive |
+| Three-window least-privilege | Overlay gets minimal permissions; log viewer gets event-only access; main window gets full permissions |
+| VAD co-download | Silero model bundled with transcription model downloads; lazy fallback for pre-VAD upgrades |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,7 +115,7 @@ All keyboard detection runs through a **single persistent rdev background thread
 #### Hold-Down Detector
 
 Simple 2-state machine:
-```
+```text
 Idle --> [key press] --> Held (emit 'hold-down-start')
 Held --> [key release] --> Idle (emit 'hold-down-stop')
 ```
@@ -126,7 +126,7 @@ In hold-down-only mode, there is no minimum hold duration: a key press immediate
 #### Double-Tap Detector
 
 4-state machine:
-```
+```text
 Idle --> [press] --> WaitingFirstUp
      --> [release <200ms] --> WaitingSecondDown
      --> [press, gap <400ms] --> WaitingSecondUp
@@ -228,7 +228,7 @@ The initial model downloader screen shows a curated subset of 4 models: `moonshi
 
 1. **Clipboard** (always): `arboard` writes text to the system clipboard. Empty/whitespace-only text is silently skipped.
 2. **Auto-paste** (optional): waits a configurable delay (10-500ms, default 50ms), then:
-   ```
+   ```bash
    osascript -e 'tell application "System Events" to keystroke "v" using command down'
    ```
    The delay allows the target window to regain focus.
@@ -275,14 +275,14 @@ The initial model downloader screen shows a curated subset of 4 models: `moonshi
 - `check_specific_model_exists`: verifies a named model exists on disk. Includes path traversal protection (rejects `..`, `/`, `\` in model names)
 - `download_model`: streaming download with progress events. Whisper models download as single `.bin` files from Hugging Face. Moonshine models download as `.tar.bz2` archives from sherpa-onnx GitHub releases, extracted via `bzip2` + `tar` on a blocking thread
 - **VAD model co-download**: when downloading any transcription model, the Silero VAD model (`ggml-silero-v5.1.2.bin`, ~1.8MB) is automatically co-downloaded if not already present. VAD download failure is non-fatal
-- **Lazy VAD download**: `ensure_vad_model` is a fallback for users who upgrade from a pre-VAD version. If the VAD model is missing at transcription time, a background download is kicked off for next time. Emits `recording-status-changed` with value `"downloading-vad"` during explicit download
+- **Lazy VAD download**: `ensure_vad_model` is a fallback for users who upgrade from a pre-VAD version. If the VAD model is missing at transcription time, a silent background download is kicked off for next time (no UI side effects)
 - All downloads use a temp-file-then-rename pattern for atomicity. Partial downloads never appear as valid models
 
 ### `telemetry.rs` -- Structured Event System
 
 Replaces the former `logging.rs`. All application logging goes through `tracing` with two output layers:
 
-```
+```text
 tracing event
     |
     +--> Pretty-printed text file (app.log / app.dev.log) via tracing_appender
@@ -478,7 +478,7 @@ Color constants map each stream and level to Tailwind classes (bg, text, dot) fo
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `audio-level` | f32 (RMS 0.0-1.0) | Real-time audio level during recording, ~60fps |
-| `recording-status-changed` | String | Status transitions: `"idle"`, `"recording"`, `"processing"`, `"downloading-vad"` |
+| `recording-status-changed` | String | Status transitions: `"idle"`, `"recording"`, `"processing"` |
 | `transcription-complete` | `{text, duration}` | Broadcast to all windows after non-empty transcription |
 | `auto-paste-failed` | String (hint) | Paste failed; text is in clipboard |
 | `download-progress` | `{received, total}` | Streaming download progress (bytes) |
@@ -506,7 +506,7 @@ Accessibility is checked via `AXIsProcessTrusted()` FFI. If not granted, a syste
 ## Data Directory
 
 All models, logs, and event data are stored under:
-```
+```text
 ~/Library/Application Support/local-dictation/
 ```
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,88 +1,204 @@
-## Local Dictation v0.4.0 — Feature Map
+## Murmur v0.8.0 — Feature Map
 
 ### Core: Voice-to-Text
-- Record voice → transcribe locally via whisper.cpp → text to clipboard
-- Metal GPU acceleration on Apple Silicon
-- 5 Whisper models: tiny, base.en, small.en, medium, large-v3-turbo
-- Configurable language (default: English)
-- Greedy inference, single-segment, blank suppression
+- Record voice, transcribe locally, output text to clipboard
+- Two transcription backends: Whisper (Metal GPU via whisper-rs) and Moonshine (CPU via sherpa-onnx/sherpa-rs)
+- 7 models across both backends:
+  - Moonshine: moonshine-tiny (~124 MB), moonshine-base (~286 MB)
+  - Whisper: tiny.en (~75 MB), base.en (~150 MB), small.en (~500 MB), medium.en (~1.5 GB), large-v3-turbo (~3 GB)
+- Default model: moonshine-tiny (fastest, sub-20ms for typical dictation)
+- Greedy inference, single-segment, blank suppression (Whisper)
+- Lazy model loading: model context created on first transcription, cached across subsequent runs
+- WhisperState caching: GPU/Metal buffers allocated once and reused (v0.7.8 optimization)
+- Moonshine models use ONNX int8 quantized inference on CPU
 - Zero cloud dependencies — fully offline
 
-### Recording Activation (2 modes)
-- **Hold Down** — hold a modifier key (Shift, Option, or Control) to record, release to stop and transcribe
-- **Double-Tap** — tap a modifier key twice to start, once to stop. Rejects held keys, combos, slow taps, triple-tap spam
+### Voice Activity Detection (VAD)
+- Silero VAD v5.1.2 pre-filters silence before transcription
+- Prevents Whisper hallucination loops on silent/noisy audio
+- Configurable sensitivity: 0-100 scale (default 50), exposed as slider in settings
+- Higher sensitivity keeps more audio; lower trims silence more aggressively
+- VAD model (~1.8 MB) co-downloaded automatically alongside any transcription model
+- Fallback: if VAD model is missing at transcription time, a background download is started for next time
+- If VAD detects no speech, transcription is skipped entirely (empty string returned)
+
+### Recording Activation (3 modes)
+- **Hold Down** — hold a modifier key to record; release to stop and transcribe
+- **Double-Tap** — tap a modifier key twice (within 400ms, each hold under 200ms) to start; single tap to stop
+- **Both** — hold-down and double-tap run simultaneously on the same key. Uses 200ms deferred hold promotion: short taps feed double-tap detection; only presses held beyond 200ms start a recording
+- Trigger key choices: Left Shift, Left Option/Alt, Right Control
+- Recordings shorter than 0.3 seconds are silently discarded as phantom triggers
+- Both detectors reject modifier+letter combos to avoid triggering during normal typing
 
 ### Text Output
-- Clipboard copy (always)
-- Optional auto-paste via osascript Cmd+V simulation (150ms delay)
+- Clipboard copy always (via arboard)
+- Optional auto-paste via osascript Cmd+V simulation
+- Configurable paste delay: 10-500ms (default 50ms), slider in settings (only shown when auto-paste enabled)
+- Auto-paste retries once on failure with 100ms backoff
+- On paste failure: "auto-paste-failed" event with hint to paste manually (auto-clears after 5 seconds)
 - Auto-paste requires accessibility permission
+- Empty/whitespace-only text is silently skipped
 
-### UI
-- Main window (720x560, dark/light theme follows macOS)
-- Start/Stop recording buttons
-- Transcription history (timestamped, copy-to-clipboard, clear all)
-- Stats bar: total words, avg WPM, total recordings, approx tokens
-- Error display banner
-- Permissions banner (microphone + accessibility status, grant buttons)
-- Dev mode banner
+### UI — Main Window
+- 720x560 default size, 520x400 minimum, centered on launch
+- Dark/light theme follows macOS system appearance (Tailwind dark: variants)
+- Header with "Murmur" title, status indicator, settings gear button; acts as Tauri drag region
+- Status indicator: Initializing (gray), Ready (green), Recording Xs (red, pulsing mic), Processing (amber, spinner)
+- Start/Stop recording buttons (disabled while not initialized or processing)
+- Transcription history: reverse-chronological, click to copy, timestamped, duration displayed
+- History capped at 50 entries, clear with confirmation dialog
+- Stats bar: Total Words, Avg WPM, Recordings, Approx Tokens
+- Error display banner; auto-paste failure hint with 5-second auto-dismiss
+- Permissions banner: microphone + accessibility status with grant buttons, auto-rechecks on window focus, dismissable
+- Close-to-hide: close request hides the window instead of destroying it
 
-### Settings Panel
-- Model selector dropdown with sizes
-- Recording mode toggle (Hold Down / Double-Tap)
-- Modifier key dropdown (shared by both modes)
-- Auto-paste toggle with accessibility status
-- Reset stats button (two-click confirm)
-- View logs button
-- Version footer
+### Settings Panel (side drawer, 280px)
+- Slides in/out from the right with width transition
+- Organized into collapsible sections with animated expand/collapse
+
+#### Section: Transcription
+- Model selector dropdown with two groups: "Moonshine (Fast, CPU)" and "Whisper (Metal GPU)"
+- Each option shows label and file size
+- Inline model download: warning when model not downloaded, progress bar, retry on error
+- Microphone selector: lists all audio input devices via system query, "System Default" option, warning if saved device not found
+
+#### Section: Recording
+- VAD Sensitivity slider: 0-100%, step 5, draft value while dragging
+- Recording Trigger mode: three toggle buttons (Hold Down, Double-Tap, Both)
+- Accessibility permission warning with grant link when not granted
+- Trigger Key selector: label changes per mode (Hold Key / Double-Tap Key / Trigger Key), contextual help text
+
+#### Section: Output
+- Auto-Paste toggle with accessibility status indicator
+- Paste Delay slider: 10-500ms, step 10ms (only visible when auto-paste enabled)
+- Launch at Login toggle, syncs with macOS login item state on mount
+
+#### Section: About (collapsed by default)
+- Model info display: name, backend, size
+- Reset Stats button with two-click confirmation (auto-resets after 3 seconds)
+- View Logs button (opens log viewer window)
+- Check for Updates button with status text
+- Version display
+
+### Model Downloader (first-launch onboarding)
+- Full-screen view shown when no model is installed
+- 4 curated model cards: moonshine-tiny, moonshine-base, large-v3-turbo, base.en
+- Each card shows label, size, description
+- Default selection: moonshine-tiny
+- Download button with progress bar (percentage + byte counter)
+- Error display with retry
+- Selection disabled during download
+- Checks both backends: download screen skipped if any model exists (Whisper or Moonshine)
 
 ### System Tray
-- Color-coded icon: gray (idle), red (recording), dark amber (processing), bright amber (idle — dev builds only, distinguishes from production)
-- Menu: Show Window, Toggle Overlay, About, Quit
-- Click to show window
+- Static white waveform icon: 66x66 RGBA (3x for 22pt Retina menu bar), 5 vertical capsule bars
+- Menu: "Show Murmur" and "Quit Murmur" only
+- Left-click on tray icon shows and focuses the main window
 - Hide-on-close (doesn't quit)
 
-### Overlay Widget
-- Floating always-on-top 200x60 window
-- 5-bar animated waveform driven by real-time audio levels
-- Click to toggle recording, double-click for locked mode
-- Color-coded states: stone (idle), red (recording), amber (processing)
+### Overlay Widget (Dynamic Island / notch overlay)
+- Separate always-on-top window (260x100), transparent, borderless, not focusable, visible on all workspaces
+- Positioned over the MacBook notch area, window level above menu bar (NSMainMenuWindowLevel + 1)
+- Notch-aware sizing: detects notch dimensions via NSScreen APIs (safe area insets, auxiliary areas)
+- Fallback dimensions: 200px wide, 37px tall when no notch detected
+- Three visual states: idle (dimmed mic icon), recording (red dot + waveform), processing (spinner + dimmed waveform)
+- 7-bar animated waveform driven by real-time audio levels via requestAnimationFrame with direct DOM manipulation
+- Center bars taller (envelope shaping), random jitter for organic feel
+- Single click (250ms debounced): stops recording if active, exits locked mode
+- Double-click: toggles locked mode; starts/stops recording
+- Locked mode persists recording across single clicks until explicitly unlocked
+- Screen change observer: re-detects notch on monitor plug/unplug or lid open/close
+- Uses `_setPreventsActivation:` private API (guarded by respondsToSelector:) to prevent overlay clicks from activating the app
+- Entire overlay is a Tauri drag region
 
-### Model Downloader
-- First-launch onboarding screen if no model found
-- Downloads from Hugging Face with streaming progress bar
-- 3 model choices with size info
-- Atomic download (.tmp → rename)
+### Log Viewer Window
+- Separate window (800x600, min 600x400), titled "Murmur -- Log Viewer"
+- Close-to-hide behavior (not destroyed)
+- Two tabs: Events and Metrics
 
-### Log Viewer
-- Modal with last 200 lines, auto-refreshes every 2s
-- Color-coded level badges (INFO/WARN/ERROR)
-- Clear and Copy All buttons
-- Per-transcription timing: audio parse, inference, injection, total pipeline
+#### Events Tab
+- Stream filter chips: toggle pipeline, audio, keyboard, system streams (colored)
+- Level filter: toggle info, warn, error levels
+- Scrollable event list with monospace font and auto-scroll (disengages on scroll up, re-engages near bottom)
+- Each row: timestamp, stream chip, level label, summary text
+- Expandable rows with JSON data detail view
+- Copy All button (filtered events as text lines)
+- Clear button (clears frontend buffer and backend ring buffer)
 
-### Resource Monitor (dev only)
+#### Metrics Tab
+- Extracts timing from pipeline events where summary is "transcription complete"
+- Last 20 transcriptions displayed
+- Toggleable series legend: Total, Inference, VAD, Paste
+- Stat cards per visible series: latest value, average, trend indicator (up/down/flat, 10% threshold)
+- Two SVG line charts: upper (Total + Inference, 150px), lower (VAD + Paste, 120px)
+- Auto-scaled Y-axis with round tick marks, X-axis by transcription index
+- Polylines with dots at each data point
+
+### Structured Event System
+- All logging via tracing crate with two layers: pretty-printed log file + structured JSONL + Tauri event emission
+- TauriEmitterLayer intercepts all tracing events, converts to AppEvent structs
+- In-memory ring buffer: 500 events max, FIFO eviction, seeded from existing JSONL on startup
+- JSONL persistence: events.jsonl (release) / events.dev.jsonl (dev), rotated at 5 MB
+- Real-time streaming: every tracing event broadcast to all frontend windows via app-event
+- Four streams: pipeline, audio, keyboard, system
+- Five levels: trace, debug, info, warn, error
+- Privacy stripping: in release builds, all string fields stripped from pipeline stream events in data object
+- Frontend logging: log_frontend command routes frontend messages through Rust tracing
+
+### Auto-Updater
+- Background update check on launch and every 24 hours
+- Endpoint: GitHub releases latest.json
+- Forced updates: if current version is below remote min_version, update is required (no skip/dismiss)
+- Skip version: user can skip a specific version (persisted to localStorage)
+- Dismiss: user can dismiss without skipping
+- Download progress with percentage
+- Auto-relaunch after successful download and install
+- Native macOS notification when update available (background check)
+- Update modal phases: available (with markdown release notes), downloading (progress), ready (installing), error (retry)
+
+### About Modal
+- App name "Murmur", version, description, copyright
+- Microphone icon, close button, backdrop click to close
+
+### Resource Monitor (dev builds only)
 - Collapsible CPU% + Memory MB panel
-- Dual-line SVG chart, 60-point rolling history
-- Polls only when expanded
+- Dual-line SVG chart: CPU (stone) and Memory (amber), 60-point rolling history
+- Grid lines at 25%, 50%, 75%
+- Polls every 1 second only when expanded (performance optimization)
+- Collapse state persisted to localStorage
 
 ### Permissions
 - Microphone: required for recording
-- Accessibility: required for double-tap mode + auto-paste
-- In-app status checks, grant buttons, opens System Settings
+- Accessibility: required for keyboard listener (all modes) and auto-paste
+- In-app status checks with grant buttons that open System Settings
+- Automatic re-check on window focus
+- Dismissable banner (session-scoped)
 
-### Platform & Distribution
+### Three-Window Architecture
+- Main window (720x560): full app UI, settings, recording controls, history
+- Overlay window (260x100): notch-anchored Dynamic Island
+- Log viewer window (800x600): structured event browser and metrics
+- Each window has separate Tauri capabilities following least privilege
+- Overlay reads settings from localStorage directly (no shared React context across windows)
+- Close-to-hide for main and log-viewer windows
+
+### Platform and Distribution
 - macOS only (12+), Apple Silicon optimized
+- Metal GPU acceleration for Whisper backend
 - Developer ID signed + notarized
 - DMG installer via GitHub Actions (tag-triggered)
-- ~1.5MB DMG, ~25MB installed
+- Binary size optimized: opt-level "s", LTO, strip, codegen-units 1, panic abort
+- Dev build has separate bundle identifier (com.localdictation.dev) and name (Local Dictation Dev)
 
 ### CI/CD
 - TypeScript type checking on push/PR
 - Omen code quality analysis on PRs
 - Claude Code automated PR review
 - Claude Code issue/PR comment bot (@claude)
+- Rust tests: single-threaded (cargo test -- --test-threads=1)
+- Frontend tests: vitest with jsdom
 
-### Developer
-- File-based logging with 5MB rotation
-- Heartbeat logging for keyboard listener (60s)
-- Per-phase timing instrumentation
-- Debug tray icon color (amber)
+### Dependencies
+- **Rust**: Tauri 2, whisper-rs (Metal), sherpa-rs (ONNX/Moonshine), cpal, arboard, rdev (git main), reqwest (rustls-tls), sysinfo, tracing/tracing-subscriber/tracing-appender, objc2/objc2-app-kit (macOS), tar/bzip2
+- **Frontend**: React 18, Tailwind CSS 4, Vite 6, TypeScript ~5.6, react-markdown, rehype-sanitize, @tauri-apps/api and plugins (autostart, updater, notification, process, opener)
+- **5 Tauri plugins**: opener, autostart (LaunchAgent), updater, notification, process

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -1,0 +1,104 @@
+# Auto-Update System
+
+## Overview
+
+The app checks for updates on launch and every 24 hours. Updates are downloaded from GitHub Releases, verified with ed25519 signatures, and installed with an automatic relaunch. A `min_version` field in the release manifest enables forced updates that cannot be skipped or dismissed.
+
+## Update Check Schedule
+
+- **On launch:** A background check runs immediately on mount via the `useAutoUpdater` hook.
+- **Periodic:** Every 24 hours (`CHECK_INTERVAL_MS = 86400000`), gated by `isDueForCheck()` which reads the last check timestamp from localStorage (`updater-last-check`).
+
+## Update Source
+
+The update manifest is fetched from:
+
+```
+https://github.com/georgenijo/murmur-app/releases/latest/download/latest.json
+```
+
+This URL is configured in `tauri.conf.json` as the updater plugin endpoint. The fetch uses `cache: 'no-store'` to bypass browser caching.
+
+The manifest contains version information, download URLs, signatures, and an optional `min_version` field for forced updates.
+
+## Update Flow
+
+### Normal Updates
+
+When a new version is available and the current version is above `min_version`:
+
+1. **Available** — Modal shows version number and release notes. Three buttons:
+   - "Update Now" — begins download
+   - "Skip This Version" — stores the version in localStorage (`skipped-update-version`), suppresses future background checks for that version
+   - "Later" — dismisses the modal without skipping
+2. **Downloading** — Progress bar with percentage. Progress reported via Tauri's `downloadAndInstall` callback.
+3. **Ready** — "Installing and relaunching..." text displayed.
+4. **Relaunch** — App restarts automatically via `@tauri-apps/plugin-process`.
+
+### Forced Updates
+
+When the current version is below the `min_version` field from the release manifest:
+
+1. The update modal shows "Required Update" instead of "Update Available"
+2. An amber warning reads "This update is required to continue using the app"
+3. Only two buttons are available: "Update Now" and "Quit" (calls `exit(0)`)
+4. No "Skip" or "Later" options
+5. Backdrop click is disabled — the modal cannot be dismissed
+6. The close button (X) is hidden
+
+### Error State
+
+If the download or install fails, the modal shows a red error banner with the error message and a "Retry" button. For forced updates in error state, the "Quit" button remains available.
+
+### Background Notifications
+
+When an update is detected during a background check (not user-initiated), a native macOS notification is sent: "Murmur vX.Y.Z is ready to install." This requires notification permission to be granted.
+
+## Semver Comparison
+
+The updater includes a semver parser (`updater.ts`) that:
+
+- Strips `v` prefix and whitespace
+- Parses major.minor.patch components
+- Strips pre-release and build metadata for comparison
+- Returns `-1 / 0 / 1 / null` (null = unparseable)
+
+**Fail-safe:** If either version is unparseable, `isBelowMinVersion` returns `true`, forcing the update. This ensures that broken version strings do not allow users to skip required updates.
+
+## Release Notes
+
+Release notes from the manifest are rendered as Markdown using `react-markdown` with `rehype-sanitize` (default sanitization schema). Custom HTML in release notes is stripped by the sanitizer.
+
+## Signed Updates
+
+Updates are signed with ed25519. The public key is embedded in `tauri.conf.json` as a base64-encoded minisign public key. The Tauri updater plugin handles signature verification automatically — unsigned or incorrectly signed updates are rejected.
+
+The build system generates updater artifacts (`createUpdaterArtifacts: true` in bundle config).
+
+## Update Status Lifecycle
+
+```typescript
+type UpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'up-to-date' }
+  | { phase: 'available'; version: string; notes: string; isForced: boolean }
+  | { phase: 'downloading'; version: string; progress: number }
+  | { phase: 'ready'; version: string }
+  | { phase: 'error'; message: string; isForced: boolean };
+```
+
+The update modal renders for `available`, `downloading`, `ready`, and `error` phases. The `idle`, `checking`, and `up-to-date` phases return null (no modal).
+
+## Settings Integration
+
+- The "Check for Updates" button in the About section of settings triggers a manual check. It is disabled during `checking` or `downloading` phases.
+- Status text shows: "Checking...", "You're up to date", "vX.Y.Z available", or "Update check failed".
+- Skipped version is stored in localStorage under `skipped-update-version`.
+
+## Dependencies
+
+- `tauri-plugin-updater` — Tauri 2 updater plugin (check, download, install)
+- `tauri-plugin-notification` — Native macOS notifications for background updates
+- `tauri-plugin-process` — App restart after install, `exit(0)` for forced update quit
+- `react-markdown` + `rehype-sanitize` — Release notes rendering

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -1,0 +1,155 @@
+# Structured Event System and Log Viewer
+
+## Overview
+
+All application logging goes through Rust's `tracing` crate, captured by a custom `TauriEmitterLayer` that routes every event to three destinations: an in-memory ring buffer, a persistent JSONL file, and real-time emission to all frontend windows. The log viewer is a dedicated Tauri window (not a modal) that displays these structured events with filtering, search, and transcription performance metrics.
+
+## Telemetry Architecture (`telemetry.rs`)
+
+The old `logging.rs` module has been replaced entirely by `telemetry.rs`. The `commands/logging.rs` file still exists as a thin command layer that delegates to `telemetry.rs` functions.
+
+### TauriEmitterLayer
+
+A custom `tracing_subscriber::Layer` that intercepts every tracing event in the application:
+
+1. **Field collection** — A `JsonVisitor` collects all tracing fields into `serde_json` values.
+2. **AppEvent construction** — Each event becomes an `AppEvent` struct:
+
+```typescript
+type AppEvent = {
+  timestamp: string;
+  stream: StreamName;   // "pipeline" | "audio" | "keyboard" | "system"
+  level: LevelName;     // "trace" | "debug" | "info" | "warn" | "error"
+  summary: string;      // the tracing message
+  data: Record<string, unknown>; // structured fields
+};
+```
+
+3. **Ring buffer** — Pushed to an in-memory `VecDeque` capped at 500 events (FIFO eviction when full).
+4. **JSONL file** — Appended as a single JSON line to `events.jsonl` (release) or `events.dev.jsonl` (dev).
+5. **Frontend emission** — Emitted as an `app-event` Tauri event to all windows.
+
+### Three Outputs
+
+| Output | Format | Capacity | Purpose |
+|--------|--------|----------|---------|
+| Ring buffer | `AppEvent` structs | 500 events | Fast in-memory access for `get_event_history` |
+| JSONL file | One JSON object per line | 5MB before rotation | Persistent log, survives restarts |
+| `app-event` emission | `AppEvent` payload | Real-time stream | Live updates in log viewer |
+
+### JSONL Rotation
+
+When the JSONL file exceeds 5MB, it is rotated — renamed to `.jsonl.1` — and a fresh file is started. On startup, the ring buffer is pre-populated with up to 500 events from the existing JSONL file.
+
+### Privacy Stripping
+
+In release builds, all string-valued fields from `pipeline` target events are stripped from the `data` object. Only numeric fields survive. The `summary` (message) field is not stripped. This prevents transcription text from being persisted in structured log data.
+
+### Pretty-Printed Log File
+
+A separate human-readable log file (`app.log` or `app.dev.log`) is maintained via `tracing_appender`. This is the file returned by `get_log_contents`.
+
+### Tracing Streams
+
+Tracing targets map to stream names used for filtering:
+
+| Target | Stream | Typical Events |
+|--------|--------|----------------|
+| `pipeline` | pipeline | Transcription timing, VAD results, model loading |
+| `audio` | audio | Device selection, sample rates, audio levels |
+| `keyboard` | keyboard | Hotkey detection, mode changes, listener lifecycle |
+| `system` | system | Startup, permissions, updates, resource usage |
+
+### Frontend Logging
+
+The `flog` utility (`lib/log.ts`) routes frontend log messages through the Rust tracing system via the `log_frontend` command. Messages appear in the log viewer alongside Rust-originated events.
+
+```typescript
+flog.info("overlay", "double-click detected");
+flog.warn("settings", "device not found", { device: name });
+flog.error("updater", "download failed", { error: msg });
+```
+
+Messages are formatted as `[tag] message` with optional JSON data. Calls are fire-and-forget (errors silenced).
+
+## Log Viewer Window
+
+The log viewer is a separate Tauri window (`label: "log-viewer"`, 800x600, min 600x400) opened via the `open_log_viewer` command. It hides on close rather than being destroyed.
+
+### Events Tab
+
+The primary view for browsing structured events.
+
+**Stream filter chips** — Colored toggle buttons for each stream (`pipeline`, `audio`, `keyboard`, `system`). Click to show/hide events from that stream. Default: `pipeline`, `audio`, `system` active.
+
+**Level filter** — Toggle buttons for `info`, `warn`, `error`. All active by default.
+
+**Event list** — Scrollable list with monospace font. Each row shows:
+- Timestamp (time portion only)
+- Stream chip (colored)
+- Level label (uppercase, colored)
+- Summary text
+
+Rows with structured data are expandable — click to reveal a `<pre>` block with formatted JSON.
+
+**Auto-scroll** — The list automatically scrolls to the bottom as new events arrive. If the user scrolls up (more than 40px from the bottom), auto-scroll disengages. Scrolling back near the bottom re-engages it.
+
+**Copy All** — Copies all filtered events as text lines: `{timestamp} [{stream}] {LEVEL} {summary}`.
+
+**Clear** — Clears all events (calls `clear_event_history` on the backend and clears the local buffer).
+
+### Metrics Tab
+
+Visualizes transcription performance data extracted from pipeline events where `summary === 'transcription complete'`.
+
+**Four timing series:**
+
+| Series | Color | Description |
+|--------|-------|-------------|
+| Total | stone-600 | End-to-end pipeline time |
+| Inference | amber-500 | Backend transcription time |
+| VAD | stone-400 | Voice activity detection time |
+| Paste | slate-500 | Text injection time |
+
+**Stat cards** — One per visible series showing the latest value, average, and a trend indicator (up arrow red, down arrow green, dash for flat). Trend threshold: 10% deviation from the average.
+
+**Line charts** — Two SVG polyline charts:
+- Upper chart (150px): Total + Inference timing
+- Lower chart (120px): VAD + Paste timing
+
+Y-axis auto-scales with "nice" round numbers and three tick marks. X-axis shows transcription index (1-based). Each data point has a dot marker.
+
+The metrics view shows the last 20 transcriptions. The series legend is toggleable — click a series label to show/hide it (at least one must remain visible).
+
+### Event Store (`useEventStore`)
+
+The frontend event buffer is managed by the `useEventStore` hook:
+
+- **Hydration** — On mount, fetches existing events via `get_event_history`.
+- **Live streaming** — Listens for `app-event` Tauri events and appends to the buffer.
+- **Batched rendering** — Uses `requestAnimationFrame` to coalesce rapid event bursts into a single React state update.
+- **Capacity** — 500 events maximum (`MAX_EVENTS`).
+- **Filtering** — `getByStream(stream)` and `getByLevel(level)` methods.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `open_log_viewer` | Shows and focuses the log-viewer window |
+| `get_log_contents` | Returns the last N lines from the pretty-printed log file |
+| `clear_logs` | Removes all log files and clears the in-memory event ring buffer |
+| `log_frontend` | Routes a frontend message through Rust tracing (INFO/WARN/ERROR) |
+| `get_event_history` | Returns all events from the in-memory ring buffer (up to 500) |
+| `clear_event_history` | Clears the in-memory event ring buffer |
+
+## Log Files
+
+All files stored in `~/Library/Application Support/local-dictation/`:
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `app.log` / `app.dev.log` | Pretty-printed text | Human-readable log (read by `get_log_contents`) |
+| `events.jsonl` / `events.dev.jsonl` | JSONL | Structured events, rotated at 5MB |
+| `events.jsonl.1` | JSONL | Previous rotated JSONL file |
+
+`clear_logs` removes all known log file variants, including legacy files (`frontend.log`, `transcription.log`, dated rolling files).

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -144,7 +144,7 @@ The frontend event buffer is managed by the `useEventStore` hook:
 
 ## Log Files
 
-All files stored in `~/Library/Application Support/local-dictation/`:
+All files stored in `~/Library/Application Support/local-dictation/logs/`:
 
 | File | Format | Purpose |
 |------|--------|---------|

--- a/docs/features/models.md
+++ b/docs/features/models.md
@@ -1,0 +1,148 @@
+# Model Management
+
+## Overview
+
+The app supports 7 transcription models across two backends. Models are downloaded on demand, loaded lazily on first transcription, and cached for reuse. Backend switching happens automatically when the user selects a model from a different engine.
+
+## Available Models
+
+| Model | Setting Value | Backend | Size | Speed | Language |
+|-------|--------------|---------|------|-------|----------|
+| Moonshine Tiny | `moonshine-tiny` | Moonshine (CPU) | ~124 MB | Fastest (~16ms for 3s audio) | English only |
+| Moonshine Base | `moonshine-base` | Moonshine (CPU) | ~286 MB | Very fast (~37ms for 3s audio) | English only |
+| Tiny | `tiny.en` | Whisper (Metal GPU) | ~75 MB | Fast | English only |
+| Base | `base.en` | Whisper (Metal GPU) | ~150 MB | Fast | English only |
+| Small | `small.en` | Whisper (Metal GPU) | ~500 MB | Medium | English only |
+| Medium | `medium.en` | Whisper (Metal GPU) | ~1.5 GB | Slow | English only |
+| Large Turbo | `large-v3-turbo` | Whisper (Metal GPU) | ~3 GB | Slow | Multilingual |
+
+**Default model:** `moonshine-tiny` (set in `settings.ts`). The Rust-side `DictationState::default()` uses `base.en`, but this is overwritten by the frontend's `configure_dictation` call during initialization before any recording can occur.
+
+## Backends
+
+### Whisper (`transcriber/whisper.rs`)
+
+Uses `whisper-rs` with Apple Metal GPU acceleration. Model files are single `.bin` files (e.g., `ggml-base.en.bin`).
+
+**Inference config:** Greedy sampling (best_of=1), single segment mode, timestamps/progress/special tokens suppressed, blank suppression enabled.
+
+**Model search paths** (checked in order):
+1. `$WHISPER_MODEL_DIR` environment variable
+2. `~/Library/Application Support/local-dictation/models`
+3. `~/Library/Application Support/pywhispercpp/models`
+4. `~/.cache/whisper.cpp`
+5. `~/.cache/whisper`
+6. `~/.whisper/models`
+
+**Download URL:** `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{name}.bin`
+
+### Moonshine (`transcriber/moonshine.rs`)
+
+Uses `sherpa-rs` with ONNX runtime, int8 quantized, CPU inference only. Model files are directories containing multiple ONNX files:
+
+- `preprocess.onnx`
+- `encode.int8.onnx`
+- `uncached_decode.int8.onnx`
+- `cached_decode.int8.onnx`
+- `tokens.txt`
+
+English-only — the `language` parameter is ignored.
+
+**Download URL:** `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-{variant}-en-int8.tar.bz2`
+
+## Storage
+
+All models are stored in `~/Library/Application Support/local-dictation/models/`.
+
+## Lazy Loading
+
+Models are not loaded at app startup. The backend's `load_model()` is called on the first transcription attempt. If the model is already loaded (`loaded_model_name` matches the requested model), the call is a no-op.
+
+### WhisperState Caching
+
+As of v0.7.8, the Whisper backend caches both the `WhisperContext` and `WhisperState` across transcriptions. Previously, `create_state()` was called per transcription, causing expensive GPU/Metal buffer alloc/free cycles. Now:
+
+1. `load_model()` creates a `WhisperContext` from the model file
+2. `ctx.create_state()` is called exactly once to produce a `WhisperState`
+3. Both are stored in the `WhisperBackend` struct and reused for all subsequent transcriptions
+4. Only a model change triggers `reset()`, which drops and recreates both
+
+This is the same pattern described in the [transcription pipeline docs](transcription.md).
+
+## First-Launch Downloader
+
+On first launch (no model downloaded), a full-screen download view presents 4 curated models:
+
+| Model | Description |
+|-------|-------------|
+| `moonshine-tiny` | "Fastest -- sub-20ms for typical dictation" |
+| `moonshine-base` | "Better accuracy, still very fast" |
+| `large-v3-turbo` | "Highest accuracy, slower (1-2 seconds)" |
+| `base.en` | "Good balance of speed and accuracy" |
+
+Default selection: `moonshine-tiny`. The user selects a model and clicks "Download." A progress bar shows percentage and byte counts. Selection is disabled during download. On error, a "Retry Download" button appears.
+
+The main app controls are gated on `initialized` (which requires a model to exist), so the download screen blocks all other interaction.
+
+## Download Pipeline
+
+### Streaming Download
+
+`stream_download()` handles all model downloads:
+
+- Uses `reqwest` with 30s connect timeout and 15-minute overall timeout
+- Writes chunks to a temp file (`.tmp` suffix)
+- Emits `download-progress` events with `{ received, total }` payload
+- On success: atomic rename from `.tmp` to final path
+- On failure: temp file cleaned up
+
+### Whisper Downloads
+
+Single `.bin` file downloaded directly from HuggingFace. Atomic rename on completion.
+
+### Moonshine Downloads
+
+`.tar.bz2` archive downloaded from GitHub, then extracted on a `spawn_blocking` thread using the `bzip2` and `tar` crates. On extraction failure, the partially extracted directory is cleaned up.
+
+### VAD Co-Download
+
+Every transcription model download also triggers a co-download of the Silero VAD model (`ggml-silero-v5.1.2.bin`, ~1.8MB) if it is not already present. VAD download failure is non-fatal. See [vad.md](vad.md) for details on the VAD fallback download mechanism.
+
+## Allowed Models
+
+The `download_model` command accepts only models from a hardcoded allow-list:
+
+```
+large-v3-turbo, small.en, base.en, tiny.en, medium.en, moonshine-tiny, moonshine-base
+```
+
+Any other model name is rejected. The `check_specific_model_exists` command also includes path traversal protection, rejecting names containing `..`, `/`, or `\`.
+
+## Backend Switching
+
+When the user changes models in settings, `configure_dictation` determines whether a backend swap is needed:
+
+- Model names starting with `moonshine-` use `MoonshineBackend`
+- All other names use `WhisperBackend`
+
+If the model change crosses the whisper/moonshine boundary, the entire `Box<dyn TranscriptionBackend>` is replaced. If the model changes within the same backend type, `reset()` is called to force a reload on the next transcription.
+
+The active backend is stored as `Mutex<Box<dyn TranscriptionBackend>>` in `AppState`.
+
+## Inline Download in Settings
+
+The settings panel supports downloading models without leaving the settings view:
+
+1. On model selection change, `check_specific_model_exists` verifies the model is on disk
+2. If not downloaded, an amber warning appears with a "Download" link
+3. During download: progress bar with percentage and "Downloading..." text
+4. On error: red error banner with message and "Retry" link
+5. Stale-request protection prevents progress updates from a previously selected model
+
+Model selection is disabled while recording is active.
+
+## Settings
+
+- `model: ModelOption` — Selected model name. Persisted to localStorage. Sent to Rust via `configure_dictation`.
+
+Model options are defined in `settings.ts` with `MODEL_OPTIONS`, `MOONSHINE_MODELS`, and `WHISPER_MODELS` arrays. Each option includes the setting value, display label, size string, and backend type.

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -1,0 +1,132 @@
+# Dynamic Island Overlay
+
+## Overview
+
+The overlay is an always-on-top transparent window anchored to the macOS notch area, styled as a "Dynamic Island." It shows recording status, an animated audio waveform, and supports click interactions to start/stop recording. The overlay is a separate Tauri window (`label: "overlay"`) that loads its own HTML entry point and has no shared React context with the main window.
+
+## Notch Detection
+
+Notch dimensions are detected via NSScreen APIs on macOS:
+
+- `safeAreaInsets()` — determines menu bar height
+- `auxiliaryTopLeftArea()` and `auxiliaryTopRightArea()` — determines the non-notch menu bar area on each side
+
+Notch width is calculated as: `screen width - left auxiliary area - right auxiliary area`.
+
+Results are cached in `State.notch_info` (a `Mutex<Option<(f64, f64)>>`). The `get_notch_info` command returns the cached dimensions to the frontend.
+
+**Fallback:** When no notch is detected (external monitor, older Mac), the overlay uses 200px wide by 37px tall as default dimensions.
+
+## Window Configuration
+
+The overlay window is configured in `tauri.conf.json`:
+- Transparent, borderless, not focusable, not resizable
+- Always on top, visible on all workspaces, skips taskbar
+- Hidden by default (shown via `show_overlay` command)
+- Default size: 260x100
+
+### Window Level
+
+The overlay is raised to **NSMainMenuWindowLevel + 1 (level 25)** via NSWindow APIs, placing it above the menu bar and other always-on-top windows.
+
+### Preventing App Activation
+
+Clicking the overlay should not activate the app (which would unhide the main window). This is achieved using the private API `_setPreventsActivation:`, guarded by `respondsToSelector:` for forward compatibility. If the API is unavailable on a future macOS version, the guard prevents a crash.
+
+### Mouse Events
+
+Tauri's `focusable: false` configuration disables mouse events on macOS. The `show_overlay` command explicitly re-enables them via `setIgnoreCursorEvents(false)`.
+
+## Sizing
+
+Overlay width adjusts based on recording state:
+
+| State | Width | Notes |
+|-------|-------|-------|
+| Idle | `notchWidth + 28` | Compact, shows only the mic icon |
+| Recording / Processing | `notchWidth + 68` | Expanded, shows waveform and status indicators |
+
+The full overlay window width is `notchWidth + 120` (60px expansion per side), with the visible content area sized within that.
+
+Height matches the menu bar height from notch detection. The overlay is horizontally centered at the top of the screen (y=0).
+
+The width transition uses a spring-like animation: `cubic-bezier(0.34, 1.56, 0.64, 1)` over 500ms.
+
+## Visual States
+
+The overlay has three visual states driven by `recording-status-changed` Tauri events:
+
+### Idle
+Small mic SVG icon at 40% white opacity. Compact width.
+
+### Recording
+Expanded width. Red pulsing dot on the left, animated 7-bar waveform on the right. The waveform responds to real-time audio levels.
+
+### Processing
+Same expanded width. Spinning circle on the left, dimmed waveform on the right.
+
+**Styling:** Dark background (`rgba(20, 20, 20, 0.92)`), 40px backdrop blur, rounded bottom corners.
+
+## Waveform Animation
+
+7 bars (`BAR_COUNT = 7`) animate via `requestAnimationFrame` with direct DOM manipulation (no React state updates per frame).
+
+- Audio levels arrive via the `audio-level` Tauri event and are stored in a ref
+- The rAF loop reads the ref and sets `el.style.height` on each bar element
+- Bar heights are computed from: baseline (random jitter), center-weighted envelope (middle bars taller), audio level (scaled x16, capped at 1), and a squared boost with random factor for organic movement
+- Animation only runs when `status === 'recording'`; bars reset to 2px when idle
+
+## Click Interactions
+
+The overlay supports both single-click and double-click, disambiguated by a 250ms debounce timer.
+
+**Single click** (after 250ms with no second click):
+- If recording: stops recording. Exits locked mode if active.
+
+**Double click** (second click within 250ms cancels the pending single-click timer):
+- Toggles "locked mode"
+- First double-click starts recording via `invoke('start_native_recording', { deviceName })`
+- Second double-click stops recording via `invoke('stop_native_recording')`
+
+### Locked Mode
+
+A boolean tracking whether recording was initiated from the overlay (vs. keyboard). When locked mode is active, single clicks stop recording and exit locked mode. When status returns to `idle`, locked mode is automatically reset to `false`.
+
+### Settings Access
+
+The overlay reads the microphone setting from `localStorage` directly (parsing the full settings object from `STORAGE_KEY`) because it runs in a separate window with no shared React context. This creates a coupling to the localStorage schema — if the settings structure changes, the overlay's direct parsing could break.
+
+## Screen Change Observer
+
+An `NSApplicationDidChangeScreenParametersNotification` observer is registered at startup to handle:
+- Monitor plug/unplug
+- Lid open/close
+- Display configuration changes
+
+When triggered, the observer:
+1. Re-detects notch dimensions via NSScreen APIs
+2. Updates the cached `State.notch_info`
+3. Repositions the overlay window
+4. Emits `notch-info-changed` event to the frontend with updated dimensions (or `null` if no notch)
+
+The frontend overlay listens for `notch-info-changed` and updates its internal `notchWidth` state accordingly.
+
+The observer is intentionally leaked (`std::mem::forget`) for app-lifetime observation.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `show_overlay` | Positions, sizes, and shows the overlay window. Re-enables mouse events. |
+| `hide_overlay` | Hides the overlay window. Gracefully handles missing window. |
+| `get_notch_info` | Returns cached `{ notch_width, notch_height }` or `null`. |
+
+## Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `recording-status-changed` | String | Drives visual state transitions |
+| `audio-level` | Number (RMS 0.0-1.0) | Real-time audio level for waveform |
+| `notch-info-changed` | `{ notch_width, notch_height }` or `null` | Display configuration changed |
+
+The entire overlay surface is a Tauri drag region (`data-tauri-drag-region`), allowing the user to reposition it. Overlay position save/restore is currently disabled (TODO: re-enable after notch positioning is stable).

--- a/docs/features/vad.md
+++ b/docs/features/vad.md
@@ -1,0 +1,75 @@
+# Voice Activity Detection
+
+## Overview
+
+Silero VAD v5.1.2 pre-filters silence and non-speech audio before it reaches the transcription backend. Without VAD, Whisper tends to hallucinate text on silent or near-silent recordings (repeating phrases, generating phantom words). VAD solves this by detecting whether the audio actually contains speech and trimming the samples to only speech segments.
+
+## How It Works
+
+VAD runs between audio capture and transcription in the pipeline. After recording stops and the samples are collected, `filter_speech` is called on a `spawn_blocking` thread (the `WhisperVadContext` is `!Send`, so it cannot run on a normal async task).
+
+```text
+audio capture → VAD filter → transcription backend → text injection
+```
+
+The VAD analysis produces one of three outcomes:
+
+- **NoSpeech** — No speech segments detected. Transcription is skipped entirely and an empty string is returned. This prevents Whisper hallucination loops on silent recordings.
+- **Speech** — Speech segments found. The samples are trimmed to only the detected speech regions and passed to the transcription backend.
+- **Error** — VAD failed for some reason. The pipeline falls back to using the unfiltered audio, so transcription still happens.
+
+### Segment Processing
+
+Silero VAD returns speech segments as centisecond timestamps. These are converted to sample indices (at 16kHz) and the corresponding sample ranges are extracted. If all extracted segments are empty after conversion, the result is treated as NoSpeech.
+
+### Configuration: 1 thread, GPU disabled
+
+The VAD context is configured to use a single thread with GPU acceleration disabled. Unlike the transcription `WhisperState`, the `WhisperVadContext` is created fresh per transcription and not cached across runs.
+
+## Sensitivity
+
+VAD sensitivity is user-configurable on a 0-100 scale (default: 50). The internal threshold is computed as:
+
+```
+threshold = 1.0 - (sensitivity / 100.0)
+```
+
+- **Higher sensitivity** (e.g., 80) = lower threshold = keeps more audio, less aggressive trimming
+- **Lower sensitivity** (e.g., 20) = higher threshold = trims silence more aggressively
+
+The slider appears in the Recording section of the settings panel, labeled "Voice Detection" with a percentage display. Values are sent to the Rust backend via `configure_dictation` and clamped to 0-100.
+
+## VAD Model
+
+The VAD model file is `ggml-silero-v5.1.2.bin` (~1.8MB), stored alongside transcription models in `~/Library/Application Support/local-dictation/models/`.
+
+### Co-download
+
+When downloading any transcription model (whisper or moonshine), the VAD model is automatically co-downloaded if not already present. VAD download failure during co-download is non-fatal — the transcription model download still succeeds.
+
+### Fallback Download
+
+For users who upgraded from a pre-VAD version, the `ensure_vad_model` function checks for the VAD model at transcription time. If missing, it:
+
+1. Emits `recording-status-changed` with value `"downloading-vad"` (a transient status)
+2. Spawns a background download
+3. Emits `recording-status-changed` with `"processing"` once done
+4. Falls back to unfiltered transcription for the current run (the downloaded model is used next time)
+
+If the background download fails, the error is logged but no explicit failure notification is sent to the frontend.
+
+## Pipeline Integration
+
+In `run_transcription_pipeline()`, the VAD phase runs after pre-VAD diagnostics (RMS and peak amplitude logging) and before the transcription phase:
+
+1. State read (model, language, VAD sensitivity, etc.)
+2. Pre-VAD audio diagnostics
+3. **VAD filter** — runs on `spawn_blocking`, returns `VadResult`
+4. Transcription — uses trimmed samples (Speech) or original samples (Error/missing model)
+5. Text injection
+
+The VAD execution time is logged as `vad_ms` in the structured telemetry output alongside `inference_ms`, `paste_ms`, and `total_ms`. This timing data is visible in the log viewer's Metrics tab. See [log-viewer.md](log-viewer.md) for details.
+
+## Settings
+
+- `vadSensitivity: number` — Sensitivity value (0-100, default 50). Persisted to localStorage. Sent to Rust via `configure_dictation`.

--- a/docs/features/vad.md
+++ b/docs/features/vad.md
@@ -30,7 +30,7 @@ The VAD context is configured to use a single thread with GPU acceleration disab
 
 VAD sensitivity is user-configurable on a 0-100 scale (default: 50). The internal threshold is computed as:
 
-```
+```text
 threshold = 1.0 - (sensitivity / 100.0)
 ```
 
@@ -49,14 +49,9 @@ When downloading any transcription model (whisper or moonshine), the VAD model i
 
 ### Fallback Download
 
-For users who upgraded from a pre-VAD version, the `ensure_vad_model` function checks for the VAD model at transcription time. If missing, it:
+For users who upgraded from a pre-VAD version, the `ensure_vad_model` function checks for the VAD model at transcription time. If missing, it spawns a silent background download with no UI side effects -- the current transcription proceeds with unfiltered audio, and the downloaded model is used on the next recording.
 
-1. Emits `recording-status-changed` with value `"downloading-vad"` (a transient status)
-2. Spawns a background download
-3. Emits `recording-status-changed` with `"processing"` once done
-4. Falls back to unfiltered transcription for the current run (the downloaded model is used next time)
-
-If the background download fails, the error is logged but no explicit failure notification is sent to the frontend.
+If the background download fails, the error is logged but no notification is sent to the frontend.
 
 ## Pipeline Integration
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,82 @@
+# Tauri Commands Reference
+
+This document lists all 30 registered Tauri commands exposed from the Rust backend to the frontend via `invoke()`. Commands are grouped by their source module under `app/src-tauri/src/`.
+
+For event-based communication (Rust to frontend), see [events.md](events.md). For frontend hooks that call these commands, see [hooks.md](hooks.md).
+
+---
+
+## Recording (`commands/recording.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `init_dictation` | _(none)_ | `Result<JSON, String>` | Returns a static `{"type":"initialized","state":"idle"}` response. No-op initialization marker. |
+| `process_audio` | `audio_data: String` | `Result<JSON, String>` | Accepts base64-encoded WAV audio, decodes it, runs the full VAD + transcription + text injection pipeline, and returns `{"type":"transcription","text":"..."}`. |
+| `get_status` | _(none)_ | `Result<JSON, String>` | Returns current dictation status, model name, and language as `{"type":"status","state":"...","model":"...","language":"..."}`. |
+| `configure_dictation` | `options: JSON` | `Result<JSON, String>` | Updates dictation settings. Accepts optional fields: `model` (string), `language` (string), `autoPaste` (bool), `autoPasteDelayMs` (u64, clamped 10-500), `vadSensitivity` (u64, clamped 0-100). Swaps transcription backend if model type changes between Whisper and Moonshine. |
+| `start_native_recording` | `device_name: Option<String>` | `Result<JSON, String>` | Begins native audio capture via cpal with an optional device name. Transitions status from Idle to Recording. Returns early if already recording or processing. |
+| `stop_native_recording` | _(none)_ | `Result<JSON, String>` | Stops audio capture, runs the full pipeline (VAD, transcription, text injection), and returns the transcription result. Recordings shorter than 0.3s are silently discarded. |
+| `cancel_native_recording` | _(none)_ | `Result<(), String>` | Cancels an in-progress recording without transcribing. Audio is discarded. Used by "both" mode for speculative recordings from short taps. |
+
+## Permissions (`commands/permissions.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `open_system_preferences` | _(none)_ | `Result<(), String>` | Opens macOS System Settings to the Microphone privacy pane. |
+| `check_accessibility_permission` | _(none)_ | `bool` | Returns `true` if macOS Accessibility permission is granted (via `AXIsProcessTrusted()`). |
+| `request_accessibility_permission` | _(none)_ | `Result<(), String>` | Triggers the macOS Accessibility permission prompt and opens System Settings to the Accessibility pane. |
+| `request_microphone_permission` | _(none)_ | `Result<(), String>` | Opens macOS System Settings to the Microphone privacy pane. |
+| `list_audio_devices` | _(none)_ | `Result<Vec<String>, String>` | Returns a list of available audio input device names via cpal. |
+
+## Keyboard (`commands/keyboard.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `start_keyboard_listener` | `hotkey: String`, `mode: String` | `Result<(), String>` | Starts the global rdev keyboard listener with the specified hotkey and mode (`"double_tap"`, `"hold_down"`, or `"both"`). Validates mode and requires Accessibility permission. |
+| `stop_keyboard_listener` | _(none)_ | `()` | Stops processing keyboard events. The rdev listener thread remains alive but idle. |
+| `update_keyboard_key` | `hotkey: String` | `()` | Changes the target hotkey at runtime without restarting the listener. If the key is changed while held down, emits `hold-down-stop` to prevent stuck recording state. |
+| `set_keyboard_recording` | `recording: bool` | `()` | Synchronizes the keyboard module's internal recording state flag. Used by the frontend to keep the double-tap detector's state machine in sync. |
+
+## Logging (`commands/logging.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `get_log_contents` | `lines: usize` | `String` | Returns the last N lines from the pretty-printed log file (`app.log` or `app.dev.log`). |
+| `clear_logs` | _(none)_ | `Result<(), String>` | Removes all log files (including rotated variants, JSONL event files, frontend logs) and clears the in-memory event ring buffer. |
+| `log_frontend` | `level: String`, `message: String` | `()` | Routes a frontend log message through the Rust tracing system. Accepts levels: `"INFO"`, `"WARN"`, `"ERROR"`. Messages appear in the structured event stream with `source="frontend"`. |
+| `open_log_viewer` | _(none)_ | `Result<(), String>` | Shows and focuses the `log-viewer` window. |
+
+## Models (`commands/models.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `check_model_exists` | _(none)_ | `bool` | Returns `true` if any transcription model exists for either backend (Whisper or Moonshine). Used to determine whether the model download screen should be shown on first launch. |
+| `check_specific_model_exists` | `model_name: String` | `bool` | Returns `true` if the specified model file or directory exists on disk. Includes path traversal protection (rejects `..`, `/`, `\` in model names). |
+| `download_model` | `model_name: String` | `Result<(), String>` | Downloads a transcription model with streaming progress events. Allowed models: `large-v3-turbo`, `small.en`, `base.en`, `tiny.en`, `medium.en`, `moonshine-tiny`, `moonshine-base`. Also co-downloads the Silero VAD model if missing. Whisper models are downloaded as single `.bin` files; Moonshine models as `.tar.bz2` archives that are extracted on a blocking thread. |
+
+## Tray (`commands/tray.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `update_tray_icon` | `_icon_state: String` | `Result<(), String>` | No-op. The tray icon is always a static white waveform. Command is retained for API compatibility. |
+
+## Overlay (`commands/overlay.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `show_overlay` | _(none)_ | `Result<(), String>` | Positions and shows the always-on-top overlay window at the macOS notch area. Re-enables mouse events (disabled by `focusable:false`). |
+| `hide_overlay` | _(none)_ | `Result<(), String>` | Hides the overlay window. Gracefully handles missing window. |
+| `get_notch_info` | _(none)_ | `Option<NotchInfo>` | Returns cached notch dimensions as `{notch_width: f64, notch_height: f64}`, or `null` if no notch is detected. Dimensions are detected via NSScreen APIs. |
+
+## Telemetry (`telemetry.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `get_event_history` | _(none)_ | `Vec<AppEvent>` | Returns all entries from the in-memory structured event ring buffer (up to 500 events). Each event has `timestamp`, `stream`, `level`, `summary`, and `data` fields. |
+| `clear_event_history` | _(none)_ | `()` | Clears the in-memory event ring buffer. Does not delete the JSONL file on disk. |
+
+## Resource Monitor (`resource_monitor.rs`)
+
+| Command | Parameters | Return Type | Description |
+|---------|-----------|-------------|-------------|
+| `get_resource_usage` | _(none)_ | `ResourceUsage` | Returns current system CPU percentage and used memory in MB as `{cpu_percent: f32, memory_mb: u64}`. Uses a persistent `sysinfo::System` instance for accurate delta-based CPU measurement. First call returns approximately 0% CPU. |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,0 +1,76 @@
+# Tauri Events Reference
+
+This document lists all events emitted from the Rust backend to the frontend via Tauri's event system. The frontend subscribes to these events using `listen()` from `@tauri-apps/api/event`.
+
+For commands invoked from the frontend to the backend, see [commands.md](commands.md). For hooks that consume these events, see [hooks.md](hooks.md).
+
+---
+
+## Recording and Transcription Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `audio-level` | `f32` (RMS value, 0.0-1.0) | `audio.rs` | Continuously during recording, throttled to ~60fps (16ms minimum gap between emissions). | Overlay window (waveform visualization), main window (`useRecordingState` stores in `audioLevel` state). |
+| `recording-status-changed` | `string` (`"idle"`, `"recording"`, `"processing"`, `"downloading-vad"`) | `commands/recording.rs` | At every dictation state transition: start recording, stop recording, begin processing, finish processing, and during VAD model download. | Main window (`useRecordingState` syncs status), overlay window (drives visual state). |
+| `transcription-complete` | `{text: string, duration: number}` | `commands/recording.rs` | After successful transcription produces non-empty text. Broadcast to all windows. Duration is in whole seconds (integer division). | Main window (`useRecordingState` updates history, stats, and transcription display). |
+| `auto-paste-failed` | `string` (hint message, e.g., "Text is in your clipboard -- press Cmd+V to paste manually.") | `commands/recording.rs` (via `injector.rs`) | When auto-paste fails or times out (2-second timeout). Text is already in the clipboard. | Main window (`useRecordingState` shows error for 5 seconds then auto-clears). |
+
+## Model Download Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `download-progress` | `{received: number, total: number}` (byte counts) | `commands/models.rs` | Periodically during model and VAD model streaming downloads. `total` may be 0 if the server does not provide `Content-Length`. | Main window (SettingsPanel download progress bar, ModelDownloader progress bar). |
+
+## Keyboard Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `double-tap-toggle` | `()` (empty) | `keyboard.rs` | When the double-tap detector recognizes a valid double-tap sequence on the trigger key. In "both" mode, emitted on key release when the hold was not promoted but the double-tap sequence completed. | Main window (`useDoubleTapToggle` calls `onToggle`, `useCombinedToggle` calls `onToggle`). |
+| `hold-down-start` | `()` (empty) | `keyboard.rs` | When the hold-down detector recognizes a key press. In hold-down-only mode, emitted immediately on key press. In "both" mode, emitted after the 200ms promotion timer confirms the key is still held. | Main window (`useHoldDownToggle` calls `onStart`, `useCombinedToggle` calls `onStart`). |
+| `hold-down-stop` | `()` (empty) | `keyboard.rs` | When the hold-down key is released (after a valid hold). Also emitted by `update_keyboard_key` if the hotkey is changed while the key is held down, to prevent stuck recording state. | Main window (`useHoldDownToggle` calls `onStop`, `useCombinedToggle` calls `onStop`). |
+| `keyboard-listener-error` | `string` (error message) | `keyboard.rs` | When the rdev listener thread encounters an error. | Main window (all three keyboard hooks listen; on error, they wait 2 seconds then attempt to restart the listener). |
+
+**Note on `hold-down-cancel`:** The frontend `useCombinedToggle.ts` registers a listener for the event name `hold-down-cancel`, but this event is never emitted from any Rust code. In "both" mode, short taps that are not promoted to holds simply emit nothing -- the recording was never started. The frontend listener is dead code.
+
+## Overlay Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `notch-info-changed` | `{notch_width: number, notch_height: number}` or `null` | `commands/overlay.rs` | When display configuration changes (monitor plug/unplug, lid open/close). Triggered by an NSNotificationCenter observer watching `NSApplicationDidChangeScreenParametersNotification`. | Overlay window (updates notch dimensions for positioning). |
+
+## Structured Logging Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `app-event` | `AppEvent {timestamp: string, stream: StreamName, level: LevelName, summary: string, data: Record<string, unknown>}` | `telemetry.rs` (TauriEmitterLayer) | For every `tracing` event in the entire Rust backend. Every log statement becomes a structured event. | Log viewer window (`useEventStore` appends to buffer). In release builds, string fields in `pipeline` stream events are stripped from the `data` object for privacy. |
+
+## Tray Menu Events
+
+| Event | Payload | Source | When It Fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `show-about` | `()` (empty) | `lib.rs` (tray menu setup) | When the user selects the "About" item from the tray menu (if present). | Main window (`useShowAboutListener` sets `showAbout` state to `true`, opening the AboutModal). |
+
+---
+
+## Event Payload Types
+
+### AppEvent
+
+```typescript
+interface AppEvent {
+  timestamp: string;        // ISO timestamp
+  stream: StreamName;       // "pipeline" | "audio" | "keyboard" | "system"
+  level: LevelName;         // "trace" | "debug" | "info" | "warn" | "error"
+  summary: string;          // The tracing message
+  data: Record<string, unknown>;  // Structured fields from the tracing event
+}
+```
+
+### Stream and Level Types
+
+```typescript
+type StreamName = 'pipeline' | 'audio' | 'keyboard' | 'system';
+type LevelName = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+```
+
+Streams correspond to Rust tracing targets. Levels correspond to standard tracing severity levels. Color mappings for both streams and levels are defined in `app/src/lib/events.ts`.

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -11,7 +11,7 @@ For commands invoked from the frontend to the backend, see [commands.md](command
 | Event | Payload | Source | When It Fires | Listeners |
 |-------|---------|--------|---------------|-----------|
 | `audio-level` | `f32` (RMS value, 0.0-1.0) | `audio.rs` | Continuously during recording, throttled to ~60fps (16ms minimum gap between emissions). | Overlay window (waveform visualization), main window (`useRecordingState` stores in `audioLevel` state). |
-| `recording-status-changed` | `string` (`"idle"`, `"recording"`, `"processing"`, `"downloading-vad"`) | `commands/recording.rs` | At every dictation state transition: start recording, stop recording, begin processing, finish processing, and during VAD model download. | Main window (`useRecordingState` syncs status), overlay window (drives visual state). |
+| `recording-status-changed` | `string` (`"idle"`, `"recording"`, `"processing"`) | `commands/recording.rs` | At every dictation state transition: start recording, stop recording, begin processing, finish processing. | Main window (`useRecordingState` syncs status), overlay window (drives visual state). |
 | `transcription-complete` | `{text: string, duration: number}` | `commands/recording.rs` | After successful transcription produces non-empty text. Broadcast to all windows. Duration is in whole seconds (integer division). | Main window (`useRecordingState` updates history, stats, and transcription display). |
 | `auto-paste-failed` | `string` (hint message, e.g., "Text is in your clipboard -- press Cmd+V to paste manually.") | `commands/recording.rs` (via `injector.rs`) | When auto-paste fails or times out (2-second timeout). Text is already in the clipboard. | Main window (`useRecordingState` shows error for 5 seconds then auto-clears). |
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,0 +1,348 @@
+# React Hooks Reference
+
+This document lists all 11 custom React hooks in Murmur. Each hook is located under `app/src/lib/hooks/` and is consumed by `App.tsx` or by window-specific entry points (overlay, log viewer).
+
+For the Tauri commands these hooks invoke, see [commands.md](commands.md). For the events they listen to, see [events.md](events.md). For settings managed by `useSettings`, see [settings.md](settings.md).
+
+---
+
+## useAutoUpdater
+
+**File:** `app/src/lib/hooks/useAutoUpdater.ts`
+
+**Parameters:** None.
+
+**Returns:** `UseAutoUpdaterReturn`
+
+```typescript
+interface UseAutoUpdaterReturn {
+  updateStatus: UpdateStatus;
+  checkForUpdate: () => Promise<void>;
+  startDownload: () => Promise<void>;
+  skipVersion: () => void;
+  dismissUpdate: () => void;
+}
+```
+
+**Responsibilities:**
+- Checks for updates on launch and every 24 hours (`CHECK_INTERVAL_MS`). Supports forced updates when the current version is below a remote `min_version` field.
+- Manages the full update lifecycle: check, download with progress, install, and relaunch via `@tauri-apps/plugin-updater` and `@tauri-apps/plugin-process`.
+- Sends a macOS notification when an update is discovered during a background check.
+
+**Key interactions:**
+- Fetches `min_version` from GitHub releases `latest.json` via HTTP.
+- Stores skipped version in localStorage under `skipped-update-version`.
+- Stores last check timestamp in localStorage under `updater-last-check`.
+
+---
+
+## useCombinedToggle
+
+**File:** `app/src/lib/hooks/useCombinedToggle.ts`
+
+**Parameters:**
+
+```typescript
+interface UseCombinedToggleProps {
+  enabled: boolean;
+  initialized: boolean;
+  accessibilityGranted: boolean | null;
+  triggerKey: string;
+  status: DictationStatus;
+  onStart: () => void;
+  onStop: () => void;
+  onToggle: () => void;
+}
+```
+
+**Returns:** `void`
+
+**Responsibilities:**
+- Combines hold-down and double-tap keyboard detection on a single trigger key. Active when `recordingMode` is `'both'`.
+- Tracks whether a hold-down press is currently active via `holdActiveRef` to prevent the eager hold-start from corrupting the double-tap state machine.
+- Syncs recording state to the backend double-tap detector via `set_keyboard_recording`, but skips syncing while a hold press is active.
+
+**Key interactions:**
+- Listens to events: `hold-down-start`, `hold-down-stop`, `double-tap-toggle`, `keyboard-listener-error`, `hold-down-cancel` (dead code -- this event is never emitted from Rust).
+- Invokes commands: `start_keyboard_listener` (mode `"both"`), `stop_keyboard_listener`, `set_keyboard_recording`, `cancel_native_recording` (in the dead `hold-down-cancel` handler).
+
+---
+
+## useDoubleTapToggle
+
+**File:** `app/src/lib/hooks/useDoubleTapToggle.ts`
+
+**Parameters:**
+
+```typescript
+interface UseDoubleTapToggleProps {
+  enabled: boolean;
+  initialized: boolean;
+  accessibilityGranted: boolean | null;
+  doubleTapKey: string;
+  status: DictationStatus;
+  onToggle: () => void;
+}
+```
+
+**Returns:** `void`
+
+**Responsibilities:**
+- Manages the double-tap keyboard listener for standalone double-tap mode. Active when `recordingMode` is `'double_tap'`.
+- Keeps the backend double-tap detector in sync with the current recording status via `set_keyboard_recording`.
+- On `keyboard-listener-error`, waits 2 seconds then attempts to restart the listener.
+
+**Key interactions:**
+- Listens to events: `double-tap-toggle`, `keyboard-listener-error`.
+- Invokes commands: `start_keyboard_listener` (mode `"double_tap"`), `stop_keyboard_listener`, `set_keyboard_recording`.
+
+---
+
+## useHoldDownToggle
+
+**File:** `app/src/lib/hooks/useHoldDownToggle.ts`
+
+**Parameters:**
+
+```typescript
+interface UseHoldDownToggleProps {
+  enabled: boolean;
+  initialized: boolean;
+  accessibilityGranted: boolean | null;
+  holdDownKey: string;
+  onStart: () => void;
+  onStop: () => void;
+}
+```
+
+**Returns:** `void`
+
+**Responsibilities:**
+- Manages the hold-down keyboard listener for standalone hold-down mode. Active when `recordingMode` is `'hold_down'`.
+- Calls `onStart` on key press and `onStop` on key release. Does not handle `hold-down-cancel`.
+- On `keyboard-listener-error`, waits 2 seconds then attempts to restart the listener.
+
+**Key interactions:**
+- Listens to events: `hold-down-start`, `hold-down-stop`, `keyboard-listener-error`.
+- Invokes commands: `start_keyboard_listener` (mode `"hold_down"`), `stop_keyboard_listener`.
+
+---
+
+## useHistoryManagement
+
+**File:** `app/src/lib/hooks/useHistoryManagement.ts`
+
+**Parameters:** None.
+
+**Returns:**
+
+```typescript
+{
+  historyEntries: HistoryEntry[];
+  addEntry: (text: string, duration: number) => void;
+  clearHistory: () => void;
+}
+```
+
+**Responsibilities:**
+- Manages the transcription history array with a maximum of 50 entries (oldest trimmed).
+- Persists history to localStorage under the key `dictation-history`.
+- Provides `addEntry` (used by `useRecordingState` via the `transcription-complete` event) and `clearHistory` callbacks.
+
+**Key interactions:**
+- Pure frontend state management. No Tauri commands or events. Delegates to `lib/history.ts` for persistence.
+
+---
+
+## useInitialization
+
+**File:** `app/src/lib/hooks/useInitialization.ts`
+
+**Parameters:** `settings: Settings`
+
+**Returns:**
+
+```typescript
+{
+  initialized: boolean;
+  error: string;
+}
+```
+
+**Responsibilities:**
+- Runs the one-time initialization sequence on mount: `initDictation()` then `configure()` with the current model, language, and autoPaste settings.
+- Sets `initialized` to `true` on success, which gates the recording controls and keyboard listeners.
+- Uses a cancellation flag to prevent stale state updates after unmount.
+
+**Key interactions:**
+- Invokes commands: `init_dictation`, `configure_dictation`.
+- Note: Does not pass `autoPasteDelayMs` or `vadSensitivity` during initial configure. Those values are sent to the backend when `useSettings.updateSettings` is called.
+
+---
+
+## useRecordingState
+
+**File:** `app/src/lib/hooks/useRecordingState.ts`
+
+**Parameters:**
+
+```typescript
+interface UseRecordingStateProps {
+  addEntry: (text: string, duration: number) => void;
+  microphone: string;
+}
+```
+
+**Returns:**
+
+```typescript
+{
+  status: DictationStatus;
+  transcription: string;
+  recordingDuration: number;
+  error: string;
+  setError: (error: string) => void;
+  handleStart: () => Promise<void>;
+  handleStop: () => Promise<void>;
+  toggleRecording: () => Promise<void>;
+  audioLevel: number;
+  lockedMode: boolean;
+  toggleLockedMode: () => Promise<void>;
+  statsVersion: number;
+}
+```
+
+**Responsibilities:**
+- Core recording state machine (`idle` -> `recording` -> `processing` -> `idle`) with guard refs to prevent concurrent start/stop calls.
+- Handles history and stats updates exclusively through the `transcription-complete` event listener to avoid race-condition duplicates.
+- Manages locked mode (overlay-initiated persistent recording), audio level tracking, recording duration timer (1-second ticks), and auto-paste error display (5-second auto-clear).
+
+**Key interactions:**
+- Listens to events: `recording-status-changed` (syncs status from overlay), `transcription-complete` (single source of truth for history/stats), `auto-paste-failed` (error display), `audio-level` (waveform data).
+- Invokes commands: `start_native_recording`, `stop_native_recording`.
+
+---
+
+## useResourceMonitor
+
+**File:** `app/src/lib/hooks/useResourceMonitor.ts`
+
+**Parameters:** `enabled: boolean`
+
+**Returns:** `ResourceReading[]`
+
+```typescript
+interface ResourceReading {
+  cpu_percent: number;
+  memory_mb: number;
+}
+```
+
+**Responsibilities:**
+- Polls `get_resource_usage` every 1 second when enabled. Stops polling when disabled.
+- Maintains a rolling window of up to 60 readings (1 minute of data).
+- Clears stale readings when re-enabled so the chart starts fresh.
+
+**Key interactions:**
+- Invokes command: `get_resource_usage`.
+- No events listened.
+
+---
+
+## useSettings
+
+**File:** `app/src/lib/hooks/useSettings.ts`
+
+**Parameters:** None.
+
+**Returns:**
+
+```typescript
+{
+  settings: Settings;
+  updateSettings: (updates: Partial<Settings>) => void;
+}
+```
+
+**Responsibilities:**
+- Wraps settings load/save with React state. Loads from localStorage on initialization, applies migrations.
+- Pushes relevant setting changes to the Rust backend via `configure_dictation` (model, language, autoPaste, autoPasteDelayMs, vadSensitivity). Uses versioned configure calls to prevent stale rollbacks.
+- Synchronizes `launchAtLogin` with the OS autostart state on mount (detects if user removed login item from System Settings). Serializes autostart enable/disable calls via a promise chain.
+
+**Key interactions:**
+- Invokes commands: `configure_dictation` (via `lib/dictation.ts`).
+- Uses `@tauri-apps/plugin-autostart` for `enable()`, `disable()`, `isEnabled()`.
+- See [settings.md](settings.md) for the full settings schema.
+
+---
+
+## useShowAboutListener
+
+**File:** `app/src/lib/hooks/useShowAboutListener.ts`
+
+**Parameters:** None.
+
+**Returns:**
+
+```typescript
+{
+  showAbout: boolean;
+  setShowAbout: (value: boolean) => void;
+}
+```
+
+**Responsibilities:**
+- Listens for the `show-about` Tauri event (emitted from the tray menu) and sets `showAbout` to `true`.
+- Consumed in `App.tsx` to control the AboutModal visibility.
+
+**Key interactions:**
+- Listens to event: `show-about`.
+- No commands invoked.
+
+---
+
+## useEventStore
+
+**File:** `app/src/lib/hooks/useEventStore.ts`
+
+**Parameters:** None.
+
+**Returns:**
+
+```typescript
+{
+  events: AppEvent[];
+  getByStream: (stream: StreamName) => AppEvent[];
+  getByLevel: (level: LevelName) => AppEvent[];
+  clear: () => void;
+}
+```
+
+**Responsibilities:**
+- Manages an in-memory buffer of up to 500 `AppEvent` objects. Hydrates from the backend on mount via `get_event_history`.
+- Streams new events in real-time via the `app-event` Tauri event. Coalesces rapid event bursts into a single React state update using `requestAnimationFrame`.
+- Provides filter methods (`getByStream`, `getByLevel`) that read directly from the mutable ref buffer (always up-to-date but not reactive on their own).
+
+**Key interactions:**
+- Listens to event: `app-event`.
+- Invokes commands: `get_event_history` (on mount), `clear_event_history` (on clear).
+
+---
+
+## Hook Activation in App.tsx
+
+All hooks are always called (Rules of Hooks), but their behavior is gated by props:
+
+| Hook | Active When |
+|------|-------------|
+| `useHoldDownToggle` | `recordingMode === 'hold_down'` |
+| `useDoubleTapToggle` | `recordingMode === 'double_tap'` |
+| `useCombinedToggle` | `recordingMode === 'both'` |
+| `useAutoUpdater` | Always |
+| `useInitialization` | Always (runs once on mount) |
+| `useRecordingState` | Always |
+| `useHistoryManagement` | Always |
+| `useSettings` | Always |
+| `useShowAboutListener` | Always |
+| `useResourceMonitor` | When the resource monitor panel is expanded |
+| `useEventStore` | Used in the log-viewer window |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -66,8 +66,8 @@ interface Settings {
 | Mode | Trigger Key Label | Behavior |
 |------|------------------|----------|
 | `hold_down` | "Hold Key" | Hold to start recording, release to stop and transcribe. |
-| `double_tap` | "Double-Tap Key" | Double-tap to start recording, single tap to stop. |
-| `both` | "Trigger Key" | Hold to record (with 200ms promotion delay), or double-tap to start and single tap to stop. |
+| `double_tap` | "Double-Tap Key" | Double-tap to start recording, single-tap to stop. |
+| `both` | "Trigger Key" | Hold to record (with 200ms promotion delay), or double-tap to start and single-tap to stop. |
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,139 @@
+# User Settings Reference
+
+This document describes all 9 user-configurable settings in Murmur. Settings are managed on the frontend by the `useSettings` hook and persisted to `localStorage`. Relevant settings are pushed to the Rust backend via the `configure_dictation` command.
+
+For the hook that manages settings, see [hooks.md](hooks.md). For the backend command that receives configuration, see [commands.md](commands.md).
+
+---
+
+## Settings Overview
+
+All settings are stored in `localStorage` under the key `dictation-settings` as a single JSON object.
+
+**Source file:** `app/src/lib/settings.ts`
+
+**TypeScript interface:**
+
+```typescript
+interface Settings {
+  model: ModelOption;
+  doubleTapKey: DoubleTapKey;
+  language: string;
+  autoPaste: boolean;
+  autoPasteDelayMs: number;
+  recordingMode: RecordingMode;
+  microphone: string;
+  launchAtLogin: boolean;
+  vadSensitivity: number;
+}
+```
+
+---
+
+## Transcription Settings
+
+| Setting | Type | Default | Valid Options/Range | Description |
+|---------|------|---------|-------------------|-------------|
+| `model` | `ModelOption` | `'moonshine-tiny'` | `'moonshine-tiny'`, `'moonshine-base'`, `'tiny.en'`, `'base.en'`, `'small.en'`, `'medium.en'`, `'large-v3-turbo'` | The transcription model to use. Determines which backend (Moonshine CPU or Whisper Metal GPU) is active. See the model options table below. |
+| `language` | `string` | `'en'` | Any language code string | Transcription language. Passed to the Whisper backend. Moonshine models are English-only and ignore this value. No validation on the frontend. |
+
+### Model Options
+
+| Value | Label | Size | Backend |
+|-------|-------|------|---------|
+| `moonshine-tiny` | Moonshine Tiny (Fastest) | ~124 MB | Moonshine (CPU, ONNX) |
+| `moonshine-base` | Moonshine Base | ~286 MB | Moonshine (CPU, ONNX) |
+| `tiny.en` | Whisper Tiny (English) | ~75 MB | Whisper (Metal GPU) |
+| `base.en` | Whisper Base (English) | ~150 MB | Whisper (Metal GPU) |
+| `small.en` | Whisper Small (English) | ~500 MB | Whisper (Metal GPU) |
+| `medium.en` | Whisper Medium (English) | ~1.5 GB | Whisper (Metal GPU) |
+| `large-v3-turbo` | Whisper Large Turbo | ~3 GB | Whisper (Metal GPU) |
+
+**Note:** The Rust-side `DictationState::default()` uses `base.en` as its default model, but this is overwritten by the frontend's `moonshine-tiny` default during initialization (before any recording can occur). A brand-new user always starts with `moonshine-tiny`.
+
+---
+
+## Recording Settings
+
+| Setting | Type | Default | Valid Options/Range | Description |
+|---------|------|---------|-------------------|-------------|
+| `recordingMode` | `RecordingMode` | `'hold_down'` | `'hold_down'`, `'double_tap'`, `'both'` | How recording is triggered via keyboard. Hold-down: press-and-hold to record. Double-tap: double-tap to start, single-tap to stop. Both: combined mode with deferred hold promotion. |
+| `doubleTapKey` | `DoubleTapKey` | `'shift_l'` | `'shift_l'` (Shift), `'alt_l'` (Option), `'ctrl_r'` (Control) | The modifier key used for recording triggers. Used by all three recording modes as the trigger key. Label in the settings UI changes based on `recordingMode`. |
+| `vadSensitivity` | `number` | `50` | 0-100, step 5 in UI | Voice Activity Detection sensitivity. Higher values keep more audio; lower values trim silence more aggressively. The backend converts this to a threshold: `1.0 - (sensitivity / 100.0)`. Clamped to 0-100 by the backend. |
+
+### Recording Mode Details
+
+| Mode | Trigger Key Label | Behavior |
+|------|------------------|----------|
+| `hold_down` | "Hold Key" | Hold to start recording, release to stop and transcribe. |
+| `double_tap` | "Double-Tap Key" | Double-tap to start recording, single tap to stop. |
+| `both` | "Trigger Key" | Hold to record (with 200ms promotion delay), or double-tap to start and single tap to stop. |
+
+---
+
+## Output Settings
+
+| Setting | Type | Default | Valid Options/Range | Description |
+|---------|------|---------|-------------------|-------------|
+| `autoPaste` | `boolean` | `false` | `true` / `false` | Whether to automatically paste transcribed text after copying it to the clipboard. Requires macOS Accessibility permission. Text is always copied to the clipboard regardless of this setting. |
+| `autoPasteDelayMs` | `number` | `50` | 10-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. The backend clamps this value to the 10-500 range. The UI slider only appears when `autoPaste` is enabled. |
+
+---
+
+## System Settings
+
+| Setting | Type | Default | Valid Options/Range | Description |
+|---------|------|---------|-------------------|-------------|
+| `microphone` | `string` | `'system_default'` | `'system_default'` or any device name from `list_audio_devices` | Audio input device for recording. When set to `'system_default'`, the frontend sends `null` to the backend, which uses the system default input device. Available devices are fetched via the `list_audio_devices` command when the settings panel opens. |
+| `launchAtLogin` | `boolean` | `false` | `true` / `false` | Whether the app starts automatically on macOS login. Uses `@tauri-apps/plugin-autostart` with `MacosLauncher::LaunchAgent`. On mount, the hook checks the actual OS autostart state and reconciles with the stored setting (handles the case where the user removed the login item from System Settings). |
+
+---
+
+## Persistence and Migration
+
+### Storage
+
+- **Key:** `dictation-settings`
+- **Method:** `localStorage.setItem` / `localStorage.getItem`
+- **Format:** Full `Settings` object serialized as JSON
+
+### Loading Behavior
+
+`loadSettings()` performs the following:
+1. Reads from `localStorage` under `dictation-settings`.
+2. If found, parses as JSON and merges with `DEFAULT_SETTINGS` (stored values override defaults).
+3. Applies migration: if `recordingMode` is missing or invalid (including the legacy `'hotkey'` value), resets to `'hold_down'`.
+4. Strips the legacy `hotkey` field if present.
+5. If not found or on parse error, returns `DEFAULT_SETTINGS`.
+
+### Backend Synchronization
+
+When settings change, `useSettings.updateSettings` pushes the following fields to the Rust backend via `configure_dictation`:
+
+| Frontend Field | Backend Field | Sent On Change |
+|----------------|--------------|----------------|
+| `model` | `model` | Yes |
+| `language` | `language` | Yes |
+| `autoPaste` | `autoPaste` | Yes |
+| `autoPasteDelayMs` | `autoPasteDelayMs` | Yes |
+| `vadSensitivity` | `vadSensitivity` | Yes |
+| `doubleTapKey` | _(sent via `update_keyboard_key`)_ | Via keyboard hooks |
+| `recordingMode` | _(controls which hook is active)_ | Frontend only |
+| `microphone` | _(sent as param to `start_native_recording`)_ | Per recording |
+| `launchAtLogin` | _(sent via autostart plugin)_ | Via OS API |
+
+**Optimistic updates with rollback:** If `configure_dictation` fails, the affected settings (model, language, autoPaste, autoPasteDelayMs, vadSensitivity) revert to their previous values. Similarly, if the autostart toggle fails, `launchAtLogin` reverts. A versioned configure ref prevents stale rollbacks from overwriting newer settings.
+
+---
+
+## Related localStorage Keys
+
+Other data persisted to localStorage by the application (not part of the `Settings` object):
+
+| Key | Purpose | Used By |
+|-----|---------|---------|
+| `dictation-history` | Transcription history entries (max 50) | `useHistoryManagement` |
+| `dictation-stats` | Cumulative transcription statistics | `lib/stats.ts` |
+| `skipped-update-version` | Version string the user chose to skip | `useAutoUpdater` |
+| `updater-last-check` | Timestamp of last update check | `useAutoUpdater` |
+| `resource-monitor-collapsed` | Whether the resource monitor panel is collapsed | ResourceMonitor component |


### PR DESCRIPTION
## Summary

- Full documentation rewrite derived from an exhaustive crawl of every source file in the codebase (5 parallel agents covering frontend UI, frontend logic, Rust commands, Rust core, and config)
- Cross-referenced all findings against existing ARCHITECTURE.md, FEATURES.md, and CHANGELOG to identify stale, missing, and undocumented features
- 13 files changed, ~2000 lines of documentation added/updated

## What changed

### Updated existing docs
- **ARCHITECTURE.md** — Rewritten for v0.8.0: VAD pipeline, structured event system (telemetry.rs replaces logging.rs), three-window architecture, WhisperState caching, 30 commands table, 12 events table, thread model, build/release details
- **FEATURES.md** — Rewritten for v0.8.0: 3 recording modes (was 2), 7 models across 2 backends (was 5), VAD, structured log viewer window (was modal), metrics tab, auto-updater, overlay locked mode, static tray icon
- **CLAUDE.md** — File map updated: logging.rs → telemetry.rs, added vad.rs/resource_monitor.rs, 15 new frontend entries, new docs references
- **CHANGELOG.md** — Backfilled v0.3.0 through v0.8.0 from git history (was empty after v0.2.0)

### New feature docs (`docs/features/`)
- **vad.md** — Silero VAD v5.1.2 speech filtering, sensitivity config, co-download, pipeline integration
- **log-viewer.md** — Structured event system architecture, Events tab, Metrics tab with timing charts
- **overlay.md** — Dynamic Island notch overlay, 7-bar waveform, locked mode, click disambiguation
- **auto-updater.md** — OTA updates, forced updates via min_version, native notifications
- **models.md** — 7 models, download pipeline, WhisperState caching, backend switching

### New reference docs (`docs/reference/`)
- **commands.md** — All 30 Tauri commands with parameters, return types, descriptions
- **events.md** — All 12 Rust→Frontend events with payloads and sources
- **hooks.md** — All 11 React hooks with props, returns, responsibilities
- **settings.md** — All 9 user settings with types, defaults, valid ranges

## Notable findings during crawl
- `hold-down-cancel` event listener in `useCombinedToggle.ts` is dead code (event never emitted from Rust)
- `logging.rs` no longer exists — fully replaced by `telemetry.rs`
- `update_tray_icon` command is a no-op (tray icon is static white now)
- `init_dictation` command does nothing (legacy)
- `process_audio` (base64 path) doesn't emit `transcription-complete` (inconsistency with native path)
- Rust default model (`base.en`) is effectively dead code — frontend always overrides with `moonshine-tiny`

## Test plan
- [ ] Review each doc file for accuracy against the codebase
- [ ] Verify cross-references between docs are valid
- [ ] Confirm CHANGELOG versions match git tag history
- [ ] Check that CLAUDE.md file map matches actual filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice Activity Detection (VAD) for improved transcription filtering
  * Auto-updater system with signed releases
  * Dedicated log viewer for debugging and analytics
  * Dynamic overlay widget for macOS notch
  * Enhanced model management with lazy loading and caching
  * Three flexible recording modes (Hold Down, Double-Tap, Both)
  * Improved clipboard and auto-paste functionality with configurable delays
  * Resource monitor for performance insights

* **Bug Fixes**
  * Reduced event noise in the transcription pipeline

* **Documentation**
  * Comprehensive architecture and feature documentation added
  * New command, event, hook, and settings references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->