### PR TITLE
feat: global disable toggle — gate hotkeys and recording behind enabled state (#136)

### DIFF
--- a/app/src-tauri/src/commands/keyboard.rs
+++ b/app/src-tauri/src/commands/keyboard.rs
@@ -37,3 +37,15 @@ pub fn update_keyboard_key(app_handle: tauri::AppHandle, hotkey: String) {
 pub fn set_keyboard_recording(recording: bool) {
     keyboard::set_recording_state(recording);
 }
+
+#[tauri::command]
+pub fn set_app_disabled(app_handle: tauri::AppHandle, disabled: bool) -> Result<(), String> {
+    keyboard::set_app_disabled(disabled);
+    tracing::info!(target: "keyboard", "set_app_disabled: {}", disabled);
+    app_handle.emit("app-disabled-changed", disabled).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_app_disabled() -> bool {
+    keyboard::is_app_disabled()
+}

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -374,6 +374,10 @@ pub async fn start_native_recording(
     state: tauri::State<'_, State>,
     device_name: Option<String>,
 ) -> Result<serde_json::Value, String> {
+    if keyboard::is_app_disabled() {
+        tracing::info!(target: "pipeline", "start_native_recording: app disabled — ignoring");
+        return Ok(serde_json::json!({ "type": "app_disabled", "state": "idle" }));
+    }
     // Check and update status in one lock; assign recording ID in the same
     // critical section so no concurrent cancel/start can slip between them.
     let rid = {

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -338,6 +338,11 @@ static HOLD_PROMOTED: AtomicBool = AtomicBool::new(false);
 /// Set by lib.rs when the transcription pipeline is running.
 static IS_PROCESSING: AtomicBool = AtomicBool::new(false);
 
+/// When true, the rdev callback ignores all keyboard events except Escape
+/// (which still cancels in-progress recordings). Set by the `set_app_disabled`
+/// Tauri command. Thread-safe, lock-free.
+static APP_DISABLED: AtomicBool = AtomicBool::new(false);
+
 /// Called by lib.rs to tell the keyboard module whether the app is processing.
 /// When transitioning out of processing, reset both detectors and apply a
 /// cooldown so rapid post-processing taps don't immediately toggle.
@@ -378,6 +383,32 @@ pub fn set_processing(processing: bool) {
 #[cfg(test)]
 pub fn is_processing() -> bool {
     IS_PROCESSING.load(Ordering::SeqCst)
+}
+
+/// Set or clear the global disabled flag. When transitioning to disabled,
+/// resets both detectors and invalidates any pending hold-promotion timer so
+/// re-enabling doesn't produce phantom events.
+pub fn set_app_disabled(disabled: bool) {
+    let was_disabled = APP_DISABLED.swap(disabled, Ordering::SeqCst);
+    if !was_disabled && disabled {
+        // Transitioning false → true: clean up any partial detector state
+        HOLD_PROMOTED.store(false, Ordering::SeqCst);
+        HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut det) = HOLD_DOWN_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() { d.reset(); }
+        }
+        if let Ok(mut det) = DOUBLE_TAP_DETECTOR.lock() {
+            if let Some(d) = det.as_mut() { d.reset(); }
+        }
+        tracing::info!(target: "keyboard", "app disabled: hotkey events gated");
+    } else if was_disabled && !disabled {
+        tracing::info!(target: "keyboard", "app enabled: hotkey events resumed");
+    }
+}
+
+/// Returns whether the app is currently disabled.
+pub fn is_app_disabled() -> bool {
+    APP_DISABLED.load(Ordering::SeqCst)
 }
 
 // -- Global listener state --
@@ -511,6 +542,10 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
 
                     tracing::info!(target: "keyboard", "Escape pressed — emitting escape-cancel");
                     let _ = handle.emit("escape-cancel", ());
+                    return;
+                }
+
+                if APP_DISABLED.load(Ordering::SeqCst) {
                     return;
                 }
 
@@ -1363,5 +1398,42 @@ mod tests {
         // Next press — fresh sequence, timer would start (no sync emission)
         let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
+    }
+
+    #[test]
+    fn app_disabled_setter_getter_roundtrip() {
+        // Ensure clean initial state
+        set_app_disabled(false);
+        assert!(!is_app_disabled());
+
+        set_app_disabled(true);
+        assert!(is_app_disabled());
+
+        set_app_disabled(false);
+        assert!(!is_app_disabled());
+    }
+
+    #[test]
+    fn app_disabled_resets_detectors() {
+        // Prime the double-tap detector into a non-idle state
+        {
+            let mut det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            let d = det.get_or_insert_with(DoubleTapDetector::new);
+            d.set_target(Some(Key::ShiftLeft));
+            d.handle_event(&EventType::KeyPress(Key::ShiftLeft));
+            assert_eq!(d.state, DetectorState::WaitingFirstUp);
+        }
+
+        set_app_disabled(true);
+
+        {
+            let det = DOUBLE_TAP_DETECTOR.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(d) = det.as_ref() {
+                assert_eq!(d.state, DetectorState::Idle);
+            }
+        }
+
+        // Restore
+        set_app_disabled(false);
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -129,6 +129,8 @@ pub fn run() {
             commands::keyboard::stop_keyboard_listener,
             commands::keyboard::update_keyboard_key,
             commands::keyboard::set_keyboard_recording,
+            commands::keyboard::set_app_disabled,
+            commands::keyboard::get_app_disabled,
             commands::logging::get_log_contents,
             commands::logging::clear_logs,
             commands::logging::log_frontend,

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -12,18 +12,21 @@ export function OverlayWidget() {
   const [status, setStatus] = useState<DictationStatus>('idle');
   const [showCancelled, setShowCancelled] = useState(false);
   const [lockedMode, setLockedMode] = useState(false);
+  const [disabled, setDisabled] = useState(false);
   const notchHeightRef = useRef(0);
   const [notchWidth, setNotchWidth] = useState(185);
   const statusRef = useRef(status);
   const lockedRef = useRef(lockedMode);
+  const disabledRef = useRef(disabled);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const audioLevelRef = useRef(0);
   const barRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { lockedRef.current = lockedMode; }, [lockedMode]);
+  useEffect(() => { disabledRef.current = disabled; }, [disabled]);
 
-  // Log mount + fetch notch dimensions
+  // Log mount + fetch notch dimensions + read initial disabled state
   useEffect(() => {
     flog.info('overlay', 'mounted');
     invoke<{ notch_width: number; notch_height: number } | null>('get_notch_info')
@@ -37,6 +40,13 @@ export function OverlayWidget() {
         }
       })
       .catch((e) => flog.warn('overlay', 'get_notch_info failed', { error: String(e) }));
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (typeof parsed.disabled === 'boolean') setDisabled(parsed.disabled);
+      }
+    } catch { /* ignore */ }
     return () => {
       flog.info('overlay', 'unmounted');
       if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
@@ -137,6 +147,19 @@ export function OverlayWidget() {
     return () => { cancelled = true; unlisten?.(); };
   }, []);
 
+  // Subscribe to app-disabled-changed events from Rust
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<boolean>('app-disabled-changed', (event) => {
+      flog.info('overlay', 'app-disabled-changed', { disabled: event.payload });
+      setDisabled(event.payload);
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
   // Animate waveform bars via rAF (direct DOM updates, no React reconciliation)
   useEffect(() => {
     if (status !== 'recording') {
@@ -174,6 +197,7 @@ export function OverlayWidget() {
     });
     const currentStatus = statusRef.current;
     if (currentStatus === 'processing') return;
+    if (disabledRef.current && currentStatus === 'idle') return;
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
@@ -292,7 +316,7 @@ export function OverlayWidget() {
             ) : status === 'processing' ? (
               <span className="w-3 h-3 border-[1.5px] border-white/20 border-t-white/70 rounded-full animate-spin block" />
             ) : (
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: disabled ? 0.15 : 1 }}>
                 <rect x="9" y="1" width="6" height="12" rx="3" />
                 <path d="M5 10a7 7 0 0 0 14 0" />
                 <line x1="12" y1="17" x2="12" y2="21" />

--- a/app/src/lib/hooks/useInitialization.ts
+++ b/app/src/lib/hooks/useInitialization.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { initDictation, configure } from '../dictation';
 import { Settings } from '../settings';
 
@@ -20,6 +21,10 @@ export function useInitialization(settings: Settings) {
           idleTimeoutMinutes: settings.idleTimeoutMinutes,
           customVocabulary: settings.customVocabulary,
         });
+      })
+      .then(() => {
+        if (cancelled) return;
+        return invoke('set_app_disabled', { disabled: settings.disabled }).catch(() => {});
       })
       .then(() => { if (!cancelled) setInitialized(true); })
       .catch((err) => { if (!cancelled) setError(String(err)); });

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { Settings, loadSettings, saveSettings } from '../settings';
 import { configure } from '../dictation';
 import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
@@ -44,6 +45,12 @@ export function useSettings() {
           setSettings(reverted);
           saveSettings(reverted);
         }
+      });
+    }
+
+    if ('disabled' in updates) {
+      invoke('set_app_disabled', { disabled: newSettings.disabled }).catch((err) => {
+        console.error('Failed to sync disabled state:', err);
       });
     }
 

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -14,6 +14,7 @@ export interface Settings {
   vadSensitivity: number;
   idleTimeoutMinutes: number;
   customVocabulary: string;
+  disabled: boolean;
 }
 
 export type ModelOption =
@@ -63,6 +64,7 @@ export const DEFAULT_SETTINGS: Settings = {
   vadSensitivity: 50,
   idleTimeoutMinutes: 5,
   customVocabulary: '',
+  disabled: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';


### PR DESCRIPTION
Closes #136

## Pipeline Run
- Plan approved through full review loop
- Builder committed implementation (commit bffeb89)
- Builder was killed after entering idle-hang state (cmux hook)
- Tester/CI not run by pipeline — needs manual validation

Logs: `pipeline-logs/murmur-app/issue-136/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to disable the app, preventing keyboard hotkey activation and audio recording.
  * The interface now visually indicates when the app is disabled.
  * Disable state is persisted in settings and synchronized between UI and backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->