### PR TITLE
feat: overlay hover-expand with quick settings panel

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.8.3"
+version = "0.8.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -3,6 +3,7 @@ use tauri::{Emitter, Manager};
 
 const NOTCH_EXPAND: f64 = 120.0; // 60px expansion room on each side
 const FALLBACK_OVERLAY_W: f64 = 200.0;
+const DROPDOWN_HEIGHT: f64 = 52.0; // extra height for hover-expand settings row
 
 #[derive(serde::Serialize, Clone)]
 pub(crate) struct NotchInfo {
@@ -114,7 +115,7 @@ fn raise_window_above_menubar(_overlay: &tauri::WebviewWindow) {}
 /// Takes cached notch_info to avoid calling NSScreen APIs off the main thread.
 pub(crate) fn position_overlay_default(overlay: &tauri::WebviewWindow, notch_info: Option<(f64, f64)>) {
     let overlay_w = notch_info.map(|(w, _)| w + NOTCH_EXPAND).unwrap_or(FALLBACK_OVERLAY_W);
-    let overlay_h = notch_info.map(|(_, h)| h).unwrap_or(37.0);
+    let overlay_h = notch_info.map(|(_, h)| h + DROPDOWN_HEIGHT).unwrap_or(37.0 + DROPDOWN_HEIGHT);
     tracing::info!(target: "system", "position_overlay_default: notch_info={:?}, overlay_w={}, overlay_h={}", notch_info, overlay_w, overlay_h);
 
     // Resize window to match notch area
@@ -174,4 +175,15 @@ pub fn hide_overlay(app: tauri::AppHandle) -> Result<(), String> {
             Ok(())
         }
     }
+}
+
+/// Show and focus the main settings window (called from overlay quick-settings gear icon).
+#[tauri::command]
+pub fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window not found".to_string())?;
+    window.show().map_err(|e| e.to_string())?;
+    window.set_focus().map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run() {
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
             commands::overlay::get_notch_info,
+            commands::overlay::show_main_window,
             telemetry::get_event_history,
             telemetry::clear_event_history,
             resource_monitor::get_resource_usage

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
         "title": "",
         "url": "overlay.html",
         "width": 260,
-        "height": 100,
+        "height": 160,
         "decorations": false,
         "alwaysOnTop": true,
         "transparent": true,

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { listen } from '@tauri-apps/api/event';
+import { listen, emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { isDictationStatus } from '../lib/types';
 import type { DictationStatus } from '../lib/types';
@@ -7,23 +7,75 @@ import { flog } from '../lib/log';
 import { STORAGE_KEY, DEFAULT_SETTINGS } from '../lib/settings';
 
 const BAR_COUNT = 7;
+const DROPDOWN_ROW_HEIGHT = 40;
+
+function readSettingsFromStorage() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch { /* ignore */ }
+  return {};
+}
+
+function writeSettingToStorage(key: string, value: unknown) {
+  try {
+    const current = readSettingsFromStorage();
+    const updated = { ...DEFAULT_SETTINGS, ...current, [key]: value };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch { /* ignore */ }
+}
 
 export function OverlayWidget() {
   const [status, setStatus] = useState<DictationStatus>('idle');
   const [showCancelled, setShowCancelled] = useState(false);
   const [lockedMode, setLockedMode] = useState(false);
-  const notchHeightRef = useRef(0);
   const [notchWidth, setNotchWidth] = useState(185);
+  const [notchHeight, setNotchHeight] = useState(37);
+  const notchHeightRef = useRef(0);
   const statusRef = useRef(status);
   const lockedRef = useRef(lockedMode);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const audioLevelRef = useRef(0);
   const barRefs = useRef<(HTMLDivElement | null)[]>([]);
 
+  // Hover state
+  const [hovered, setHovered] = useState(false);
+  const [showControls, setShowControls] = useState(false);
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const controlsFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Quick settings state (read from localStorage)
+  const [autoPaste, setAutoPaste] = useState(false);
+  const [disabled, setDisabled] = useState(false);
+
+  // Recording timer
+  const [recordingStartTime, setRecordingStartTime] = useState<number | null>(null);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { lockedRef.current = lockedMode; }, [lockedMode]);
 
-  // Log mount + fetch notch dimensions
+  // Track recording start time for timer
+  useEffect(() => {
+    if (status === 'recording') {
+      setRecordingStartTime(Date.now());
+      setRecordingDuration(0);
+    } else {
+      setRecordingStartTime(null);
+      setRecordingDuration(0);
+    }
+  }, [status]);
+
+  // Update recording timer every second while recording
+  useEffect(() => {
+    if (recordingStartTime === null) return;
+    const interval = setInterval(() => {
+      setRecordingDuration(Math.floor((Date.now() - recordingStartTime) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [recordingStartTime]);
+
+  // Log mount + fetch notch dimensions + read settings
   useEffect(() => {
     flog.info('overlay', 'mounted');
     invoke<{ notch_width: number; notch_height: number } | null>('get_notch_info')
@@ -31,39 +83,26 @@ export function OverlayWidget() {
         if (info) {
           flog.info('overlay', 'notch info', { notch_width: info.notch_width, notch_height: info.notch_height });
           notchHeightRef.current = info.notch_height;
+          setNotchHeight(info.notch_height);
           setNotchWidth(info.notch_width);
         } else {
           flog.info('overlay', 'no notch detected');
         }
       })
       .catch((e) => flog.warn('overlay', 'get_notch_info failed', { error: String(e) }));
+
+    // Read settings from localStorage
+    const stored = readSettingsFromStorage();
+    setAutoPaste(stored.autoPaste ?? DEFAULT_SETTINGS.autoPaste);
+    setDisabled(stored.disabled ?? false);
+
     return () => {
       flog.info('overlay', 'unmounted');
       if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+      if (controlsFadeRef.current) clearTimeout(controlsFadeRef.current);
     };
   }, []);
-
-  // Restore saved position (Rust handles default positioning)
-  // TODO: re-enable after notch positioning is stable
-  // useEffect(() => {
-  //   (async () => {
-  //     try {
-  //       const saved = localStorage.getItem(POSITION_KEY);
-  //       if (saved) {
-  //         const { x, y } = JSON.parse(saved) as { x: number; y: number };
-  //         console.log('[overlay] restoring saved position:', { x, y });
-  //         await getCurrentWindow().setPosition(new PhysicalPosition(x, y));
-  //       } else {
-  //         console.log('[overlay] no saved position, using Rust default');
-  //       }
-  //     } catch (e) {
-  //       console.warn('[overlay] position restore failed:', e);
-  //     }
-  //   })();
-  // }, []);
-
-  // TODO: re-enable position persistence after notch positioning is stable.
-  // Both save (onMoved) and restore are disabled to avoid saving programmatic repositions.
 
   // Subscribe to recording status events from Rust
   useEffect(() => {
@@ -113,10 +152,12 @@ export function OverlayWidget() {
       if (event.payload) {
         flog.info('overlay', 'notch info changed', { notch_width: event.payload.notch_width, notch_height: event.payload.notch_height });
         notchHeightRef.current = event.payload.notch_height;
+        setNotchHeight(event.payload.notch_height);
         setNotchWidth(event.payload.notch_width);
       } else {
         flog.info('overlay', 'notch removed (no notch on new display)');
         notchHeightRef.current = 0;
+        setNotchHeight(37);
         setNotchWidth(140);
       }
     }).then((fn) => {
@@ -131,6 +172,20 @@ export function OverlayWidget() {
     let unlisten: (() => void) | null = null;
     listen<number>('audio-level', (event) => {
       audioLevelRef.current = event.payload;
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
+  // Listen for settings-changed from main window (keeps overlay in sync)
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<Record<string, unknown>>('settings-changed', (event) => {
+      const payload = event.payload;
+      if ('autoPaste' in payload) setAutoPaste(payload.autoPaste as boolean);
+      if ('disabled' in payload) setDisabled(payload.disabled as boolean);
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
     });
@@ -164,6 +219,33 @@ export function OverlayWidget() {
     rafId = requestAnimationFrame(animate);
     return () => cancelAnimationFrame(rafId);
   }, [status]);
+
+  // Hover handlers
+  const handleMouseEnter = useCallback(() => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setHovered(true);
+    // Re-read settings from localStorage on each hover-expand
+    const stored = readSettingsFromStorage();
+    setAutoPaste(stored.autoPaste ?? DEFAULT_SETTINGS.autoPaste);
+    setDisabled(stored.disabled ?? false);
+    // Delayed controls fade-in
+    controlsFadeRef.current = setTimeout(() => setShowControls(true), 100);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (controlsFadeRef.current) {
+      clearTimeout(controlsFadeRef.current);
+      controlsFadeRef.current = null;
+    }
+    // 300ms hover-intent delay before collapsing
+    hoverTimeoutRef.current = setTimeout(() => {
+      setHovered(false);
+      setShowControls(false);
+    }, 300);
+  }, []);
 
   // Double-click: toggle locked mode. Cancel any pending single-click first.
   const handleDoubleClick = useCallback(async (e: React.MouseEvent) => {
@@ -255,6 +337,39 @@ export function OverlayWidget() {
     });
   }, []);
 
+  // Dropdown control handlers
+  const handleToggleDisabled = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const newVal = !disabled;
+    setDisabled(newVal);
+    writeSettingToStorage('disabled', newVal);
+    emit('settings-changed', { disabled: newVal });
+  }, [disabled]);
+
+  const handleToggleAutoPaste = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (disabled) return;
+    const newVal = !autoPaste;
+    setAutoPaste(newVal);
+    writeSettingToStorage('autoPaste', newVal);
+    emit('settings-changed', { autoPaste: newVal });
+  }, [autoPaste, disabled]);
+
+  const handleOpenSettings = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    invoke('show_main_window').catch((err) =>
+      flog.warn('overlay', 'show_main_window failed', { error: String(err) })
+    );
+  }, []);
+
+  const pillHeight = hovered ? notchHeight + DROPDOWN_ROW_HEIGHT : notchHeight;
+
+  const formatDuration = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  };
+
   return (
     <div
       data-tauri-drag-region
@@ -264,23 +379,24 @@ export function OverlayWidget() {
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}
     >
-      {/* Dynamic Island: same height as notch, expands horizontally.
-          Idle = small icon on the left showing app is alive.
-          Active = expands with red dot on left, waveform on right. */}
       <div
-        className="cursor-pointer select-none overflow-hidden transition-all duration-[500ms] ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+        className="cursor-pointer select-none overflow-hidden"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         style={{
           borderRadius: '0 0 12px 12px',
           width: isActive ? notchWidth + 68 : notchWidth + 28,
           marginLeft: 32,
-          height: '100%',
+          height: pillHeight,
           background: 'rgba(20, 20, 20, 0.92)',
           backdropFilter: 'blur(40px)',
           WebkitBackdropFilter: 'blur(40px)',
+          transition: 'width 500ms cubic-bezier(0.34, 1.56, 0.64, 1), height 350ms cubic-bezier(0.34, 1.56, 0.64, 1)',
         }}
       >
-        <div className="flex items-center h-full" style={{ paddingLeft: 10, paddingRight: 10 }}>
-          {/* Left side — mic icon (idle) or red dot (recording) or spinner (processing) or red X (cancelled), all same position */}
+        {/* Top bar — same content as before, fixed height matching notch */}
+        <div className="flex items-center shrink-0" style={{ height: notchHeight, paddingLeft: 10, paddingRight: 10 }}>
+          {/* Left side — mic icon / red dot / spinner / red X */}
           <div className="shrink-0 w-3 h-3 flex items-center justify-center">
             {showCancelled ? (
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
@@ -292,13 +408,31 @@ export function OverlayWidget() {
             ) : status === 'processing' ? (
               <span className="w-3 h-3 border-[1.5px] border-white/20 border-t-white/70 rounded-full animate-spin block" />
             ) : (
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="12" height="12" viewBox="0 0 24 24" fill="none"
+                stroke={disabled ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.4)'}
+                strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                style={{ transition: 'stroke 200ms ease' }}
+              >
                 <rect x="9" y="1" width="6" height="12" rx="3" />
                 <path d="M5 10a7 7 0 0 0 14 0" />
                 <line x1="12" y1="17" x2="12" y2="21" />
               </svg>
             )}
           </div>
+
+          {/* Inline recording timer (visible only when recording + hovered) */}
+          {status === 'recording' && hovered && (
+            <span style={{
+              fontSize: 10,
+              color: 'rgba(255,255,255,0.6)',
+              marginLeft: 4,
+              fontVariantNumeric: 'tabular-nums',
+              fontFamily: 'system-ui, -apple-system, sans-serif',
+            }}>
+              {formatDuration(recordingDuration)}
+            </span>
+          )}
 
           {/* Spacer */}
           <div className="flex-1" />
@@ -322,6 +456,96 @@ export function OverlayWidget() {
               />
             ))}
           </div>
