### PR TITLE
fix: clear skipped version on manual update check to prevent freeze

### DIFF
--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -39,6 +39,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
     isCheckingRef.current = true;
 
     if (!opts.isBackground) {
+      clearSkippedVersion();
       setUpdateStatus({ phase: 'checking' });
     }
 
@@ -126,7 +127,6 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, [performCheck]);
 
   const checkForUpdate = useCallback(async () => {
-    clearSkippedVersion();
     await performCheck({ isBackground: false });
   }, [performCheck]);
 

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -67,6 +67,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       // If not forced and user previously skipped this version, suppress
       if (!isForced && getSkippedVersion() === update.version) {
         flog.info('updater', 'user skipped this version', { version: update.version });
+        if (!opts.isBackground) {
+          setUpdateStatus({ phase: 'idle' });
+        }
         isCheckingRef.current = false;
         return;
       }
@@ -123,6 +126,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, [performCheck]);
 
   const checkForUpdate = useCallback(async () => {
+    clearSkippedVersion();
     await performCheck({ isBackground: false });
   }, [performCheck]);
 


### PR DESCRIPTION
## Summary

- Manual "Check for Updates" now clears `skippedVersion` before checking, so the user always sees the update prompt when they explicitly ask
- The skip code path now resets UI status to `idle` for foreground checks, preventing the "Checking..." freeze
- Background/auto checks still respect the skipped version (no nagging on launch)

## Test plan

- [ ] Skip an available update, then click "Check for Updates" — should show the update prompt again (not freeze)
- [ ] Skip an update, relaunch — background check should still suppress the skipped version
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed update status display when updates are skipped in the UI
  * Improved update checking mechanism to properly handle previously skipped versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->