### PR TITLE
fix: disable webkit2gtk DMABUF renderer on Linux to fix blank window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,56 @@ jobs:
         with:
           projectPath: app
 
+      - name: Install smoke test dependencies
+        run: sudo apt-get install -y xvfb dbus-x11 at-spi2-core
+
+      - name: Smoke test — verify binary launches and frontend mounts
+        run: |
+          BINARY="app/src-tauri/target/release/ui"
+          LOG="$HOME/.local/share/local-dictation/logs/app.log"
+
+          echo "=== Verifying binary exists ==="
+          ls -la "$BINARY"
+
+          echo "=== Clearing any prior log ==="
+          rm -f "$LOG"
+
+          echo "=== Launching under xvfb + dbus ==="
+          xvfb-run -a --server-args="-screen 0 1280x800x24" \
+            dbus-run-session -- "$BINARY" > /tmp/murmur-smoke.log 2>&1 &
+          PID=$!
+          echo "Started with PID $PID"
+
+          echo "=== Waiting up to 20s for [main] App mounted ==="
+          MOUNTED=0
+          for i in $(seq 1 20); do
+            sleep 1
+            if ! kill -0 "$PID" 2>/dev/null; then
+              echo "FAIL: Process died after ${i}s"
+              echo "--- stderr ---"; tail -50 /tmp/murmur-smoke.log || true
+              echo "--- app.log ---"; tail -50 "$LOG" 2>/dev/null || echo "(no log)"
+              exit 1
+            fi
+            if grep -q "\[main\] App mounted" "$LOG" 2>/dev/null; then
+              echo "  Mounted at ${i}s"
+              MOUNTED=1
+              break
+            fi
+            echo "  Alive at ${i}s (not mounted yet)"
+          done
+
+          if [ "$MOUNTED" != "1" ]; then
+            echo "FAIL: Frontend never mounted within 20s"
+            echo "--- stderr ---"; tail -50 /tmp/murmur-smoke.log || true
+            echo "--- app.log ---"; tail -80 "$LOG" 2>/dev/null || echo "(no log)"
+            kill "$PID" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "=== Smoke test passed — killing process ==="
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+
       - name: Collect updater artifact info
         run: |
           ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -61,8 +61,43 @@ pub(crate) struct State {
     pub(crate) notch_info: Mutex<Option<(f64, f64)>>,
 }
 
