### PR TITLE
feat: surface amber overlay pulse when double-tap timing is rejected (#154)

### DIFF
--- a/app/src-tauri/src/keyboard/detectors.rs
+++ b/app/src-tauri/src/keyboard/detectors.rs
@@ -1,0 +1,1625 @@
+//! Keyboard detector types and logic (platform-neutral).
+//!
+//! Contains the local `Key` and `EventType` enums, both detector structs
+//! (`DoubleTapDetector`, `HoldDownDetector`), all shared global statics, and
+//! the `handle_event` dispatch function used by the listener thread.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
+use tauri::Emitter;
+#[cfg(not(target_os = "macos"))]
+use rdev;
+
+// ---------------------------------------------------------------------------
+// Platform-neutral key / event types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Key {
+    ShiftLeft,
+    ShiftRight,
+    Alt,
+    AltGr,
+    ControlLeft,
+    ControlRight,
+    MetaLeft,
+    MetaRight,
+    Escape,
+    OtherNonModifier,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EventType {
+    KeyPress(Key),
+    KeyRelease(Key),
+}
+
+// ---------------------------------------------------------------------------
+// Platform conversions
+// ---------------------------------------------------------------------------
+
+/// Convert an rdev key to the local Key type.
+/// Only used on non-macOS platforms; macOS uses raw keycodes via CGEvent tap.
+#[cfg(not(target_os = "macos"))]
+pub fn from_rdev_key(k: rdev::Key) -> Key {
+    match k {
+        rdev::Key::ShiftLeft => Key::ShiftLeft,
+        rdev::Key::ShiftRight => Key::ShiftRight,
+        rdev::Key::Alt => Key::Alt,
+        rdev::Key::AltGr => Key::AltGr,
+        rdev::Key::ControlLeft => Key::ControlLeft,
+        rdev::Key::ControlRight => Key::ControlRight,
+        rdev::Key::MetaLeft => Key::MetaLeft,
+        rdev::Key::MetaRight => Key::MetaRight,
+        rdev::Key::Escape => Key::Escape,
+        _ => Key::OtherNonModifier,
+    }
+}
+
+/// Convert a raw macOS virtual keycode (from CGEventTap) to the local Key type.
+#[cfg(target_os = "macos")]
+pub fn from_macos_keycode(code: i64) -> Key {
+    match code {
+        53 => Key::Escape,
+        54 => Key::MetaRight,
+        55 => Key::MetaLeft,
+        56 => Key::ShiftLeft,
+        58 => Key::Alt,
+        59 => Key::ControlLeft,
+        60 => Key::ShiftRight,
+        61 => Key::AltGr,
+        62 => Key::ControlRight,
+        _ => Key::OtherNonModifier,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Max duration a single tap can be held before it's rejected
+pub(crate) const MAX_HOLD_DURATION_MS: u128 = 200;
+
+/// Max gap between first key-up and second key-down
+pub(crate) const DOUBLE_TAP_WINDOW_MS: u128 = 400;
+
+/// Cooldown after firing to prevent triple-tap spam
+pub(crate) const COOLDOWN_MS: u128 = 50;
+
+/// Cooldown after hold-down stop to prevent accidental re-trigger
+pub(crate) const HOLD_DOWN_COOLDOWN_MS: u128 = 50;
+
+// ---------------------------------------------------------------------------
+// Rejection feedback types
+// ---------------------------------------------------------------------------
+
+/// The reason a double-tap sequence was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RejectReason {
+    HeldTooLong,
+    GapTooLong,
+    SecondTapHeldTooLong,
+}
+
+impl RejectReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            RejectReason::HeldTooLong => "held_too_long",
+            RejectReason::GapTooLong => "gap_too_long",
+            RejectReason::SecondTapHeldTooLong => "second_tap_held_too_long",
+        }
+    }
+}
+
+/// The outcome of a `DoubleTapDetector::handle_event` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TapOutcome {
+    Fired,
+    Rejected(RejectReason),
+    None,
+}
+
+impl TapOutcome {
+    pub(crate) fn fired(self) -> bool {
+        matches!(self, TapOutcome::Fired)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Double-tap detector
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum DetectorState {
+    Idle,
+    WaitingFirstUp,
+    WaitingSecondDown,
+    WaitingSecondUp,
+}
+
+pub(crate) struct DoubleTapDetector {
+    pub(crate) state: DetectorState,
+    pub(crate) target_key: Option<Key>,
+    pub(crate) recording: bool,
+    pub(crate) state_entered_at: Instant,
+    pub(crate) last_fired_at: Option<Instant>,
+}
+
+impl DoubleTapDetector {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: DetectorState::Idle,
+            target_key: None,
+            recording: false,
+            state_entered_at: Instant::now(),
+            last_fired_at: None,
+        }
+    }
+
+    pub(crate) fn set_target(&mut self, key: Option<Key>) {
+        self.target_key = key;
+        self.reset();
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.state = DetectorState::Idle;
+        self.state_entered_at = Instant::now();
+    }
+
+    fn transition(&mut self, new_state: DetectorState) {
+        self.state = new_state;
+        self.state_entered_at = Instant::now();
+    }
+
+    pub(crate) fn elapsed_ms(&self) -> u128 {
+        self.state_entered_at.elapsed().as_millis()
+    }
+
+    fn in_cooldown(&self) -> bool {
+        self.last_fired_at
+            .map(|t| t.elapsed().as_millis() < COOLDOWN_MS)
+            .unwrap_or(false)
+    }
+
+    /// Process a keyboard event. Returns `TapOutcome::Fired` if a double-tap was
+    /// detected, `TapOutcome::Rejected(reason)` if a timing miss was detected on
+    /// the user-visible terminator event, or `TapOutcome::None` otherwise.
+    ///
+    /// Rejection is emitted only on the sequence-ending event (a release that came
+    /// too late, or a target-key press after the gap window). Silent resets (key
+    /// repeats, combo keys, mouse events) return `None` to avoid false alarms.
+    pub(crate) fn handle_event(&mut self, event_type: &EventType) -> TapOutcome {
+        let target = match self.target_key {
+            Some(k) => k,
+            None => return TapOutcome::None,
+        };
+
+        if self.in_cooldown() {
+            return TapOutcome::None;
+        }
+
+        match self.state {
+            DetectorState::Idle => {
+                if let EventType::KeyPress(key) = event_type {
+                    if is_same_modifier(*key, target) {
+                        self.transition(DetectorState::WaitingFirstUp);
+                    }
+                }
+                TapOutcome::None
+            }
+
+            DetectorState::WaitingFirstUp => {
+                match event_type {
+                    EventType::KeyRelease(key) if is_same_modifier(*key, target) => {
+                        let elapsed = self.elapsed_ms();
+                        if elapsed <= MAX_HOLD_DURATION_MS {
+                            if self.recording {
+                                // Single tap to stop — fire immediately
+                                self.last_fired_at = Some(Instant::now());
+                                self.reset();
+                                return TapOutcome::Fired;
+                            }
+                            self.transition(DetectorState::WaitingSecondDown);
+                            TapOutcome::None
+                        } else {
+                            // Held too long — sequence-ending release event
+                            self.reset();
+                            tracing::debug!(target: "keyboard", reason = RejectReason::HeldTooLong.as_str(), elapsed_ms = elapsed as u64, "tap rejected");
+                            TapOutcome::Rejected(RejectReason::HeldTooLong)
+                        }
+                    }
+                    EventType::KeyPress(key) if !is_modifier(*key) => {
+                        // User is typing a combo like Shift+A
+                        self.reset();
+                        TapOutcome::None
+                    }
+                    EventType::KeyPress(key) if is_same_modifier(*key, target) => {
+                        // Key repeat event — check if we've been held too long (silent reset)
+                        if self.elapsed_ms() > MAX_HOLD_DURATION_MS {
+                            self.reset();
+                        }
+                        TapOutcome::None
+                    }
+                    _ => {
+                        // Check timeout (silent reset — emission happens at release)
+                        if self.elapsed_ms() > MAX_HOLD_DURATION_MS {
+                            self.reset();
+                        }
+                        TapOutcome::None
+                    }
+                }
+            }
+
+            DetectorState::WaitingSecondDown => {
+                let elapsed = self.elapsed_ms();
+                if elapsed > DOUBLE_TAP_WINDOW_MS {
+                    self.reset();
+                    // Emit rejection only when the user is clearly retrying the target modifier
+                    if let EventType::KeyPress(key) = event_type {
+                        if is_same_modifier(*key, target) {
+                            tracing::debug!(target: "keyboard", reason = RejectReason::GapTooLong.as_str(), elapsed_ms = elapsed as u64, "tap rejected");
+                            return TapOutcome::Rejected(RejectReason::GapTooLong);
+                        }
+                    }
+                    return TapOutcome::None;
+                }
+                match event_type {
+                    EventType::KeyPress(key) if is_same_modifier(*key, target) => {
+                        self.transition(DetectorState::WaitingSecondUp);
+                    }
+                    EventType::KeyPress(_) => {
+                        // Any other key press — abort
+                        self.reset();
+                    }
+                    _ => {}
+                }
+                TapOutcome::None
+            }
+
+            DetectorState::WaitingSecondUp => {
+                match event_type {
+                    EventType::KeyRelease(key) if is_same_modifier(*key, target) => {
+                        let elapsed = self.elapsed_ms();
+                        if elapsed <= MAX_HOLD_DURATION_MS {
+                            // Double-tap detected!
+                            self.last_fired_at = Some(Instant::now());
+                            self.reset();
+                            TapOutcome::Fired
+                        } else {
+                            // Second tap held too long — sequence-ending release event
+                            self.reset();
+                            tracing::debug!(target: "keyboard", reason = RejectReason::SecondTapHeldTooLong.as_str(), elapsed_ms = elapsed as u64, "tap rejected");
+                            TapOutcome::Rejected(RejectReason::SecondTapHeldTooLong)
+                        }
+                    }
+                    EventType::KeyPress(key) if !is_modifier(*key) => {
+                        // Combo like Shift+A on second press
+                        self.reset();
+                        TapOutcome::None
+                    }
+                    EventType::KeyPress(key) if is_same_modifier(*key, target) => {
+                        // Key repeat — silent reset if overlong
+                        if self.elapsed_ms() > MAX_HOLD_DURATION_MS {
+                            self.reset();
+                        }
+                        TapOutcome::None
+                    }
+                    _ => {
+                        if self.elapsed_ms() > MAX_HOLD_DURATION_MS {
+                            self.reset();
+                        }
+                        TapOutcome::None
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hold-down detector
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum HoldDownEvent {
+    None,
+    Start,
+    Stop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum HoldState {
+    Idle,
+    Held,
+}
+
+pub(crate) struct HoldDownDetector {
+    pub(crate) state: HoldState,
+    pub(crate) target_key: Option<Key>,
+    pub(crate) last_stopped_at: Option<Instant>,
+}
+
+impl HoldDownDetector {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: HoldState::Idle,
+            target_key: None,
+            last_stopped_at: None,
+        }
+    }
+
+    /// Set the target key. Returns `true` if the detector was in `Held` state
+    /// (i.e. the caller should emit a stop event to the frontend).
+    pub(crate) fn set_target(&mut self, key: Option<Key>) -> bool {
+        let was_held = self.state == HoldState::Held;
+        if was_held {
+            self.state = HoldState::Idle;
+            self.last_stopped_at = Some(Instant::now());
+        }
+        self.target_key = key;
+        was_held
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.state = HoldState::Idle;
+    }
+
+    fn in_cooldown(&self) -> bool {
+        self.last_stopped_at
+            .map(|t| t.elapsed().as_millis() < HOLD_DOWN_COOLDOWN_MS)
+            .unwrap_or(false)
+    }
+
+    /// Process a keyboard event. Returns Start, Stop, or None.
+    pub(crate) fn handle_event(&mut self, event_type: &EventType) -> HoldDownEvent {
+        let target = match self.target_key {
+            Some(k) => k,
+            None => return HoldDownEvent::None,
+        };
+
+        match self.state {
+            HoldState::Idle => {
+                if let EventType::KeyPress(key) = event_type {
+                    if is_same_modifier(*key, target) && !self.in_cooldown() {
+                        self.state = HoldState::Held;
+                        return HoldDownEvent::Start;
+                    }
+                }
+                HoldDownEvent::None
+            }
+
+            HoldState::Held => {
+                match event_type {
+                    EventType::KeyRelease(key) if is_same_modifier(*key, target) => {
+                        self.state = HoldState::Idle;
+                        self.last_stopped_at = Some(Instant::now());
+                        HoldDownEvent::Stop
+                    }
+                    EventType::KeyPress(key) if is_same_modifier(*key, target) => {
+                        // Key repeat — ignore, stay held
+                        HoldDownEvent::None
+                    }
+                    EventType::KeyPress(key) if !is_modifier(*key) => {
+                        // User is typing a combo like Shift+A — cancel hold
+                        self.state = HoldState::Idle;
+                        self.last_stopped_at = Some(Instant::now());
+                        HoldDownEvent::Stop
+                    }
+                    _ => HoldDownEvent::None,
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum DetectorMode {
+    DoubleTap,
+    HoldDown,
+    Both,
+}
+
+/// Map hotkey string from settings to local Key
+pub(crate) fn hotkey_to_key(hotkey: &str) -> Option<Key> {
+    match hotkey {
+        "shift_l" => Some(Key::ShiftLeft),
+        "alt_l" => Some(Key::Alt),
+        "ctrl_r" => Some(Key::ControlRight),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// Check if a key is any modifier key
+pub(crate) fn is_modifier(key: Key) -> bool {
+    matches!(
+        key,
+        Key::ShiftLeft
+            | Key::ShiftRight
+            | Key::Alt
+            | Key::AltGr
+            | Key::ControlLeft
+            | Key::ControlRight
+            | Key::MetaLeft
+            | Key::MetaRight
+    )
+}
+
+/// Check if two keys are the same modifier, using strict equality
+pub(crate) fn is_same_modifier(a: Key, b: Key) -> bool {
+    a == b
+}
+
+// ---------------------------------------------------------------------------
+// Both-mode arbitration state
+// ---------------------------------------------------------------------------
+
+/// Monotonic counter to invalidate stale hold-promotion timers.
+pub(crate) static HOLD_PRESS_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// Set to true by the timer thread when it promotes a press to a real hold.
+pub(crate) static HOLD_PROMOTED: AtomicBool = AtomicBool::new(false);
+/// When true, the Both-mode callback ignores all key events.
+/// Set by lib.rs when the transcription pipeline is running.
+pub(crate) static IS_PROCESSING: AtomicBool = AtomicBool::new(false);
+
+// ---------------------------------------------------------------------------
+// Global listener state
+// ---------------------------------------------------------------------------
+
+pub(crate) static LISTENER_ACTIVE: AtomicBool = AtomicBool::new(false);
+pub(crate) static LISTENER_THREAD_SPAWNED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) static ACTIVE_MODE: Mutex<DetectorMode> = Mutex::new(DetectorMode::DoubleTap);
+pub(crate) static DOUBLE_TAP_DETECTOR: Mutex<Option<DoubleTapDetector>> = Mutex::new(None);
+pub(crate) static HOLD_DOWN_DETECTOR: Mutex<Option<HoldDownDetector>> = Mutex::new(None);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Called by lib.rs to tell the keyboard module whether the app is processing.
+/// When transitioning out of processing, reset both detectors and apply a
+/// cooldown so rapid post-processing taps don't immediately toggle.
+pub fn set_processing(processing: bool) {
+    let was_processing = IS_PROCESSING.swap(processing, Ordering::SeqCst);
+    if !was_processing && processing {
+        // Entering processing: invalidate any pending hold-promotion timer
+        // so it can't fire hold-down-start during active processing.
+        HOLD_PROMOTED.store(false, Ordering::SeqCst);
+        HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut det) = HOLD_DOWN_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() { d.reset(); }
+        }
+        if let Ok(mut det) = DOUBLE_TAP_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() { d.reset(); }
+        }
+    } else if was_processing && !processing {
+        // Exiting processing: reset detectors with cooldown so rapid
+        // post-processing taps don't immediately toggle.
+        if let Ok(mut det) = HOLD_DOWN_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() {
+                d.reset();
+                d.last_stopped_at = Some(Instant::now());
+            }
+        }
+        if let Ok(mut det) = DOUBLE_TAP_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() {
+                d.reset();
+                d.last_fired_at = Some(Instant::now());
+            }
+        }
+        HOLD_PROMOTED.store(false, Ordering::SeqCst);
+        HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// Returns whether the app is currently in the processing state.
+#[cfg(test)]
+pub fn is_processing() -> bool {
+    IS_PROCESSING.load(Ordering::SeqCst)
+}
+
+/// Update the target key without stopping/restarting the listener.
+/// Returns `true` if a hold-down stop event should be emitted (key changed while held).
+pub fn set_target_key(hotkey: &str) -> bool {
+    let target = hotkey_to_key(hotkey);
+    let mode = {
+        let m = ACTIVE_MODE.lock().unwrap_or_else(|p| p.into_inner());
+        *m
+    };
+    match mode {
+        DetectorMode::DoubleTap => {
+            let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(d) = det.as_mut() {
+                d.set_target(target);
+            }
+            false
+        }
+        DetectorMode::HoldDown => {
+            let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(d) = det.as_mut() {
+                d.set_target(target)
+            } else {
+                false
+            }
+        }
+        DetectorMode::Both => {
+            let was_held = {
+                let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.set_target(target)
+                } else {
+                    false
+                }
+            };
+            {
+                let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.set_target(target);
+                }
+            }
+            was_held
+        }
+    }
+}
+
+/// Tell the double-tap detector whether we're currently recording.
+/// When recording, a single tap fires (to stop). When idle, double-tap fires (to start).
+/// Only relevant for double-tap mode; hold-down mode is stateless.
+pub fn set_recording_state(recording: bool) {
+    let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(d) = det.as_mut() {
+        d.recording = recording;
+    }
+}
+
+/// Stop processing keyboard events (the thread stays alive but idle).
+pub fn stop_listener() {
+    LISTENER_ACTIVE.store(false, Ordering::SeqCst);
+    { let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner()); if let Some(d) = det.as_mut() { d.reset(); } }
+    { let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner()); if let Some(d) = det.as_mut() { d.reset(); } }
+    HOLD_PROMOTED.store(false, Ordering::SeqCst);
+    HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Dispatch a keyboard event to the appropriate detector(s) and emit Tauri events.
+///
+/// This contains the full dispatch logic from the rdev listener callback,
+/// adapted to use the local `EventType`/`Key` types instead of rdev types.
+pub fn handle_event(app: &tauri::AppHandle, ev: EventType) {
+    if !LISTENER_ACTIVE.load(Ordering::SeqCst) {
+        return;
+    }
+
+    // Escape key: cancel recording/transcription regardless of mode.
+    // Must be checked before mode-specific logic so it works even
+    // during IS_PROCESSING (which gates the Both-mode block).
+    if let EventType::KeyPress(Key::Escape) = ev {
+        // Reset both detectors with cooldown timestamps so that the
+        // subsequent trigger-key release (if user was holding it) is
+        // treated as a no-op instead of firing hold-down-stop.
+        {
+            let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(d) = det.as_mut() {
+                d.reset();
+                d.last_stopped_at = Some(Instant::now());
+            }
+        }
+        {
+            let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(d) = det.as_mut() {
+                d.reset();
+                d.last_fired_at = Some(Instant::now());
+            }
+        }
+        // Invalidate pending hold-promotion timers
+        HOLD_PROMOTED.store(false, Ordering::SeqCst);
+        HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        tracing::info!(target: "keyboard", "Escape pressed — emitting escape-cancel");
+        let _ = app.emit("escape-cancel", ());
+        return;
+    }
+
+    let mode = {
+        let m = ACTIVE_MODE.lock().unwrap_or_else(|p| p.into_inner());
+        *m
+    };
+
+    match mode {
+        DetectorMode::DoubleTap => {
+            let outcome: TapOutcome = {
+                let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.handle_event(&ev)
+                } else {
+                    TapOutcome::None
+                }
+            };
+            match outcome {
+                TapOutcome::Fired => {
+                    tracing::info!(target: "keyboard", "DOUBLE_TAP -> emit double-tap-toggle");
+                    let _ = app.emit("double-tap-toggle", ());
+                }
+                TapOutcome::Rejected(reason) => {
+                    tracing::info!(target: "keyboard", reason = reason.as_str(), "DOUBLE_TAP -> emit tap-rejected");
+                    let _ = app.emit("tap-rejected", reason.as_str());
+                }
+                TapOutcome::None => {}
+            }
+        }
+        // hold_down-only mode has no timing rejection — any press is a valid start.
+        DetectorMode::HoldDown => {
+            let result = {
+                let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.handle_event(&ev)
+                } else {
+                    HoldDownEvent::None
+                }
+            };
+            match result {
+                HoldDownEvent::Start => { let _ = app.emit("hold-down-start", ()); }
+                HoldDownEvent::Stop => { let _ = app.emit("hold-down-stop", ()); }
+                HoldDownEvent::None => {}
+            }
+        }
+        DetectorMode::Both => {
+            // Skip all events while the app is processing a transcription.
+            if IS_PROCESSING.load(Ordering::SeqCst) {
+                return;
+            }
+
+            // Deferred hold: on press, start a background timer.
+            // After MAX_HOLD_DURATION_MS, if the key is still held,
+            // the timer emits hold-down-start (promoting to a real hold).
+            // Short taps never start recording → no state thrash during double-tap.
+
+            // Check dtap phase BEFORE feeding — also verify the window hasn't expired
+            let dtap_second_phase = {
+                let det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                det.as_ref().map(|d| matches!(d.state,
+                    DetectorState::WaitingSecondDown | DetectorState::WaitingSecondUp
+                ) && d.elapsed_ms() <= DOUBLE_TAP_WINDOW_MS).unwrap_or(false)
+            };
+
+            // Only feed hold-down when NOT in second phase
+            let hold_result = if !dtap_second_phase {
+                let mut det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.handle_event(&ev)
+                } else {
+                    HoldDownEvent::None
+                }
+            } else {
+                HoldDownEvent::None
+            };
+
+            // Always feed double-tap
+            let dtap_outcome: TapOutcome = {
+                let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                if let Some(d) = det.as_mut() {
+                    d.handle_event(&ev)
+                } else {
+                    TapOutcome::None
+                }
+            };
+            let dtap_fired = dtap_outcome.fired();
+
+            match hold_result {
+                HoldDownEvent::Start => {
+                    // Don't emit hold-down-start yet — start a timer.
+                    // The timer will promote after MAX_HOLD_DURATION_MS.
+                    HOLD_PROMOTED.store(false, Ordering::SeqCst);
+                    let press_id = HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
+                    let timer_handle = app.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(MAX_HOLD_DURATION_MS as u64));
+                        if HOLD_PRESS_COUNTER.load(Ordering::SeqCst) == press_id {
+                            let still_held = {
+                                let det = HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                                det.as_ref().map(|d| d.state == HoldState::Held).unwrap_or(false)
+                            };
+                            if still_held {
+                                HOLD_PROMOTED.store(true, Ordering::SeqCst);
+                                tracing::info!(target: "keyboard", "BOTH -> timer promoted to hold-down-start");
+                                let _ = timer_handle.emit("hold-down-start", ());
+                            }
+                        }
+                    });
+                    // Emit tap-rejected if dtap returned a rejection (e.g. GapTooLong on delayed retry)
+                    if let TapOutcome::Rejected(r) = dtap_outcome {
+                        tracing::info!(target: "keyboard", reason = r.as_str(), "BOTH -> emit tap-rejected (on Start)");
+                        let _ = app.emit("tap-rejected", r.as_str());
+                    }
+                }
+                HoldDownEvent::Stop => {
+                    let promoted = HOLD_PROMOTED.load(Ordering::SeqCst);
+                    HOLD_PROMOTED.store(false, Ordering::SeqCst);
+                    // Invalidate any pending timer
+                    HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+                    if promoted {
+                        // Real hold ended — stop + transcribe
+                        tracing::info!(target: "keyboard", "BOTH -> emit hold-down-stop (promoted hold)");
+                        let _ = app.emit("hold-down-stop", ());
+                    } else if dtap_fired {
+                        // Double-tap completed
+                        tracing::info!(target: "keyboard", "BOTH -> emit double-tap-toggle");
+                        let _ = app.emit("double-tap-toggle", ());
+                    }
+                    // Short single tap emits nothing — only delayed second-tap via GapTooLong produces feedback.
+                    if !promoted {
+                        if let TapOutcome::Rejected(r) = dtap_outcome {
+                            tracing::info!(target: "keyboard", reason = r.as_str(), "BOTH -> emit tap-rejected (on Stop)");
+                            let _ = app.emit("tap-rejected", r.as_str());
+                        }
+                    }
+                }
+                HoldDownEvent::None => {
+                    if dtap_fired {
+                        tracing::info!(target: "keyboard", "BOTH -> emit double-tap-toggle (hold=None)");
+                        let _ = app.emit("double-tap-toggle", ());
+                    }
+                    if let TapOutcome::Rejected(r) = dtap_outcome {
+                        tracing::info!(target: "keyboard", reason = r.as_str(), "BOTH -> emit tap-rejected (on None)");
+                        let _ = app.emit("tap-rejected", r.as_str());
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    fn make_detector(key: Key) -> DoubleTapDetector {
+        let mut d = DoubleTapDetector::new();
+        d.set_target(Some(key));
+        d
+    }
+
+    fn press(key: Key) -> EventType {
+        EventType::KeyPress(key)
+    }
+
+    fn release(key: Key) -> EventType {
+        EventType::KeyRelease(key)
+    }
+
+    // ── DoubleTapDetector tests ──────────────────────────────────────────────
+
+    #[test]
+    fn basic_double_tap_fires() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap: press then release quickly
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Second tap: press then release quickly
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingSecondUp);
+
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn no_target_key_never_fires() {
+        let mut d = DoubleTapDetector::new();
+        // target_key is None
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+    }
+
+    #[test]
+    fn wrong_key_ignored() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Press Alt instead of Shift — should stay idle
+        assert_eq!(d.handle_event(&press(Key::Alt)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn modifier_plus_letter_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Shift down
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        // Then a non-modifier key while Shift held — user is typing Shift+A (intentional combo)
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn held_too_long_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        // Wait longer than MAX_HOLD_DURATION_MS
+        sleep(Duration::from_millis(350));
+
+        // Release after too long — rejected (sequence-ending release event)
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::HeldTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn slow_gap_between_taps_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap — quick
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Wait longer than DOUBLE_TAP_WINDOW_MS
+        sleep(Duration::from_millis(450));
+
+        // Second press after too long a gap — rejected (delayed retry of target modifier)
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::GapTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn cooldown_prevents_triple_tap() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Successful double-tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+
+        // Immediately try another double-tap — should be blocked by cooldown
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        // in_cooldown() returns true, so handle_event returns None early
+    }
+
+    #[test]
+    fn cooldown_expires() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Successful double-tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+
+        // Wait for cooldown to expire
+        sleep(Duration::from_millis(550));
+
+        // Now another double-tap should work
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+    }
+
+    #[test]
+    fn second_tap_held_too_long_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap — quick
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+
+        // Second tap — press quick but hold too long before release
+        d.handle_event(&press(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondUp);
+
+        sleep(Duration::from_millis(350));
+
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::SecondTapHeldTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn letter_during_second_tap_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+
+        // Second tap — Shift down then non-modifier key (intentional combo, not timing miss)
+        d.handle_event(&press(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondUp);
+
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn other_key_between_taps_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Press a different (non-modifier) key in the gap
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn key_repeat_during_first_tap_within_hold_duration() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        // Key repeat (same key press again) — should stay in state
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        // Release quickly
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+    }
+
+    #[test]
+    fn alt_key_double_tap() {
+        let mut d = make_detector(Key::Alt);
+
+        d.handle_event(&press(Key::Alt));
+        d.handle_event(&release(Key::Alt));
+        d.handle_event(&press(Key::Alt));
+        assert!(d.handle_event(&release(Key::Alt)).fired());
+    }
+
+    #[test]
+    fn ctrl_key_double_tap() {
+        let mut d = make_detector(Key::ControlRight);
+
+        d.handle_event(&press(Key::ControlRight));
+        d.handle_event(&release(Key::ControlRight));
+        d.handle_event(&press(Key::ControlRight));
+        assert!(d.handle_event(&release(Key::ControlRight)).fired());
+    }
+
+    #[test]
+    fn single_tap_does_not_fire() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+        // No second tap — never fires
+    }
+
+    #[test]
+    fn set_target_resets_state() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Start a first tap
+        d.handle_event(&press(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        // Change target — should reset
+        d.set_target(Some(Key::Alt));
+        assert_eq!(d.state, DetectorState::Idle);
+        assert_eq!(d.target_key, Some(Key::Alt));
+    }
+
+    #[test]
+    fn hotkey_string_mapping() {
+        assert_eq!(hotkey_to_key("shift_l"), Some(Key::ShiftLeft));
+        assert_eq!(hotkey_to_key("alt_l"), Some(Key::Alt));
+        assert_eq!(hotkey_to_key("ctrl_r"), Some(Key::ControlRight));
+        assert_eq!(hotkey_to_key("unknown"), None);
+    }
+
+    #[test]
+    fn is_modifier_classification() {
+        assert!(is_modifier(Key::ShiftLeft));
+        assert!(is_modifier(Key::ShiftRight));
+        assert!(is_modifier(Key::Alt));
+        assert!(is_modifier(Key::ControlLeft));
+        assert!(is_modifier(Key::ControlRight));
+        assert!(is_modifier(Key::MetaLeft));
+        assert!(!is_modifier(Key::OtherNonModifier));
+        assert!(!is_modifier(Key::Escape));
+    }
+
+    // ── Single-tap-to-stop tests (recording=true) ────────────────────────────
+
+    #[test]
+    fn single_tap_stops_when_recording() {
+        let mut d = make_detector(Key::ShiftLeft);
+        d.recording = true;
+
+        // Single tap: press then release quickly
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::WaitingFirstUp);
+
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn single_tap_held_too_long_does_not_stop() {
+        let mut d = make_detector(Key::ShiftLeft);
+        d.recording = true;
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        sleep(Duration::from_millis(350));
+
+        // Held too long — rejected (user tried to stop-tap but held too long)
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::HeldTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn single_tap_with_letter_does_not_stop() {
+        let mut d = make_detector(Key::ShiftLeft);
+        d.recording = true;
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        // User types non-modifier — should not stop recording (intentional combo)
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn double_tap_still_required_when_not_recording() {
+        let mut d = make_detector(Key::ShiftLeft);
+        d.recording = false;
+
+        // Single tap should NOT fire
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+        // Needs second tap to fire
+    }
+
+    #[test]
+    fn full_cycle_double_tap_start_single_tap_stop() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Not recording — double tap to start
+        d.recording = false;
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+
+        // Wait for cooldown
+        sleep(Duration::from_millis(550));
+
+        // Now recording — single tap to stop
+        d.recording = true;
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+    }
+
+    // ── New DoubleTapDetector rejection reason tests ─────────────────────────
+
+    #[test]
+    fn held_too_long_reports_held_too_long() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        d.handle_event(&press(Key::ShiftLeft));
+        sleep(Duration::from_millis(250));
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::HeldTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn gap_too_long_letter_press_is_noop() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Wait for the gap window to expire
+        sleep(Duration::from_millis(450));
+
+        // Press a non-target key — not a delayed retry, so no rejection
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn gap_too_long_target_modifier_press_rejects() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Wait for the gap window to expire
+        sleep(Duration::from_millis(450));
+
+        // Press the target modifier — delayed retry, emit GapTooLong
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::GapTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn second_tap_held_too_long_reports_reason() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap (quick)
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+
+        // Second tap — press quickly, hold too long before release
+        d.handle_event(&press(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondUp);
+
+        sleep(Duration::from_millis(250));
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::Rejected(RejectReason::SecondTapHeldTooLong));
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn long_hold_with_key_repeats_emits_at_most_one_rejection() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Press and feed key repeats until we exceed MAX_HOLD_DURATION_MS
+        let mut outcomes = Vec::new();
+        outcomes.push(d.handle_event(&press(Key::ShiftLeft)));
+        for _ in 0..5 {
+            sleep(Duration::from_millis(50));
+            outcomes.push(d.handle_event(&press(Key::ShiftLeft)));
+        }
+        // Release after all the key repeats
+        outcomes.push(d.handle_event(&release(Key::ShiftLeft)));
+
+        // At most one Rejected variant observed across the whole sequence
+        let rejection_count = outcomes.iter().filter(|o| matches!(o, TapOutcome::Rejected(_))).count();
+        assert!(rejection_count <= 1, "expected at most one rejection, got {rejection_count}: {outcomes:?}");
+    }
+
+    #[test]
+    fn mouse_event_during_gap_does_not_reject() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // First tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        assert_eq!(d.state, DetectorState::WaitingSecondDown);
+
+        // Wait for the gap window to expire
+        sleep(Duration::from_millis(450));
+
+        // Feed a non-modifier, non-target press (simulates a non-retry event) — no rejection
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), TapOutcome::None);
+        assert_eq!(d.state, DetectorState::Idle);
+    }
+
+    #[test]
+    fn no_target_key_returns_none() {
+        let mut d = DoubleTapDetector::new(); // no target set
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), TapOutcome::None);
+    }
+
+    #[test]
+    fn cooldown_returns_none() {
+        let mut d = make_detector(Key::ShiftLeft);
+
+        // Complete a successful double-tap
+        d.handle_event(&press(Key::ShiftLeft));
+        d.handle_event(&release(Key::ShiftLeft));
+        d.handle_event(&press(Key::ShiftLeft));
+        assert!(d.handle_event(&release(Key::ShiftLeft)).fired());
+
+        // Immediately press — cooldown active, returns None
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), TapOutcome::None);
+    }
+
+    // ── Hold-down detector tests ─────────────────────────────────────────────
+
+    fn make_hold_detector(key: Key) -> HoldDownDetector {
+        let mut d = HoldDownDetector::new();
+        d.set_target(Some(key));
+        d
+    }
+
+    #[test]
+    fn hold_basic_press_starts_release_stops() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        assert_eq!(d.state, HoldState::Held);
+
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::Stop);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_no_target_key_never_fires() {
+        let mut d = HoldDownDetector::new();
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::None);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::None);
+    }
+
+    #[test]
+    fn hold_wrong_key_ignored() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::Alt)), HoldDownEvent::None);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_key_repeat_ignored_while_held() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+
+        // Key repeat events — should be ignored
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::None);
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::None);
+        assert_eq!(d.state, HoldState::Held);
+
+        // Release still works
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::Stop);
+    }
+
+    #[test]
+    fn hold_modifier_plus_letter_cancels() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        assert_eq!(d.state, HoldState::Held);
+
+        // User types non-modifier key — should cancel and stop
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), HoldDownEvent::Stop);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_release_without_press_ignored() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        // Release while idle — nothing happens
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::None);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_cooldown_after_stop() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        // Hold and release
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::Stop);
+
+        // Immediately press again — should be blocked by cooldown
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::None);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_cooldown_expires() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        assert_eq!(d.handle_event(&release(Key::ShiftLeft)), HoldDownEvent::Stop);
+
+        // Wait for cooldown to expire
+        sleep(Duration::from_millis(350));
+
+        // Now press again — should work
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+    }
+
+    #[test]
+    fn hold_alt_key() {
+        let mut d = make_hold_detector(Key::Alt);
+
+        assert_eq!(d.handle_event(&press(Key::Alt)), HoldDownEvent::Start);
+        assert_eq!(d.handle_event(&release(Key::Alt)), HoldDownEvent::Stop);
+    }
+
+    #[test]
+    fn hold_ctrl_key() {
+        let mut d = make_hold_detector(Key::ControlRight);
+
+        assert_eq!(d.handle_event(&press(Key::ControlRight)), HoldDownEvent::Start);
+        assert_eq!(d.handle_event(&release(Key::ControlRight)), HoldDownEvent::Stop);
+    }
+
+    #[test]
+    fn hold_set_target_while_held_stops() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        assert_eq!(d.state, HoldState::Held);
+
+        // Change target while held — resets to Idle, returns true (should emit stop)
+        assert!(d.set_target(Some(Key::Alt)));
+        assert_eq!(d.state, HoldState::Idle);
+
+        // Changing target while idle — returns false
+        assert!(!d.set_target(Some(Key::ControlRight)));
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_non_modifier_press_in_idle_ignored() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        // Random non-modifier key presses while idle — nothing happens
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), HoldDownEvent::None);
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), HoldDownEvent::None);
+        assert_eq!(d.state, HoldState::Idle);
+    }
+
+    #[test]
+    fn hold_cooldown_after_letter_cancel() {
+        let mut d = make_hold_detector(Key::ShiftLeft);
+
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::Start);
+        // Cancel with non-modifier key
+        assert_eq!(d.handle_event(&press(Key::OtherNonModifier)), HoldDownEvent::Stop);
+
+        // Immediate re-press should be blocked by cooldown
+        assert_eq!(d.handle_event(&press(Key::ShiftLeft)), HoldDownEvent::None);
+    }
+
+    // ── Both-mode tests (deferred hold with second-phase suppression) ─────────
+
+    /// Events that the Both-mode callback would emit synchronously.
+    /// hold-down-start is emitted asynchronously by a timer thread and is
+    /// NOT part of the synchronous return value.
+    #[derive(Debug, PartialEq)]
+    enum BothEmit {
+        HoldStop,
+        DoubleTapToggle,
+        TapRejected(&'static str),
+    }
+
+    /// Simulate the Both-mode deferred-hold arbitration logic.
+    /// `promoted` simulates whether the timer thread promoted the press
+    /// to a real hold (i.e. HOLD_PROMOTED was true).
+    fn both_handle_event(
+        hold: &mut HoldDownDetector,
+        dtap: &mut DoubleTapDetector,
+        event_type: &EventType,
+        promoted: bool,
+    ) -> Vec<BothEmit> {
+        // Check dtap phase BEFORE feeding — also verify the window hasn't expired
+        let dtap_second_phase = matches!(dtap.state,
+            DetectorState::WaitingSecondDown | DetectorState::WaitingSecondUp)
+            && dtap.elapsed_ms() <= DOUBLE_TAP_WINDOW_MS;
+
+        // Only feed hold-down when NOT in second phase
+        let hold_result = if !dtap_second_phase {
+            hold.handle_event(event_type)
+        } else {
+            HoldDownEvent::None
+        };
+
+        // Always feed double-tap
+        let dtap_outcome = dtap.handle_event(event_type);
+        let dtap_fired = dtap_outcome.fired();
+        let mut emitted = Vec::new();
+
+        match hold_result {
+            HoldDownEvent::Start => {
+                // In real code: spawns a timer thread, no synchronous emission
+                if let TapOutcome::Rejected(r) = dtap_outcome {
+                    emitted.push(BothEmit::TapRejected(r.as_str()));
+                }
+            }
+            HoldDownEvent::Stop => {
+                if promoted {
+                    emitted.push(BothEmit::HoldStop);
+                } else if dtap_fired {
+                    emitted.push(BothEmit::DoubleTapToggle);
+                }
+                // Short single tap emits nothing — only delayed second-tap via GapTooLong produces feedback.
+                if !promoted {
+                    if let TapOutcome::Rejected(r) = dtap_outcome {
+                        emitted.push(BothEmit::TapRejected(r.as_str()));
+                    }
+                }
+            }
+            HoldDownEvent::None => {
+                if dtap_fired {
+                    emitted.push(BothEmit::DoubleTapToggle);
+                }
+                if let TapOutcome::Rejected(r) = dtap_outcome {
+                    emitted.push(BothEmit::TapRejected(r.as_str()));
+                }
+            }
+        }
+        emitted
+    }
+
+    #[test]
+    fn both_long_hold_starts_and_stops() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // Press — no synchronous emission (timer deferred)
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+
+        // Wait past the tap threshold (timer would have promoted)
+        sleep(Duration::from_millis(250));
+
+        // Release — promoted hold → stop (dtap HeldTooLong is suppressed by !promoted guard)
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true);
+        assert_eq!(e, vec![BothEmit::HoldStop]);
+    }
+
+    #[test]
+    fn both_short_tap_emits_nothing() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // Quick press + release — no promotion, no emission
+        // Short single tap is silent — the user's first tap of an intended double-tap.
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+        assert_eq!(dtap.state, DetectorState::WaitingSecondDown);
+    }
+
+    #[test]
+    fn both_double_tap_fires() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // First tap
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+        assert_eq!(dtap.state, DetectorState::WaitingSecondDown);
+
+        // Second tap — hold suppressed (second phase), dtap completes
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]); // hold suppressed
+        assert_eq!(dtap.state, DetectorState::WaitingSecondUp);
+
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+        assert_eq!(e, vec![BothEmit::DoubleTapToggle]);
+    }
+
+    #[test]
+    fn both_single_tap_stops_when_recording() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+        dtap.recording = true;
+
+        // Press — no sync emission
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+
+        // Quick release — dtap fires (single tap to stop)
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+        assert_eq!(e, vec![BothEmit::DoubleTapToggle]);
+    }
+
+    #[test]
+    fn both_gap_too_long_emits_rejection_after_expired_window() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // First tap
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+
+        // Wait for double-tap window + hold cooldown to expire
+        sleep(Duration::from_millis(550));
+
+        // Next press — dtap was in WaitingSecondDown with elapsed > 400ms, target modifier pressed
+        // → GapTooLong rejection emitted from the HoldDownEvent::Start arm
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![BothEmit::TapRejected("gap_too_long")]);
+    }
+
+    // ── New Both-mode rejection tests ────────────────────────────────────────
+
+    #[test]
+    fn both_promoted_hold_suppresses_tap_rejection() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // Press — no sync emission
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+
+        // Wait past the tap threshold (timer would have promoted)
+        sleep(Duration::from_millis(250));
+
+        // Release with promoted=true — "hold wins" rule suppresses the HeldTooLong rejection
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true);
+        assert_eq!(e, vec![BothEmit::HoldStop]);
+    }
+
+    #[test]
+    fn both_delayed_second_tap_rejects_on_modifier_press() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // First tap
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+
+        // Wait for double-tap window to expire
+        sleep(Duration::from_millis(450));
+
+        // Press target modifier — dtap returns GapTooLong rejection
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![BothEmit::TapRejected("gap_too_long")]);
+    }
+
+    #[test]
+    fn both_delayed_second_tap_with_letter_is_noop() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // First tap
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+
+        // Wait for double-tap window to expire
+        sleep(Duration::from_millis(450));
+
+        // Press a non-modifier key — not a delayed retry of the target, so no rejection
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::OtherNonModifier), false);
+        assert_eq!(e, vec![]);
+    }
+
+    // Note: In practice a 250ms hold almost always triggers the deferred timer promotion,
+    // but this test passes promoted=false to isolate the !promoted guard behavior.
+    #[test]
+    fn both_first_tap_held_too_long_not_promoted_emits_rejection() {
+        let mut hold = make_hold_detector(Key::ShiftLeft);
+        let mut dtap = make_detector(Key::ShiftLeft);
+
+        // Press — no sync emission
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        assert_eq!(e, vec![]);
+
+        // Wait past the tap threshold
+        sleep(Duration::from_millis(250));
+
+        // Release with promoted=false — dtap in WaitingFirstUp, elapsed > 200ms → HeldTooLong
+        // Since !promoted, the rejection is emitted
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
+        assert_eq!(e, vec![BothEmit::TapRejected("held_too_long")]);
+    }
+}

