### PR TITLE
chore: Codex /feature skill, agent docs, and test WAV scripts

### DIFF
--- a/.codex/skills/murmur-feature/SKILL.md
+++ b/.codex/skills/murmur-feature/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: murmur-feature
+description: >-
+  End-to-end Murmur feature delivery in Codex: GitHub issue worktree (work
+  flow), plan and implement from prompts/PROMPT.md, self-review, native app
+  smoke test via Computer Use, PR creation, validation, and merge when green.
+  Use when the user invokes /feature, ships a feature from an issue number,
+  or wants plan + build + review + test + merge in one workflow.
+disable-model-invocation: true
+---
+
+# Murmur Feature — Plan → Ship → Merge
+
+Single Codex workflow combining **codex-work** (issue worktree + `PROMPT.md`) and **murmur-pr-test** (checks, native app, merge). Do not spawn another agent.
+
+**Repo:** `georgenijo/murmur-app`
+
+## Invocation
+
+- `/feature <issue-number>` — full pipeline from issue to merge (when green)
+- `/feature` — ask for issue number, or resume in an existing `../murmur-app-issue-<n>` worktree
+
+**Stop early** only if the user asks (e.g. "plan only", "no merge"). Otherwise run all phases in order.
+
+---
+
+## Phase 1 — Prepare (codex-work)
+
+From anywhere in the repo:
+
+```bash
+python3 .codex/skills/murmur-feature/scripts/prepare_issue_worktree.py <issue-number>
+```
+
+- Use `--dry-run --no-fetch` to inspect without changes.
+- Read everything between `ASSIGNMENT START` and `ASSIGNMENT END`.
+- **All later commands run in the printed worktree path** (sibling dir `../murmur-app-issue-<n>`).
+- Do not create another branch.
+
+Record: issue #, title, worktree path, branch name.
+
+---
+
+## Phase 2 — Plan (`prompts/PROMPT.md`)
+
+Follow the assignment and **PROMPT.md** sections 1–4:
+
+1. Load context (`CLAUDE.md`, `CHANGELOG.md`, relevant `docs/features/`, etc.).
+2. Silent health check (`git status` in worktree).
+3. Read issue body from the assignment — do not re-fetch unless the user asks.
+4. **Plan mode:** design approach (files, risks, tests). **Wait for user approval before any code.**
+
+No scope creep beyond the issue.
+
+---
+
+## Phase 3 — Implement
+
+After approval, implement exactly the plan (PROMPT.md §5):
+
+- Match project patterns in `CLAUDE.md` / `AGENTS.md`.
+- **Settings UI:** Playwright MCP against `http://localhost:1420` only when dev server is running and the change is the settings webview — screenshot and iterate.
+- **Native Murmur behavior** (overlay, hotkeys, dictation, tray): do not treat Vite alone as sufficient; you will verify in Phase 5 with the real `.app`.
+
+Commit in focused chunks on the issue branch.
+
+---
+
+## Phase 4 — Self-review (pre-PR)
+
+Review your own diff before opening a PR:
+
+```bash
+git diff origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+
+Check for:
+
+| Area | Murmur-specific |
+|------|-----------------|
+| Correctness | Mutex/rdev threading, recording state machine, audio pipeline |
+| Security / privacy | No cloud leakage; telemetry stripping; clipboard handling |
+| Scope | Only issue changes; no drive-by refactors |
+| Tests | Rust tests for backend logic; TS types clean |
+| Platform | macOS vs Linux `#[cfg]` paths when touching OS code |
+
+Fix blocking issues. Skip style nits linters already cover.
+
+---
+
+## Phase 5 — Verify (required checks)
+
+From the **worktree**, all must pass:
+
+```bash
+cd app/src-tauri && cargo check
+cd app/src-tauri && cargo test -- --test-threads=1
+cd app && npx tsc --noEmit
+```
+
+If any fail, fix and re-run before a PR.
+
+### Native app smoke (when behavior or UI changed)
+
+Build dev bundle:
+
+```bash
+cd app
+npx tauri build --debug --config src-tauri/tauri.dev.conf.json
+```
+
+If exit code is nonzero only due to missing `TAURI_SIGNING_PRIVATE_KEY`, confirm the `.app` still exists — that alone is not a blocker.
+
+Launch:
+
+```bash
+open -n app/src-tauri/target/debug/bundle/macos/Local\ Dictation\ Dev.app
+```
+
+**Use Computer Use** (Codex desktop automation) to exercise the feature in the real app: hotkeys, overlay, transcription flow, settings that affect native behavior. Do not substitute browser-only testing for native Murmur behavior.
+
+Report what you exercised and what you observed.
+
+---
+
+## Phase 6 — Pull request
+
+When checks (and native smoke, if applicable) pass:
+
+```bash
+git push -u origin <branch-name>
+gh pr create \
+  --title "<concise title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1-3 bullets>
+
+## Test plan
+- [ ] cargo check / test / tsc
+- [ ] native app smoke (if applicable)
+- [ ] <issue-specific steps>
+
+Closes #<issue-number>
+EOF
+)" \
+  --repo georgenijo/murmur-app
+```
+
+Note the PR number and URL.
+
+---
+
+## Phase 7 — PR validation & merge (murmur-pr-test)
+
+Treat your PR like any other Murmur PR:
+
+1. `gh pr view <number> --repo georgenijo/murmur-app`
+2. If not mergeable, merge `origin/main` into the worktree, resolve conflicts, re-run Phase 5 checks, push.
+3. Re-read CI / checks on GitHub if present.
+
+**Merge only when:**
+
+- Phase 5 checks passed (re-run after any merge-from-main).
+- Native smoke passed when the feature touched user-visible behavior.
+- No known blockers in the PR or issue.
+- User has not said "stop before merge" — default for `/feature` is to **merge when green**.
+
+```bash
+gh pr merge <number> --repo georgenijo/murmur-app --merge
+```
+
+Use `--admin` only if the user explicitly authorized bypassing branch protection and local verification is clean.
+
+---
+
+## Final report
+
+Keep it short:
+
+- Issue # and title
+- Worktree path and branch
+- Plan summary (one line)
+- Checks run (pass/fail)
+- Native smoke (what was tested, or N/A)
+- PR URL
+- Merge result (commit SHA or "not merged" + why)
+
+---
+
+## Partial runs
+
+| User intent | Stop after |
+|-------------|------------|
+| "plan only" / "work 152" style | Phase 2 (after approved plan or at plan presentation) |
+| "implement only" | Phase 3–5, no PR/merge |
+| "test PR N" | Phase 7 only (use **murmur-pr-test** skill) |
+| Full `/feature N` | Phase 7 merge when green |
+
+## Related skills
+
+- **codex-work** (`~/.codex/skills/codex-work`) — prepare worktree only; same script also lives under this skill's `scripts/`.
+- **murmur-pr-test** (`.codex/skills/murmur-pr-test`) — validate/merge existing PRs without building from an issue.