+/// WebKitGTK environment defaults applied on Linux before GTK/webkit init.
+///
+/// On Linux/Wayland, webkit2gtk's DMABUF renderer leaves windows invisible
+/// on many mesa/NVIDIA stacks (Fedora, Nobara, Ubuntu 23+). Disabling the
+/// DMABUF renderer and compositing mode restores rendering. Users can
+/// override either default by pre-setting the variable in their environment.
+#[cfg(target_os = "linux")]
+const LINUX_WEBKIT_ENV_DEFAULTS: &[(&str, &str)] = &[
+    ("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
+    ("WEBKIT_DISABLE_COMPOSITING_MODE", "1"),
+];
+
+/// Apply `LINUX_WEBKIT_ENV_DEFAULTS` via injected get/set closures.
+///
+/// Separated from `run()` so tests can exercise it against a fake env map
+/// without touching process-global state.
+#[cfg(target_os = "linux")]
+fn apply_linux_webkit_env_defaults<F, G>(mut get: F, mut set: G)
+where
+    F: FnMut(&str) -> Option<std::ffi::OsString>,
+    G: FnMut(&str, &str),
+{
+    for (key, default) in LINUX_WEBKIT_ENV_DEFAULTS {
+        if get(key).is_none() {
+            set(key, default);
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    apply_linux_webkit_env_defaults(
+        |k| std::env::var_os(k),
+        |k, v| std::env::set_var(k, v),
+    );
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_autostart::init(
@@ -227,4 +262,86 @@ pub fn run() {
             }
         }
     });
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::ffi::OsString;
+
+    /// Empty env: both defaults must be applied.
+    #[test]
+    fn applies_all_defaults_when_env_empty() {
+        let env: RefCell<HashMap<String, OsString>> = RefCell::new(HashMap::new());
+        apply_linux_webkit_env_defaults(
+            |k| env.borrow().get(k).cloned(),
+            |k, v| {
+                env.borrow_mut().insert(k.to_string(), OsString::from(v));
+            },
+        );
+        let map = env.borrow();
+        assert_eq!(map.get("WEBKIT_DISABLE_DMABUF_RENDERER"), Some(&OsString::from("1")));
+        assert_eq!(map.get("WEBKIT_DISABLE_COMPOSITING_MODE"), Some(&OsString::from("1")));
+    }
+
+    /// User-provided values must be preserved (including explicit "0" opt-outs).
+    #[test]
+    fn preserves_user_overrides() {
+        let env: RefCell<HashMap<String, OsString>> = RefCell::new(HashMap::new());
+        env.borrow_mut().insert("WEBKIT_DISABLE_DMABUF_RENDERER".into(), OsString::from("0"));
+        env.borrow_mut().insert("WEBKIT_DISABLE_COMPOSITING_MODE".into(), OsString::from("custom"));
+
+        apply_linux_webkit_env_defaults(
+            |k| env.borrow().get(k).cloned(),
+            |k, v| {
+                env.borrow_mut().insert(k.to_string(), OsString::from(v));
+            },
+        );
+
+        let map = env.borrow();
+        assert_eq!(map.get("WEBKIT_DISABLE_DMABUF_RENDERER"), Some(&OsString::from("0")));
+        assert_eq!(map.get("WEBKIT_DISABLE_COMPOSITING_MODE"), Some(&OsString::from("custom")));
+    }
+
+    /// Partial user override: only the unset default should be applied.
+    #[test]
+    fn applies_only_missing_defaults() {
+        let env: RefCell<HashMap<String, OsString>> = RefCell::new(HashMap::new());
+        env.borrow_mut().insert("WEBKIT_DISABLE_DMABUF_RENDERER".into(), OsString::from("0"));
+        let writes: RefCell<Vec<(String, String)>> = RefCell::new(Vec::new());
+
+        apply_linux_webkit_env_defaults(
+            |k| env.borrow().get(k).cloned(),
+            |k, v| {
+                writes.borrow_mut().push((k.to_string(), v.to_string()));
+                env.borrow_mut().insert(k.to_string(), OsString::from(v));
+            },
+        );
+
+        assert_eq!(
+            *writes.borrow(),
+            vec![("WEBKIT_DISABLE_COMPOSITING_MODE".to_string(), "1".to_string())],
+        );
+        assert_eq!(
+            env.borrow().get("WEBKIT_DISABLE_DMABUF_RENDERER"),
+            Some(&OsString::from("0")),
+        );
+    }
+
+    /// Empty string is a valid value and must be preserved (matches `var_os` semantics).
+    #[test]
+    fn treats_empty_string_as_set() {
+        let env: RefCell<HashMap<String, OsString>> = RefCell::new(HashMap::new());
+        env.borrow_mut().insert("WEBKIT_DISABLE_DMABUF_RENDERER".into(), OsString::from(""));
+        let writes: RefCell<Vec<String>> = RefCell::new(Vec::new());
+
+        apply_linux_webkit_env_defaults(
+            |k| env.borrow().get(k).cloned(),
+            |k, _v| writes.borrow_mut().push(k.to_string()),
+        );
+
+        assert!(!writes.borrow().contains(&"WEBKIT_DISABLE_DMABUF_RENDERER".to_string()));
+    }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -342,6 +342,9 @@ mod tests {
             |k, _v| writes.borrow_mut().push(k.to_string()),
         );
 
-        assert!(!writes.borrow().contains(&"WEBKIT_DISABLE_DMABUF_RENDERER".to_string()));
+        assert_eq!(
+            *writes.borrow(),
+            vec!["WEBKIT_DISABLE_COMPOSITING_MODE".to_string()],
+        );
     }
 }


### PR DESCRIPTION
## Summary

On Linux/Wayland with mesa or NVIDIA stacks (Fedora, Nobara, Ubuntu 23+), webkit2gtk's DMABUF renderer leaves Tauri windows rendered invisibly. The window chrome appears but the webview surface never paints — users see a blank window and conclude the app is broken.

Reproduced locally on Nobara (Fedora 43) / Wayland / NVIDIA: `./target/release/ui` rendered a blank dark window. Setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` in the environment restored rendering immediately.

This PR bakes the workaround into the binary so Linux users get a working window out of the box, with an env-var opt-out for anyone whose stack renders correctly without it.

## Changes

- `app/src-tauri/src/lib.rs` — Sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1` at the top of `run()`, cfg-gated to Linux. Only applied if the variable isn't already set, so users can opt out or customize. The logic lives in `apply_linux_webkit_env_defaults()` with injected get/set closures, letting the precedence rules be unit tested against a fake env map.
- 4 new unit tests covering: empty env, user overrides preserved, partial defaults, empty-string treated as set.
- `.github/workflows/release.yml` — New smoke test step in `release-linux` that launches the built binary under `xvfb-run` + `dbus-run-session` and waits up to 20s for `[main] App mounted` in the telemetry log. Fails the release if the frontend never mounts — catches rendering regressions before they ship.

## Test plan

- [x] `cargo test --lib` — 70 passed (4 new)
- [x] Locally: `./target/release/ui` renders window + mounts React on Nobara Wayland without any env vars
- [ ] CI: `rust-linux` job runs the new unit tests on ubuntu
- [ ] CI: `release-linux` smoke test runs on next tag push

## Notes

macOS behavior is untouched — the entire apply function and tests are `#[cfg(target_os = "linux")]`.

The smoke test is the first automated launch verification for Linux. It mirrors the existing macOS smoke test (release.yml:87) but adds a stronger assertion (frontend mount vs just process-alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated Linux smoke tests for release builds that validate app startup, initialization, and mount signal detection, with detailed logging on failure.

* **Chores**
  * Applied Linux-specific defaults to improve web-rendering and startup stability on Linux builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->