--- a/app/src-tauri/src/keyboard/linux.rs
+++ b/app/src-tauri/src/keyboard/linux.rs
@@ -1,0 +1,121 @@
+// rdev-based keyboard listener for Linux (and other non-macOS platforms).
+// On macOS this module is replaced by `macos.rs` which uses a native CGEventTap.
+
+use rdev::{listen, Event, EventType as RdevEventType};
+use std::sync::atomic::Ordering;
+use super::detectors;
+
+pub use super::detectors::{stop_listener, set_target_key, set_recording_state, set_processing};
+
+pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
+    let detector_mode = match mode {
+        "hold_down" => detectors::DetectorMode::HoldDown,
+        "both" => detectors::DetectorMode::Both,
+        _ => detectors::DetectorMode::DoubleTap,
+    };
+
+    {
+        let mut m = detectors::ACTIVE_MODE.lock().unwrap_or_else(|p| p.into_inner());
+        *m = detector_mode;
+    }
+
+    let target = detectors::hotkey_to_key(hotkey);
+
+    match detector_mode {
+        detectors::DetectorMode::DoubleTap => {
+            let mut det = detectors::DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            match det.as_mut() {
+                Some(d) => d.set_target(target),
+                None => {
+                    let mut d = detectors::DoubleTapDetector::new();
+                    d.set_target(target);
+                    *det = Some(d);
+                }
+            }
+        }
+        detectors::DetectorMode::HoldDown => {
+            let mut det = detectors::HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            match det.as_mut() {
+                Some(d) => { let _ = d.set_target(target); }
+                None => {
+                    let mut d = detectors::HoldDownDetector::new();
+                    let _ = d.set_target(target);
+                    *det = Some(d);
+                }
+            }
+        }
+        detectors::DetectorMode::Both => {
+            {
+                let mut det = detectors::HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                match det.as_mut() {
+                    Some(d) => { let _ = d.set_target(target); }
+                    None => {
+                        let mut d = detectors::HoldDownDetector::new();
+                        let _ = d.set_target(target);
+                        *det = Some(d);
+                    }
+                }
+            }
+            {
+                let mut det = detectors::DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                match det.as_mut() {
+                    Some(d) => d.set_target(target),
+                    None => {
+                        let mut d = detectors::DoubleTapDetector::new();
+                        d.set_target(target);
+                        *det = Some(d);
+                    }
+                }
+            }
+        }
+    }
+
+    detectors::LISTENER_ACTIVE.store(true, Ordering::SeqCst);
+
+    if detectors::LISTENER_THREAD_SPAWNED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let handle = app_handle.clone();
+        let error_handle = app_handle.clone();
+
+        std::thread::spawn(move || {
+            tracing::info!(target: "keyboard", "rdev listener thread started");
+
+            let callback = move |event: Event| {
+                if !detectors::LISTENER_ACTIVE.load(Ordering::SeqCst) {
+                    return;
+                }
+                let ev = match event.event_type {
+                    RdevEventType::KeyPress(k) => {
+                        detectors::EventType::KeyPress(detectors::from_rdev_key(k))
+                    }
+                    RdevEventType::KeyRelease(k) => {
+                        detectors::EventType::KeyRelease(detectors::from_rdev_key(k))
+                    }
+                    _ => return,
+                };
+                detectors::handle_event(&handle, ev);
+            };
+
+            if let Err(e) = listen(callback) {
+                tracing::error!(target: "keyboard", "rdev listener error: {:?}", e);
+                detectors::LISTENER_THREAD_SPAWNED.store(false, Ordering::SeqCst);
+                detectors::LISTENER_ACTIVE.store(false, Ordering::SeqCst);
+                let _ = {
+                    use tauri::Emitter;
+                    error_handle.emit("keyboard-listener-error", format!("{:?}", e))
+                };
+            }
+        });
+
+        std::thread::spawn(|| loop {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+            if detectors::LISTENER_ACTIVE.load(Ordering::SeqCst) {
+                tracing::trace!(target: "keyboard", "listener heartbeat — active");
+            } else if !detectors::LISTENER_THREAD_SPAWNED.load(Ordering::SeqCst) {
+                break;
+            }
+        });
+    }
+}