--- a/.codex/skills/murmur-feature/scripts/prepare_issue_worktree.py
+++ b/.codex/skills/murmur-feature/scripts/prepare_issue_worktree.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Prepare a GitHub issue worktree for Codex /feature workflow.
+
+Ports George's zsh `work <issue-number>` helper without launching Claude.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(args: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(args, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if check and proc.returncode != 0:
+        cmd = " ".join(args)
+        detail = proc.stderr.strip() or proc.stdout.strip()
+        raise SystemExit(f"Command failed: {cmd}\n{detail}")
+    return proc
+
+
+def repo_root(start: Path) -> Path:
+    proc = run(["git", "rev-parse", "--show-toplevel"], cwd=start)
+    return Path(proc.stdout.strip())
+
+
+def gh_json(args: list[str], cwd: Path) -> dict:
+    proc = run(["gh", *args], cwd=cwd)
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Could not parse gh JSON output: {exc}") from exc
+
+
+def slugify(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return slug or "issue"
+
+
+def local_branch_exists(root: Path, branch: str) -> bool:
+    proc = run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=root, check=False)
+    return proc.returncode == 0
+
+
+def worktree_exists(path: Path) -> bool:
+    return path.exists() and path.is_dir()
+
+
+def load_prompt(root: Path) -> str:
+    prompt_path = root / "prompts" / "PROMPT.md"
+    if prompt_path.exists():
+        return prompt_path.read_text()
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prepare a GitHub issue worktree for Codex.")
+    parser.add_argument("issue", help="GitHub issue number, e.g. 152")
+    parser.add_argument("--cwd", default=os.getcwd(), help="Directory inside the repo. Defaults to cwd.")
+    parser.add_argument("--no-fetch", action="store_true", help="Skip fetching origin/default-branch.")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would happen without creating a worktree.")
+    ns = parser.parse_args()
+
+    root = repo_root(Path(ns.cwd))
+    repo = gh_json(["repo", "view", "--json", "nameWithOwner,defaultBranchRef"], cwd=root)
+    repo_name = repo["nameWithOwner"]
+    default_branch = repo.get("defaultBranchRef", {}).get("name") or "main"
+    repo_slug = root.name
+
+    if not ns.no_fetch:
+        run(["git", "fetch", "origin", default_branch], cwd=root)
+
+    issue = gh_json(
+        ["issue", "view", ns.issue, "--repo", repo_name, "--json", "title,body,url"],
+        cwd=root,
+    )
+    title = issue["title"]
+    body = issue.get("body") or ""
+    branch = f"issue/{ns.issue}-{slugify(title)}"
+    worktree_dir = root.parent / f"{repo_slug}-issue-{ns.issue}"
+
+    action = "reused"
+    if worktree_exists(worktree_dir):
+        action = "reused existing worktree"
+    elif local_branch_exists(root, branch):
+        if ns.dry_run:
+            action = "would create worktree from existing branch"
+        else:
+            run(["git", "worktree", "add", str(worktree_dir), branch], cwd=root)
+            action = "created worktree from existing branch"
+    else:
+        if ns.dry_run:
+            action = "would create worktree and branch"
+        else:
+            run(["git", "worktree", "add", str(worktree_dir), "-b", branch, f"origin/{default_branch}"], cwd=root)
+            action = "created worktree and branch"
+
+    base_prompt = load_prompt(root)
+    assignment = f"""{base_prompt}
+
+## Your Assignment
+
+You are working on GitHub Issue #{ns.issue}: {title}
+
+{body}
+
+Work on this issue and nothing else. Your branch is already created: {branch}. Do not create a new branch.
+Start by entering plan mode. Present your implementation plan and wait for approval before writing any code.
+""".strip()
+
+    print(f"Prepared issue #{ns.issue}: {title}")
+    print(f"Repo:      {repo_name}")
+    print(f"Worktree:  {worktree_dir}")
+    print(f"Branch:    {branch}")
+    print(f"Base:      origin/{default_branch}")
+    print(f"Action:    {action}")
+    if issue.get("url"):
+        print(f"URL:       {issue['url']}")
+    print("")
+    print("----- ASSIGNMENT START -----")
+    print(assignment)
+    print("----- ASSIGNMENT END -----")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/murmur-pr-test/SKILL.md
+++ b/.codex/skills/murmur-pr-test/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Tests and validates Murmur pull requests in isolated worktrees with cargo,
   TypeScript checks, and native Tauri smoke tests. Use when testing a PR,
   merging a verified PR, picking the next PR from the queue, or continuing
