### PR TITLE
feat: escape key to cancel and discard recording/transcription

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.7.8"
+version = "0.8.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -218,11 +218,15 @@ pub async fn process_audio(
     let t_parse = std::time::Instant::now();
     let wav_bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &audio_data)
         .map_err(|e| {
-            let _ = app_handle.emit("recording-status-changed", "idle");
+            if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+                let _ = app_handle.emit("recording-status-changed", "idle");
+            }
             format!("Failed to decode base64: {}", e)
         })?;
     let samples = transcriber::parse_wav_to_samples(&wav_bytes).map_err(|e| {
-        let _ = app_handle.emit("recording-status-changed", "idle");
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
         e
     })?;
     tracing::info!(target: "pipeline", "audio parse (base64 + WAV): {:?}", t_parse.elapsed());
@@ -431,7 +435,9 @@ pub async fn stop_native_recording(
     let t_total = std::time::Instant::now();
     let samples = audio::stop_recording().map_err(|e| {
         tracing::error!(target: "audio", "stop_native_recording: stop_recording failed: {}", e);
-        let _ = app_handle.emit("recording-status-changed", "idle");
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
         e
     })?;
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
@@ -439,7 +445,9 @@ pub async fn stop_native_recording(
     if samples.is_empty() {
         tracing::info!(target: "pipeline", "stop_native_recording: no audio captured");
         // guard drops on return, resetting status to Idle
-        let _ = app_handle.emit("recording-status-changed", "idle");
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
         return Ok(serde_json::json!({
             "type": "transcription",
             "text": "",
@@ -454,7 +462,9 @@ pub async fn stop_native_recording(
     if samples.len() < MIN_RECORDING_SAMPLES {
         tracing::info!(target: "pipeline", "stop_native_recording: recording too short ({}ms), discarding",
             samples.len() / 16); // samples / 16_000 * 1000
-        let _ = app_handle.emit("recording-status-changed", "idle");
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
         return Ok(serde_json::json!({
             "type": "transcription",
             "text": "",

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -544,27 +544,30 @@ pub async fn cancel_native_recording(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<(), String> {
-    let prev_status = {
+    let (prev_status, rid) = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         let prev = dictation.status;
+        let rid = state.app_state.recording_id.load(Ordering::SeqCst);
         match prev {
             DictationStatus::Idle => return Ok(()),
             DictationStatus::Recording | DictationStatus::Processing => {
                 dictation.status = DictationStatus::Idle;
             }
         }
-        prev
+        (prev, rid)
     };
 
     match prev_status {
         DictationStatus::Recording => {
             // Stop audio capture and discard samples
-            let _ = audio::stop_recording();
+            if let Err(e) = audio::stop_recording() {
+                tracing::error!(target: "audio", "cancel_native_recording: stop_recording failed: {}", e);
+                return Err(e);
+            }
             tracing::info!(target: "pipeline", "cancel_native_recording: recording discarded");
         }
         DictationStatus::Processing => {
             // Mark current recording as cancelled — pipeline will check at next checkpoint
-            let rid = state.app_state.recording_id.load(std::sync::atomic::Ordering::SeqCst);
             state.app_state.cancel_recording(rid);
             tracing::info!(target: "pipeline", "cancel_native_recording: processing cancelled (recording_id={})", rid);
         }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -2,18 +2,24 @@ use crate::{MutexExt, State};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
 use crate::{audio, injector, keyboard, vad};
+use std::sync::atomic::Ordering;
 use tauri::Emitter;
 
 /// RAII guard that resets dictation status to Idle on drop,
 /// ensuring status is restored on any early return or error path.
+///
+/// Tracks `recording_id` so it only resets state if this recording is still
+/// the active one — prevents a stale pipeline from clobbering a new recording
+/// that started after an Escape cancel.
 struct IdleGuard<'a> {
     app_state: &'a AppState,
+    recording_id: u64,
     disarmed: bool,
 }
 
 impl<'a> IdleGuard<'a> {
-    fn new(app_state: &'a AppState) -> Self {
-        Self { app_state, disarmed: false }
+    fn new(app_state: &'a AppState, recording_id: u64) -> Self {
+        Self { app_state, recording_id, disarmed: false }
     }
 
     fn disarm(&mut self) {
@@ -24,6 +30,13 @@ impl<'a> IdleGuard<'a> {
 impl Drop for IdleGuard<'_> {
     fn drop(&mut self) {
         if !self.disarmed {
+            // Only reset if this recording is still the active one.
+            // If cancel + new recording happened, current_rid will differ
+            // and we must not clobber the new recording's state.
+            let current_rid = self.app_state.recording_id.load(Ordering::SeqCst);
+            if current_rid != self.recording_id {
+                return;
+            }
             let mut dictation = self.app_state.dictation.lock_or_recover();
             dictation.status = DictationStatus::Idle;
             keyboard::set_processing(false);
@@ -37,14 +50,18 @@ pub(crate) struct PipelineTimings {
     pub paste_ms: u64,
 }
 
-/// Shared transcription pipeline: model init -> transcribe -> inject text -> set idle
+/// Shared transcription pipeline: model init -> transcribe -> inject text -> set idle.
+/// `recording_id` is checked against `app_state.cancelled_id` at checkpoints;
+/// if cancelled, returns empty text without clipboard write or paste.
 async fn run_transcription_pipeline(
     samples: &[f32],
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
+    recording_id: u64,
 ) -> Result<(String, PipelineTimings), String> {
-    // Guard resets status to Idle on any return path (error or success)
-    let _guard = IdleGuard::new(app_state);
+    // Guard resets status to Idle on any return path (error or success),
+    // but only if this recording is still the active one
+    let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
     let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity) = {
@@ -57,6 +74,12 @@ async fn run_transcription_pipeline(
     let peak = audio::compute_peak(samples);
     let device = audio::last_device_name().unwrap_or_else(|| "unknown".to_string());
     tracing::info!(target: "pipeline", "audio rms={:.4} peak={:.4} (device={})", rms, peak, device);
+
+    // Checkpoint 1: cancelled before VAD?
+    if app_state.is_cancelled(recording_id) {
+        tracing::info!(target: "pipeline", "cancelled before VAD (recording_id={})", recording_id);
+        return Ok((String::new(), PipelineTimings { vad_ms: 0, inference_ms: 0, paste_ms: 0 }));
+    }
 
     // Phase: VAD -- filter out silence to prevent Whisper hallucination loops
     let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
@@ -105,6 +128,12 @@ async fn run_transcription_pipeline(
     };
     let vad_ms = t_vad.elapsed().as_millis() as u64;
 
+    // Checkpoint 2: cancelled before transcription?
+    if app_state.is_cancelled(recording_id) {
+        tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
+        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms: 0, paste_ms: 0 }));
+    }
+
     // Phase: Transcription (includes lazy model load on first run)
     let t_transcribe = std::time::Instant::now();
     let text = {
@@ -114,6 +143,12 @@ async fn run_transcription_pipeline(
     };
     let inference_ms = t_transcribe.elapsed().as_millis() as u64;
     tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
+
+    // Checkpoint 3: cancelled before text injection?
+    if app_state.is_cancelled(recording_id) {
+        tracing::info!(target: "pipeline", "cancelled before injection (recording_id={})", recording_id);
+        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms, paste_ms: 0 }));
+    }
 
     // Phase: Text injection (clipboard write + optional osascript paste)
     let t_inject = std::time::Instant::now();
@@ -176,7 +211,8 @@ pub async fn process_audio(
     let _ = app_handle.emit("recording-status-changed", "processing");
 
     // Guard resets status to Idle if decode/parse fails before reaching the pipeline
-    let mut guard = IdleGuard::new(&state.app_state);
+    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
+    let mut guard = IdleGuard::new(&state.app_state, rid);
 
     // Phase: Audio parse (base64 decode + WAV to samples)
     let t_parse = std::time::Instant::now();
@@ -195,9 +231,13 @@ pub async fn process_audio(
     guard.disarm();
 
     let t_total = std::time::Instant::now();
-    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state).await;
-    keyboard::set_processing(false);
-    let _ = app_handle.emit("recording-status-changed", "idle");
+    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
+    // Only emit idle if this recording wasn't cancelled/superseded
+    let current_rid = state.app_state.recording_id.load(Ordering::SeqCst);
+    if current_rid == rid {
+        keyboard::set_processing(false);
+        let _ = app_handle.emit("recording-status-changed", "idle");
+    }
     let (text, timings) = pipeline_result?;
 
     let total_ms = t_total.elapsed().as_millis() as u64;
@@ -335,7 +375,9 @@ pub async fn start_native_recording(
         }
     }
 
-    tracing::info!(target: "pipeline", "start_native_recording: device={}", device_name.as_deref().unwrap_or("system_default"));
+    // Assign a unique ID to this recording session
+    let rid = state.app_state.next_recording_id();
+    tracing::info!(target: "pipeline", "start_native_recording: device={} recording_id={}", device_name.as_deref().unwrap_or("system_default"), rid);
     if let Err(e) = audio::start_recording(Some(app_handle.clone()), device_name) {
         tracing::error!(target: "audio", "start_native_recording: audio failed: {}", e);
         let mut dictation = state.app_state.dictation.lock_or_recover();
@@ -382,7 +424,8 @@ pub async fn stop_native_recording(
 
     // Guard resets status to Idle if stop_recording fails or samples are empty;
     // disarmed before handing off to run_transcription_pipeline (which has its own guard)
-    let mut guard = IdleGuard::new(&state.app_state);
+    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
+    let mut guard = IdleGuard::new(&state.app_state, rid);
 
     // Phase: Audio teardown + 16kHz resample
     let t_total = std::time::Instant::now();
@@ -422,9 +465,14 @@ pub async fn stop_native_recording(
     // Hand off status management to the pipeline's own guard
     guard.disarm();
 
-    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state).await;
-    keyboard::set_processing(false);
-    let _ = app_handle.emit("recording-status-changed", "idle");
+    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
+    // Only emit idle if this recording wasn't cancelled/superseded by a new one.
+    // Cancel already handled status reset and set_processing(false).
+    let current_rid = state.app_state.recording_id.load(Ordering::SeqCst);
+    if current_rid == rid {
+        keyboard::set_processing(false);
+        let _ = app_handle.emit("recording-status-changed", "idle");
+    }
     let (text, timings) = pipeline_result.map_err(|e| {
         tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", e);
         e
@@ -474,24 +522,48 @@ pub async fn stop_native_recording(
     }))
 }
 
-/// Cancel an in-progress recording without transcribing (used by Both mode
-/// to silently discard the speculative recording from a short tap).
+/// Cancel an in-progress recording or transcription.
+///
+/// - **Recording**: stops audio capture, discards samples, resets to Idle.
+/// - **Processing**: marks the current recording_id as cancelled so the
+///   pipeline discards its result at the next checkpoint; immediately
+///   emits idle status so the UI resets without waiting for whisper.
+/// - **Idle**: no-op.
 #[tauri::command]
 pub async fn cancel_native_recording(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<(), String> {
-    {
+    let prev_status = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
-        if dictation.status != DictationStatus::Recording {
-            return Ok(());
+        let prev = dictation.status;
+        match prev {
+            DictationStatus::Idle => return Ok(()),
+            DictationStatus::Recording | DictationStatus::Processing => {
+                dictation.status = DictationStatus::Idle;
+            }
         }
-        dictation.status = DictationStatus::Idle;
+        prev
+    };
+
+    match prev_status {
+        DictationStatus::Recording => {
+            // Stop audio capture and discard samples
+            let _ = audio::stop_recording();
+            tracing::info!(target: "pipeline", "cancel_native_recording: recording discarded");
+        }
+        DictationStatus::Processing => {
+            // Mark current recording as cancelled — pipeline will check at next checkpoint
+            let rid = state.app_state.recording_id.load(std::sync::atomic::Ordering::SeqCst);
+            state.app_state.cancel_recording(rid);
+            tracing::info!(target: "pipeline", "cancel_native_recording: processing cancelled (recording_id={})", rid);
+        }
+        DictationStatus::Idle => unreachable!(),
     }
-    // Stop audio capture and discard samples
-    let _ = audio::stop_recording();
+
+    keyboard::set_processing(false);
     let _ = app_handle.emit("recording-status-changed", "idle");
-    tracing::info!(target: "pipeline", "cancel_native_recording: speculative recording discarded");
+    let _ = app_handle.emit("recording-cancelled", ());
     Ok(())
 }
 
@@ -502,12 +574,13 @@ mod tests {
     #[test]
     fn idle_guard_resets_status_on_drop() {
         let app_state = AppState::default();
+        let rid = app_state.next_recording_id();
         {
             let mut dictation = app_state.dictation.lock().unwrap();
             dictation.status = DictationStatus::Processing;
         }
         {
-            let _guard = IdleGuard::new(&app_state);
+            let _guard = IdleGuard::new(&app_state, rid);
             // guard drops here
         }
         let dictation = app_state.dictation.lock().unwrap();
@@ -517,12 +590,13 @@ mod tests {
     #[test]
     fn idle_guard_disarm_prevents_reset() {
         let app_state = AppState::default();
+        let rid = app_state.next_recording_id();
         {
             let mut dictation = app_state.dictation.lock().unwrap();
             dictation.status = DictationStatus::Processing;
         }
         {
-            let mut guard = IdleGuard::new(&app_state);
+            let mut guard = IdleGuard::new(&app_state, rid);
             guard.disarm();
             // guard drops here, but disarmed -- no reset
         }
@@ -534,9 +608,58 @@ mod tests {
     fn idle_guard_calls_set_processing_false() {
         keyboard::set_processing(true);
         let app_state = AppState::default();
+        let rid = app_state.next_recording_id();
         {
-            let _guard = IdleGuard::new(&app_state);
+            let _guard = IdleGuard::new(&app_state, rid);
         }
         assert!(!keyboard::is_processing());
+    }
+
+    #[test]
+    fn idle_guard_skips_reset_when_recording_superseded() {
+        let app_state = AppState::default();
+        let rid1 = app_state.next_recording_id(); // 1
+        {
+            let mut dictation = app_state.dictation.lock().unwrap();
+            dictation.status = DictationStatus::Recording;
+        }
+        // Simulate new recording starting (increments rid)
+        let _rid2 = app_state.next_recording_id(); // 2
+        {
+            let _guard = IdleGuard::new(&app_state, rid1);
+            // guard drops here, but rid1 != current_rid(2), so no reset
+        }
+        let dictation = app_state.dictation.lock().unwrap();
+        assert_eq!(dictation.status, DictationStatus::Recording);
+    }
+
+    #[test]
+    fn generation_counter_cancel_current_recording() {
+        let app_state = AppState::default();
+        let id = app_state.next_recording_id(); // 1
+        assert!(!app_state.is_cancelled(id));
+        app_state.cancel_recording(id);
+        assert!(app_state.is_cancelled(id));
+    }
+
+    #[test]
+    fn generation_counter_new_recording_not_cancelled() {
+        let app_state = AppState::default();
+        let id1 = app_state.next_recording_id(); // 1
+        app_state.cancel_recording(id1);
+        let id2 = app_state.next_recording_id(); // 2
+        assert!(app_state.is_cancelled(id1));
+        assert!(!app_state.is_cancelled(id2));
+    }
+
+    #[test]
+    fn generation_counter_monotonic_ids() {
+        let app_state = AppState::default();
+        let id1 = app_state.next_recording_id();
+        let id2 = app_state.next_recording_id();
+        let id3 = app_state.next_recording_id();
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
     }
 }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -236,11 +236,15 @@ pub async fn process_audio(
 
     let t_total = std::time::Instant::now();
     let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
-    // Only emit idle if this recording wasn't cancelled/superseded
-    let current_rid = state.app_state.recording_id.load(Ordering::SeqCst);
-    if current_rid == rid {
-        keyboard::set_processing(false);
-        let _ = app_handle.emit("recording-status-changed", "idle");
+    // Only emit idle if this recording wasn't cancelled/superseded.
+    // Hold the dictation lock across the check+emit to prevent a concurrent
+    // start from interleaving a "recording" status between our check and emit.
+    {
+        let _dictation = state.app_state.dictation.lock_or_recover();
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            keyboard::set_processing(false);
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
     }
     let (text, timings) = pipeline_result?;
 
@@ -402,8 +406,8 @@ pub async fn stop_native_recording(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
-    // Atomic check-and-set in a single lock to avoid TOCTOU gap
-    {
+    // Atomic check-and-set + rid capture in a single lock to avoid TOCTOU gap
+    let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         match dictation.status {
             DictationStatus::Processing => return Ok(serde_json::json!({
@@ -419,18 +423,13 @@ pub async fn stop_native_recording(
             }
             DictationStatus::Recording => {
                 dictation.status = DictationStatus::Processing;
+                state.app_state.recording_id.load(Ordering::SeqCst)
             }
         }
-    }
+    };
     keyboard::set_processing(true);
     tracing::info!(target: "pipeline", "stop_native_recording: stopping");
     let _ = app_handle.emit("recording-status-changed", "processing");
-
-    // Capture rid under the same conceptual critical section as the status
-    // transition above (Recording → Processing happened in the lock block).
-    // We read it here immediately after — no concurrent start can interleave
-    // because start requires Idle status, which we're not in.
-    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
 
     // Guard resets status to Idle if stop_recording fails or samples are empty;
     // disarmed before handing off to run_transcription_pipeline (which has its own guard)
@@ -482,11 +481,14 @@ pub async fn stop_native_recording(
 
     let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
     // Only emit idle if this recording wasn't cancelled/superseded by a new one.
-    // Cancel already handled status reset and set_processing(false).
-    let current_rid = state.app_state.recording_id.load(Ordering::SeqCst);
-    if current_rid == rid {
-        keyboard::set_processing(false);
-        let _ = app_handle.emit("recording-status-changed", "idle");
+    // Hold the dictation lock across the check+emit to prevent a concurrent
+    // start from interleaving a "recording" status between our check and emit.
+    {
+        let _dictation = state.app_state.dictation.lock_or_recover();
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            keyboard::set_processing(false);
+            let _ = app_handle.emit("recording-status-changed", "idle");
+        }
     }
     let (text, timings) = pipeline_result.map_err(|e| {
         tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", e);

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -30,14 +30,14 @@ impl<'a> IdleGuard<'a> {
 impl Drop for IdleGuard<'_> {
     fn drop(&mut self) {
         if !self.disarmed {
-            // Only reset if this recording is still the active one.
-            // If cancel + new recording happened, current_rid will differ
-            // and we must not clobber the new recording's state.
+            // Lock first, then check recording_id — prevents TOCTOU where
+            // a concurrent start advances the ID between our check and the
+            // status write.
+            let mut dictation = self.app_state.dictation.lock_or_recover();
             let current_rid = self.app_state.recording_id.load(Ordering::SeqCst);
             if current_rid != self.recording_id {
                 return;
             }
-            let mut dictation = self.app_state.dictation.lock_or_recover();
             dictation.status = DictationStatus::Idle;
             keyboard::set_processing(false);
         }
@@ -203,15 +203,15 @@ pub async fn process_audio(
     audio_data: String,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
-    {
+    let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         dictation.status = DictationStatus::Processing;
-    }
+        state.app_state.recording_id.load(Ordering::SeqCst)
+    };
     keyboard::set_processing(true);
     let _ = app_handle.emit("recording-status-changed", "processing");
 
     // Guard resets status to Idle if decode/parse fails before reaching the pipeline
-    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
     let mut guard = IdleGuard::new(&state.app_state, rid);
 
     // Phase: Audio parse (base64 decode + WAV to samples)
@@ -355,8 +355,9 @@ pub async fn start_native_recording(
     state: tauri::State<'_, State>,
     device_name: Option<String>,
 ) -> Result<serde_json::Value, String> {
-    // Check and update status in one lock
-    {
+    // Check and update status in one lock; assign recording ID in the same
+    // critical section so no concurrent cancel/start can slip between them.
+    let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         match dictation.status {
             DictationStatus::Recording => {
@@ -374,13 +375,12 @@ pub async fn start_native_recording(
                 }));
             }
             DictationStatus::Idle => {
+                let rid = state.app_state.next_recording_id();
                 dictation.status = DictationStatus::Recording;
+                rid
             }
         }
-    }
-
-    // Assign a unique ID to this recording session
-    let rid = state.app_state.next_recording_id();
+    };
     tracing::info!(target: "pipeline", "start_native_recording: device={} recording_id={}", device_name.as_deref().unwrap_or("system_default"), rid);
     if let Err(e) = audio::start_recording(Some(app_handle.clone()), device_name) {
         tracing::error!(target: "audio", "start_native_recording: audio failed: {}", e);
@@ -426,9 +426,14 @@ pub async fn stop_native_recording(
     tracing::info!(target: "pipeline", "stop_native_recording: stopping");
     let _ = app_handle.emit("recording-status-changed", "processing");
 
+    // Capture rid under the same conceptual critical section as the status
+    // transition above (Recording → Processing happened in the lock block).
+    // We read it here immediately after — no concurrent start can interleave
+    // because start requires Idle status, which we're not in.
+    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
+
     // Guard resets status to Idle if stop_recording fails or samples are empty;
     // disarmed before handing off to run_transcription_pipeline (which has its own guard)
-    let rid = state.app_state.recording_id.load(Ordering::SeqCst);
     let mut guard = IdleGuard::new(&state.app_state, rid);
 
     // Phase: Audio teardown + 16kHz resample
@@ -557,27 +562,35 @@ pub async fn cancel_native_recording(
         (prev, rid)
     };
 
-    match prev_status {
+    let stop_err = match prev_status {
         DictationStatus::Recording => {
             // Stop audio capture and discard samples
             if let Err(e) = audio::stop_recording() {
                 tracing::error!(target: "audio", "cancel_native_recording: stop_recording failed: {}", e);
-                return Err(e);
+                Some(e)
+            } else {
+                tracing::info!(target: "pipeline", "cancel_native_recording: recording discarded");
+                None
             }
-            tracing::info!(target: "pipeline", "cancel_native_recording: recording discarded");
         }
         DictationStatus::Processing => {
             // Mark current recording as cancelled — pipeline will check at next checkpoint
             state.app_state.cancel_recording(rid);
             tracing::info!(target: "pipeline", "cancel_native_recording: processing cancelled (recording_id={})", rid);
+            None
         }
         DictationStatus::Idle => unreachable!(),
-    }
+    };
 
+    // Always emit feedback so the UI resets, even if stop_recording failed
     keyboard::set_processing(false);
     let _ = app_handle.emit("recording-status-changed", "idle");
     let _ = app_handle.emit("recording-cancelled", ());
-    Ok(())
+
+    match stop_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -481,6 +481,36 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
                     return;
                 }
 
+                // Escape key: cancel recording/transcription regardless of mode.
+                // Must be checked before mode-specific logic so it works even
+                // during IS_PROCESSING (which gates the Both-mode block).
+                if let EventType::KeyPress(Key::Escape) = event.event_type {
+                    // Reset both detectors with cooldown timestamps so that the
+                    // subsequent trigger-key release (if user was holding it) is
+                    // treated as a no-op instead of firing hold-down-stop.
+                    {
+                        let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                        if let Some(d) = det.as_mut() {
+                            d.reset();
+                            d.last_stopped_at = Some(Instant::now());
+                        }
+                    }
+                    {
+                        let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                        if let Some(d) = det.as_mut() {
+                            d.reset();
+                            d.last_fired_at = Some(Instant::now());
+                        }
+                    }
+                    // Invalidate pending hold-promotion timers
+                    HOLD_PROMOTED.store(false, Ordering::SeqCst);
+                    HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+                    tracing::info!(target: "keyboard", "Escape pressed — emitting escape-cancel");
+                    let _ = handle.emit("escape-cancel", ());
+                    return;
+                }
+
                 let mode = {
                     let m = ACTIVE_MODE.lock().unwrap_or_else(|p| p.into_inner());
                     *m

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use serde::{Deserialize, Serialize};
 use crate::transcriber::{TranscriptionBackend, WhisperBackend};
 
@@ -44,6 +45,28 @@ impl Default for DictationState {
 pub struct AppState {
     pub dictation: Mutex<DictationState>,
     pub backend: Mutex<Box<dyn TranscriptionBackend>>,
+    /// Monotonically increasing ID assigned to each recording session.
+    pub recording_id: AtomicU64,
+    /// Set to the recording_id of a cancelled recording. Pipeline checks
+    /// `cancelled_id >= my_id` at checkpoints to discard cancelled work.
+    pub cancelled_id: AtomicU64,
+}
+
+impl AppState {
+    /// Increment and return the next recording ID.
+    pub fn next_recording_id(&self) -> u64 {
+        self.recording_id.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Mark a recording as cancelled by storing its ID.
+    pub fn cancel_recording(&self, id: u64) {
+        self.cancelled_id.fetch_max(id, Ordering::SeqCst);
+    }
+
+    /// Check whether a given recording ID has been cancelled.
+    pub fn is_cancelled(&self, id: u64) -> bool {
+        self.cancelled_id.load(Ordering::SeqCst) >= id
+    }
 }
 
 impl Default for AppState {
@@ -51,6 +74,8 @@ impl Default for AppState {
         Self {
             dictation: Mutex::new(DictationState::default()),
             backend: Mutex::new(Box::new(WhisperBackend::new())),
+            recording_id: AtomicU64::new(0),
+            cancelled_id: AtomicU64::new(0),
         }
     }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { useHoldDownToggle } from './lib/hooks/useHoldDownToggle';
 import { useDoubleTapToggle } from './lib/hooks/useDoubleTapToggle';
 import { useCombinedToggle } from './lib/hooks/useCombinedToggle';
 import { useShowAboutListener } from './lib/hooks/useShowAboutListener';
+import { useEscapeCancel } from './lib/hooks/useEscapeCancel';
 import { useAutoUpdater } from './lib/hooks/useAutoUpdater';
 import { UpdateModal } from './components/UpdateModal';
 import type { UpdateStatus } from './lib/updater';
@@ -77,6 +78,7 @@ function App() {
   useHoldDownToggle({ enabled: settings.recordingMode === 'hold_down', initialized, accessibilityGranted, holdDownKey: settings.doubleTapKey, onStart: handleStart, onStop: handleStop });
   useDoubleTapToggle({ enabled: settings.recordingMode === 'double_tap', initialized, accessibilityGranted, doubleTapKey: settings.doubleTapKey, status, onToggle: toggleRecording });
   useCombinedToggle({ enabled: settings.recordingMode === 'both', initialized, accessibilityGranted, triggerKey: settings.doubleTapKey, status, onStart: handleStart, onStop: handleStop, onToggle: toggleRecording });
+  useEscapeCancel({ status, enabled: initialized && accessibilityGranted === true });
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -87,15 +87,22 @@ export function OverlayWidget() {
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     listen('recording-cancelled', () => {
+      if (timeoutId) clearTimeout(timeoutId);
       setShowCancelled(true);
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         if (!cancelled) setShowCancelled(false);
+        timeoutId = null;
       }, 800);
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
     });
-    return () => { cancelled = true; unlisten?.(); };
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      unlisten?.();
+    };
   }, []);
 
   // Subscribe to notch info changes (display config change: monitor plug/unplug, lid)

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -10,6 +10,7 @@ const BAR_COUNT = 7;
 
 export function OverlayWidget() {
   const [status, setStatus] = useState<DictationStatus>('idle');
+  const [showCancelled, setShowCancelled] = useState(false);
   const [lockedMode, setLockedMode] = useState(false);
   const notchHeightRef = useRef(0);
   const [notchWidth, setNotchWidth] = useState(185);
@@ -76,6 +77,21 @@ export function OverlayWidget() {
           setLockedMode(false);
         }
       }
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
+  // Subscribe to recording-cancelled for brief red X flash
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen('recording-cancelled', () => {
+      setShowCancelled(true);
+      setTimeout(() => {
+        if (!cancelled) setShowCancelled(false);
+      }, 800);
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
     });
@@ -220,7 +236,7 @@ export function OverlayWidget() {
     }, 250);
   }, []);
 
-  const isActive = status === 'recording' || status === 'processing';
+  const isActive = status === 'recording' || status === 'processing' || showCancelled;
 
   // Raw mousedown — fires before click/double-click debouncing
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -257,9 +273,14 @@ export function OverlayWidget() {
         }}
       >
         <div className="flex items-center h-full" style={{ paddingLeft: 10, paddingRight: 10 }}>
-          {/* Left side — mic icon (idle) or red dot (recording) or spinner (processing), all same position */}
+          {/* Left side — mic icon (idle) or red dot (recording) or spinner (processing) or red X (cancelled), all same position */}
           <div className="shrink-0 w-3 h-3 flex items-center justify-center">
-            {status === 'recording' ? (
+            {showCancelled ? (
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="6" y1="6" x2="18" y2="18" />
+                <line x1="18" y1="6" x2="6" y2="18" />
+              </svg>
+            ) : status === 'recording' ? (
               <div className="w-2.5 h-2.5 rounded-full bg-red-500" style={{ animation: 'pulse 0.8s ease-in-out infinite' }} />
             ) : status === 'processing' ? (
               <span className="w-3 h-3 border-[1.5px] border-white/20 border-t-white/70 rounded-full animate-spin block" />

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -48,6 +48,10 @@ export async function stopRecording(): Promise<DictationResponse> {
   }
 }
 
+export async function cancelRecording(): Promise<void> {
+  await invoke('cancel_native_recording');
+}
+
 export async function getStatus(): Promise<DictationResponse> {
   return await invoke('get_status');
 }

--- a/app/src/lib/hooks/useEscapeCancel.ts
+++ b/app/src/lib/hooks/useEscapeCancel.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { cancelRecording } from '../dictation';
+import type { DictationStatus } from '../types';
+
+interface UseEscapeCancelProps {
+  status: DictationStatus;
+  enabled: boolean;
+}
+
+export function useEscapeCancel({ status, enabled }: UseEscapeCancelProps) {
+  const statusRef = useRef(status);
+  const cancellingRef = useRef(false);
+  useEffect(() => { statusRef.current = status; }, [status]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+
+    listen('escape-cancel', async () => {
+      if (cancelled) return;
+      if (statusRef.current === 'idle') return;
+      if (cancellingRef.current) return;
+      cancellingRef.current = true;
+      try {
+        await cancelRecording();
+      } catch (err) {
+        console.error('cancel_native_recording failed:', err);
+      } finally {
+        cancellingRef.current = false;
+      }
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [enabled]);
+}

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -187,9 +187,10 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
       // Only update status from the return value if we're still in
       // processing. If cancel already set us to idle (or a new recording
       // started), don't clobber the current state with a stale result.
-      if (statusRef.current === 'processing') {
-        setStatus(isDictationStatus(res.state) ? res.state : 'idle');
-      }
+      // Functional update ensures atomic check-and-set even if statusRef
+      // hasn't synced yet.
+      const newStatus = isDictationStatus(res.state) ? res.state : 'idle';
+      setStatus(prev => prev === 'processing' ? newStatus : prev);
     } catch (err) {
       setError(String(err));
       setStatus('idle');

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -67,6 +67,11 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
           recordingStartTimeRef.current = null;
           setRecordingStartTime(null);
         }
+        // If idle arrived externally (e.g. Escape cancel), unblock handleStop
+        // so the next recording cycle can stop normally.
+        if (event.payload === 'idle') {
+          isStoppingRef.current = false;
+        }
       }
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
@@ -179,7 +184,12 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
         // to avoid race-condition duplicates.
       }
       if (res.type === 'error') setError(res.error || 'Unknown error');
-      setStatus(isDictationStatus(res.state) ? res.state : 'idle');
+      // Only update status from the return value if we're still in
+      // processing. If cancel already set us to idle (or a new recording
+      // started), don't clobber the current state with a stale result.
+      if (statusRef.current === 'processing') {
+        setStatus(isDictationStatus(res.state) ? res.state : 'idle');
+      }
     } catch (err) {
       setError(String(err));
       setStatus('idle');


### PR DESCRIPTION
## Summary

Closes #40

- **Escape key cancels recording or in-progress transcription** from any recording mode (hold-down, double-tap, both)
- Uses **generation counters** (`recording_id` / `cancelled_id`) so cancelling one recording never interferes with a subsequent one — no race conditions between old pipelines and new recordings
- Pipeline checks cancellation at 3 checkpoints (before VAD, before transcription, before text injection) and discards silently
- Overlay shows a brief **red X icon** (~800ms) on cancel before returning to idle
- Fixes stale pipeline bug where old `stop_native_recording` could emit idle and clobber a new recording after cancel

## Changes

**Rust**
- `state.rs`: Added `recording_id` and `cancelled_id` AtomicU64 fields with helper methods
- `keyboard.rs`: Escape detection in rdev callback before mode-specific logic, resets detectors with cooldown
- `commands/recording.rs`: Enhanced `cancel_native_recording` for both Recording and Processing states; added 3 pipeline checkpoints; `IdleGuard` tracks recording_id to prevent stale clobbering

**Frontend**
- `lib/dictation.ts`: Added `cancelRecording()` wrapper
- `lib/hooks/useEscapeCancel.ts`: New hook listening for `escape-cancel` event
- `lib/hooks/useRecordingState.ts`: Reset `isStoppingRef` on idle events; guard `setStatus` against stale results
- `App.tsx`: Wired up `useEscapeCancel` hook
- `components/OverlayWidget.tsx`: Red X visual feedback on `recording-cancelled` event

## Test plan

- [x] Hold-down mode: Escape during recording / during processing
- [x] Double-tap mode: Escape during recording / during processing  
- [x] Both mode: Escape during recording / during processing
- [x] Cancel during processing → immediate double-tap starts recording on first try (no phantom extra tap)
- [x] Old pipeline finishing after cancel does not clobber new recording
- [x] Escape when idle — no-op
- [x] Rapid double-Escape — no crash, debounced
- [x] Overlay shows red X briefly, then returns to idle
- [x] No text in clipboard after cancel
- [x] Next recording after cancel works normally
- [x] 67 Rust unit tests pass (4 new: generation counter + IdleGuard supersede test)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-recording IDs to isolate sessions and a frontend cancellation action; new frontend hook enables Escape-key cancellation when active.
  * UI shows a brief cancelled indicator after a recording is cancelled.

* **Bug Fixes**
  * Prevented stale or superseded transcription and UI updates after cancellation with early-exit checkpoints.
  * Hardened rapid start/stop and cross-mode cancellation races.

* **Tests**
  * Added tests covering cancellation, superseded recordings, and monotonic IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->