--- a/app/src-tauri/src/keyboard/macos.rs
+++ b/app/src-tauri/src/keyboard/macos.rs
@@ -1,0 +1,515 @@
+// CGEventTap listener for macOS.
+//
+// Lifetime: the tap runs on a dedicated std::thread that calls CFRunLoopRun()
+// which blocks forever. The current API deliberately does not expose a way to
+// tear the tap down; stop_listener() only clears LISTENER_ACTIVE so callback
+// events become no-ops. If a future change needs to stop the run loop, call
+// CFRunLoopStop(run_loop) from any thread — do NOT simply drop the thread.
+//
+// Thread safety: the tap callback runs on the CFRunLoop thread (not main).
+// CGEventGetIntegerValueField, CGEventGetFlags, and CGEventTapEnable are
+// documented thread-safe. We do NOT call any TIS/TSM APIs, so no main-thread
+// affinity is required. (Contrast with rdev on macOS which DOES call TIS via
+// dispatch_sync to main, which can stall under contention and trigger the
+// active-tap timeout.)
+//
+// Tap level: kCGHIDEventTap delivers events at the hardware-input layer,
+// before window routing — system-wide regardless of which app is focused.
+// kCGEventTapOptionListenOnly means the tap is passive and not subject to the
+// macOS event-tap timeout penalty that disables active taps under load.
+
+use std::os::raw::c_void;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::Emitter;
+
+use super::{detectors, sys};
+
+pub use super::detectors::{stop_listener, set_target_key, set_recording_state, set_processing};
+
+// ── Module-level state ────────────────────────────────────────────────────────
+
+/// Wrapper making CFMachPortRef (a raw pointer) usable in a Mutex static.
+struct SendMachPort(sys::CFMachPortRef);
+unsafe impl Send for SendMachPort {}
+unsafe impl Sync for SendMachPort {}
+
+static STORED_TAP: Mutex<Option<SendMachPort>> = Mutex::new(None);
+static APP_HANDLE: Mutex<Option<tauri::AppHandle>> = Mutex::new(None);
+
+// Diagnostic counters (bumped for modifier/Escape callbacks and re-enables)
+static MODIFIER_CALLBACK_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static TAP_REENABLE_COUNT: AtomicU64 = AtomicU64::new(0);
+static LAST_MODIFIER_CALLBACK_AT_MILLIS: AtomicU64 = AtomicU64::new(0);
+
+// Per-modifier latches for FlagsChanged press/release disambiguation.
+// A FlagsChanged event for a modifier does not carry explicit press/release info;
+// we derive it by comparing the event's flag bits to the latch (prior state).
+static LATCH_SHIFT_L: AtomicBool = AtomicBool::new(false);
+static LATCH_SHIFT_R: AtomicBool = AtomicBool::new(false);
+static LATCH_CTRL_L: AtomicBool = AtomicBool::new(false);
+static LATCH_CTRL_R: AtomicBool = AtomicBool::new(false);
+static LATCH_OPT_L: AtomicBool = AtomicBool::new(false);
+static LATCH_OPT_R: AtomicBool = AtomicBool::new(false);
+static LATCH_CMD_L: AtomicBool = AtomicBool::new(false);
+static LATCH_CMD_R: AtomicBool = AtomicBool::new(false);
+
+static TAP_ENABLER: Mutex<Option<Arc<dyn TapEnabler + Send + Sync>>> = Mutex::new(None);
+
+// ── TapEnabler trait (abstracts re-enable for testability) ────────────────────
+
+pub(crate) trait TapEnabler {
+    fn reenable(&self);
+}
+
+struct RealEnabler;
+
+impl TapEnabler for RealEnabler {
+    fn reenable(&self) {
+        let guard = STORED_TAP.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(port) = guard.as_ref() {
+            unsafe { sys::CGEventTapEnable(port.0, true) };
+            tracing::info!(target: "keyboard", "tap re-enabled");
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn now_millis() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Returns the device-specific CGEventFlags bit mask for a modifier key.
+fn modifier_flag_mask(key: detectors::Key) -> u64 {
+    match key {
+        detectors::Key::ShiftLeft    => sys::NX_DEVICELSHIFTKEYMASK,
+        detectors::Key::ShiftRight   => sys::NX_DEVICERSHIFTKEYMASK,
+        detectors::Key::ControlLeft  => sys::NX_DEVICELCTLKEYMASK,
+        detectors::Key::ControlRight => sys::NX_DEVICERCTLKEYMASK,
+        detectors::Key::Alt          => sys::NX_DEVICELALTKEYMASK,
+        detectors::Key::AltGr        => sys::NX_DEVICERALTKEYMASK,
+        detectors::Key::MetaLeft     => sys::NX_DEVICELCMDKEYMASK,
+        detectors::Key::MetaRight    => sys::NX_DEVICERCMDKEYMASK,
+        _ => 0,
+    }
+}
+
+fn get_latch(key: detectors::Key) -> bool {
+    match key {
+        detectors::Key::ShiftLeft    => LATCH_SHIFT_L.load(Ordering::Relaxed),
+        detectors::Key::ShiftRight   => LATCH_SHIFT_R.load(Ordering::Relaxed),
+        detectors::Key::ControlLeft  => LATCH_CTRL_L.load(Ordering::Relaxed),
+        detectors::Key::ControlRight => LATCH_CTRL_R.load(Ordering::Relaxed),
+        detectors::Key::Alt          => LATCH_OPT_L.load(Ordering::Relaxed),
+        detectors::Key::AltGr        => LATCH_OPT_R.load(Ordering::Relaxed),
+        detectors::Key::MetaLeft     => LATCH_CMD_L.load(Ordering::Relaxed),
+        detectors::Key::MetaRight    => LATCH_CMD_R.load(Ordering::Relaxed),
+        _ => false,
+    }
+}
+
+fn set_latch(key: detectors::Key, val: bool) {
+    match key {
+        detectors::Key::ShiftLeft    => LATCH_SHIFT_L.store(val, Ordering::Relaxed),
+        detectors::Key::ShiftRight   => LATCH_SHIFT_R.store(val, Ordering::Relaxed),
+        detectors::Key::ControlLeft  => LATCH_CTRL_L.store(val, Ordering::Relaxed),
+        detectors::Key::ControlRight => LATCH_CTRL_R.store(val, Ordering::Relaxed),
+        detectors::Key::Alt          => LATCH_OPT_L.store(val, Ordering::Relaxed),
+        detectors::Key::AltGr        => LATCH_OPT_R.store(val, Ordering::Relaxed),
+        detectors::Key::MetaLeft     => LATCH_CMD_L.store(val, Ordering::Relaxed),
+        detectors::Key::MetaRight    => LATCH_CMD_R.store(val, Ordering::Relaxed),
+        _ => {}
+    }
+}
+
+fn reset_modifier_latches() {
+    LATCH_SHIFT_L.store(false, Ordering::Relaxed);
+    LATCH_SHIFT_R.store(false, Ordering::Relaxed);
+    LATCH_CTRL_L.store(false, Ordering::Relaxed);
+    LATCH_CTRL_R.store(false, Ordering::Relaxed);
+    LATCH_OPT_L.store(false, Ordering::Relaxed);
+    LATCH_OPT_R.store(false, Ordering::Relaxed);
+    LATCH_CMD_L.store(false, Ordering::Relaxed);
+    LATCH_CMD_R.store(false, Ordering::Relaxed);
+}
+
+fn any_modifier_held() -> bool {
+    LATCH_SHIFT_L.load(Ordering::Relaxed)
+        || LATCH_SHIFT_R.load(Ordering::Relaxed)
+        || LATCH_CTRL_L.load(Ordering::Relaxed)
+        || LATCH_CTRL_R.load(Ordering::Relaxed)
+        || LATCH_OPT_L.load(Ordering::Relaxed)
+        || LATCH_OPT_R.load(Ordering::Relaxed)
+        || LATCH_CMD_L.load(Ordering::Relaxed)
+        || LATCH_CMD_R.load(Ordering::Relaxed)
+}
+
+// ── Disable-event recovery ────────────────────────────────────────────────────
+
+/// Called when a kCGEventTapDisabledBy* event arrives. Increments the reenable
+/// counter, calls the enabler, and updates diagnostic timestamps. Does NOT touch
+/// LISTENER_ACTIVE — the tap being re-enabled is transparent to callers.
+pub(crate) fn handle_disable_event(enabler: &dyn TapEnabler, reason: &str) {
+    TAP_REENABLE_COUNT.fetch_add(1, Ordering::Relaxed);
+    tracing::warn!(target: "keyboard", "tap disabled ({}); re-enabling", reason);
+    enabler.reenable();
+    MODIFIER_CALLBACK_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+    LAST_MODIFIER_CALLBACK_AT_MILLIS.store(now_millis(), Ordering::Relaxed);
+    reset_modifier_latches();
+}
+
+// ── CGEventTap callback ───────────────────────────────────────────────────────
+
+unsafe extern "C" fn tap_callback(
+    _proxy: sys::CGEventTapProxy,
+    etype: sys::CGEventType,
+    event: sys::CGEventRef,
+    _user_info: *mut c_void,
+) -> sys::CGEventRef {
+    // Handle tap-disable meta-events first
+    if etype == sys::K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT
+        || etype == sys::K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT
+    {
+        let enabler_opt = {
+            let guard = TAP_ENABLER.lock().unwrap_or_else(|p| p.into_inner());
+            guard.clone()
+        };
+        if let Some(enabler) = enabler_opt {
+            let reason = if etype == sys::K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT {
+                "timeout"
+            } else {
+                "user_input"
+            };
+            handle_disable_event(enabler.as_ref(), reason);
+        }
+        return event;
+    }
+
+    if !detectors::LISTENER_ACTIVE.load(Ordering::Relaxed) {
+        return event;
+    }
+
+    let keycode = sys::CGEventGetIntegerValueField(event, sys::K_CG_KEYBOARD_EVENT_KEYCODE);
+    let key = detectors::from_macos_keycode(keycode);
+
+    match etype {
+        sys::K_CG_EVENT_FLAGS_CHANGED => {
+            // Only modifier keys generate FlagsChanged. Determine press vs release
+            // by comparing the current event flags against the per-modifier latch.
+            if detectors::is_modifier(key) {
+                let flags = sys::CGEventGetFlags(event);
+                let mask = modifier_flag_mask(key);
+                let now_held = mask != 0 && (flags & mask) != 0;
+                let was_held = get_latch(key);
+
+                if now_held && !was_held {
+                    set_latch(key, true);
+                    MODIFIER_CALLBACK_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                    LAST_MODIFIER_CALLBACK_AT_MILLIS.store(now_millis(), Ordering::Relaxed);
+                    let app_opt = {
+                        let guard = APP_HANDLE.lock().unwrap_or_else(|p| p.into_inner());
+                        guard.as_ref().cloned()
+                    };
+                    if let Some(app) = app_opt {
+                        detectors::handle_event(&app, detectors::EventType::KeyPress(key));
+                    }
+                } else if !now_held && was_held {
+                    set_latch(key, false);
+                    MODIFIER_CALLBACK_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                    LAST_MODIFIER_CALLBACK_AT_MILLIS.store(now_millis(), Ordering::Relaxed);
+                    let app_opt = {
+                        let guard = APP_HANDLE.lock().unwrap_or_else(|p| p.into_inner());
+                        guard.as_ref().cloned()
+                    };
+                    if let Some(app) = app_opt {
+                        detectors::handle_event(&app, detectors::EventType::KeyRelease(key));
+                    }
+                }
+            }
+        }
+
+        sys::K_CG_EVENT_KEY_DOWN => {
+            match key {
+                detectors::Key::Escape => {
+                    MODIFIER_CALLBACK_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                    LAST_MODIFIER_CALLBACK_AT_MILLIS.store(now_millis(), Ordering::Relaxed);
+                    let app_opt = {
+                        let guard = APP_HANDLE.lock().unwrap_or_else(|p| p.into_inner());
+                        guard.as_ref().cloned()
+                    };
+                    if let Some(app) = app_opt {
+                        detectors::handle_event(&app, detectors::EventType::KeyPress(detectors::Key::Escape));
+                    }
+                }
+                detectors::Key::OtherNonModifier => {
+                    // Only dispatch if a modifier is currently held so we can
+                    // cancel an in-progress double-tap or hold sequence without
+                    // bumping diagnostics on every regular keystroke.
+                    if any_modifier_held() {
+                        let app_opt = {
+                            let guard = APP_HANDLE.lock().unwrap_or_else(|p| p.into_inner());
+                            guard.as_ref().cloned()
+                        };
+                        if let Some(app) = app_opt {
+                            detectors::handle_event(&app, detectors::EventType::KeyPress(detectors::Key::OtherNonModifier));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        _ => {}
+    }
+
+    event
+}
+
+// ── Listener lifecycle ────────────────────────────────────────────────────────
+
+pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
+    let detector_mode = match mode {
+        "hold_down" => detectors::DetectorMode::HoldDown,
+        "both"      => detectors::DetectorMode::Both,
+        _           => detectors::DetectorMode::DoubleTap,
+    };
+
+    {
+        let mut m = detectors::ACTIVE_MODE.lock().unwrap_or_else(|p| p.into_inner());
+        *m = detector_mode;
+    }
+
+    let target = detectors::hotkey_to_key(hotkey);
+
+    match detector_mode {
+        detectors::DetectorMode::DoubleTap => {
+            let mut det = detectors::DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            match det.as_mut() {
+                Some(d) => d.set_target(target),
+                None => {
+                    let mut d = detectors::DoubleTapDetector::new();
+                    d.set_target(target);
+                    *det = Some(d);
+                }
+            }
+        }
+        detectors::DetectorMode::HoldDown => {
+            let mut det = detectors::HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            match det.as_mut() {
+                Some(d) => { let _ = d.set_target(target); }
+                None => {
+                    let mut d = detectors::HoldDownDetector::new();
+                    let _ = d.set_target(target);
+                    *det = Some(d);
+                }
+            }
+        }
+        detectors::DetectorMode::Both => {
+            {
+                let mut det = detectors::HOLD_DOWN_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                match det.as_mut() {
+                    Some(d) => { let _ = d.set_target(target); }
+                    None => {
+                        let mut d = detectors::HoldDownDetector::new();
+                        let _ = d.set_target(target);
+                        *det = Some(d);
+                    }
+                }
+            }
+            {
+                let mut det = detectors::DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+                match det.as_mut() {
+                    Some(d) => d.set_target(target),
+                    None => {
+                        let mut d = detectors::DoubleTapDetector::new();
+                        d.set_target(target);
+                        *det = Some(d);
+                    }
+                }
+            }
+        }
+    }
+
+    // Store the AppHandle for use in the callback
+    {
+        let mut guard = APP_HANDLE.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = Some(app_handle.clone());
+    }
+
+    detectors::LISTENER_ACTIVE.store(true, Ordering::SeqCst);
+    reset_modifier_latches();
+    LAST_MODIFIER_CALLBACK_AT_MILLIS.store(now_millis(), Ordering::Relaxed);
+
+    if detectors::LISTENER_THREAD_SPAWNED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        // Set the real tap enabler
+        {
+            let mut guard = TAP_ENABLER.lock().unwrap_or_else(|p| p.into_inner());
+            *guard = Some(Arc::new(RealEnabler));
+        }
+
+        let error_handle = app_handle.clone();
+
+        std::thread::Builder::new()
+            .name("keyboard-tap".into())
+            .spawn(move || {
+                let event_mask = sys::cg_event_mask_bit(sys::K_CG_EVENT_KEY_DOWN)
+                    | sys::cg_event_mask_bit(sys::K_CG_EVENT_KEY_UP)
+                    | sys::cg_event_mask_bit(sys::K_CG_EVENT_FLAGS_CHANGED)
+                    | sys::cg_event_mask_bit(sys::K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT)
+                    | sys::cg_event_mask_bit(sys::K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT);
+
+                let tap = unsafe {
+                    sys::CGEventTapCreate(
+                        sys::K_CG_HID_EVENT_TAP,
+                        sys::K_CG_HEAD_INSERT_EVENT_TAP,
+                        sys::K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+                        event_mask,
+                        tap_callback,
+                        std::ptr::null_mut(),
+                    )
+                };
+
+                let tap = if tap.is_null() {
+                    tracing::warn!(target: "keyboard",
+                        "HID tap creation failed; retrying with session tap (degraded focus behavior)");
+                    let session_tap = unsafe {
+                        sys::CGEventTapCreate(
+                            sys::K_CG_SESSION_EVENT_TAP,
+                            sys::K_CG_HEAD_INSERT_EVENT_TAP,
+                            sys::K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+                            event_mask,
+                            tap_callback,
+                            std::ptr::null_mut(),
+                        )
+                    };
+                    if session_tap.is_null() {
+                        tracing::error!(target: "keyboard",
+                            "Both HID and session CGEventTap creation failed — keyboard listener unavailable");
+                        detectors::LISTENER_THREAD_SPAWNED.store(false, Ordering::SeqCst);
+                        detectors::LISTENER_ACTIVE.store(false, Ordering::SeqCst);
+                        let _ = error_handle.emit(
+                            "keyboard-listener-error",
+                            "CGEventTapCreate failed for both HID and session tap levels",
+                        );
+                        return;
+                    }
+                    let _ = error_handle.emit(
+                        "keyboard-listener-degraded",
+                        serde_json::json!({ "reason": "session_tap_fallback" }),
+                    );
+                    tracing::warn!(target: "keyboard",
+                        "running on session tap — hotkeys may not work when Desktop is focused");
+                    session_tap
+                } else {
+                    tap
+                };
+
+                // Retain the port so it stays alive for the duration of the app
+                unsafe { sys::CFRetain(tap as *const c_void) };
+                {
+                    let mut guard = STORED_TAP.lock().unwrap_or_else(|p| p.into_inner());
+                    *guard = Some(SendMachPort(tap));
+                }
+
+                let source = unsafe {
+                    sys::CFMachPortCreateRunLoopSource(std::ptr::null_mut(), tap, 0)
+                };
+                let rl = unsafe { sys::CFRunLoopGetCurrent() };
+                unsafe {
+                    sys::CFRunLoopAddSource(rl, source, sys::kCFRunLoopCommonModes);
+                    sys::CGEventTapEnable(tap, true);
+                    tracing::info!(target: "keyboard", "CGEventTap started on keyboard-tap thread");
+                    sys::CFRunLoopRun(); // blocks forever on this thread
+                }
+            })
+            .expect("failed to spawn keyboard-tap thread");
+
+        // Heartbeat thread: logs diagnostic counters every 60 s and attempts
+        // a belt-and-suspenders re-enable if the tap appears silent for 120 s.
+        std::thread::spawn(|| {
+            let mut prev_invocations = MODIFIER_CALLBACK_INVOCATIONS.load(Ordering::Relaxed);
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(60));
+                if !detectors::LISTENER_THREAD_SPAWNED.load(Ordering::Relaxed) {
+                    break;
+                }
+                if detectors::LISTENER_ACTIVE.load(Ordering::Relaxed) {
+                    let invocations = MODIFIER_CALLBACK_INVOCATIONS.load(Ordering::Relaxed);
+                    let reenable_count = TAP_REENABLE_COUNT.load(Ordering::Relaxed);
+                    let last_ms = LAST_MODIFIER_CALLBACK_AT_MILLIS.load(Ordering::Relaxed);
+                    let now_ms = now_millis();
+                    let ms_since = now_ms.saturating_sub(last_ms);
+
+                    tracing::info!(
+                        target: "keyboard",
+                        modifier_invocations = invocations,
+                        reenable_count = reenable_count,
+                        ms_since_last_callback = ms_since,
+                        "tap heartbeat"
+                    );
+
+                    if invocations == prev_invocations && ms_since >= 120_000 {
+                        tracing::warn!(target: "keyboard",
+                            "tap silent — zero modifier callbacks in last heartbeat window; attempting re-enable");
+                        let guard = STORED_TAP.lock().unwrap_or_else(|p| p.into_inner());
+                        if let Some(port) = guard.as_ref() {
+                            unsafe { sys::CGEventTapEnable(port.0, true) };
+                        }
+                    }
+                    prev_invocations = invocations;
+                }
+            }
+        });
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+
+    struct MockEnabler {
+        reenables: AtomicU64,
+    }
+
+    impl TapEnabler for MockEnabler {
+        fn reenable(&self) {
+            self.reenables.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn test_handle_disable_event_reenables_and_counts() {
+        let prev_reenable_count = TAP_REENABLE_COUNT.load(Ordering::Relaxed);
+        let was_active = detectors::LISTENER_ACTIVE.load(Ordering::Relaxed);
+
+        let enabler = MockEnabler { reenables: AtomicU64::new(0) };
+        handle_disable_event(&enabler, "test");
+
+        assert_eq!(
+            enabler.reenables.load(Ordering::Relaxed),
+            1,
+            "reenable() should be called exactly once"
+        );
+        assert_eq!(
+            TAP_REENABLE_COUNT.load(Ordering::Relaxed),
+            prev_reenable_count + 1,
+            "TAP_REENABLE_COUNT should increment by 1"
+        );
+        assert_eq!(
+            detectors::LISTENER_ACTIVE.load(Ordering::Relaxed),
+            was_active,
+            "handle_disable_event must not modify LISTENER_ACTIVE"
+        );
+    }
+}

--- a/app/src-tauri/src/keyboard/mod.rs
+++ b/app/src-tauri/src/keyboard/mod.rs
@@ -1,0 +1,14 @@
+pub(crate) mod detectors;
+
+#[cfg(target_os = "macos")]
+mod sys;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::{start_listener, stop_listener, set_target_key, set_recording_state, set_processing};
+
+#[cfg(not(target_os = "macos"))]
+mod linux;
+#[cfg(not(target_os = "macos"))]
+pub use linux::{start_listener, stop_listener, set_target_key, set_recording_state, set_processing};

--- a/app/src-tauri/src/keyboard/sys.rs
+++ b/app/src-tauri/src/keyboard/sys.rs
@@ -1,0 +1,124 @@
+// Manual FFI declarations for CGEventTap (CoreGraphics) and CFRunLoop / CFMachPort
+// (CoreFoundation). Using hand-rolled FFI keeps CGEventTap* coverage stable
+// across macOS SDK versions and avoids the partial coverage risk of the
+// `core-graphics` crate. This mirrors the pattern in injector.rs for AX APIs.
+
+#![allow(dead_code)]
+
+use std::os::raw::c_void;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+pub type CGEventTapProxy = *mut c_void;
+pub type CGEventRef = *mut c_void;
+pub type CGEventType = u32;
+pub type CGEventMask = u64;
+pub type CGEventFlags = u64;
+pub type CFMachPortRef = *mut c_void;
+pub type CFRunLoopRef = *mut c_void;
+pub type CFRunLoopSourceRef = *mut c_void;
+pub type CFAllocatorRef = *mut c_void;
+
+pub type CGEventTapCallBack = unsafe extern "C" fn(
+    proxy: CGEventTapProxy,
+    etype: CGEventType,
+    event: CGEventRef,
+    user_info: *mut c_void,
+) -> CGEventRef;
+
+// ── CGEventTap location (CGEventTapLocation) ─────────────────────────────────
+
+/// Events injected at the HID level, before session and application routing.
+/// Delivered regardless of which app (if any) is focused.
+pub const K_CG_HID_EVENT_TAP: u32 = 0;
+/// Events at the session level; may not be delivered when no window is focused.
+pub const K_CG_SESSION_EVENT_TAP: u32 = 1;
+
+// ── CGEventTap placement (CGEventTapPlacement) ────────────────────────────────
+
+pub const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
+
+// ── CGEventTap options ────────────────────────────────────────────────────────
+
+/// Passive tap — not subject to macOS event-tap timeout penalty.
+pub const K_CG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+
+// ── CGEventType constants ─────────────────────────────────────────────────────
+
+pub const K_CG_EVENT_KEY_DOWN: u32 = 10;
+pub const K_CG_EVENT_KEY_UP: u32 = 11;
+/// Fires when a modifier key (Shift, Option, Control, Command) is pressed or
+/// released. Modifier keys do NOT generate KeyDown/KeyUp events on macOS.
+pub const K_CG_EVENT_FLAGS_CHANGED: u32 = 12;
+/// Synthesized event delivered to the tap when macOS disables it due to timeout.
+pub const K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFFFFFE;
+/// Synthesized event delivered when the tap is disabled by user input throttling.
+pub const K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = 0xFFFFFFFF;
+
+// ── CGEventField constants ────────────────────────────────────────────────────
+
+pub const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
+
+// ── Device-specific modifier flag masks (from IOKit/hid/IOLLEvent.h) ─────────
+//
+// These bits appear in CGEventFlags (returned by CGEventGetFlags) and identify
+// which hand's modifier key was pressed, enabling Left/Right disambiguation
+// for Shift, Option, Control, and Command.
+
+pub const NX_DEVICELCTLKEYMASK: u64 = 0x0000_0001;
+pub const NX_DEVICELSHIFTKEYMASK: u64 = 0x0000_0002;
+pub const NX_DEVICERSHIFTKEYMASK: u64 = 0x0000_0004;
+pub const NX_DEVICELCMDKEYMASK: u64 = 0x0000_0008;
+pub const NX_DEVICERCMDKEYMASK: u64 = 0x0000_0010;
+pub const NX_DEVICELALTKEYMASK: u64 = 0x0000_0020;
+pub const NX_DEVICERALTKEYMASK: u64 = 0x0000_0040;
+pub const NX_DEVICERCTLKEYMASK: u64 = 0x0000_2000;
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// Compute the event mask bit for a given CGEventType value.
+pub const fn cg_event_mask_bit(t: u32) -> u64 {
+    1u64 << (t as u64)
+}
+
+// ── CoreGraphics FFI ──────────────────────────────────────────────────────────
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    pub fn CGEventTapCreate(
+        tap: u32,
+        place: u32,
+        options: u32,
+        events_of_interest: CGEventMask,
+        callback: CGEventTapCallBack,
+        user_info: *mut c_void,
+    ) -> CFMachPortRef;
+
+    pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
+
+    pub fn CGEventGetIntegerValueField(event: CGEventRef, field: u32) -> i64;
+
+    pub fn CGEventGetFlags(event: CGEventRef) -> CGEventFlags;
+}
+
+// ── CoreFoundation FFI ────────────────────────────────────────────────────────
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    pub fn CFRetain(cf: *const c_void) -> *const c_void;
+    pub fn CFRelease(cf: *const c_void);
+
+    pub fn CFMachPortCreateRunLoopSource(
+        allocator: CFAllocatorRef,
+        port: CFMachPortRef,
+        order: isize,
+    ) -> CFRunLoopSourceRef;
+
+    pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+
+    pub fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: *const c_void);
+
+    pub fn CFRunLoopRun();
+
+    pub static kCFRunLoopCommonModes: *const c_void;
+}

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -11,6 +11,7 @@ const BAR_COUNT = 7;
 export function OverlayWidget() {
   const [status, setStatus] = useState<DictationStatus>('idle');
   const [showCancelled, setShowCancelled] = useState(false);
+  const [showTapRejected, setShowTapRejected] = useState(false);
   const [lockedMode, setLockedMode] = useState(false);
   const notchHeightRef = useRef(0);
   const [notchWidth, setNotchWidth] = useState(185);
@@ -19,6 +20,7 @@ export function OverlayWidget() {
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const audioLevelRef = useRef(0);
   const barRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const feedbackEnabledRef = useRef<boolean>(DEFAULT_SETTINGS.showTimingMissFeedback);
 
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { lockedRef.current = lockedMode; }, [lockedMode]);
@@ -98,6 +100,50 @@ export function OverlayWidget() {
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
     });
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      unlisten?.();
+    };
+  }, []);
+
+  // Read showTimingMissFeedback from localStorage on mount and whenever the
+  // 'storage' event fires (fires when localStorage is changed from ANOTHER window).
+  useEffect(() => {
+    const readSetting = () => {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          feedbackEnabledRef.current =
+            parsed.showTimingMissFeedback ?? DEFAULT_SETTINGS.showTimingMissFeedback;
+        } else {
+          feedbackEnabledRef.current = DEFAULT_SETTINGS.showTimingMissFeedback;
+        }
+      } catch {
+        feedbackEnabledRef.current = DEFAULT_SETTINGS.showTimingMissFeedback;
+      }
+    };
+    readSetting();
+    window.addEventListener('storage', readSetting);
+    return () => window.removeEventListener('storage', readSetting);
+  }, []);
+
+  // Subscribe to tap-rejected for brief amber pulse
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    listen<string>('tap-rejected', (event) => {
+      if (!feedbackEnabledRef.current) return;
+      flog.info('overlay', 'tap rejected', { reason: event.payload });
+      if (timeoutId) clearTimeout(timeoutId);
+      setShowTapRejected(true);
+      timeoutId = setTimeout(() => {
+        if (!cancelled) setShowTapRejected(false);
+        timeoutId = null;
+      }, 250);
+    }).then((fn) => { if (cancelled) { fn(); } else { unlisten = fn; } });
     return () => {
       cancelled = true;
       if (timeoutId) clearTimeout(timeoutId);
@@ -268,7 +314,7 @@ export function OverlayWidget() {
           Idle = small icon on the left showing app is alive.
           Active = expands with red dot on left, waveform on right. */}
       <div
-        className="cursor-pointer select-none overflow-hidden transition-all duration-[500ms] ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+        className="cursor-pointer select-none overflow-hidden"
         style={{
           borderRadius: '0 0 12px 12px',
           width: isActive ? notchWidth + 68 : notchWidth + 28,
@@ -277,6 +323,10 @@ export function OverlayWidget() {
           background: 'rgba(20, 20, 20, 0.92)',
           backdropFilter: 'blur(40px)',
           WebkitBackdropFilter: 'blur(40px)',
+          boxShadow: showTapRejected
+            ? '0 0 0 1.5px rgba(245, 158, 11, 0.85), 0 0 12px 2px rgba(245, 158, 11, 0.45)'
+            : 'none',
+          transition: 'width 500ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 120ms ease-out',
         }}
       >
         <div className="flex items-center h-full" style={{ paddingLeft: 10, paddingRight: 10 }}>

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -463,6 +463,38 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             {keyHelpText}
           </p>
         </div>
+
+        {/* Flash on timing miss — only relevant in double-tap or both modes */}
+        {settings.recordingMode !== 'hold_down' && (
+          <div>
+            <div className="flex items-center justify-between">
+              <div>
+                <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+                  Flash on timing miss
+                </label>
+                <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                  Briefly highlight the overlay when a double-tap is rejected for holding too long or tapping too slowly.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.showTimingMissFeedback}
+                aria-label="Flash on timing miss"
+                onClick={() => onUpdateSettings({ showTimingMissFeedback: !settings.showTimingMissFeedback })}
+                className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                  settings.showTimingMissFeedback ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                    settings.showTimingMissFeedback ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+        )}
         </SettingsSection>
 
         <SettingsSection title="Output" subtitle="Auto-paste, launch at login">

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -14,6 +14,7 @@ export interface Settings {
   vadSensitivity: number;
   idleTimeoutMinutes: number;
   customVocabulary: string;
+  showTimingMissFeedback: boolean;
 }
 
 export type ModelOption =
@@ -63,6 +64,7 @@ export const DEFAULT_SETTINGS: Settings = {
   vadSensitivity: 50,
   idleTimeoutMinutes: 5,
   customVocabulary: '',
+  showTimingMissFeedback: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
Closes #154

## Pipeline Run
- Plan approved through full review loop
- Builder committed implementation (commit 163f929)
- Builder was killed by watchdog after completion (known cmux-hook hang)
- Tester/CI not run by pipeline — needs manual validation

Logs: `pipeline-logs/murmur-app/issue-154/`