-  PR validation for georgenijo/murmur-app.
+  PR validation for georgenijo/murmur-app. For issue-to-merge delivery, use
+  murmur-feature (/feature) instead.
 ---
 
 # Murmur PR Test
@@ -147,3 +148,7 @@ Report:
 - Merge commit or PR URL if merged.
 
 Keep the report concise. If a PR is blocked, say why and move to the next PR only if the user asked to continue the queue.
+
+## Related
+
+- **murmur-feature** (`.codex/skills/murmur-feature`) — full `/feature <issue>` pipeline: worktree, plan, implement, review, native smoke, PR, merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Read these before working on a feature:
 Use these modes when the user invokes them by name in a Codex session.
 
 - **Murmur chat mode**: Read `prompts/PROMPT_CHAT.md` and follow it for the conversation. Act as a concise product and engineering advisor. Discuss ideas, tradeoffs, bugs, and feature shape. Do not edit files or write code unless the user explicitly asks.
-- **Murmur feature mode**: Read `prompts/PROMPT.md` and follow it. Load the requested context, check repo health, identify the assigned ticket from the user's prompt, and present a plan before writing code. Do not implement until the user approves the plan.
+- **Murmur feature mode**: Read `prompts/PROMPT.md` and follow it. Load the requested context, check repo health, identify the assigned ticket from the user's prompt, and present a plan before writing code. Do not implement until the user approves the plan. In Codex, **`/feature <issue-number>`** uses `.codex/skills/murmur-feature` for the full pipeline (worktree → plan → implement → review → native smoke → PR → merge when green).
 - **Murmur bug mode**: Read `prompts/PROMPT_BUG.md` and follow it. Keep the work scoped to the selected bug, investigate before editing, and verify with the required checks before wrapping up.
 - **Murmur release mode**: Read `prompts/PROMPT_RELEASE.md` and follow it. Treat release operations as high-risk: inspect state first, explain the intended release action, and only proceed when the user explicitly confirms.
 - **Murmur swarm mode**: Read `prompts/PROMPT_SWARM.md` and follow it. Use only when the user explicitly asks to coordinate multiple issues in parallel.

