### PR TITLE
UI cleanup: compact stats, breathing room, visual hierarchy

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -139,7 +139,7 @@ function App() {
       <StatsBar statsVersion={combinedStatsVersion} />
 
       <div className="flex-1 flex overflow-hidden">
-        <main className="flex-1 flex flex-col overflow-hidden p-4 gap-4">
+        <main className="flex-1 flex flex-col overflow-hidden p-5 gap-4">
           <TranscriptionView
             historyEntries={historyEntries}
             onClearHistory={clearHistory}

--- a/app/src/components/RecordingControls.tsx
+++ b/app/src/components/RecordingControls.tsx
@@ -25,9 +25,9 @@ export function RecordingControls({ status, initialized, onStart, onStop }: Reco
         <button
           onClick={onStart}
           disabled={!initialized || status === 'processing'}
-          className="flex items-center gap-2 px-6 py-3 bg-stone-800 hover:bg-stone-900 active:bg-stone-950 dark:bg-stone-100 dark:hover:bg-white dark:text-stone-900 text-white font-medium rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 px-4 py-2 text-sm bg-transparent border border-stone-300 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-600 dark:text-stone-400 font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
             <circle cx="10" cy="10" r="6" />
           </svg>
           {status === 'processing' ? 'Processing...' : 'Start Recording'}

--- a/app/src/components/StatsBar.tsx
+++ b/app/src/components/StatsBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { loadStats, getWPM, getApproxTokens } from '../lib/stats';
+import { loadStats, getWPM } from '../lib/stats';
 import type { DictationStats } from '../lib/stats';
 
 interface StatsBarProps {
@@ -10,23 +10,21 @@ export function StatsBar({ statsVersion }: StatsBarProps) {
   const [stats, setStats] = useState<DictationStats>(() => loadStats());
   useEffect(() => { setStats(loadStats()); }, [statsVersion]);
   const wpm = getWPM(stats);
-  const tokens = getApproxTokens(stats);
 
   return (
-    <div className="shrink-0 flex gap-2 px-4 py-2">
-      <Chip label="Total Words" value={stats.totalWords.toLocaleString()} />
+    <div className="shrink-0 flex gap-2 px-4 py-1.5">
+      <Chip label="Words" value={stats.totalWords.toLocaleString()} />
       <Chip label="Avg WPM" value={wpm > 0 ? wpm.toLocaleString() : '—'} />
       <Chip label="Recordings" value={stats.totalRecordings.toLocaleString()} />
-      <Chip label="Approx Tokens" value={tokens > 0 ? tokens.toLocaleString() : '—'} />
     </div>
   );
 }
 
 function Chip({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex-1 flex flex-col items-center px-3 py-2 rounded-lg bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700">
-      <span className="text-xs font-semibold text-stone-800 dark:text-stone-100 tabular-nums">{value}</span>
-      <span className="text-[10px] text-stone-500 dark:text-stone-400 mt-0.5 leading-none">{label}</span>
+    <div className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1 rounded-lg bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700">
+      <span className="text-[10px] text-stone-500 dark:text-stone-400 leading-none">{label}</span>
+      <span className="text-[11px] font-semibold text-stone-800 dark:text-stone-100 tabular-nums">{value}</span>
     </div>
   );
 }

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -63,12 +63,12 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Scrollable list */}
-      <div className="flex-1 overflow-y-auto space-y-2">
+      <div className="flex-1 overflow-y-auto space-y-3">
         {sortedEntries.map((entry) => (
           <button
             key={entry.id}
             onClick={() => handleCopy(entry)}
-            className={`w-full text-left p-3 rounded-lg border transition-all ${
+            className={`w-full text-left p-3.5 rounded-lg border transition-all ${
               copiedId === entry.id
                 ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-300 dark:border-emerald-700'
                 : 'bg-stone-50 dark:bg-stone-700/50 border-stone-200 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-700'
@@ -105,7 +105,7 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
               </div>
             </div>
             {/* Text content */}
-            <p className="text-sm text-stone-900 dark:text-stone-100 overflow-y-auto max-h-32">
+            <p className="text-xs text-stone-900 dark:text-stone-100 overflow-y-auto max-h-32">
               {entry.text}
             </p>
           </button>

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -256,8 +256,8 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
   return (
     <aside
-      className={`shrink-0 border-l border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800 transition-all duration-200 ${
-        isOpen ? 'w-[280px] overflow-y-auto' : 'w-0 overflow-hidden'
+      className={`shrink-0 border-l border-stone-200 dark:border-stone-700 bg-stone-50/80 dark:bg-stone-800/80 backdrop-blur-sm transition-all duration-200 ${
+        isOpen ? 'w-[260px] overflow-y-auto' : 'w-0 overflow-hidden'
       }`}
     >
       {/* Header */}


### PR DESCRIPTION
Closes #130

## Summary
- **Stats bar**: Remove Approx Tokens chip, switch to horizontal inline layout with smaller sizing
- **History cards**: Increase vertical gap (`space-y-3`) and padding (`p-3.5`), reduce body text to `text-xs`
- **Recording button**: Outlined idle style (transparent bg, border, muted text), smaller padding/icon; stop button stays bold
- **Settings panel**: Translucent background (`bg-stone-50/80 backdrop-blur-sm`), narrower width (260px)
- **Main content**: Increase padding (`p-5`) for breathing room

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `cargo test --lib` passes
- [ ] `npm test` passes
- [ ] Visual inspection: stats bar compact, cards spaced, idle button subtle, settings lighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)