### PR TITLE
fix: stop cpal audio callback from leaking unbounded memory at idle

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -791,25 +791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,15 +2669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3686,26 +3658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rdev"
 version = "0.6.0"
 source = "git+https://github.com/Narsil/rdev?branch=main#c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2"
@@ -4599,20 +4551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5496,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -5516,7 +5454,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sherpa-rs",
- "sysinfo",
  "tar",
  "tauri",
  "tauri-build",
@@ -5969,8 +5906,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -6093,16 +6030,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -6135,24 +6062,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -6164,8 +6079,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -6184,31 +6099,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -29,7 +29,6 @@ hound = "3.5"
 dirs = "5"
 cpal = "0.15"
 rdev = { git = "https://github.com/Narsil/rdev", branch = "main" }
-sysinfo = "0.32"
 memory-stats = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/app/src-tauri/src/alloc.rs
+++ b/app/src-tauri/src/alloc.rs
@@ -31,6 +31,7 @@ unsafe extern "C" {
     fn malloc_set_zone_name(zone: *mut MallocZone, name: *const c_char);
     fn malloc_zone_malloc(zone: *mut MallocZone, size: usize) -> *mut c_void;
     fn malloc_zone_memalign(zone: *mut MallocZone, align: usize, size: usize) -> *mut c_void;
+    fn malloc_zone_realloc(zone: *mut MallocZone, ptr: *mut c_void, size: usize) -> *mut c_void;
     fn malloc_zone_free(zone: *mut MallocZone, ptr: *mut c_void);
     fn malloc_zone_statistics(zone: *mut MallocZone, stats: *mut MallocStatistics);
 }
@@ -72,6 +73,12 @@ unsafe impl GlobalAlloc for RustZoneAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         unsafe { malloc_zone_free(rust_zone(), ptr as *mut c_void) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        // Use zone-aware realloc for in-place growth when possible,
+        // instead of the default alloc+copy+free.
+        unsafe { malloc_zone_realloc(rust_zone(), ptr as *mut c_void, new_size) as *mut u8 }
     }
 }
 

--- a/app/src-tauri/src/alloc.rs
+++ b/app/src-tauri/src/alloc.rs
@@ -75,10 +75,24 @@ unsafe impl GlobalAlloc for RustZoneAllocator {
         unsafe { malloc_zone_free(rust_zone(), ptr as *mut c_void) }
     }
 