--- a/scripts/list-mics.sh
+++ b/scripts/list-mics.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Show ffmpeg avfoundation audio input indices for record-test-wav.sh
+
+set -euo pipefail
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ffmpeg not found. Install with: brew install ffmpeg"
+  exit 1
+fi
+
+echo "Audio devices (use index with MURMUR_MIC=…):"
+echo ""
+ffmpeg -f avfoundation -list_devices true -i "" 2>&1 \
+  | awk '/AVFoundation audio devices:/{a=1;next} a && /\[/{print}'

--- a/scripts/record-test-wav.sh
+++ b/scripts/record-test-wav.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Record a Murmur-compatible test WAV (16 kHz mono 16-bit PCM).
+# Re-run anytime; overwrites the same file.
+#
+# Usage:
+#   ./scripts/record-test-wav.sh
+#
+# Optional env:
+#   MURMUR_WAV=~/Desktop/murmur-test.wav   output path
+#   MURMUR_MIC=2                           avfoundation audio device index
+#   MURMUR_DURATION=5                      seconds to record
+#
+# List mics: ./scripts/list-mics.sh
+
+set -euo pipefail
+
+OUT="${MURMUR_WAV:-$HOME/Desktop/murmur-test.wav}"
+MIC="${MURMUR_MIC:-2}"
+DUR="${MURMUR_DURATION:-5}"
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ffmpeg not found. Install with: brew install ffmpeg"
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Murmur test recording"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  File:     $OUT"
+echo "  Mic:      avfoundation audio device :$MIC"
+echo "  Duration: ${DUR}s"
+echo ""
+echo "  Wrong mic? Run: ./scripts/list-mics.sh"
+echo "  Then: MURMUR_MIC=<index> ./scripts/record-test-wav.sh"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Press Enter when ready to record (Ctrl+C to quit)… " _
+
+for i in 3 2 1; do
+  printf '\rStarting in %s… ' "$i"
+  sleep 1
+done
+printf '\r\033[K'
+echo "🔴  SPEAK NOW (${DUR}s)"
+echo ""
+
+ffmpeg -loglevel warning -y \
+  -f avfoundation -i ":$MIC" \
+  -t "$DUR" \
+  -ar 16000 -ac 1 \
+  -c:a pcm_s16le \
+  "$OUT"
+
+echo ""
+echo "✅  Saved: $OUT"
+ffprobe -hide_banner "$OUT" 2>&1 | grep -E "Duration|Stream #0" || true
+echo ""
+echo "Run the same command again to re-record (overwrites)."


### PR DESCRIPTION
## Summary
- Add `.codex/skills/murmur-feature` for end-to-end `/feature <issue>` delivery (worktree prep, plan, implement, review, native smoke, PR, merge).
- Cross-link from `AGENTS.md` and `murmur-pr-test` skill.
- Add `scripts/record-test-wav.sh` and `scripts/list-mics.sh` to record Murmur-compatible 16 kHz mono test WAVs via ffmpeg.

## Test plan
- [x] Markdown and shell scripts only — no app code changes
- [ ] `./scripts/list-mics.sh` lists devices
- [ ] `./scripts/record-test-wav.sh` writes `~/Desktop/murmur-test.wav`

Made with [Cursor](https://cursor.com)