### PR TITLE
chore: prep Linux release pipeline (drop strip, ship .rpm, install doc)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,7 @@ jobs:
           name: linux-artifacts
           path: |
             app/src-tauri/target/release/bundle/deb/*.deb
+            app/src-tauri/target/release/bundle/rpm/*.rpm
             app/src-tauri/target/release/bundle/appimage/*.AppImage
             app/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz
             app/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz.sig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ cd app && npx tsc --noEmit         # TypeScript check
 Read these before working on a feature:
 
 - **[docs/onboarding.md](docs/onboarding.md)** — Setup, permissions, model installation, logs
+- **[docs/install-linux.md](docs/install-linux.md)** — Linux end-user install (deb / rpm / AppImage), runtime deps, Wayland notes
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -53,4 +53,7 @@ panic = "abort"
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = true
+# strip is intentionally disabled: Tauri's bundler patches a __TAURI_BUNDLE_TYPE
+# marker into the binary post-build so the updater plugin can detect the
+# artifact format (deb / rpm / AppImage / app). Stripping erases the marker
+# and breaks updater detection on Linux. Larger binary is the trade-off.

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -1,0 +1,71 @@
+# Linux Install
+
+Murmur ships `.deb`, `.rpm`, and `.AppImage` artifacts for Linux x86_64. These are built on every release and attached to the corresponding [GitHub Release](https://github.com/georgenijo/murmur-app/releases/latest).
+
+## Install
+
+### Debian / Ubuntu / Pop!_OS
+
+```bash
+sudo apt install ./Murmur_<version>_amd64.deb
+```
+
+### Fedora / Nobara / RHEL
+
+```bash
+sudo dnf install ./Murmur-<version>-1.x86_64.rpm
+```
+
+### AppImage (any distro)
+
+```bash
+chmod +x Murmur_<version>_amd64.AppImage
+./Murmur_<version>_amd64.AppImage
+```
+
+## Runtime dependencies
+
+The packages declare their direct deps, but for reference Murmur needs:
+
+- `webkit2gtk-4.1` — webview rendering
+- `libayatana-appindicator3` — tray icon
+- `libasound2` — ALSA audio capture
+- `xdotool` — auto-paste injection (X11) or `wtype` (Wayland, install separately)
+- CUDA 12.8+ runtime — GPU-accelerated whisper inference. Without it the app falls back to CPU and is significantly slower.
+
+## Permissions
+
+Murmur reads global keyboard events via [`rdev`](https://github.com/Narsil/rdev). On Linux this requires either:
+
+- Running as a user in the `input` group: `sudo usermod -aG input $USER` (then re-login), or
+- Granting read access to `/dev/uinput`: `sudo chmod a+rw /dev/uinput`
+
+Microphone access uses ALSA directly — no portal involved. If your distro uses PipeWire, the ALSA-PipeWire bridge handles it transparently.
+
+## Wayland
+
+Murmur sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1` automatically on Linux to work around a webkit2gtk rendering bug on mesa/NVIDIA stacks (Fedora, Nobara, Ubuntu 23+) where the window would otherwise appear blank. To opt out — for example if you're on a stack where DMABUF works fine — set the variable to anything else before launching:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=0 murmur
+```
+
+## Auto-update
+
+The Tauri updater checks `latest.json` against the running version. Linux artifacts are signed with the same minisign key used for macOS. Updates download as a fresh `.AppImage.tar.gz` and replace the running binary on next launch.
+
+`.deb` and `.rpm` installs do **not** auto-update — use your package manager. Auto-update only applies to AppImage.
+
+## Logs
+
+Structured event log: `~/.local/share/local-dictation/logs/app.log`
+
+JSONL event stream: `~/.local/share/local-dictation/logs/events.jsonl`
+
+Open the in-app log viewer from the tray menu for a live view.
+
+## Known issues
+
+- **Notch overlay is disabled on Linux.** The Dynamic Island–style overlay is macOS-specific (depends on a real notch). Status feedback comes from the tray icon and main window only.
+- **Auto-paste on Wayland is best-effort.** `xdotool` only works under XWayland; native Wayland clients may not receive the synthesized keystroke. The transcription is always written to the clipboard, so manual paste (`Ctrl+Shift+V`) is the reliable fallback.
+- **First launch builds the whisper context** — expect a few seconds of latency on the first transcription while the model loads into VRAM.


### PR DESCRIPTION
## Summary

Three small changes to get the Linux release pipeline ready for an actual tag push, after #160 unblocked rendering.

- **`Cargo.toml`** — Drop `strip = true` from `[profile.release]`. Tauri's bundler patches a `__TAURI_BUNDLE_TYPE` marker into the binary post-build so the updater plugin can detect the artifact format (deb/rpm/AppImage/app). Stripping erases the marker, which is what was producing the warning we saw locally on every Linux build. Trade-off: larger binary; correctness over size.
- **`release.yml`** — Add `bundle/rpm/*.rpm` to the `linux-artifacts` upload glob. Cargo already builds the RPM, the workflow just wasn't picking it up. Matters for Fedora / RHEL / Nobara users (#151 partially).
- **`docs/install-linux.md`** — End-user install doc covering deb/rpm/AppImage paths, runtime deps (webkit2gtk, libayatana, ALSA, xdotool, CUDA 12.8 runtime), `rdev` keyboard permissions (input group / uinput), the Wayland DMABUF workaround from #160 with opt-out instructions, log locations, and known issues. Linked from `CLAUDE.md`.

## Test plan

- [x] `cargo check` passes locally on Linux
- [ ] `rust-linux` and `rust-macos` CI jobs pass
- [ ] Verify on next tag push: release-linux uploads `.deb`, `.rpm`, `.AppImage`, and the bundler warning is gone

## Notes

This is the second of three PRs for Linux release readiness:
1. ~~#160 — Wayland blank-window fix~~ (merged)
2. **This PR** — packaging polish + install doc
3. Next — cut `v0.8.9-rc1` to dry-run the pipeline end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Linux installation guide covering Debian, RPM, and AppImage distributions with required dependencies, permission setup, and Wayland configuration instructions.

* **Chores**
  * Updated release workflow to include RPM packages in artifact uploads for Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->