-    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
-        // Use zone-aware realloc for in-place growth when possible,
-        // instead of the default alloc+copy+free.
-        unsafe { malloc_zone_realloc(rust_zone(), ptr as *mut c_void, new_size) as *mut u8 }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let zone = rust_zone();
+        if layout.align() <= 16 {
+            // Default macOS malloc alignment — zone realloc preserves this.
+            return unsafe { malloc_zone_realloc(zone, ptr as *mut c_void, new_size) as *mut u8 };
+        }
+        // Over-aligned: malloc_zone_realloc may not preserve stricter alignment
+        // if the block moves, so allocate aligned + copy + free.
+        let new_ptr =
+            unsafe { malloc_zone_memalign(zone, layout.align(), new_size) as *mut u8 };
+        if new_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size().min(new_size));
+            malloc_zone_free(zone, ptr as *mut c_void);
+        }
+        new_ptr
     }
 }
 

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1,6 +1,7 @@
 use crate::state::WHISPER_SAMPLE_RATE;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Sample, SampleFormat};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -30,13 +31,20 @@ const AUDIO_LEVEL_THROTTLE_MS: u64 = 16;
 /// computes RMS for each buffer chunk and emits an "audio-level" event if an AppHandle
 /// is provided, throttled to ~60 fps to avoid IPC spam.
 macro_rules! build_mono_input_stream {
-    ($device:expr, $config:expr, $shared:expr, $channels:expr, $err_fn:expr, $sample_type:ty, $app_handle:expr) => {{
+    ($device:expr, $config:expr, $shared:expr, $channels:expr, $err_fn:expr, $sample_type:ty, $app_handle:expr, $active:expr) => {{
         let samples_ref = Arc::clone(&$shared);
+        let active_ref = Arc::clone(&$active);
         let app_handle_opt: Option<tauri::AppHandle> = $app_handle;
         let last_emit_ms = std::sync::atomic::AtomicU64::new(0);
         $device.build_input_stream(
             &$config.into(),
             move |data: &[$sample_type], _: &_| {
+                // Stop accumulating once recording is over — prevents unbounded
+                // buffer growth if the cpal stream outlives the recording session.
+                if !active_ref.load(Ordering::Relaxed) {
+                    return;
+                }
+
                 let mono: Vec<f32> = data.chunks($channels)
                     .map(|chunk| {
                         let sum: f32 = chunk.iter().map(|&s| s.to_float_sample()).sum();
@@ -50,9 +58,9 @@ macro_rules! build_mono_input_stream {
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()
                         .as_millis() as u64;
-                    let last = last_emit_ms.load(std::sync::atomic::Ordering::Relaxed);
+                    let last = last_emit_ms.load(Ordering::Relaxed);
                     if now.saturating_sub(last) >= AUDIO_LEVEL_THROTTLE_MS {
-                        last_emit_ms.store(now, std::sync::atomic::Ordering::Relaxed);
+                        last_emit_ms.store(now, Ordering::Relaxed);
                         let rms = compute_rms(&mono);
                         let _ = handle.emit("audio-level", rms);
                     }
@@ -84,6 +92,10 @@ struct RecordingState {
     /// The cpal callback holds an Arc clone — when the stream drops and the
     /// thread joins, that clone drops too. Next recording gets a fresh Vec.
     shared: Option<Arc<Mutex<Vec<f32>>>>,
+    /// Atomic flag shared with the cpal callback. Set to `false` on stop so
+    /// the callback stops accumulating samples even if the stream hasn't been
+    /// fully torn down yet (prevents unbounded buffer growth).
+    active: Arc<AtomicBool>,
     /// Device sample rate for the current/last recording.
     sample_rate: u32,
     /// Wall-clock instant when recording started.
@@ -98,6 +110,7 @@ fn get_state() -> &'static Mutex<RecordingState> {
             command_sender: None,
             thread_handle: None,
             shared: None,
+            active: Arc::new(AtomicBool::new(false)),
             sample_rate: WHISPER_SAMPLE_RATE,
             started_at: None,
             device_name: None,
@@ -136,6 +149,8 @@ pub fn start_recording(app_handle: Option<tauri::AppHandle>, device_name: Option
     // Create a brand-new buffer for this recording — no stale data possible
     let new_buffer = Arc::new(Mutex::new(Vec::<f32>::new()));
     state_guard.shared = Some(Arc::clone(&new_buffer));
+    let active = Arc::new(AtomicBool::new(true));
+    state_guard.active = Arc::clone(&active);
     tracing::info!(target: "audio", "start_recording: created fresh sample buffer");
 
     let (cmd_tx, cmd_rx) = channel::<AudioCommand>();
@@ -143,7 +158,7 @@ pub fn start_recording(app_handle: Option<tauri::AppHandle>, device_name: Option
 
     // Spawn audio thread
     let handle = thread::spawn(move || {
-        if let Err(e) = run_audio_capture(cmd_rx, new_buffer, ready_tx.clone(), app_handle, device_name) {
+        if let Err(e) = run_audio_capture(cmd_rx, new_buffer, active, ready_tx.clone(), app_handle, device_name) {
             tracing::error!(target: "audio", "Audio capture error: {}", e);
             let _ = ready_tx.send(Err(e));
         }
@@ -178,6 +193,7 @@ pub fn start_recording(app_handle: Option<tauri::AppHandle>, device_name: Option
 fn run_audio_capture(
     cmd_rx: Receiver<AudioCommand>,
     shared: Arc<Mutex<Vec<f32>>>,
+    active: Arc<AtomicBool>,
     ready_tx: Sender<Result<(u32, String), String>>,
     app_handle: Option<tauri::AppHandle>,
     device_name: Option<String>,
@@ -227,8 +243,8 @@ fn run_audio_capture(
     let err_fn = |err| tracing::error!(target: "audio", "Audio stream error: {}", err);
 
     let stream = match sample_format {
-        SampleFormat::F32 => build_mono_input_stream!(device, config, shared, channels, err_fn, f32, app_handle.clone()),
-        SampleFormat::I16 => build_mono_input_stream!(device, config, shared, channels, err_fn, i16, app_handle),
+        SampleFormat::F32 => build_mono_input_stream!(device, config, shared, channels, err_fn, f32, app_handle.clone(), active),
+        SampleFormat::I16 => build_mono_input_stream!(device, config, shared, channels, err_fn, i16, app_handle, active),
         _ => return Err(format!("Unsupported sample format: {:?}", sample_format)),
     };
 
@@ -246,6 +262,9 @@ fn run_audio_capture(
         }
     }
 
+    // Explicitly pause before dropping to ensure CoreAudio stops calling us
+    let _ = stream.pause();
+
     Ok(())
 }
 
@@ -255,6 +274,10 @@ pub fn stop_recording() -> Result<Vec<f32>, String> {
         tracing::warn!(target: "audio", "stop_recording: recording state mutex was poisoned, recovering");
         poisoned.into_inner()
     });
+
+    // Signal the callback to stop accumulating BEFORE sending Stop.
+    // This prevents buffer growth even if the cpal stream lingers.
+    state_guard.active.store(false, Ordering::SeqCst);
 
     // Send stop command
     if let Some(sender) = state_guard.command_sender.take() {
@@ -273,7 +296,7 @@ pub fn stop_recording() -> Result<Vec<f32>, String> {
     let sample_rate = state_guard.sample_rate;
 
     let samples = if let Some(buf) = buffer {
-        let guard = buf.lock().unwrap_or_else(|poisoned| {
+        let mut guard = buf.lock().unwrap_or_else(|poisoned| {
             tracing::warn!(target: "audio", "stop_recording: samples mutex was poisoned, recovering");
             poisoned.into_inner()
         });
@@ -286,7 +309,7 @@ pub fn stop_recording() -> Result<Vec<f32>, String> {
             tracing::info!(target: "audio", "stop_recording: raw_samples={}, sample_rate={}, duration_secs={:.1} (no timestamp)",
                 raw_count, sample_rate, raw_duration);
         }
-        guard.clone()
+        std::mem::take(&mut *guard)
         // guard drops, buf drops — buffer is gone, zero stale data
     } else {
         tracing::info!(target: "audio", "stop_recording: no buffer (was not recording)");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -129,50 +129,8 @@ pub fn run() {
                 tracing::info!(target: "system", rss_mb = rss, rust_heap_mb = heap, ffi_heap_mb = ffi, "startup_baseline");
             }
 
-            // Spawn heartbeat + idle timeout checker (runs every 60s)
-            {
-                let app_handle = app.handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    let state_handle = app_handle.state::<State>();
-                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-                    loop {
-                        interval.tick().await;
-
-                        // Heartbeat: emit memory stats
-                        let rss = resource_monitor::get_process_rss_mb();
-                        let heap = rust_heap_mb();
-                        let ffi = ffi_heap_mb();
-                        tracing::info!(target: "system", rss_mb = rss, rust_heap_mb = heap, ffi_heap_mb = ffi, "heartbeat");
-
-                        // Idle timeout: release whisper model if idle too long
-                        let timeout_minutes = *state_handle.app_state.idle_timeout_minutes.lock_or_recover();
-                        if timeout_minutes == 0 {
-                            continue;
-                        }
-                        let threshold = std::time::Duration::from_secs(timeout_minutes as u64 * 60);
-                        let should_release = {
-                            let last = state_handle.app_state.last_transcription_at.lock_or_recover();
-                            last.map_or(false, |t| t.elapsed() >= threshold)
-                        };
-                        if should_release {
-                            let mut backend = state_handle.app_state.backend.lock_or_recover();
-                            // Re-check after acquiring the lock (a transcription may have started)
-                            let still_idle = {
-                                let last = state_handle.app_state.last_transcription_at.lock_or_recover();
-                                last.map_or(false, |t| t.elapsed() >= threshold)
-                            };
-                            if still_idle {
-                                backend.reset();
-                                *state_handle.app_state.last_transcription_at.lock_or_recover() = None;
-                                let rss = resource_monitor::get_process_rss_mb();
-                                let heap = rust_heap_mb();
-                                let ffi = ffi_heap_mb();
-                                tracing::info!(target: "pipeline", rss_mb = rss, rust_heap_mb = heap, ffi_heap_mb = ffi, "whisper_idle_release");
-                            }
-                        }
-                    }
-                });
-            }
+            // Periodic heartbeat: memory telemetry + idle timeout
+            resource_monitor::start_heartbeat(app.handle().clone());
 
             // Cache notch dimensions on the main thread (safe for NSScreen APIs).
             let notch = commands::overlay::detect_notch_info();

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -1,8 +1,5 @@
-use std::sync::Mutex;
 use serde::Serialize;
-use sysinfo::{CpuRefreshKind, RefreshKind, System};
-
-static SYS: Mutex<Option<System>> = Mutex::new(None);
+use std::sync::Mutex;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ResourceUsage {
@@ -20,21 +17,177 @@ pub fn get_process_rss_mb() -> u64 {
         .unwrap_or(0)
 }
 
+// ---------------------------------------------------------------------------
+// macOS-native CPU tracking via host_statistics64 (replaces sysinfo crate)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+mod cpu {
+    use std::os::raw::c_int;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct HostCpuLoadInfo {
+        ticks: [u32; 4], // user, system, idle, nice
+    }
+
+    const HOST_CPU_LOAD_INFO: c_int = 3;
+    const HOST_CPU_LOAD_INFO_COUNT: u32 = 4; // 4 × u32
+
+    unsafe extern "C" {
+        fn mach_host_self() -> u32;
+        fn host_statistics64(
+            host: u32,
+            flavor: c_int,
+            info: *mut HostCpuLoadInfo,
+            count: *mut u32,
+        ) -> c_int;
+    }
+
+    struct CpuSnapshot {
+        user: u64,
+        system: u64,
+        idle: u64,
+    }
+
+    fn snapshot() -> CpuSnapshot {
+        let mut info = HostCpuLoadInfo::default();
+        let mut count = HOST_CPU_LOAD_INFO_COUNT;
+        unsafe {
+            host_statistics64(mach_host_self(), HOST_CPU_LOAD_INFO, &mut info, &mut count);
+        }
+        CpuSnapshot {
+            user: info.ticks[0] as u64 + info.ticks[3] as u64, // user + nice
+            system: info.ticks[1] as u64,
+            idle: info.ticks[2] as u64,
+        }
+    }
+
+    static PREV: std::sync::Mutex<Option<CpuSnapshot>> = std::sync::Mutex::new(None);
+
+    pub fn cpu_percent() -> f32 {
+        let cur = snapshot();
+        let mut prev = PREV.lock().unwrap_or_else(|p| p.into_inner());
+        let pct = if let Some(ref p) = *prev {
+            let d_user = cur.user.wrapping_sub(p.user);
+            let d_sys = cur.system.wrapping_sub(p.system);
+            let d_idle = cur.idle.wrapping_sub(p.idle);
+            let total = d_user + d_sys + d_idle;
+            if total > 0 {
+                ((d_user + d_sys) as f64 / total as f64 * 100.0) as f32
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+        *prev = Some(cur);
+        pct
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod cpu {
+    pub fn cpu_percent() -> f32 { 0.0 }
+}
+
+// ---------------------------------------------------------------------------
+// Idle timeout: release whisper model after inactivity
+// ---------------------------------------------------------------------------
+
+static IDLE_TIMEOUT: Mutex<Option<IdleState>> = Mutex::new(None);
+
+struct IdleState {
+    app_handle: tauri::AppHandle,
+}
+
+pub fn set_idle_timeout(app_handle: tauri::AppHandle) {
+    if let Ok(mut guard) = IDLE_TIMEOUT.lock() {
+        *guard = Some(IdleState { app_handle });
+    }
+}
+
+fn check_idle_timeout() {
+    use crate::MutexExt;
+    use tauri::Manager;
+
+    let handle = {
+        let guard = match IDLE_TIMEOUT.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        match guard.as_ref() {
+            Some(s) => s.app_handle.clone(),
+            None => return,
+        }
+    };
+
+    let state = handle.state::<crate::State>();
+    let timeout_min = *state.app_state.idle_timeout_minutes.lock_or_recover();
+    if timeout_min == 0 {
+        return;
+    }
+
+    let threshold = std::time::Duration::from_secs(timeout_min as u64 * 60);
+    let should_release = {
+        let last = state.app_state.last_transcription_at.lock_or_recover();
+        last.map_or(false, |t: std::time::Instant| t.elapsed() >= threshold)
+    };
+    if should_release {
+        let mut backend = state.app_state.backend.lock_or_recover();
+        // Re-check after acquiring the lock (a transcription may have started)
+        let still_idle = {
+            let last = state.app_state.last_transcription_at.lock_or_recover();
+            last.map_or(false, |t: std::time::Instant| t.elapsed() >= threshold)
+        };
+        if still_idle {
+            backend.reset();
+            *state.app_state.last_transcription_at.lock_or_recover() = None;
+            let rss = get_process_rss_mb();
+            let heap = crate::rust_heap_mb();
+            let ffi = crate::ffi_heap_mb();
+            tracing::info!(target: "pipeline", rss_mb = rss, rust_heap_mb = heap, ffi_heap_mb = ffi, "whisper_idle_release");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Heartbeat task: periodic telemetry + idle timeout check
+// ---------------------------------------------------------------------------
+
+pub fn start_heartbeat(app_handle: tauri::AppHandle) {
+    set_idle_timeout(app_handle.clone());
+
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+
+            let rss = get_process_rss_mb();
+            let rust = crate::rust_heap_mb();
+            let ffi = crate::ffi_heap_mb();
+            tracing::info!(
+                target: "system",
+                rss_mb = rss,
+                rust_heap_mb = rust,
+                ffi_heap_mb = ffi,
+                "heartbeat"
+            );
+
+            check_idle_timeout();
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tauri command
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 pub fn get_resource_usage() -> ResourceUsage {
-    let mut guard = SYS.lock().unwrap_or_else(|p| p.into_inner());
-    let sys = guard.get_or_insert_with(|| {
-        System::new_with_specifics(
-            RefreshKind::new()
-                .with_cpu(CpuRefreshKind::new().with_cpu_usage()),
-        )
-    });
-    sys.refresh_cpu_usage();
-
     let rss_mb = get_process_rss_mb();
-
     ResourceUsage {
-        cpu_percent: sys.global_cpu_usage(),
+        cpu_percent: cpu::cpu_percent(),
         memory_mb: rss_mb,
         rss_mb,
         rust_heap_mb: crate::rust_heap_mb(),

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -34,8 +34,12 @@ mod cpu {
     const HOST_CPU_LOAD_INFO: c_int = 3;
     const HOST_CPU_LOAD_INFO_COUNT: u32 = 4; // 4 × u32
 
+    const KERN_SUCCESS: c_int = 0;
+
     unsafe extern "C" {
         fn mach_host_self() -> u32;
+        fn mach_task_self() -> u32;
+        fn mach_port_deallocate(task: u32, name: u32) -> c_int;
         fn host_statistics64(
             host: u32,
             flavor: c_int,
@@ -53,8 +57,13 @@ mod cpu {
     fn snapshot() -> CpuSnapshot {
         let mut info = HostCpuLoadInfo::default();
         let mut count = HOST_CPU_LOAD_INFO_COUNT;
-        unsafe {
-            host_statistics64(mach_host_self(), HOST_CPU_LOAD_INFO, &mut info, &mut count);
+        let host = unsafe { mach_host_self() };
+        let kr = unsafe {
+            host_statistics64(host, HOST_CPU_LOAD_INFO, &mut info, &mut count)
+        };
+        unsafe { mach_port_deallocate(mach_task_self(), host) };
+        if kr != KERN_SUCCESS {
+            return CpuSnapshot { user: 0, system: 0, idle: 0 };
         }
         CpuSnapshot {
             user: info.ticks[0] as u64 + info.ticks[3] as u64, // user + nice

--- a/docs/sessions/issue-124-memory-leak.md
+++ b/docs/sessions/issue-124-memory-leak.md
@@ -1,0 +1,207 @@
+# Issue #124 — Rust Heap Memory Leak (~60-70 MB/min at Idle)
+
+## Overview
+
+The app leaked ~60-70 MB/min of Rust heap memory while completely idle (no recording, no transcription). RSS grew unboundedly until the process was killed.
+
+**Root cause**: The cpal CoreAudio audio callback continued running after `stop_recording()` returned, pushing samples into a `Vec<f32>` buffer that nobody consumed. The Vec doubled its capacity on each growth, producing the characteristic exponential heap expansion.
+
+---
+
+## Evidence
+
+Zone telemetry from heartbeat logs showed Rust heap climbing steadily at idle:
+
+| Time | RSS (MB) | Rust Heap (MB) | FFI Heap (MB) |
+|------|----------|-----------------|----------------|
+| +0 min | ~180 | ~8 | ~170 |
+| +1 min | ~240 | ~68 | ~170 |
+| +2 min | ~310 | ~138 | ~170 |
+| +5 min | ~520 | ~348 | ~170 |
+
+FFI heap (whisper.cpp, sherpa-onnx) stayed flat. The Rust heap was the sole contributor to RSS growth — growing ~60-70 MB per minute at idle.
+
+---
+
+## Session 1: Binary search isolation
+
+Systematically disabled suspected subsystems to isolate the leak source.
+
+### Test 1: Bypass sysinfo CPU refresh
+
+Skipped `sys.refresh_cpu_usage()` in `get_resource_usage()`.
+
+**Result**: Leak rate dropped by roughly half (~30-35 MB/min → still leaking). Confirmed sysinfo was a partial contributor but not the sole cause.
+
+### Test 2: Hardcode get_resource_usage
+
+Replaced the entire `get_resource_usage()` body with hardcoded values (no sysinfo calls at all).
+
+**Result**: Leak continued at the reduced rate. Something else was still allocating.
+
+### Test 3: Disable tracing heartbeat emission
+
+Stopped the 60-second heartbeat from emitting tracing events.
+
+**Result**: Leak continued. Tracing/event emission was not the source.
+
+### Test 4: Zone diagnostics — block count analysis
+
+Added `malloc_zone_statistics()` logging to the heartbeat to track allocation block counts alongside size.
+
+**Result**: Block count stayed stable (not growing). But `size_in_use` kept doubling — meaning a single allocation was being reallocated to ever-larger sizes. This is the signature of a `Vec` that keeps getting `extend()`ed without ever being drained.
+
+### Test 5: Disable heartbeat entirely
+
+Commented out the entire heartbeat spawned task.
+
+**Result**: Heap was stable at idle... until a transcription was triggered. After one record/stop cycle, the leak resumed at ~60-70 MB/min even with no further interaction.
+
+**Key insight**: The leak was triggered by recording, not by the heartbeat. The heartbeat was an innocent bystander (except for sysinfo's own allocations).
+
+---
+
+## Session 2: Identifying the doubling allocation
+
+Used macOS memory tools to narrow down the leak:
+
+- **`heap <pid>`**: Showed a massive `MALLOC_TINY`/`MALLOC_SMALL` region under the RustHeapZone growing over time, consistent with Vec reallocation.
+- **`leaks <pid>`**: Did not flag the buffer as a leak because it was still reachable — the `Arc<Mutex<Vec<f32>>>` in `RecordingState.shared` held a live reference. This is a logical leak (unbounded growth of a reachable object), not a classical dangling-pointer leak.
+
+---
+
+## Session 3: Allocator instrumentation (alloc-spy)
+
+### Technique
+
+Overrode `GlobalAlloc::realloc` in the custom `RustZoneAllocator` to intercept large reallocations:
+
+```rust
+unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    if new_size > 1_000_000 {
+        // Log to stderr using raw write() (async-signal-safe, no allocation)
+        backtrace_symbols_fd(...);
+    }
+    malloc_zone_realloc(rust_zone(), ptr as *mut c_void, new_size) as *mut u8
+}
+```
+
+Key details:
+- Threshold at 1 MB to filter out noise
+- Used `backtrace_symbols_fd()` + raw `write()` to stderr — these are async-signal-safe and don't allocate, so they won't recurse into the allocator
+- Ran with `RUST_BACKTRACE=1` for symbol resolution
+
+### Result
+
+Every single large-realloc backtrace showed the same stack:
+
+```
+CoreAudio HALC_IOThread
+  → cpal input_data_callback
+    → audio::build_mono_input_stream closure
+      → Vec<f32>::extend
+```
+
+The cpal audio stream's CoreAudio callback was still firing on the HAL IO thread, pushing samples into the shared `Vec<f32>`, long after `stop_recording()` had returned. Nobody was draining the buffer, so it grew without bound.
+
+---
+
+## Root cause
+
+`stop_recording()` sent `AudioCommand::Stop` through the channel and joined the audio thread, but the **cpal stream was not explicitly stopped**. On macOS, cpal's CoreAudio backend continues calling the input callback on its own HAL IO thread even after the `Stream` object's owning thread has exited. The stream only stops when it is dropped — but the drop was racing with the thread join, and in practice the callback kept firing.
+
+The callback closure captured an `Arc<Mutex<Vec<f32>>>` and called `extend()` on every CoreAudio buffer delivery (~every 5-10ms). With no consumer, the Vec doubled its allocation on each capacity exhaustion, producing ~60-70 MB/min of Rust heap growth.
+
+---
+
+## Fix (commit 929a4ef)
+
+### Core fix: AtomicBool active flag
+
+```rust
+// In audio.rs — shared between recording state and cpal callback
+active: Arc<AtomicBool>
+
+// In the cpal callback (build_mono_input_stream macro):
+if !active_ref.load(Ordering::Relaxed) {
+    return;  // Stop accumulating immediately
+}
+
+// In stop_recording() — set BEFORE sending Stop command:
+state_guard.active.store(false, Ordering::SeqCst);
+```
+
+The `AtomicBool` gives instant, lock-free signaling to the CoreAudio HAL IO thread. Setting it `false` before sending `AudioCommand::Stop` ensures zero buffer growth during teardown.
+
+### Explicit stream.pause()
+
+```rust
+// At end of run_audio_capture, before stream drops:
+let _ = stream.pause();
+```
+
+Tells CoreAudio to stop delivering audio buffers before the stream is dropped.
+
+### mem::take instead of clone
+
+```rust
+// Old: copied the entire buffer (potentially hundreds of MB)
+guard.clone()
+
+// New: moves the buffer out, leaving an empty Vec
+std::mem::take(&mut *guard)
+```
+
+### sysinfo removal
+
+Replaced the `sysinfo` crate (which contributed ~half the leak via `refresh_cpu_usage()`) with direct macOS `host_statistics64()` FFI calls. This also removed transitive dependencies (rayon, crossbeam-deque, ntapi).
+
+### malloc_zone_realloc
+
+Added `realloc` override to `RustZoneAllocator` so Vec growth can happen in-place when the zone has room, instead of the default alloc+copy+free path.
+
+### Heartbeat refactor
+
+Moved the heartbeat spawned task and idle timeout checker from `lib.rs` into `resource_monitor.rs` as `start_heartbeat()`.
+
+---
+
+## Key findings
+
+| What was tested | Result | Conclusion |
+|----------------|--------|------------|
+| Bypass sysinfo refresh | Leak halved | sysinfo was a partial contributor |
+| Hardcode resource usage | Still leaking | Another source existed |
+| Disable tracing heartbeat | Still leaking | Tracing was not the cause |
+| Zone block count analysis | Blocks stable, size doubling | Single Vec growing unboundedly |
+| Disable heartbeat entirely | Stable until first recording | Leak triggered by record/stop cycle |
+| alloc-spy backtrace | CoreAudio → cpal → Vec::extend | cpal callback was the sole remaining source |
+
+---
+
+## Reusable debugging technique: alloc-spy
+
+For future Rust heap leak investigations on macOS:
+
+1. **Custom `GlobalAlloc::realloc`** — override realloc in your zone allocator to intercept large reallocations (threshold at 1 MB+)
+2. **`backtrace_symbols_fd` + `write()`** — async-signal-safe backtrace capture that doesn't recurse into the allocator
+3. **Filter by size** — most noise is small allocations; large reallocs point directly to the unbounded buffer
+4. **Zone statistics** — `malloc_zone_statistics()` gives block count vs size-in-use; stable blocks + growing size = single allocation doubling (Vec pattern)
+
+This technique identified the exact callsite in one iteration after multiple hours of indirect binary-search debugging.
+
+---
+
+## Key files
+
+| File | Change |
+|------|--------|
+| `app/src-tauri/src/audio.rs` | AtomicBool active flag in cpal callback, stream.pause(), mem::take |
+| `app/src-tauri/src/resource_monitor.rs` | macOS-native CPU via host_statistics64(), heartbeat + idle timeout moved here |
+| `app/src-tauri/src/alloc.rs` | malloc_zone_realloc override for in-place Vec growth |
+| `app/src-tauri/src/lib.rs` | Removed inline heartbeat task, calls resource_monitor::start_heartbeat() |
+| `app/src-tauri/Cargo.toml` | Removed sysinfo dependency |
+
+## PR
+
+https://github.com/georgenijo/murmur-app/pull/124

--- a/docs/sessions/issue-124-memory-leak.md
+++ b/docs/sessions/issue-124-memory-leak.md
@@ -204,4 +204,4 @@ This technique identified the exact callsite in one iteration after multiple hou
 
 ## PR
 
-https://github.com/georgenijo/murmur-app/pull/124
+https://github.com/georgenijo/murmur-app/pull/125


### PR DESCRIPTION
## Summary

Fixes #124 — Rust heap memory leak (~60-70 MB/min growth at idle).

- **Root cause**: The cpal CoreAudio callback continued running after `stop_recording()`, pushing audio samples into a `Vec<f32>` buffer indefinitely. The buffer doubled on each growth, leaking ~60-70 MB/min. Multiple recording sessions compounded the leak.
- **Fix**: Add an `AtomicBool` "active" flag shared with the callback — callback returns immediately when `false`. Set `active=false` before sending Stop. Add explicit `stream.pause()` before drop. Replace `guard.clone()` with `std::mem::take()` to avoid copying the audio buffer.
- **Secondary fix**: Replace `sysinfo` crate (which contributed ~half the leak via `refresh_cpu_usage()`) with zero-allocation macOS-native `host_statistics64()` FFI for CPU tracking.
- **Allocator improvement**: Add `malloc_zone_realloc` override for in-place Vec growth instead of default alloc+copy+free.

## How it was found

Custom allocator instrumentation (`alloc-spy`) logged all allocations >1MB with backtraces. Every realloc pointed to:

```
CoreAudio HALC_IOThread
  → coreaudio::audio_unit::render_callback::input_proc
    → cpal::Device::build_input_stream_raw::{{closure}}
      → ui_lib::audio::run_audio_capture::{{closure}}   ← s.extend(mono)
        → Vec::extend → Vec::grow_amortized → realloc
```

## Test plan

- [x] `cargo test --lib -- --test-threads=1` — 67 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Dev mode: Rust heap stable at 2 MB after transcription + 3 min idle (was 100+ MB)
- [ ] Verify transcription still works end-to-end
- [ ] Verify idle timeout releases whisper model
- [ ] Verify CPU % displays in Metrics tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio recording buffer growth by ensuring recording stops promptly and preventing unbounded memory accumulation.

* **Performance**
  * Improved memory reallocation efficiency on macOS for reduced fragmentation and faster resizing.
  * Enhanced resource monitoring with periodic telemetry and automatic idle-timeout release of unused resources.
  * More accurate CPU usage reporting with platform-specific tracking.

* **Documentation**
  * Added a detailed incident report documenting the memory leak, root cause, and fix steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->