+        </div>
+
+        {/* Dropdown controls row */}
+        <div
+          className="flex items-center justify-center gap-3"
+          style={{
+            height: DROPDOWN_ROW_HEIGHT,
+            opacity: showControls ? 1 : 0,
+            pointerEvents: showControls ? 'auto' : 'none',
+            transition: 'opacity 200ms ease',
+            paddingLeft: 12,
+            paddingRight: 12,
+          }}
+        >
+          {/* Speaker-slash icon — global disable toggle */}
+          <button
+            onClick={handleToggleDisabled}
+            onDoubleClick={(e) => e.stopPropagation()}
+            className="flex items-center justify-center rounded-full"
+            style={{
+              width: 28,
+              height: 28,
+              background: disabled ? 'rgba(239,68,68,0.12)' : 'transparent',
+              transition: 'background 200ms ease',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke={disabled ? '#ef4444' : 'rgba(255,255,255,0.5)'}
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              style={{ transition: 'stroke 200ms ease' }}
+            >
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+              <line x1="23" y1="9" x2="17" y2="15" />
+              <line x1="17" y1="9" x2="23" y2="15" />
+            </svg>
+          </button>
+
+          {/* Auto-paste toggle */}
+          <button
+            onClick={handleToggleAutoPaste}
+            onDoubleClick={(e) => e.stopPropagation()}
+            className="flex items-center justify-center rounded-full"
+            style={{
+              width: 28,
+              height: 28,
+              background: autoPaste && !disabled ? 'rgba(255,255,255,0.12)' : 'transparent',
+              opacity: disabled ? 0.35 : 1,
+              transition: 'background 200ms ease, opacity 200ms ease',
+              border: 'none',
+              cursor: disabled ? 'default' : 'pointer',
+              padding: 0,
+            }}
+          >
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke={autoPaste && !disabled ? 'rgba(255,255,255,0.9)' : 'rgba(255,255,255,0.5)'}
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              style={{ transition: 'stroke 200ms ease' }}
+            >
+              <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+              <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+            </svg>
+          </button>
+
+          {/* Gear icon — open settings */}
+          <button
+            onClick={handleOpenSettings}
+            onDoubleClick={(e) => e.stopPropagation()}
+            className="flex items-center justify-center rounded-full"
+            style={{
+              width: 28,
+              height: 28,
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke="rgba(255,255,255,0.5)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
         </div>
       </div>
     </div>

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import { Settings, loadSettings, saveSettings } from '../settings';
 import { configure } from '../dictation';
 import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
@@ -24,6 +25,33 @@ export function useSettings() {
     }).catch((err) => {
       console.error('Failed to check autostart status:', err);
     });
+  }, []);
+
+  // Listen for settings changes from other windows (e.g. overlay quick-settings panel)
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<Partial<Settings>>('settings-changed', () => {
+      // Re-read from localStorage to get the latest state
+      const fresh = loadSettings();
+      const prev = settingsRef.current;
+      settingsRef.current = fresh;
+      setSettings(fresh);
+      // Re-configure backend if configure-relevant fields changed
+      if (fresh.autoPaste !== prev.autoPaste || fresh.autoPasteDelayMs !== prev.autoPasteDelayMs ||
+          fresh.model !== prev.model || fresh.language !== prev.language ||
+          fresh.vadSensitivity !== prev.vadSensitivity || fresh.idleTimeoutMinutes !== prev.idleTimeoutMinutes ||
+          fresh.customVocabulary !== prev.customVocabulary) {
+        configure({
+          model: fresh.model, language: fresh.language, autoPaste: fresh.autoPaste,
+          autoPasteDelayMs: fresh.autoPasteDelayMs, vadSensitivity: fresh.vadSensitivity,
+          idleTimeoutMinutes: fresh.idleTimeoutMinutes, customVocabulary: fresh.customVocabulary,
+        }).catch((err) => console.error('Failed to reconfigure after settings-changed:', err));
+      }
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
   }, []);
 
   const updateSettings = (updates: Partial<Settings>) => {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -14,6 +14,7 @@ export interface Settings {
   vadSensitivity: number;
   idleTimeoutMinutes: number;
   customVocabulary: string;
+  disabled: boolean;
 }
 
 export type ModelOption =
@@ -63,6 +64,7 @@ export const DEFAULT_SETTINGS: Settings = {
   vadSensitivity: 50,
   idleTimeoutMinutes: 5,
   customVocabulary: '',
+  disabled: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
Closes #135

## Summary
- Hovering the Dynamic Island overlay pill expands it downward to reveal a compact row of quick-access controls: global disable toggle, auto-paste toggle, and gear icon to open settings
- Pre-allocates a taller overlay window with transparent overflow for flicker-free CSS height transitions
- Adds `disabled` field to Settings schema and `show_main_window` Rust command
- Cross-window settings sync via `settings-changed` Tauri event so overlay and main window stay in sync
- Inline recording timer (M:SS) appears in the top bar during recording + hover
- 300ms hover-intent delay on mouse-leave prevents flicker; controls fade in 100ms after expansion starts

## Test plan
- [ ] Hover over the overlay pill — verify it expands downward with a smooth animation
- [ ] Mouse-leave — verify it collapses after ~300ms delay
- [ ] Click speaker-slash icon — verify it toggles red disabled state; mic icon dims to 15% opacity
- [ ] Click auto-paste toggle — verify it toggles; verify main window settings panel reflects the change
- [ ] Click gear icon — verify main settings window opens and receives focus
- [ ] While disabled, verify auto-paste button is dimmed at 35% opacity and non-interactive
- [ ] Start recording via hotkey, then hover — verify red dot + inline timer + waveform in top bar
- [ ] Verify click/double-click on the pill (outside dropdown) still starts/stops recording
- [ ] Verify dropdown buttons don't trigger recording start/stop (stopPropagation)
- [ ] Test on external monitor (no notch) — verify fallback dimensions work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Overlay controls now appear on hover, enabling quick access to disable, auto-paste toggle, and settings.
  * Recording duration displays while recording and hovering over the overlay.
  * Settings are automatically saved and persist between sessions.
  * Improved overlay window sizing for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->