### PR TITLE
feat: cfg-gate macOS-specific code for Linux compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Unit tests
         run: cd app && npm test
 
-  rust:
+  rust-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,4 +51,40 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CMAKE_C_FLAGS: "-march=armv8.5-a"
           CMAKE_CXX_FLAGS: "-march=armv8.5-a"
+        run: cd app/src-tauri && cargo test --lib -- --test-threads=1
+
+  rust-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libxdo-dev \
+            libasound2-dev
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.21
+        with:
+          cuda: '12.8.0'
+          method: 'network'
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+
+      - name: Compile check
+        run: cd app/src-tauri && cargo check
+
+      - name: Run tests
         run: cd app/src-tauri && cargo test --lib -- --test-threads=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Unit tests
         run: cd app && npm test
 
-  release:
+  release-macos:
     needs: [typecheck]
     runs-on: macos-latest
     permissions:
@@ -117,6 +117,147 @@ jobs:
           kill "$PID" 2>/dev/null || true
           wait "$PID" 2>/dev/null || true
 
+      - name: Collect updater artifact info
+        run: |
+          ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
+          TAR_GZ_FILE=$(echo "$ARTIFACTS" | jq -r '.[]' | grep '\.app\.tar\.gz$' | head -1)
+          TAR_GZ_BASENAME=$(basename "$TAR_GZ_FILE")
+          RUNNER_ARCH=$(uname -m)
+          [ "$RUNNER_ARCH" = "arm64" ] && RUNNER_ARCH="aarch64"
+
+          SIG_FILE="${TAR_GZ_FILE}.sig"
+          SIGNATURE=""
+          if [ -f "$SIG_FILE" ]; then
+            SIGNATURE=$(cat "$SIG_FILE")
+          fi
+
+          mkdir -p updater-info
+          cat > updater-info/macos.json <<ENDJSON
+          {
+            "platform": "darwin-${RUNNER_ARCH}",
+            "url_basename": "${TAR_GZ_BASENAME}",
+            "signature": "${SIGNATURE}"
+          }
+          ENDJSON
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-artifacts
+          path: |
+            app/src-tauri/target/release/bundle/dmg/*.dmg
+            app/src-tauri/target/release/bundle/macos/*.app.tar.gz
+            app/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
+
+      - name: Upload updater info
+        uses: actions/upload-artifact@v4
+        with:
+          name: updater-macos
+          path: updater-info/macos.json
+
+  release-linux:
+    needs: [typecheck]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libxdo-dev \
+            libasound2-dev
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.21
+        with:
+          cuda: '12.8.0'
+          method: 'network'
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+
+      - name: Install frontend dependencies
+        run: cd app && npm ci
+
+      - name: Build
+        id: tauri-build
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: app
+
+      - name: Collect updater artifact info
+        run: |
+          ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
+          APPIMAGE_FILE=$(echo "$ARTIFACTS" | jq -r '.[]' | grep '\.AppImage\.tar\.gz$' | head -1)
+          APPIMAGE_BASENAME=$(basename "$APPIMAGE_FILE")
+          RUNNER_ARCH=$(uname -m)
+
+          SIG_FILE="${APPIMAGE_FILE}.sig"
+          SIGNATURE=""
+          if [ -f "$SIG_FILE" ]; then
+            SIGNATURE=$(cat "$SIG_FILE")
+          fi
+
+          mkdir -p updater-info
+          cat > updater-info/linux.json <<ENDJSON
+          {
+            "platform": "linux-${RUNNER_ARCH}",
+            "url_basename": "${APPIMAGE_BASENAME}",
+            "signature": "${SIGNATURE}"
+          }
+          ENDJSON
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifacts
+          path: |
+            app/src-tauri/target/release/bundle/deb/*.deb
+            app/src-tauri/target/release/bundle/appimage/*.AppImage
+            app/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz
+            app/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz.sig
+
+      - name: Upload updater info
+        uses: actions/upload-artifact@v4
+        with:
+          name: updater-linux
+          path: updater-info/linux.json
+
+  publish:
+    needs: [release-macos, release-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -131,15 +272,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
-          echo "Artifacts: $ARTIFACTS"
-          echo "$ARTIFACTS" | jq -r '.[]' | while read -r artifact; do
-            if [ ! -f "$artifact" ]; then
-              echo "Skipping (not a file): $artifact"
-              continue
-            fi
-            echo "Uploading: $artifact"
-            gh release upload "${{ github.ref_name }}" "$artifact" \
+          find artifacts/macos-artifacts artifacts/linux-artifacts -type f | while read -r file; do
+            echo "Uploading: $file"
+            gh release upload "${{ github.ref_name }}" "$file" \
               --repo "${{ github.repository }}"
           done
 
@@ -149,46 +284,42 @@ jobs:
         run: |
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#v}"
+          REPO="${{ github.repository }}"
+          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 
-          # Discover the .app.tar.gz artifact and its .sig sibling from build outputs
-          ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
-          TAR_GZ_FILE=$(echo "$ARTIFACTS" | jq -r '.[]' | grep '\.app\.tar\.gz$' | head -1)
-          if [ -z "$TAR_GZ_FILE" ] || [ ! -f "$TAR_GZ_FILE" ]; then
-            echo "ERROR: No .app.tar.gz artifact found in build outputs"
-            echo "Artifacts: $ARTIFACTS"
-            exit 1
-          fi
-          TAR_GZ_BASENAME=$(basename "$TAR_GZ_FILE")
-          # Derive platform from runner arch — uname -m returns arm64 on Apple Silicon,
-          # map to aarch64 to match Tauri's platform key convention.
-          RUNNER_ARCH=$(uname -m)
-          [ "$RUNNER_ARCH" = "arm64" ] && RUNNER_ARCH="aarch64"
-          PLATFORM="darwin-${RUNNER_ARCH}"
+          # Read platform info from both builds
+          MACOS=$(cat artifacts/updater-macos/macos.json)
+          LINUX=$(cat artifacts/updater-linux/linux.json)
 
-          SIG_FILE="${TAR_GZ_FILE}.sig"
-          SIGNATURE=""
-          if [ -f "$SIG_FILE" ]; then
-            SIGNATURE=$(cat "$SIG_FILE")
-          else
-            echo "WARNING: No .sig file found at ${SIG_FILE}"
-          fi
+          MACOS_PLATFORM=$(echo "$MACOS" | jq -r '.platform')
+          MACOS_URL="${BASE_URL}/$(echo "$MACOS" | jq -r '.url_basename')"
+          MACOS_SIG=$(echo "$MACOS" | jq -r '.signature')
 
-          TAR_GZ_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${TAR_GZ_BASENAME}"
+          LINUX_PLATFORM=$(echo "$LINUX" | jq -r '.platform')
+          LINUX_URL="${BASE_URL}/$(echo "$LINUX" | jq -r '.url_basename')"
+          LINUX_SIG=$(echo "$LINUX" | jq -r '.signature')
 
-          cat > latest.json <<ENDJSON
-          {
-            "version": "${VERSION}",
-            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "platforms": {
-              "${PLATFORM}": {
-                "url": "${TAR_GZ_URL}",
-                "signature": "${SIGNATURE}"
-              }
-            },
-            "notes": "See release notes at https://github.com/${{ github.repository }}/releases/tag/${TAG}"
-          }
-          ENDJSON
+          jq -n \
+            --arg version "$VERSION" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg macos_platform "$MACOS_PLATFORM" \
+            --arg macos_url "$MACOS_URL" \
+            --arg macos_sig "$MACOS_SIG" \
+            --arg linux_platform "$LINUX_PLATFORM" \
+            --arg linux_url "$LINUX_URL" \
+            --arg linux_sig "$LINUX_SIG" \
+            --arg notes "See release notes at https://github.com/${REPO}/releases/tag/${TAG}" \
+            '{
+              version: $version,
+              pub_date: $pub_date,
+              platforms: {
+                ($macos_platform): { url: $macos_url, signature: $macos_sig },
+                ($linux_platform): { url: $linux_url, signature: $linux_sig }
+              },
+              notes: $notes
+            }' > latest.json
 
+          cat latest.json
           gh release upload "${TAG}" latest.json \
             --repo "${{ github.repository }}" \
             --clobber

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.8.3"
+version = "0.8.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3574,6 +3574,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "winapi",
+ "x11",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -44,6 +44,9 @@ objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSScreen", "NSApplic
 objc2-foundation = "0.3"
 block2 = "0.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rdev = { git = "https://github.com/Narsil/rdev", branch = "main", features = ["x11"] }
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ block2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", branch = "main", features = ["x11"] }
+whisper-rs = { version = "0.15", features = ["cuda"] }
 
 [profile.release]
 panic = "abort"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "sync", "rt", "fs"] }
 base64 = "0.22"
-whisper-rs = { version = "0.15", features = ["metal", "log_backend"] }
+whisper-rs = { version = "0.15", features = ["log_backend"] }
 arboard = "3"
 hound = "3.5"
 dirs = "5"
@@ -38,6 +38,7 @@ tracing-appender = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.15", features = ["metal"] }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSScreen", "NSApplication", "NSRunningApplication"] }
 objc2-foundation = "0.3"

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -3,7 +3,9 @@ use crate::{MutexExt, State};
 use tauri::Emitter;
 use tauri::Manager;
 
+#[cfg(target_os = "macos")]
 const NOTCH_EXPAND: f64 = 120.0; // 60px expansion room on each side
+#[cfg(target_os = "macos")]
 const FALLBACK_OVERLAY_W: f64 = 200.0;
 
 #[derive(serde::Serialize, Clone)]
@@ -108,12 +110,10 @@ fn raise_window_above_menubar(overlay: &tauri::WebviewWindow) {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-fn raise_window_above_menubar(_overlay: &tauri::WebviewWindow) {}
-
 /// Position and size the overlay to match the notch, anchored at the top of the screen.
 /// The window is notch-height tall and wide enough for horizontal expansion.
 /// Takes cached notch_info to avoid calling NSScreen APIs off the main thread.
+#[cfg(target_os = "macos")]
 pub(crate) fn position_overlay_default(overlay: &tauri::WebviewWindow, notch_info: Option<(f64, f64)>) {
     let overlay_w = notch_info.map(|(w, _)| w + NOTCH_EXPAND).unwrap_or(FALLBACK_OVERLAY_W);
     let overlay_h = notch_info.map(|(_, h)| h).unwrap_or(37.0);
@@ -147,21 +147,29 @@ pub fn get_notch_info(state: tauri::State<'_, State>) -> Option<NotchInfo> {
     state.notch_info.lock_or_recover().map(|(w, h)| NotchInfo { notch_width: w, notch_height: h })
 }
 
-/// Show the always-on-top overlay window.
+/// Show the always-on-top overlay window (macOS notch overlay; no-op on Linux).
 #[tauri::command]
 pub fn show_overlay(app: tauri::AppHandle, state: tauri::State<'_, State>) -> Result<(), String> {
-    let notch = *state.notch_info.lock_or_recover();
-    match app.get_webview_window("overlay") {
-        Some(overlay) => {
-            position_overlay_default(&overlay, notch);
-            overlay.show().map_err(|e| e.to_string())?;
-            // Re-enable mouse events (focusable:false disables them on macOS)
-            let _ = overlay.set_ignore_cursor_events(false);
-            Ok(())
-        }
-        None => {
-            tracing::warn!(target: "system", "show_overlay: overlay window not found — skipping");
-            Ok(())
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (&app, &state);
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let notch = *state.notch_info.lock_or_recover();
+        match app.get_webview_window("overlay") {
+            Some(overlay) => {
+                position_overlay_default(&overlay, notch);
+                overlay.show().map_err(|e| e.to_string())?;
+                let _ = overlay.set_ignore_cursor_events(false);
+                Ok(())
+            }
+            None => {
+                tracing::warn!(target: "system", "show_overlay: overlay window not found — skipping");
+                Ok(())
+            }
         }
     }
 }

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -1,5 +1,7 @@
 use crate::{MutexExt, State};
-use tauri::{Emitter, Manager};
+#[cfg(target_os = "macos")]
+use tauri::Emitter;
+use tauri::Manager;
 
 const NOTCH_EXPAND: f64 = 120.0; // 60px expansion room on each side
 const FALLBACK_OVERLAY_W: f64 = 200.0;

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -82,7 +82,7 @@ fn simulate_paste() -> Result<(), String> {
     tracing::info!(target: "pipeline", "simulate_paste: using xdotool to simulate Ctrl+V");
 
     let output = Command::new("xdotool")
-        .args(["key", "ctrl+v"])
+        .args(["key", "ctrl+shift+v"])
         .output()
         .map_err(|e| format!("Failed to run xdotool: {}", e))?;
 

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -25,29 +25,20 @@ pub fn inject_text(text: &str, auto_paste: bool, delay_ms: u64) -> Result<(), St
         return Ok(());
     }
 
-    // Auto-paste is macOS-only for now (uses osascript). Follow-up: xdotool on Linux.
-    #[cfg(not(target_os = "macos"))]
-    {
-        tracing::info!(target: "pipeline", "inject_text: auto-paste not yet supported on this platform — text in clipboard only");
-        return Ok(());
-    }
-
-    #[cfg(target_os = "macos")]
     {
         use std::thread;
         use std::time::Duration;
 
-        // Check accessibility permission before attempting paste simulation
+        // Check accessibility permission before attempting paste simulation (macOS only)
         if !is_accessibility_enabled() {
-            // Don't error - text is in clipboard, user can paste manually
             tracing::warn!(target: "pipeline", "inject_text: accessibility permission not granted — text in clipboard only");
             return Ok(());
         }
 
-        // Wait for window focus to settle (clipboard write via NSPasteboard is synchronous)
+        // Wait for window focus to settle
         thread::sleep(Duration::from_millis(delay_ms));
 
-        // Simulate Cmd+V paste, retry once on failure
+        // Simulate paste keystroke, retry once on failure
         match simulate_paste() {
             Ok(()) => Ok(()),
             Err(first_err) => {
@@ -80,6 +71,27 @@ fn simulate_paste() -> Result<(), String> {
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(format!("osascript failed: {}", stderr))
+    }
+}
+
+/// Simulate Ctrl+V keystroke using xdotool (X11)
+#[cfg(target_os = "linux")]
+fn simulate_paste() -> Result<(), String> {
+    use std::process::Command;
+
+    tracing::info!(target: "pipeline", "simulate_paste: using xdotool to simulate Ctrl+V");
+
+    let output = Command::new("xdotool")
+        .args(["key", "ctrl+v"])
+        .output()
+        .map_err(|e| format!("Failed to run xdotool: {}", e))?;
+
+    if output.status.success() {
+        tracing::info!(target: "pipeline", "simulate_paste: completed successfully");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("xdotool failed: {}", stderr))
     }
 }
 

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -27,30 +27,41 @@ pub fn inject_text(text: &str, auto_paste: bool, delay_ms: u64) -> Result<(), St
         return Ok(());
     }
 
-    // Check accessibility permission before attempting paste simulation
-    if !is_accessibility_enabled() {
-        // Don't error - text is in clipboard, user can paste manually
-        tracing::warn!(target: "pipeline", "inject_text: accessibility permission not granted — text in clipboard only");
+    // Auto-paste is macOS-only for now (uses osascript). Follow-up: xdotool on Linux.
+    #[cfg(not(target_os = "macos"))]
+    {
+        tracing::info!(target: "pipeline", "inject_text: auto-paste not yet supported on this platform — text in clipboard only");
         return Ok(());
     }
 
-    // Wait for window focus to settle (clipboard write via NSPasteboard is synchronous)
-    thread::sleep(Duration::from_millis(delay_ms));
+    #[cfg(target_os = "macos")]
+    {
+        // Check accessibility permission before attempting paste simulation
+        if !is_accessibility_enabled() {
+            // Don't error - text is in clipboard, user can paste manually
+            tracing::warn!(target: "pipeline", "inject_text: accessibility permission not granted — text in clipboard only");
+            return Ok(());
+        }
 
-    // Simulate Cmd+V paste, retry once on failure
-    match simulate_paste() {
-        Ok(()) => Ok(()),
-        Err(first_err) => {
-            tracing::warn!(target: "pipeline", "inject_text: first paste attempt failed: {}, retrying in 100ms", first_err);
-            thread::sleep(Duration::from_millis(100));
-            simulate_paste().map_err(|retry_err| {
-                format!("Auto-paste failed after retry: {}", retry_err)
-            })
+        // Wait for window focus to settle (clipboard write via NSPasteboard is synchronous)
+        thread::sleep(Duration::from_millis(delay_ms));
+
+        // Simulate Cmd+V paste, retry once on failure
+        match simulate_paste() {
+            Ok(()) => Ok(()),
+            Err(first_err) => {
+                tracing::warn!(target: "pipeline", "inject_text: first paste attempt failed: {}, retrying in 100ms", first_err);
+                thread::sleep(Duration::from_millis(100));
+                simulate_paste().map_err(|retry_err| {
+                    format!("Auto-paste failed after retry: {}", retry_err)
+                })
+            }
         }
     }
 }
 
 /// Simulate Cmd+V keystroke using osascript (most reliable on macOS Sonoma/Sequoia)
+#[cfg(target_os = "macos")]
 fn simulate_paste() -> Result<(), String> {
     use std::process::Command;
 

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -1,6 +1,4 @@
 use arboard::Clipboard;
-use std::thread;
-use std::time::Duration;
 
 /// Copy text to clipboard and optionally simulate Cmd+V paste.
 /// `delay_ms` controls the pause before pasting (window focus settling).
@@ -36,6 +34,9 @@ pub fn inject_text(text: &str, auto_paste: bool, delay_ms: u64) -> Result<(), St
 
     #[cfg(target_os = "macos")]
     {
+        use std::thread;
+        use std::time::Duration;
+
         // Check accessibility permission before attempting paste simulation
         if !is_accessibility_enabled() {
             // Don't error - text is in clipboard, user can paste manually

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -12,7 +12,9 @@
 //!
 //! Both modes reject modifier+letter combos (e.g. Shift+A).
 
-use rdev::{listen, set_is_main_thread, Event, EventType, Key};
+use rdev::{listen, Event, EventType, Key};
+#[cfg(target_os = "macos")]
+use rdev::set_is_main_thread;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -473,6 +475,7 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
             // run on the main thread on macOS. This flag tells rdev to dispatch
             // those calls to the main queue via dispatch_sync instead of calling
             // them directly from this background thread.
+            #[cfg(target_os = "macos")]
             set_is_main_thread(false);
             tracing::info!(target: "keyboard", "rdev listener thread started");
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -145,6 +145,8 @@ pub fn run() {
             // Re-enable mouse events on the overlay window.
             // focusable:false sets ignoresMouseEvents=true on macOS;
             // we override that while keeping the window non-activating.
+            // On Linux, skip the overlay — it's designed for the macOS notch.
+            #[cfg(target_os = "macos")]
             if let Some(overlay_win) = app.get_webview_window("overlay") {
                 tracing::info!(target: "system", "setup: overlay window found, enabling cursor events");
                 commands::overlay::position_overlay_default(&overlay_win, notch);

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -34,7 +34,9 @@ pub fn ffi_heap_mb() -> u64 { 0 }
 
 use state::AppState;
 use std::sync::{Mutex, MutexGuard};
-use tauri::{Manager, RunEvent};
+use tauri::Manager;
+#[cfg(target_os = "macos")]
+use tauri::RunEvent;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 
@@ -207,15 +209,16 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| {
+    app.run(|_app_handle, _event| {
         // Suppress Tauri's default RunEvent::Reopen behaviour which shows
         // the main window whenever the macOS app is activated — including
         // when the overlay is clicked.  We only re-show the main window
         // when there are truly no visible windows (e.g. dock-icon click
         // after the user closed everything).
-        if let RunEvent::Reopen { has_visible_windows, .. } = &event {
+        #[cfg(target_os = "macos")]
+        if let RunEvent::Reopen { has_visible_windows, .. } = &_event {
             if !has_visible_windows {
-                if let Some(win) = app_handle.get_webview_window("main") {
+                if let Some(win) = _app_handle.get_webview_window("main") {
                     let _ = win.show();
                     let _ = win.set_focus();
                 }

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -95,7 +95,59 @@ mod cpu {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod cpu {
+    struct CpuSnapshot {
+        user: u64,
+        nice: u64,
+        system: u64,
+        idle: u64,
+        iowait: u64,
+    }
+
+    fn snapshot() -> Option<CpuSnapshot> {
+        let contents = std::fs::read_to_string("/proc/stat").ok()?;
+        let line = contents.lines().next()?;
+        let mut parts = line.split_whitespace();
+        if parts.next()? != "cpu" {
+            return None;
+        }
+        Some(CpuSnapshot {
+            user: parts.next()?.parse().ok()?,
+            nice: parts.next()?.parse().ok()?,
+            system: parts.next()?.parse().ok()?,
+            idle: parts.next()?.parse().ok()?,
+            iowait: parts.next()?.parse().unwrap_or(0),
+        })
+    }
+
+    static PREV: std::sync::Mutex<Option<CpuSnapshot>> = std::sync::Mutex::new(None);
+
+    pub fn cpu_percent() -> f32 {
+        let cur = match snapshot() {
+            Some(s) => s,
+            None => return 0.0,
+        };
+        let mut prev = PREV.lock().unwrap_or_else(|p| p.into_inner());
+        let pct = if let Some(ref p) = *prev {
+            let d_user = cur.user.wrapping_sub(p.user) + cur.nice.wrapping_sub(p.nice);
+            let d_sys = cur.system.wrapping_sub(p.system);
+            let d_idle = cur.idle.wrapping_sub(p.idle) + cur.iowait.wrapping_sub(p.iowait);
+            let total = d_user + d_sys + d_idle;
+            if total > 0 {
+                ((d_user + d_sys) as f64 / total as f64 * 100.0) as f32
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+        *prev = Some(cur);
+        pct
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod cpu {
     pub fn cpu_percent() -> f32 { 0.0 }
 }

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -120,10 +120,10 @@ mod cpu {
             nice: parts.next()?.parse().ok()?,
             system: parts.next()?.parse().ok()?,
             idle: parts.next()?.parse().ok()?,
-            iowait: parts.next()?.parse().unwrap_or(0),
-            irq: parts.next()?.parse().unwrap_or(0),
-            softirq: parts.next()?.parse().unwrap_or(0),
-            steal: parts.next()?.parse().unwrap_or(0),
+            iowait: parts.next().and_then(|s| s.parse().ok()).unwrap_or(0),
+            irq: parts.next().and_then(|s| s.parse().ok()).unwrap_or(0),
+            softirq: parts.next().and_then(|s| s.parse().ok()).unwrap_or(0),
+            steal: parts.next().and_then(|s| s.parse().ok()).unwrap_or(0),
         })
     }
 

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -103,6 +103,9 @@ mod cpu {
         system: u64,
         idle: u64,
         iowait: u64,
+        irq: u64,
+        softirq: u64,
+        steal: u64,
     }
 
     fn snapshot() -> Option<CpuSnapshot> {
@@ -118,6 +121,9 @@ mod cpu {
             system: parts.next()?.parse().ok()?,
             idle: parts.next()?.parse().ok()?,
             iowait: parts.next()?.parse().unwrap_or(0),
+            irq: parts.next()?.parse().unwrap_or(0),
+            softirq: parts.next()?.parse().unwrap_or(0),
+            steal: parts.next()?.parse().unwrap_or(0),
         })
     }
 
@@ -131,7 +137,10 @@ mod cpu {
         let mut prev = PREV.lock().unwrap_or_else(|p| p.into_inner());
         let pct = if let Some(ref p) = *prev {
             let d_user = cur.user.wrapping_sub(p.user) + cur.nice.wrapping_sub(p.nice);
-            let d_sys = cur.system.wrapping_sub(p.system);
+            let d_sys = cur.system.wrapping_sub(p.system)
+                + cur.irq.wrapping_sub(p.irq)
+                + cur.softirq.wrapping_sub(p.softirq)
+                + cur.steal.wrapping_sub(p.steal);
             let d_idle = cur.idle.wrapping_sub(p.idle) + cur.iowait.wrapping_sub(p.iowait);
             let total = d_user + d_sys + d_idle;
             if total > 0 {

--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -115,6 +115,16 @@ impl TranscriptionBackend for WhisperBackend {
             .ok_or_else(|| "Model path contains invalid UTF-8 characters".to_string())?;
 
         let params = WhisperContextParameters::default();
+
+        let gpu_backend = if cfg!(target_os = "macos") {
+            "metal"
+        } else if cfg!(target_os = "linux") && std::path::Path::new("/dev/nvidia0").exists() {
+            "cuda"
+        } else {
+            "cpu"
+        };
+        tracing::info!(target: "pipeline", model = model_name, gpu = gpu_backend, "whisper_model_loading");
+
         let ctx = WhisperContext::new_with_params(path_str, params)
             .map_err(|e| format!("Failed to load whisper model: {}", e))?;
 
@@ -125,7 +135,7 @@ impl TranscriptionBackend for WhisperBackend {
         self.state = Some(state);
         self.loaded_model_name = Some(model_name.to_string());
         let rss = crate::resource_monitor::get_process_rss_mb();
-        tracing::info!(target: "pipeline", rss_mb = rss, "whisper_cache_miss");
+        tracing::info!(target: "pipeline", rss_mb = rss, gpu = gpu_backend, "whisper_cache_miss");
         Ok(())
     }
 


### PR DESCRIPTION
Closes #144

## Summary

- Move whisper-rs `metal` feature to macOS-only target deps — Linux compiles with CPU-only whisper backend
- cfg-gate osascript auto-paste in `injector.rs` — on Linux, auto-paste is a no-op (text lands in clipboard; xdotool support is a follow-up)
- cfg-gate rdev `set_is_main_thread` in `keyboard.rs` — macOS TIS/TSM workaround not needed on Linux

## What was already cross-platform

Most macOS-specific code was already properly cfg-gated:
- `alloc.rs` (custom malloc zone allocator)
- `commands/permissions.rs` (TCC checks, System Settings shortcuts)
- `commands/overlay.rs` (notch detection, NSScreen APIs, screen change observer)
- `resource_monitor.rs` (Mach host_statistics64 CPU tracking)
- `rust_heap_mb()` / `ffi_heap_mb()` stubs in `lib.rs`

## Test plan

- [ ] `cargo check` succeeds on Linux x86_64 (requires build deps: `build-essential cmake libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev libasound2-dev libssl-dev librsvg2-dev`)
- [ ] `cargo check` still succeeds on macOS (Metal feature merged from both dep sections)
- [ ] `cargo test -- --test-threads=1` passes on both platforms
- [ ] Verify no macOS-only code runs unconditionally on Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved paste behavior with macOS- and Linux-specific simulation; platforms without accessibility support fall back to clipboard-only operations.
  * Keyboard listener, overlay/notch handling, and app reopen behavior are now macOS-only; non-macOS builds skip those flows.
  * Resource monitoring adds a Linux-specific CPU measurement for more accurate usage reporting; other OSes use a stub.
  * Model loading now detects and logs the selected GPU backend (metal/cuda/cpu).

* **Chores**
  * Platform dependency configuration updated to enable native GPU and input features per OS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->