### PR TITLE
feat: custom vocabulary / initial prompt for Whisper

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -140,10 +140,11 @@ async fn run_transcription_pipeline(
     let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
     let t_transcribe = std::time::Instant::now();
     let text = {
-        let prompt = if custom_vocabulary.is_empty() {
+        let sanitized = custom_vocabulary.replace('\0', "");
+        let prompt = if sanitized.trim().is_empty() {
             None
         } else {
-            Some(custom_vocabulary.replace('\0', ""))
+            Some(sanitized)
         };
         let mut backend = app_state.backend.lock_or_recover();
         backend.load_model(&model_name)?;

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -66,9 +66,9 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity)
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone())
     };
 
     // Pre-VAD signal level logging for mic diagnosis
@@ -140,9 +140,14 @@ async fn run_transcription_pipeline(
     let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
     let t_transcribe = std::time::Instant::now();
     let text = {
+        let prompt = if custom_vocabulary.is_empty() {
+            None
+        } else {
+            Some(custom_vocabulary.replace('\0', ""))
+        };
         let mut backend = app_state.backend.lock_or_recover();
         backend.load_model(&model_name)?;
-        backend.transcribe(&samples_for_transcription, &language)?
+        backend.transcribe(&samples_for_transcription, &language, prompt.as_deref())?
     };
     let inference_ms = t_transcribe.elapsed().as_millis() as u64;
     let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
@@ -336,6 +341,10 @@ pub async fn configure_dictation(
 
     if let Some(sensitivity) = options.get("vadSensitivity").and_then(|v| v.as_u64()) {
         dictation.vad_sensitivity = (sensitivity as u32).clamp(0, 100);
+    }
+
+    if let Some(vocab) = options.get("customVocabulary").and_then(|v| v.as_str()) {
+        dictation.custom_vocabulary = vocab.to_string();
     }
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {
@@ -611,6 +620,15 @@ pub async fn cancel_native_recording(
         Some(e) => Err(e),
         None => Ok(()),
     }
+}
+
+#[tauri::command]
+pub async fn count_vocab_tokens(
+    text: String,
+    state: tauri::State<'_, State>,
+) -> Result<Option<usize>, String> {
+    let backend = state.app_state.backend.lock_or_recover();
+    Ok(backend.token_count(&text))
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             commands::recording::start_native_recording,
             commands::recording::stop_native_recording,
             commands::recording::cancel_native_recording,
+            commands::recording::count_vocab_tokens,
             commands::permissions::open_system_preferences,
             commands::permissions::check_accessibility_permission,
             commands::permissions::request_accessibility_permission,

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -28,6 +28,7 @@ pub struct DictationState {
     pub auto_paste: bool,
     pub auto_paste_delay_ms: u64,
     pub vad_sensitivity: u32,
+    pub custom_vocabulary: String,
 }
 
 impl Default for DictationState {
@@ -39,6 +40,7 @@ impl Default for DictationState {
             auto_paste: false,
             auto_paste_delay_ms: 50,
             vad_sensitivity: 50,
+            custom_vocabulary: String::new(),
         }
     }
 }

--- a/app/src-tauri/src/transcriber/mod.rs
+++ b/app/src-tauri/src/transcriber/mod.rs
@@ -21,7 +21,10 @@ pub trait TranscriptionBackend: Send + Sync {
     fn load_model(&mut self, model_name: &str) -> Result<(), String>;
 
     /// Run inference on 16kHz mono f32 samples.
-    fn transcribe(&mut self, samples: &[f32], language: &str) -> Result<String, String>;
+    fn transcribe(&mut self, samples: &[f32], language: &str, initial_prompt: Option<&str>) -> Result<String, String>;
+
+    /// Count tokens in text using the model's tokenizer. Returns None if model not loaded.
+    fn token_count(&self, text: &str) -> Option<usize>;
 
     /// Check if any model file exists in search paths.
     fn model_exists(&self) -> bool;

--- a/app/src-tauri/src/transcriber/moonshine.rs
+++ b/app/src-tauri/src/transcriber/moonshine.rs
@@ -122,7 +122,7 @@ impl TranscriptionBackend for MoonshineBackend {
         Ok(())
     }
 
-    fn transcribe(&mut self, samples: &[f32], _language: &str) -> Result<String, String> {
+    fn transcribe(&mut self, samples: &[f32], _language: &str, _initial_prompt: Option<&str>) -> Result<String, String> {
         let recognizer = self
             .recognizer
             .as_mut()
@@ -130,6 +130,10 @@ impl TranscriptionBackend for MoonshineBackend {
 
         let result = recognizer.transcribe(16000, samples);
         Ok(result.text.trim().to_string())
+    }
+
+    fn token_count(&self, _text: &str) -> Option<usize> {
+        None
     }
 
     fn model_exists(&self) -> bool {

--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -129,7 +129,7 @@ impl TranscriptionBackend for WhisperBackend {
         Ok(())
     }
 
-    fn transcribe(&mut self, samples: &[f32], language: &str) -> Result<String, String> {
+    fn transcribe(&mut self, samples: &[f32], language: &str, initial_prompt: Option<&str>) -> Result<String, String> {
         let state = self
             .state
             .as_mut()
@@ -144,6 +144,9 @@ impl TranscriptionBackend for WhisperBackend {
         params.set_print_timestamps(false);
         params.set_suppress_blank(true);
         params.set_single_segment(true);
+        if let Some(prompt) = initial_prompt {
+            params.set_initial_prompt(prompt);
+        }
         params.set_debug_mode(false);
 
         state
@@ -164,6 +167,11 @@ impl TranscriptionBackend for WhisperBackend {
         }
 
         Ok(text.trim().to_string())
+    }
+
+    fn token_count(&self, text: &str) -> Option<usize> {
+        let ctx = self.context.as_ref()?;
+        ctx.tokenize(text, 1024).ok().map(|tokens| tokens.len())
     }
 
     fn model_exists(&self) -> bool {

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
+import { countVocabTokens } from '../../lib/dictation';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
 
@@ -39,6 +40,58 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
         Delay before paste. Increase if paste lands in the wrong window.
       </p>
+    </div>
+  );
+}
+
+function CustomVocabularyTextarea({ value, onCommit, showMoonshineWarning }: { value: string; onCommit: (v: string) => void; showMoonshineWarning: boolean }) {
+  const [draft, setDraft] = useState(value);
+  const [tokenCount, setTokenCount] = useState<number | null>(null);
+  useEffect(() => { setDraft(value); }, [value]);
+
+  useEffect(() => {
+    if (!draft.trim()) { setTokenCount(null); return; }
+    let stale = false;
+    countVocabTokens(draft).then((count) => { if (!stale) setTokenCount(count); });
+    return () => { stale = true; };
+  }, [draft]);
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+        Custom Vocabulary
+      </label>
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (draft !== value) onCommit(draft); }}
+        placeholder="e.g. Tauri, Claude, whisper-rs, macOS"
+        rows={3}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500 resize-y"
+      />
+      <div className="mt-1.5 flex items-start justify-between gap-2">
+        <p className="text-xs text-stone-500 dark:text-stone-400">
+          Comma-separated. Whisper models only.
+        </p>
+        {draft.length > 0 && (() => {
+          const displayCount = tokenCount ?? Math.ceil(draft.length / 4);
+          const isEstimate = tokenCount === null;
+          return (
+            <span className={`text-xs tabular-nums whitespace-nowrap ${displayCount > 200 ? 'text-amber-600 dark:text-amber-400' : 'text-stone-400 dark:text-stone-500'}`}>
+              {isEstimate ? `~${displayCount}` : displayCount} tokens
+            </span>
+          );
+        })()}
+      </div>
+      {showMoonshineWarning && (
+        <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+          Custom vocabulary is only supported by Whisper models.
+        </p>
+      )}
     </div>
   );
 }
@@ -345,6 +398,13 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             Free memory by unloading the model when idle. Set to Never to keep it loaded.
           </p>
         </div>
+
+        {/* Custom Vocabulary */}
+        <CustomVocabularyTextarea
+          value={settings.customVocabulary}
+          onCommit={(value) => onUpdateSettings({ customVocabulary: value })}
+          showMoonshineWarning={selectedModel?.backend === 'moonshine' && settings.customVocabulary.trim() !== ''}
+        />
         </SettingsSection>
 
         <SettingsSection title="Recording" subtitle="Trigger mode, shortcut key">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -52,7 +52,9 @@ function CustomVocabularyTextarea({ value, onCommit, showMoonshineWarning }: { v
   useEffect(() => {
     if (!draft.trim()) { setTokenCount(null); return; }
     let stale = false;
-    countVocabTokens(draft).then((count) => { if (!stale) setTokenCount(count); });
+    countVocabTokens(draft)
+      .then((count) => { if (!stale) setTokenCount(count); })
+      .catch(() => { if (!stale) setTokenCount(null); });
     return () => { stale = true; };
   }, [draft]);
 
@@ -77,8 +79,8 @@ function CustomVocabularyTextarea({ value, onCommit, showMoonshineWarning }: { v
         <p className="text-xs text-stone-500 dark:text-stone-400">
           Comma-separated. Whisper models only.
         </p>
-        {draft.length > 0 && (() => {
-          const displayCount = tokenCount ?? Math.ceil(draft.length / 4);
+        {draft.trim().length > 0 && (() => {
+          const displayCount = tokenCount ?? Math.ceil(draft.trim().length / 4);
           const isEstimate = tokenCount === null;
           return (
             <span className={`text-xs tabular-nums whitespace-nowrap ${displayCount > 200 ? 'text-amber-600 dark:text-amber-400' : 'text-stone-400 dark:text-stone-500'}`}>

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -63,8 +63,13 @@ export interface ConfigureOptions {
   autoPasteDelayMs?: number;
   vadSensitivity?: number;
   idleTimeoutMinutes?: number;
+  customVocabulary?: string;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
   return await invoke('configure_dictation', { options });
+}
+
+export async function countVocabTokens(text: string): Promise<number | null> {
+  return await invoke('count_vocab_tokens', { text });
 }

--- a/app/src/lib/hooks/useInitialization.ts
+++ b/app/src/lib/hooks/useInitialization.ts
@@ -11,7 +11,15 @@ export function useInitialization(settings: Settings) {
     initDictation()
       .then(() => {
         if (cancelled) return;
-        return configure({ model: settings.model, language: settings.language, autoPaste: settings.autoPaste, customVocabulary: settings.customVocabulary });
+        return configure({
+          model: settings.model,
+          language: settings.language,
+          autoPaste: settings.autoPaste,
+          autoPasteDelayMs: settings.autoPasteDelayMs,
+          vadSensitivity: settings.vadSensitivity,
+          idleTimeoutMinutes: settings.idleTimeoutMinutes,
+          customVocabulary: settings.customVocabulary,
+        });
       })
       .then(() => { if (!cancelled) setInitialized(true); })
       .catch((err) => { if (!cancelled) setError(String(err)); });

--- a/app/src/lib/hooks/useInitialization.ts
+++ b/app/src/lib/hooks/useInitialization.ts
@@ -11,7 +11,7 @@ export function useInitialization(settings: Settings) {
     initDictation()
       .then(() => {
         if (cancelled) return;
-        return configure({ model: settings.model, language: settings.language, autoPaste: settings.autoPaste });
+        return configure({ model: settings.model, language: settings.language, autoPaste: settings.autoPaste, customVocabulary: settings.customVocabulary });
       })
       .then(() => { if (!cancelled) setInitialized(true); })
       .catch((err) => { if (!cancelled) setError(String(err)); });

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -47,9 +47,9 @@ export function useSettings() {
       });
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates) {
       const version = ++configureVersionRef.current;
-      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity, idleTimeoutMinutes: newSettings.idleTimeoutMinutes })
+      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity, idleTimeoutMinutes: newSettings.idleTimeoutMinutes, customVocabulary: newSettings.customVocabulary })
         .catch((err) => {
           console.error('Failed to configure:', err);
           if (configureVersionRef.current === version) {
@@ -61,6 +61,7 @@ export function useSettings() {
               autoPasteDelayMs: previousSettings.autoPasteDelayMs,
               vadSensitivity: previousSettings.vadSensitivity,
               idleTimeoutMinutes: previousSettings.idleTimeoutMinutes,
+              customVocabulary: previousSettings.customVocabulary,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -13,6 +13,7 @@ export interface Settings {
   launchAtLogin: boolean;
   vadSensitivity: number;
   idleTimeoutMinutes: number;
+  customVocabulary: string;
 }
 
 export type ModelOption =
@@ -68,6 +69,7 @@ export const DEFAULT_SETTINGS: Settings = {
   launchAtLogin: false,
   vadSensitivity: 50,
   idleTimeoutMinutes: 5,
+  customVocabulary: '',
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
## Summary
- Adds a **Custom Vocabulary** textarea in Settings → Transcription that passes user-defined terms as Whisper's `initial_prompt`, biasing the decoder toward technical words (e.g. Tauri, Claude, rdev, cpal)
- Adds `token_count()` to the transcription backend trait using Whisper's built-in BPE tokenizer, with a live token counter in the UI (falls back to `~N tokens` estimate when model not loaded)
- Moonshine backend silently ignores the param, with an amber warning in Settings when vocab is non-empty

## Changes
| File | Change |
|------|--------|
| `transcriber/mod.rs` | Added `initial_prompt: Option<&str>` to `transcribe()` + `token_count()` to trait |
| `transcriber/whisper.rs` | Calls `set_initial_prompt()` when provided + implements `token_count()` |
| `transcriber/moonshine.rs` | Accepts and ignores both new params |
| `state.rs` | Added `custom_vocabulary: String` to `DictationState` |
| `commands/recording.rs` | Threads vocab through pipeline with null-byte sanitization + `count_vocab_tokens` command |
| `lib.rs` | Registers `count_vocab_tokens` command |
| `settings.ts` | Added `customVocabulary` to Settings interface + defaults |
| `dictation.ts` | Added `customVocabulary` to `ConfigureOptions` + `countVocabTokens()` wrapper |
| `useSettings.ts` | Wired `customVocabulary` into configure trigger/call/revert |
| `useInitialization.ts` | Passes `customVocabulary` in initial configure |
| `SettingsPanel.tsx` | `CustomVocabularyTextarea` component with draft/blur pattern, token counter, Moonshine warning |

## Test plan
- [x] Add vocab "Tauri", record saying "Tauri" → recognized correctly
- [x] Clear vocab, switch model to reset cache, record "Tauri" → misrecognized (confirms feature works)
- [x] Token counter shows exact count after first transcription, estimate before
- [ ] Moonshine model selected with vocab → amber warning displayed
- [ ] Quit and relaunch → vocab persisted in localStorage
- [ ] Special characters in vocab (C++, .claude) → no crashes

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom vocabulary support added to transcription settings (persisted and used as an optional prompt).
  * Real-time token counter shows vocabulary size estimates.
  * New custom vocabulary field in Settings with contextual guidance for specific backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->