### PR TITLE
Add audio route diagnostics for ducking reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
 - Add Bluetooth headset microphone warnings, audio route diagnostics, and a log-viewer Audio tab for macOS ducking reports
+- Add native window/app activation diagnostics and a macOS audio log capture helper for focus-related ducking investigations
 
 ## [0.8.0] - 2026-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
+- Add Bluetooth headset microphone warnings, audio route diagnostics, and a log-viewer Audio tab for macOS ducking reports
 
 ## [0.8.0] - 2026-03-02
 

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -21,6 +21,35 @@ pub fn compute_peak(samples: &[f32]) -> f32 {
     samples.iter().map(|s| s.abs()).fold(0.0_f32, f32::max)
 }
 
+fn telemetry_device_name(name: &str) -> String {
+    if cfg!(debug_assertions) {
+        name.to_string()
+    } else {
+        "<redacted>".to_string()
+    }
+}
+
+/// Best-effort classifier for headset-style Bluetooth inputs. These devices
+/// commonly make macOS switch playback into a call route while the mic is open.
+pub fn is_likely_bluetooth_input_name(device_name: &str) -> bool {
+    let normalized = device_name.to_lowercase();
+    [
+        "airpods",
+        "beats",
+        "bluetooth",
+        "bose",
+        "galaxy buds",
+        "hands-free",
+        "handsfree",
+        "headset",
+        "hfp",
+        "jabra",
+        "sony",
+    ]
+    .iter()
+    .any(|keyword| normalized.contains(keyword))
+}
+
 /// Build an input stream that converts interleaved multi-channel samples to mono f32,
 /// computes RMS for each buffer chunk and emits an "audio-level" event if an AppHandle
 /// is provided.
@@ -129,6 +158,74 @@ pub fn list_input_devices() -> Result<Vec<String>, String> {
     Ok(names)
 }
 
+pub fn default_input_device_name() -> Result<Option<String>, String> {
+    let host = cpal::default_host();
+    Ok(host.default_input_device().and_then(|d| d.name().ok()))
+}
+
+fn input_config_summary(device: &cpal::Device) -> (u32, u16, String) {
+    match device.default_input_config() {
+        Ok(config) => (
+            config.sample_rate().0,
+            config.channels(),
+            format!("{:?}", config.sample_format()),
+        ),
+        Err(_) => (0, 0, "unknown".to_string()),
+    }
+}
+
+fn output_config_summary(device: &cpal::Device) -> (u32, u16, String) {
+    match device.default_output_config() {
+        Ok(config) => (
+            config.sample_rate().0,
+            config.channels(),
+            format!("{:?}", config.sample_format()),
+        ),
+        Err(_) => (0, 0, "unknown".to_string()),
+    }
+}
+
+pub fn log_audio_route_snapshot(reason: &str) -> Result<(), String> {
+    let host = cpal::default_host();
+    let input = host.default_input_device();
+    let output = host.default_output_device();
+
+    let input_name = input
+        .as_ref()
+        .and_then(|d| d.name().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    let output_name = output
+        .as_ref()
+        .and_then(|d| d.name().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    let (input_sample_rate, input_channels, input_format) = input
+        .as_ref()
+        .map(input_config_summary)
+        .unwrap_or_else(|| (0, 0, "unknown".to_string()));
+    let (output_sample_rate, output_channels, output_format) = output
+        .as_ref()
+        .map(output_config_summary)
+        .unwrap_or_else(|| (0, 0, "unknown".to_string()));
+
+    tracing::info!(
+        target: "audio",
+        reason = reason,
+        input_device = telemetry_device_name(&input_name).as_str(),
+        output_device = telemetry_device_name(&output_name).as_str(),
+        input_bluetooth_like = is_likely_bluetooth_input_name(&input_name),
+        output_bluetooth_like = is_likely_bluetooth_input_name(&output_name),
+        input_sample_rate = input_sample_rate,
+        output_sample_rate = output_sample_rate,
+        input_channels = input_channels,
+        output_channels = output_channels,
+        input_format = input_format.as_str(),
+        output_format = output_format.as_str(),
+        "audio route snapshot"
+    );
+
+    Ok(())
+}
+
 pub fn start_recording(app_handle: Option<tauri::AppHandle>, device_name: Option<String>) -> Result<(), String> {
     let state = get_state();
     let mut state_guard = state.lock().unwrap_or_else(|poisoned| {
@@ -224,6 +321,10 @@ fn run_audio_capture(
     };
 
     let actual_name = device.name().unwrap_or_else(|_| "unknown".to_string());
+    let output_name = host.default_output_device()
+        .and_then(|d| d.name().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    let input_is_bluetooth_like = is_likely_bluetooth_input_name(&actual_name);
 
     let config = device.default_input_config()
         .map_err(|e| format!("Failed to get input config: {}", e))?;
@@ -232,13 +333,24 @@ fn run_audio_capture(
     let sample_format = config.sample_format();
     let channels = config.channels() as usize;
 
-    let telemetry_device = if cfg!(debug_assertions) {
-        actual_name.clone()
-    } else {
-        "<redacted>".to_string()
-    };
-    tracing::info!(target: "audio", "run_audio_capture: device='{}', sample_rate={}, channels={}, format={:?}",
-        telemetry_device, device_sample_rate, channels, sample_format);
+    let telemetry_device = telemetry_device_name(&actual_name);
+    let telemetry_output = telemetry_device_name(&output_name);
+    tracing::info!(
+        target: "audio",
+        input_device = telemetry_device.as_str(),
+        output_device = telemetry_output.as_str(),
+        input_bluetooth_like = input_is_bluetooth_like,
+        sample_rate = device_sample_rate,
+        channels = channels,
+        format = ?sample_format,
+        "audio capture route selected"
+    );
+    if input_is_bluetooth_like {
+        tracing::warn!(
+            target: "audio",
+            "Bluetooth-like input selected; macOS may lower or reroute other audio while the capture stream is open"
+        );
+    }
 
     let err_fn = |err| tracing::error!(target: "audio", "Audio stream error: {}", err);
 
@@ -249,6 +361,7 @@ fn run_audio_capture(
     };
 
     stream.play().map_err(|e| format!("Failed to start stream: {}", e))?;
+    tracing::info!(target: "audio", "audio capture stream started");
 
     // Signal ready with the device sample rate and name
     let _ = ready_tx.send(Ok((device_sample_rate, actual_name.clone())));
@@ -264,6 +377,7 @@ fn run_audio_capture(
 
     // Explicitly pause before dropping to ensure CoreAudio stops calling us
     let _ = stream.pause();
+    tracing::info!(target: "audio", "audio capture stream stopped");
 
     Ok(())
 }
@@ -406,6 +520,19 @@ mod tests {
     fn peak_negative() {
         let samples = vec![0.1f32, -0.8, 0.3, 0.2];
         assert!((compute_peak(&samples) - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bluetooth_input_classifier_flags_headsets() {
+        assert!(is_likely_bluetooth_input_name("George's AirPods Pro"));
+        assert!(is_likely_bluetooth_input_name("Jabra Hands-Free Audio"));
+        assert!(is_likely_bluetooth_input_name("Bose QC Headset"));
+    }
+
+    #[test]
+    fn bluetooth_input_classifier_ignores_builtin_and_usb_mics() {
+        assert!(!is_likely_bluetooth_input_name("MacBook Pro Microphone"));
+        assert!(!is_likely_bluetooth_input_name("USB Audio Device"));
     }
 }
 

--- a/app/src-tauri/src/commands/logging.rs
+++ b/app/src-tauri/src/commands/logging.rs
@@ -26,7 +26,17 @@ pub fn open_log_viewer(app: tauri::AppHandle) -> Result<(), String> {
     let window = app
         .get_webview_window("log-viewer")
         .ok_or_else(|| "log-viewer window is not configured".to_string())?;
+    tracing::info!(target: "system", action = "open_log_viewer", "window action requested");
+    crate::diagnostics::log_window_state_snapshot(&app, "before_open_log_viewer");
     window.show().map_err(|e| e.to_string())?;
     window.set_focus().map_err(|e| e.to_string())?;
+    crate::diagnostics::log_window_state_snapshot(&app, "after_open_log_viewer");
+    let _ = crate::audio::log_audio_route_snapshot("after_open_log_viewer");
+    Ok(())
+}
+
+#[tauri::command]
+pub fn log_window_state_snapshot(app: tauri::AppHandle, reason: String) -> Result<(), String> {
+    crate::diagnostics::log_window_state_snapshot(&app, &reason);
     Ok(())
 }

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -161,9 +161,13 @@ pub fn show_overlay(app: tauri::AppHandle, state: tauri::State<'_, State>) -> Re
         let notch = *state.notch_info.lock_or_recover();
         match app.get_webview_window("overlay") {
             Some(overlay) => {
+                tracing::info!(target: "system", action = "show_overlay", "window action requested");
+                crate::diagnostics::log_webview_window_state(&overlay, "before_show_overlay");
                 position_overlay_default(&overlay, notch);
                 overlay.show().map_err(|e| e.to_string())?;
                 let _ = overlay.set_ignore_cursor_events(false);
+                crate::diagnostics::log_webview_window_state(&overlay, "after_show_overlay");
+                let _ = crate::audio::log_audio_route_snapshot("after_show_overlay");
                 Ok(())
             }
             None => {
@@ -178,7 +182,14 @@ pub fn show_overlay(app: tauri::AppHandle, state: tauri::State<'_, State>) -> Re
 #[tauri::command]
 pub fn hide_overlay(app: tauri::AppHandle) -> Result<(), String> {
     match app.get_webview_window("overlay") {
-        Some(overlay) => overlay.hide().map_err(|e| e.to_string()),
+        Some(overlay) => {
+            tracing::info!(target: "system", action = "hide_overlay", "window action requested");
+            crate::diagnostics::log_webview_window_state(&overlay, "before_hide_overlay");
+            overlay.hide().map_err(|e| e.to_string())?;
+            crate::diagnostics::log_webview_window_state(&overlay, "after_hide_overlay");
+            let _ = crate::audio::log_audio_route_snapshot("after_hide_overlay");
+            Ok(())
+        }
         None => {
             tracing::warn!(target: "system", "hide_overlay: overlay window not found — skipping");
             Ok(())

--- a/app/src-tauri/src/commands/permissions.rs
+++ b/app/src-tauri/src/commands/permissions.rs
@@ -54,3 +54,13 @@ pub fn request_microphone_permission() -> Result<(), String> {
 pub fn list_audio_devices() -> Result<Vec<String>, String> {
     audio::list_input_devices()
 }
+
+#[tauri::command]
+pub fn get_default_audio_input_device() -> Result<Option<String>, String> {
+    audio::default_input_device_name()
+}
+
+#[tauri::command]
+pub fn log_audio_route_snapshot(reason: String) -> Result<(), String> {
+    audio::log_audio_route_snapshot(&reason)
+}

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -439,6 +439,7 @@ pub async fn start_native_recording(
         }
     };
     tracing::info!(target: "pipeline", "start_native_recording: device={} recording_id={}", device_name.as_deref().unwrap_or("system_default"), rid);
+    let _ = audio::log_audio_route_snapshot("before_start_recording");
     if let Err(e) = audio::start_recording(Some(app_handle.clone()), device_name) {
         tracing::error!(target: "audio", "start_native_recording: audio failed: {}", e);
         let mut dictation = state.app_state.dictation.lock_or_recover();
@@ -447,6 +448,7 @@ pub async fn start_native_recording(
     }
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(target: "pipeline", "start_native_recording: started");
+    let _ = audio::log_audio_route_snapshot("after_start_recording");
 
     Ok(serde_json::json!({
         "type": "recording_started",
@@ -483,6 +485,7 @@ pub async fn stop_native_recording(
     keyboard::set_processing(true);
     tracing::info!(target: "pipeline", "stop_native_recording: stopping");
     let _ = app_handle.emit("recording-status-changed", "processing");
+    let _ = audio::log_audio_route_snapshot("processing_before_audio_stop");
 
     // Guard resets status to Idle if stop_recording fails or samples are empty;
     // disarmed before handing off to run_transcription_pipeline (which has its own guard)
@@ -498,6 +501,7 @@ pub async fn stop_native_recording(
         e
     })?;
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
+    let _ = audio::log_audio_route_snapshot("processing_after_audio_stop");
 
     if samples.is_empty() {
         tracing::info!(target: "pipeline", "stop_native_recording: no audio captured");
@@ -532,7 +536,9 @@ pub async fn stop_native_recording(
     // Hand off status management to the pipeline's own guard
     guard.disarm();
 
+    let _ = audio::log_audio_route_snapshot("before_transcription_pipeline");
     let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
+    let _ = audio::log_audio_route_snapshot("after_transcription_pipeline");
     // Only emit idle if this recording wasn't cancelled/superseded by a new one.
     // Hold the dictation lock across the check+emit to prevent a concurrent
     // start from interleaving a "recording" status between our check and emit.

--- a/app/src-tauri/src/diagnostics.rs
+++ b/app/src-tauri/src/diagnostics.rs
@@ -1,0 +1,240 @@
+use tauri::{AppHandle, Manager, WebviewWindow, Window, WindowEvent};
+
+const WINDOW_LABELS: &[&str] = &["main", "log-viewer", "overlay"];
+
+fn result_bool(value: tauri::Result<bool>) -> (bool, bool) {
+    match value {
+        Ok(value) => (value, true),
+        Err(_) => (false, false),
+    }
+}
+
+fn result_i32_pair<T, F>(value: tauri::Result<T>, map: F) -> (i32, i32, bool)
+where
+    F: FnOnce(T) -> (i32, i32),
+{
+    match value {
+        Ok(value) => {
+            let (a, b) = map(value);
+            (a, b, true)
+        }
+        Err(_) => (0, 0, false),
+    }
+}
+
+fn result_scale_factor(value: tauri::Result<f64>) -> (f64, bool) {
+    match value {
+        Ok(value) => (value, true),
+        Err(_) => (0.0, false),
+    }
+}
+
+trait DiagnosticWindow {
+    fn label(&self) -> &str;
+    fn is_visible(&self) -> tauri::Result<bool>;
+    fn is_focused(&self) -> tauri::Result<bool>;
+    fn is_minimized(&self) -> tauri::Result<bool>;
+    fn outer_position(&self) -> tauri::Result<tauri::PhysicalPosition<i32>>;
+    fn inner_size(&self) -> tauri::Result<tauri::PhysicalSize<u32>>;
+    fn scale_factor(&self) -> tauri::Result<f64>;
+}
+
+impl DiagnosticWindow for WebviewWindow {
+    fn label(&self) -> &str {
+        self.label()
+    }
+
+    fn is_visible(&self) -> tauri::Result<bool> {
+        self.is_visible()
+    }
+
+    fn is_focused(&self) -> tauri::Result<bool> {
+        self.is_focused()
+    }
+
+    fn is_minimized(&self) -> tauri::Result<bool> {
+        self.is_minimized()
+    }
+
+    fn outer_position(&self) -> tauri::Result<tauri::PhysicalPosition<i32>> {
+        self.outer_position()
+    }
+
+    fn inner_size(&self) -> tauri::Result<tauri::PhysicalSize<u32>> {
+        self.inner_size()
+    }
+
+    fn scale_factor(&self) -> tauri::Result<f64> {
+        self.scale_factor()
+    }
+}
+
+impl DiagnosticWindow for Window {
+    fn label(&self) -> &str {
+        self.label()
+    }
+
+    fn is_visible(&self) -> tauri::Result<bool> {
+        self.is_visible()
+    }
+
+    fn is_focused(&self) -> tauri::Result<bool> {
+        self.is_focused()
+    }
+
+    fn is_minimized(&self) -> tauri::Result<bool> {
+        self.is_minimized()
+    }
+
+    fn outer_position(&self) -> tauri::Result<tauri::PhysicalPosition<i32>> {
+        self.outer_position()
+    }
+
+    fn inner_size(&self) -> tauri::Result<tauri::PhysicalSize<u32>> {
+        self.inner_size()
+    }
+
+    fn scale_factor(&self) -> tauri::Result<f64> {
+        self.scale_factor()
+    }
+}
+
+fn log_any_window_state(window: &impl DiagnosticWindow, reason: &str) {
+    let label = window.label();
+    let (visible, visible_known) = result_bool(window.is_visible());
+    let (focused, focused_known) = result_bool(window.is_focused());
+    let (minimized, minimized_known) = result_bool(window.is_minimized());
+    let (x, y, position_known) = result_i32_pair(window.outer_position(), |p| (p.x, p.y));
+    let (width, height, size_known) =
+        result_i32_pair(window.inner_size(), |s| (s.width as i32, s.height as i32));
+    let (scale_factor, scale_factor_known) = result_scale_factor(window.scale_factor());
+
+    tracing::info!(
+        target: "system",
+        reason = reason,
+        label = label,
+        exists = true,
+        visible = visible,
+        visible_known = visible_known,
+        focused = focused,
+        focused_known = focused_known,
+        minimized = minimized,
+        minimized_known = minimized_known,
+        x = x,
+        y = y,
+        position_known = position_known,
+        width = width,
+        height = height,
+        size_known = size_known,
+        scale_factor = scale_factor,
+        scale_factor_known = scale_factor_known,
+        "window state snapshot"
+    );
+}
+
+pub fn log_webview_window_state(window: &WebviewWindow, reason: &str) {
+    log_any_window_state(window, reason);
+}
+
+pub fn log_native_window_state(window: &Window, reason: &str) {
+    log_any_window_state(window, reason);
+}
+
+pub fn log_window_state_snapshot(app: &AppHandle, reason: &str) {
+    for label in WINDOW_LABELS {
+        if let Some(window) = app.get_webview_window(label) {
+            log_webview_window_state(&window, reason);
+        } else {
+            tracing::info!(
+                target: "system",
+                reason = reason,
+                label = *label,
+                exists = false,
+                "window state snapshot"
+            );
+        }
+    }
+}
+
+pub fn log_window_event(window: &Window, event: &WindowEvent) {
+    match event {
+        WindowEvent::Focused(focused) => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                focused = *focused,
+                "native window focus changed"
+            );
+            log_native_window_state(window, "native_window_focus_changed");
+            let _ = crate::audio::log_audio_route_snapshot("native_window_focus_changed");
+        }
+        WindowEvent::CloseRequested { .. } => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                "native window close requested"
+            );
+            log_native_window_state(window, "native_window_close_requested");
+        }
+        WindowEvent::Destroyed => {
+            tracing::info!(target: "system", label = window.label(), "native window destroyed");
+        }
+        WindowEvent::Resized(size) => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                width = size.width,
+                height = size.height,
+                "native window resized"
+            );
+        }
+        WindowEvent::Moved(position) => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                x = position.x,
+                y = position.y,
+                "native window moved"
+            );
+        }
+        WindowEvent::ScaleFactorChanged {
+            scale_factor,
+            new_inner_size,
+            ..
+        } => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                scale_factor = *scale_factor,
+                width = new_inner_size.width,
+                height = new_inner_size.height,
+                "native window scale factor changed"
+            );
+        }
+        WindowEvent::ThemeChanged(theme) => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                theme = ?theme,
+                "native window theme changed"
+            );
+        }
+        WindowEvent::DragDrop(event) => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                event = ?event,
+                "native window drag-drop event"
+            );
+        }
+        #[allow(unreachable_patterns)]
+        _ => {
+            tracing::info!(
+                target: "system",
+                label = window.label(),
+                event = ?event,
+                "native window event"
+            );
+        }
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod alloc;
 mod audio;
 mod audio_decode;
 mod commands;
+mod diagnostics;
 mod injector;
 mod keyboard;
 mod resource_monitor;
@@ -36,7 +37,6 @@ pub fn ffi_heap_mb() -> u64 { 0 }
 use state::AppState;
 use std::sync::{Mutex, MutexGuard};
 use tauri::Manager;
-#[cfg(target_os = "macos")]
 use tauri::RunEvent;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -140,6 +140,7 @@ pub fn run() {
             commands::logging::clear_logs,
             commands::logging::log_frontend,
             commands::logging::open_log_viewer,
+            commands::logging::log_window_state_snapshot,
             commands::models::check_model_exists,
             commands::models::check_specific_model_exists,
             commands::models::download_model,
@@ -152,12 +153,14 @@ pub fn run() {
             resource_monitor::get_resource_usage
         ])
         .on_window_event(|window, event| {
+            diagnostics::log_window_event(window, event);
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 // Hide instead of destroy for persistent windows
                 if window.label() == "main" || window.label() == "log-viewer" {
                     api.prevent_close();
                     let _ = window.hide();
                     tracing::info!(target: "system", "{} window hidden on close request", window.label());
+                    diagnostics::log_native_window_state(window, "after_close_request_hide");
                 }
             }
         })
@@ -165,6 +168,8 @@ pub fn run() {
             telemetry::init(app.handle().clone());
 
             tracing::info!(target: "system", "app setup — Murmur v{}", env!("CARGO_PKG_VERSION"));
+            diagnostics::log_window_state_snapshot(app.handle(), "setup_start");
+            let _ = audio::log_audio_route_snapshot("setup_start");
 
             // Emit startup baseline memory snapshot
             {
@@ -191,11 +196,13 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             if let Some(overlay_win) = app.get_webview_window("overlay") {
                 tracing::info!(target: "system", "setup: overlay window found, enabling cursor events");
+                diagnostics::log_webview_window_state(&overlay_win, "before_setup_overlay_show");
                 commands::overlay::position_overlay_default(&overlay_win, notch);
                 let _ = overlay_win.show();
                 if let Err(e) = overlay_win.set_ignore_cursor_events(false) {
                     tracing::warn!(target: "system", "Failed to set overlay cursor events: {}", e);
                 }
+                diagnostics::log_webview_window_state(&overlay_win, "after_setup_overlay_show");
             } else {
                 tracing::warn!(target: "system", "setup: overlay window NOT found");
             }
@@ -223,12 +230,17 @@ pub fn run() {
                 .on_menu_event(move |app_handle, event| {
                     match event.id().as_ref() {
                         "show" => {
+                            tracing::info!(target: "system", source = "tray_menu", action = "show_main", "window action requested");
+                            diagnostics::log_window_state_snapshot(app_handle, "before_tray_menu_show_main");
                             if let Some(win) = app_handle.get_webview_window("main") {
                                 let _ = win.show();
                                 let _ = win.set_focus();
                             }
+                            diagnostics::log_window_state_snapshot(app_handle, "after_tray_menu_show_main");
+                            let _ = audio::log_audio_route_snapshot("after_tray_menu_show_main");
                         }
                         "quit" => {
+                            tracing::info!(target: "system", source = "tray_menu", action = "quit", "window action requested");
                             app_handle.exit(0);
                         }
                         _ => {}
@@ -240,10 +252,14 @@ pub fn run() {
                         button_state: MouseButtonState::Up,
                         ..
                     }) {
+                        tracing::info!(target: "system", source = "tray_icon", event = ?event, action = "show_main", "tray icon clicked");
+                        diagnostics::log_window_state_snapshot(&handle, "before_tray_icon_show_main");
                         if let Some(win) = handle.get_webview_window("main") {
                             let _ = win.show();
                             let _ = win.set_focus();
                         }
+                        diagnostics::log_window_state_snapshot(&handle, "after_tray_icon_show_main");
+                        let _ = audio::log_audio_route_snapshot("after_tray_icon_show_main");
                     }
                 })
                 .build(app)?;
@@ -254,6 +270,33 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(|_app_handle, _event| {
+        match &_event {
+            RunEvent::Ready => {
+                tracing::info!(target: "system", "tauri run event ready");
+                diagnostics::log_window_state_snapshot(_app_handle, "run_event_ready");
+                let _ = audio::log_audio_route_snapshot("run_event_ready");
+            }
+            RunEvent::Resumed => {
+                tracing::info!(target: "system", "tauri run event resumed");
+                diagnostics::log_window_state_snapshot(_app_handle, "run_event_resumed");
+                let _ = audio::log_audio_route_snapshot("run_event_resumed");
+            }
+            RunEvent::ExitRequested { code, .. } => {
+                tracing::info!(target: "system", code = ?code, "tauri run event exit requested");
+                diagnostics::log_window_state_snapshot(_app_handle, "run_event_exit_requested");
+            }
+            RunEvent::Exit => {
+                tracing::info!(target: "system", "tauri run event exit");
+            }
+            #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+            RunEvent::Opened { urls } => {
+                tracing::info!(target: "system", count = urls.len(), urls = ?urls, "tauri run event opened");
+                diagnostics::log_window_state_snapshot(_app_handle, "run_event_opened");
+                let _ = audio::log_audio_route_snapshot("run_event_opened");
+            }
+            _ => {}
+        }
+
         // Suppress Tauri's default RunEvent::Reopen behaviour which shows
         // the main window whenever the macOS app is activated — including
         // when the overlay is clicked.  We only re-show the main window
@@ -261,10 +304,20 @@ pub fn run() {
         // after the user closed everything).
         #[cfg(target_os = "macos")]
         if let RunEvent::Reopen { has_visible_windows, .. } = &_event {
+            tracing::info!(
+                target: "system",
+                has_visible_windows = *has_visible_windows,
+                "tauri run event reopen"
+            );
+            diagnostics::log_window_state_snapshot(_app_handle, "run_event_reopen");
+            let _ = audio::log_audio_route_snapshot("run_event_reopen");
             if !has_visible_windows {
                 if let Some(win) = _app_handle.get_webview_window("main") {
+                    diagnostics::log_window_state_snapshot(_app_handle, "before_reopen_show_main");
                     let _ = win.show();
                     let _ = win.set_focus();
+                    diagnostics::log_window_state_snapshot(_app_handle, "after_reopen_show_main");
+                    let _ = audio::log_audio_route_snapshot("after_reopen_show_main");
                 }
             }
         }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -128,6 +128,8 @@ pub fn run() {
             commands::permissions::request_accessibility_permission,
             commands::permissions::request_microphone_permission,
             commands::permissions::list_audio_devices,
+            commands::permissions::get_default_audio_input_device,
+            commands::permissions::log_audio_route_snapshot,
             commands::keyboard::start_keyboard_listener,
             commands::keyboard::stop_keyboard_listener,
             commands::keyboard::update_keyboard_key,

--- a/app/src-tauri/tauri.dev.conf.json
+++ b/app/src-tauri/tauri.dev.conf.json
@@ -1,4 +1,91 @@
 {
   "identifier": "com.localdictation.dev",
-  "productName": "Local Dictation Dev"
+  "productName": "Local Dictation Dev",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Murmur",
+        "url": "http://localhost:1420",
+        "width": 720,
+        "height": 560,
+        "minWidth": 520,
+        "minHeight": 400,
+        "center": true
+      },
+      {
+        "label": "overlay",
+        "title": "",
+        "url": "http://localhost:1420/overlay.html",
+        "width": 260,
+        "height": 100,
+        "decorations": false,
+        "alwaysOnTop": true,
+        "transparent": true,
+        "skipTaskbar": true,
+        "visible": false,
+        "resizable": false,
+        "focusable": false,
+        "visibleOnAllWorkspaces": true
+      },
+      {
+        "label": "log-viewer",
+        "title": "Murmur - Log Viewer",
+        "url": "http://localhost:1420/log-viewer.html",
+        "width": 800,
+        "height": 600,
+        "minWidth": 600,
+        "minHeight": 400,
+        "center": true,
+        "visible": false
+      }
+    ],
+    "security": {
+      "capabilities": [
+        {
+          "identifier": "dev-main",
+          "description": "Development capability for the main window served by Vite",
+          "windows": ["main"],
+          "remote": {
+            "urls": ["http://localhost:1420/*"]
+          },
+          "permissions": [
+            "core:default",
+            "opener:default",
+            "autostart:allow-enable",
+            "autostart:allow-disable",
+            "autostart:allow-is-enabled",
+            "updater:default",
+            "notification:default",
+            "process:allow-restart",
+            "process:allow-exit",
+            "dialog:allow-open"
+          ]
+        },
+        {
+          "identifier": "dev-log-viewer",
+          "description": "Development capability for the log viewer window served by Vite",
+          "windows": ["log-viewer"],
+          "remote": {
+            "urls": ["http://localhost:1420/*"]
+          },
+          "permissions": ["core:default", "core:event:default"]
+        },
+        {
+          "identifier": "dev-overlay",
+          "description": "Development capability for the overlay window served by Vite",
+          "windows": ["overlay"],
+          "remote": {
+            "urls": ["http://localhost:1420/*"]
+          },
+          "permissions": [
+            "core:event:default",
+            "core:window:allow-start-dragging",
+            "core:window:allow-set-position",
+            "core:default"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,13 +28,27 @@ import { ModelDownloader } from './components/ModelDownloader';
 function App() {
   // --- Diagnostic: track when main window becomes visible/focused ---
   useEffect(() => {
-    const onFocus = () => flog.info('main', 'FOCUS');
-    const onBlur = () => flog.info('main', 'BLUR');
-    const onVisibility = () => flog.info('main', 'VISIBILITY', { hidden: document.hidden });
+    const logAudioRoute = (reason: string) => {
+      invoke('log_audio_route_snapshot', { reason }).catch(() => {});
+    };
+    const onFocus = () => {
+      flog.info('main', 'FOCUS');
+      logAudioRoute('main_focus');
+    };
+    const onBlur = () => {
+      flog.info('main', 'BLUR');
+      logAudioRoute('main_blur');
+    };
+    const onVisibility = () => {
+      const reason = document.hidden ? 'main_hidden' : 'main_visible';
+      flog.info('main', 'VISIBILITY', { hidden: document.hidden });
+      logAudioRoute(reason);
+    };
     window.addEventListener('focus', onFocus);
     window.addEventListener('blur', onBlur);
     document.addEventListener('visibilitychange', onVisibility);
     flog.info('main', 'App mounted');
+    logAudioRoute('main_mount');
     return () => {
       window.removeEventListener('focus', onFocus);
       window.removeEventListener('blur', onBlur);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,30 +28,71 @@ import { ModelDownloader } from './components/ModelDownloader';
 function App() {
   // --- Diagnostic: track when main window becomes visible/focused ---
   useEffect(() => {
-    const logAudioRoute = (reason: string) => {
+    const logDiagnostics = (reason: string, data: Record<string, unknown> = {}) => {
+      flog.info('main', `DIAGNOSTIC ${reason}`, {
+        ...data,
+        documentHidden: document.hidden,
+        hasFocus: document.hasFocus(),
+        visibilityState: document.visibilityState,
+      });
       invoke('log_audio_route_snapshot', { reason }).catch(() => {});
+      invoke('log_window_state_snapshot', { reason }).catch(() => {});
     };
     const onFocus = () => {
       flog.info('main', 'FOCUS');
-      logAudioRoute('main_focus');
+      logDiagnostics('main_focus');
     };
     const onBlur = () => {
       flog.info('main', 'BLUR');
-      logAudioRoute('main_blur');
+      logDiagnostics('main_blur');
     };
     const onVisibility = () => {
       const reason = document.hidden ? 'main_hidden' : 'main_visible';
       flog.info('main', 'VISIBILITY', { hidden: document.hidden });
-      logAudioRoute(reason);
+      logDiagnostics(reason);
+    };
+    const onPageShow = (event: PageTransitionEvent) => {
+      logDiagnostics('main_pageshow', { persisted: event.persisted });
+    };
+    const onPageHide = (event: PageTransitionEvent) => {
+      logDiagnostics('main_pagehide', { persisted: event.persisted });
+    };
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target.tagName : 'unknown';
+      logDiagnostics('main_focusin', { target });
+    };
+    const onFocusOut = (event: FocusEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target.tagName : 'unknown';
+      logDiagnostics('main_focusout', { target });
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target.tagName : 'unknown';
+      logDiagnostics('main_pointer_down', {
+        button: event.button,
+        pointerType: event.pointerType,
+        target,
+        x: Math.round(event.clientX),
+        y: Math.round(event.clientY),
+      });
     };
     window.addEventListener('focus', onFocus);
     window.addEventListener('blur', onBlur);
+    window.addEventListener('pageshow', onPageShow);
+    window.addEventListener('pagehide', onPageHide);
+    window.addEventListener('focusin', onFocusIn);
+    window.addEventListener('focusout', onFocusOut);
+    window.addEventListener('pointerdown', onPointerDown, { capture: true });
     document.addEventListener('visibilitychange', onVisibility);
     flog.info('main', 'App mounted');
-    logAudioRoute('main_mount');
+    logDiagnostics('main_mount');
     return () => {
       window.removeEventListener('focus', onFocus);
       window.removeEventListener('blur', onBlur);
+      window.removeEventListener('pageshow', onPageShow);
+      window.removeEventListener('pagehide', onPageHide);
+      window.removeEventListener('focusin', onFocusIn);
+      window.removeEventListener('focusout', onFocusOut);
+      window.removeEventListener('pointerdown', onPointerDown, { capture: true });
       document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);

--- a/app/src/components/log-viewer/AudioRouteView.tsx
+++ b/app/src/components/log-viewer/AudioRouteView.tsx
@@ -1,0 +1,231 @@
+import type { AppEvent } from '../../lib/events';
+
+interface AudioRouteViewProps {
+  events: AppEvent[];
+}
+
+interface RoutePoint {
+  timestamp: string;
+  label: string;
+  input: string;
+  output: string;
+  inputRate: number;
+  outputRate: number;
+  inputBluetooth: boolean;
+  outputBluetooth: boolean;
+  kind: 'snapshot' | 'capture' | 'warning' | 'focus';
+}
+
+function asString(value: unknown, fallback = 'unknown'): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' ? value : 0;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function timeLabel(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function extractRoutePoints(events: AppEvent[]): RoutePoint[] {
+  return events
+    .filter((event) =>
+      event.stream === 'audio' &&
+      (
+        event.summary === 'audio route snapshot' ||
+        event.summary === 'audio capture route selected' ||
+        event.summary === 'audio capture stream started' ||
+        event.summary === 'audio capture stream stopped' ||
+        event.summary.includes('Bluetooth-like input selected')
+      )
+    )
+    .slice(-60)
+    .map((event) => {
+      if (event.summary === 'audio capture stream started') {
+        return {
+          timestamp: event.timestamp,
+          label: 'capture started',
+          input: '',
+          output: '',
+          inputRate: 0,
+          outputRate: 0,
+          inputBluetooth: false,
+          outputBluetooth: false,
+          kind: 'capture' as const,
+        };
+      }
+      if (event.summary === 'audio capture stream stopped') {
+        return {
+          timestamp: event.timestamp,
+          label: 'capture stopped',
+          input: '',
+          output: '',
+          inputRate: 0,
+          outputRate: 0,
+          inputBluetooth: false,
+          outputBluetooth: false,
+          kind: 'capture' as const,
+        };
+      }
+      if (event.summary.includes('Bluetooth-like input selected')) {
+        return {
+          timestamp: event.timestamp,
+          label: 'Bluetooth warning',
+          input: '',
+          output: '',
+          inputRate: 0,
+          outputRate: 0,
+          inputBluetooth: true,
+          outputBluetooth: false,
+          kind: 'warning' as const,
+        };
+      }
+
+      const label = event.summary === 'audio route snapshot'
+        ? asString(event.data.reason, 'snapshot').replace(/_/g, ' ')
+        : 'recording route';
+      return {
+        timestamp: event.timestamp,
+        label,
+        input: asString(event.data.input_device),
+        output: asString(event.data.output_device),
+        inputRate: asNumber(event.data.input_sample_rate ?? event.data.sample_rate),
+        outputRate: asNumber(event.data.output_sample_rate),
+        inputBluetooth: asBoolean(event.data.input_bluetooth_like),
+        outputBluetooth: asBoolean(event.data.output_bluetooth_like),
+        kind: event.summary === 'audio route snapshot' ? 'snapshot' : 'capture',
+      };
+    });
+}
+
+function latestRoute(points: RoutePoint[]): RoutePoint | undefined {
+  return [...points].reverse().find((point) => point.input || point.output);
+}
+
+function Timeline({ points }: { points: RoutePoint[] }) {
+  if (points.length === 0) return null;
+
+  const width = 700;
+  const height = 84;
+  const padding = { left: 28, right: 28, top: 24, bottom: 24 };
+  const innerW = width - padding.left - padding.right;
+  const step = points.length > 1 ? innerW / (points.length - 1) : 0;
+
+  const colorFor = (point: RoutePoint) => {
+    if (point.kind === 'warning' || point.inputBluetooth || point.outputBluetooth) return '#f59e0b';
+    if (point.label.includes('started')) return '#10b981';
+    if (point.label.includes('stopped')) return '#64748b';
+    return '#3b82f6';
+  };
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" preserveAspectRatio="xMidYMid meet">
+      <line
+        x1={padding.left}
+        y1={height / 2}
+        x2={width - padding.right}
+        y2={height / 2}
+        stroke="currentColor"
+        strokeOpacity={0.12}
+      />
+      {points.map((point, index) => {
+        const x = padding.left + (points.length > 1 ? index * step : innerW / 2);
+        return (
+          <g key={`${point.timestamp}-${index}`}>
+            <circle cx={x} cy={height / 2} r={5} fill={colorFor(point)} />
+            {(index === 0 || index === points.length - 1) && (
+              <text x={x} y={height - 6} textAnchor="middle" className="fill-stone-400 dark:fill-stone-500" fontSize="9">
+                {timeLabel(point.timestamp)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export function AudioRouteView({ events }: AudioRouteViewProps) {
+  const points = extractRoutePoints(events);
+  const latest = latestRoute(points);
+  const bluetoothActive = latest?.inputBluetooth || latest?.outputBluetooth;
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-lg border border-stone-200 dark:border-stone-700 p-3">
+          <div className="text-[11px] text-stone-500 dark:text-stone-400 mb-1">Input</div>
+          <div className="text-sm font-medium text-stone-900 dark:text-stone-100 truncate">
+            {latest?.input || 'unknown'}
+          </div>
+          <div className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            {latest?.inputRate ? `${latest.inputRate} Hz` : 'no rate'}
+          </div>
+        </div>
+        <div className="rounded-lg border border-stone-200 dark:border-stone-700 p-3">
+          <div className="text-[11px] text-stone-500 dark:text-stone-400 mb-1">Output</div>
+          <div className="text-sm font-medium text-stone-900 dark:text-stone-100 truncate">
+            {latest?.output || 'unknown'}
+          </div>
+          <div className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            {latest?.outputRate ? `${latest.outputRate} Hz` : 'no rate'}
+          </div>
+        </div>
+        <div className={`rounded-lg border p-3 ${
+          bluetoothActive
+            ? 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20'
+            : 'border-stone-200 dark:border-stone-700'
+        }`}>
+          <div className="text-[11px] text-stone-500 dark:text-stone-400 mb-1">Route Risk</div>
+          <div className={`text-sm font-medium ${
+            bluetoothActive ? 'text-amber-700 dark:text-amber-300' : 'text-stone-900 dark:text-stone-100'
+          }`}>
+            {bluetoothActive ? 'Bluetooth call route likely' : 'No Bluetooth route detected'}
+          </div>
+          <div className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            {points.length} route events
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-stone-200 dark:border-stone-700 p-3">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-xs font-semibold text-stone-700 dark:text-stone-300">Audio Route Timeline</h2>
+          <div className="flex items-center gap-3 text-[10px] text-stone-500 dark:text-stone-400">
+            <span><span className="inline-block w-2 h-2 rounded-full bg-blue-500 mr-1" />snapshot</span>
+            <span><span className="inline-block w-2 h-2 rounded-full bg-emerald-500 mr-1" />start</span>
+            <span><span className="inline-block w-2 h-2 rounded-full bg-amber-500 mr-1" />Bluetooth</span>
+          </div>
+        </div>
+        {points.length === 0 ? (
+          <div className="flex items-center justify-center h-24 text-sm text-stone-400 dark:text-stone-500">
+            No audio route events yet
+          </div>
+        ) : (
+          <Timeline points={points} />
+        )}
+      </div>
+
+      <div className="rounded-lg border border-stone-200 dark:border-stone-700 overflow-hidden">
+        {points.length === 0 ? null : points.slice().reverse().map((point, index) => (
+          <div
+            key={`${point.timestamp}-${index}`}
+            className="grid grid-cols-[84px_1fr_1fr_1fr] gap-3 px-3 py-2 text-xs border-b last:border-b-0 border-stone-100 dark:border-stone-800"
+          >
+            <span className="text-stone-400 dark:text-stone-500 tabular-nums">{timeLabel(point.timestamp)}</span>
+            <span className="font-medium text-stone-700 dark:text-stone-300 truncate">{point.label}</span>
+            <span className="text-stone-500 dark:text-stone-400 truncate">{point.input || '-'}</span>
+            <span className="text-stone-500 dark:text-stone-400 truncate">{point.output || '-'}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/log-viewer/LogViewerApp.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.tsx
@@ -5,9 +5,10 @@ import { StreamChips } from './StreamChips';
 import { LevelFilter } from './LevelFilter';
 import { EventRow } from './EventRow';
 import { MetricsView } from './MetricsView';
+import { AudioRouteView } from './AudioRouteView';
 import type { StreamName, LevelName } from '../../lib/events';
 
-type Tab = 'events' | 'metrics';
+type Tab = 'events' | 'metrics' | 'audio';
 
 export function LogViewerApp() {
   const { events, clear } = useEventStore();
@@ -71,7 +72,7 @@ export function LogViewerApp() {
         <div className="flex items-center justify-between mb-3">
           {/* Tabs */}
           <div className="flex gap-1">
-            {(['events', 'metrics'] as Tab[]).map((t) => (
+            {(['events', 'metrics', 'audio'] as Tab[]).map((t) => (
               <button
                 key={t}
                 onClick={() => setTab(t)}
@@ -127,9 +128,13 @@ export function LogViewerApp() {
             ))
           )}
         </div>
-      ) : (
+      ) : tab === 'metrics' ? (
         <div className="flex-1 overflow-y-auto">
           <MetricsView events={events} resourceReadings={resourceReadings} />
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          <AudioRouteView events={events} />
         </div>
       )}
     </div>

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   Settings, RecordingMode, DEFAULT_SETTINGS,
   MODEL_OPTIONS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
   IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS,
+  isLikelyBluetoothMicrophone,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
@@ -227,17 +228,25 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
   // Audio device enumeration
   const [audioDevices, setAudioDevices] = useState<string[]>([]);
+  const [defaultAudioInput, setDefaultAudioInput] = useState<string | null>(null);
   useEffect(() => {
     if (!isOpen) return;
     invoke<string[]>('list_audio_devices')
       .then(setAudioDevices)
       .catch(() => setAudioDevices([]));
+    invoke<string | null>('get_default_audio_input_device')
+      .then(setDefaultAudioInput)
+      .catch(() => setDefaultAudioInput(null));
   }, [isOpen]);
 
   const savedDeviceMissing =
     settings.microphone !== DEFAULT_SETTINGS.microphone &&
     audioDevices.length > 0 &&
     !audioDevices.includes(settings.microphone);
+  const selectedBluetoothMic =
+    settings.microphone === DEFAULT_SETTINGS.microphone
+      ? defaultAudioInput !== null && isLikelyBluetoothMicrophone(defaultAudioInput)
+      : isLikelyBluetoothMicrophone(settings.microphone);
 
   const isDoubleTap = settings.recordingMode === 'double_tap';
   const isBoth = settings.recordingMode === 'both';
@@ -422,6 +431,14 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
               <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
               <span>Selected device not found — will use System Default</span>
+            </div>
+          )}
+          {selectedBluetoothMic && (
+            <div className="mt-2 flex items-start gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
+              <span className="mt-1 w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+              <span>
+                Bluetooth headset microphones can make macOS switch audio into a call-style route while recording. Select the Mac or USB mic to keep other audio stable.
+              </span>
             </div>
           )}
         </div>

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { loadSettings, DEFAULT_SETTINGS } from './settings';
+import { loadSettings, DEFAULT_SETTINGS, isLikelyBluetoothMicrophone } from './settings';
 
 beforeEach(() => {
-  localStorage.clear();
+  const store = new Map<string, string>();
+  const localStorageMock = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => { store.delete(key); },
+    setItem: (key: string, value: string) => { store.set(key, value); },
+  } satisfies Storage;
+  Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true });
+  Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
 });
 
 describe('loadSettings', () => {
@@ -96,5 +108,18 @@ describe('loadSettings', () => {
       const settings = loadSettings();
       expect(settings.recordingMode).toBe(mode);
     }
+  });
+});
+
+describe('isLikelyBluetoothMicrophone', () => {
+  it('flags common Bluetooth headset microphones', () => {
+    expect(isLikelyBluetoothMicrophone("George's AirPods Pro")).toBe(true);
+    expect(isLikelyBluetoothMicrophone('Bose QC Headset')).toBe(true);
+    expect(isLikelyBluetoothMicrophone('Jabra Hands-Free Audio')).toBe(true);
+  });
+
+  it('does not flag built-in or USB-style microphones', () => {
+    expect(isLikelyBluetoothMicrophone('MacBook Pro Microphone')).toBe(false);
+    expect(isLikelyBluetoothMicrophone('USB Audio Device')).toBe(false);
   });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -84,6 +84,25 @@ export const DEFAULT_SETTINGS: Settings = {
 
 export const STORAGE_KEY = 'dictation-settings';
 
+const BLUETOOTH_MIC_KEYWORDS = [
+  'airpods',
+  'beats',
+  'bluetooth',
+  'bose',
+  'galaxy buds',
+  'hands-free',
+  'handsfree',
+  'headset',
+  'hfp',
+  'jabra',
+  'sony',
+];
+
+export function isLikelyBluetoothMicrophone(deviceName: string): boolean {
+  const normalized = deviceName.toLowerCase();
+  return BLUETOOTH_MIC_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
 export function loadSettings(): Settings {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -131,6 +131,8 @@ Shows route diagnostics for macOS audio ducking investigations:
 
 The main window emits route snapshots on mount, focus, blur, and visibility changes. The native recording path also snapshots before/after capture starts, after capture stops, and before/after the transcription pipeline. This makes it possible to correlate Chrome/system audio quieting with focus changes, active capture, processing, or a Bluetooth call-style input route.
 
+The `system` stream also records native Tauri window diagnostics for ducking investigations: focused/unfocused events, close/hide/show paths, tray and reopen activation paths, and per-window state snapshots for `main`, `log-viewer`, and `overlay` (visible, focused, minimized, position, size, and scale factor). These events are useful when audio changes happen while no capture stream is open.
+
 ### Event Store (`useEventStore`)
 
 The frontend event buffer is managed by the `useEventStore` hook:
@@ -150,6 +152,7 @@ The frontend event buffer is managed by the `useEventStore` hook:
 | `clear_logs` | Removes all log files and clears the in-memory event ring buffer |
 | `log_frontend` | Routes a frontend message through Rust tracing (INFO/WARN/ERROR) |
 | `log_audio_route_snapshot` | Logs current default input/output route diagnostics |
+| `log_window_state_snapshot` | Logs current native state for Murmur's main, log-viewer, and overlay windows |
 | `get_event_history` | Returns all events from the in-memory ring buffer (up to 500) |
 | `clear_event_history` | Clears the in-memory event ring buffer |
 

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -121,6 +121,16 @@ Y-axis auto-scales with "nice" round numbers and three tick marks. X-axis shows 
 
 The metrics view shows the last 20 transcriptions. The series legend is toggleable — click a series label to show/hide it (at least one must remain visible).
 
+### Audio Tab
+
+Shows route diagnostics for macOS audio ducking investigations:
+
+- Latest default input and output device names, sample rates, and Bluetooth/headset risk state
+- A compact timeline of route snapshots, capture start/stop events, and Bluetooth warnings
+- A newest-first route event list showing the trigger reason, input route, and output route
+
+The main window emits route snapshots on mount, focus, blur, and visibility changes. The native recording path also snapshots before/after capture starts, after capture stops, and before/after the transcription pipeline. This makes it possible to correlate Chrome/system audio quieting with focus changes, active capture, processing, or a Bluetooth call-style input route.
+
 ### Event Store (`useEventStore`)
 
 The frontend event buffer is managed by the `useEventStore` hook:
@@ -139,6 +149,7 @@ The frontend event buffer is managed by the `useEventStore` hook:
 | `get_log_contents` | Returns the last N lines from the pretty-printed log file |
 | `clear_logs` | Removes all log files and clears the in-memory event ring buffer |
 | `log_frontend` | Routes a frontend message through Rust tracing (INFO/WARN/ERROR) |
+| `log_audio_route_snapshot` | Logs current default input/output route diagnostics |
 | `get_event_history` | Returns all events from the in-memory ring buffer (up to 500) |
 | `clear_event_history` | Clears the in-memory event ring buffer |
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -15,6 +15,18 @@ All processing is local during transcription (network only required to download 
 - Multi-channel to mono conversion (averages channels)
 - Resamples to 16kHz (expected sample rate for the backend)
 - Samples stored as `Vec<f32>` in memory — no temp files
+- Logs the selected input route, current output route, sample rate, channel count, sample format, and capture stream start/stop events to the `audio` stream
+
+### macOS Audio Ducking / Bluetooth Routes
+
+Murmur does not intentionally lower, mix, or control other apps' output volume. On macOS, the capture path opens a CoreAudio input stream through `cpal`; the app does not open an output stream or call any volume APIs.
+
+If the selected microphone is a Bluetooth headset-style input (for example AirPods, Beats, Bose, Jabra, Sony, or a "Hands-Free" device), macOS may switch the device into a call-style route while the input stream is open. That route can make other app/system audio sound quieter, lower quality, or otherwise different until recording stops. This can look like a focus-change bug because background keyboard triggers and overlay interactions start recording while another app is playing audio, but the relevant trigger is the input capture lifecycle.
+
+Workarounds:
+- Use the Mac built-in microphone or a USB microphone for Murmur.
+- Keep Bluetooth headphones as the output device, but avoid selecting their microphone as Murmur's input.
+- Use the log viewer's `audio` stream to compare `audio capture stream started` / `audio capture stream stopped` events against the moment other audio changes.
 
 ## Transcription Backend (`transcriber/`)
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -84,3 +84,13 @@ The app searches these locations in order:
 ## Logs
 
 App logs are at `~/Library/Application Support/local-dictation/logs/app.log` with automatic rotation at 5 MB.
+
+Structured event logs are written to `~/Library/Application Support/local-dictation/logs/events.jsonl` in release builds and `events.dev.jsonl` in dev builds. The log viewer reads these events and includes audio route snapshots plus native window focus/visibility diagnostics.
+
+For macOS audio ducking investigations, capture system audio logs while reproducing:
+
+```bash
+scripts/tail-macos-audio-ducking.sh
+```
+
+The script writes a timestamped `macos-audio-*.log` file in the same logs directory and streams filtered CoreAudio/HAL/audio-route messages to the terminal.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -27,6 +27,8 @@ For event-based communication (Rust to frontend), see [events.md](events.md). Fo
 | `request_accessibility_permission` | _(none)_ | `Result<(), String>` | Triggers the macOS Accessibility permission prompt and opens System Settings to the Accessibility pane. |
 | `request_microphone_permission` | _(none)_ | `Result<(), String>` | Opens macOS System Settings to the Microphone privacy pane. |
 | `list_audio_devices` | _(none)_ | `Result<Vec<String>, String>` | Returns a list of available audio input device names via cpal. |
+| `get_default_audio_input_device` | _(none)_ | `Result<Option<String>, String>` | Returns the current system default audio input device name when available. Used to warn about Bluetooth headset mics even when Microphone is set to System Default. |
+| `log_audio_route_snapshot` | `reason: String` | `Result<(), String>` | Logs the current default input/output device names, sample rates, channel counts, formats, and Bluetooth/headset risk flags to the `audio` event stream. |
 
 ## Keyboard (`commands/keyboard.rs`)
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -47,6 +47,7 @@ For event-based communication (Rust to frontend), see [events.md](events.md). Fo
 | `clear_logs` | _(none)_ | `Result<(), String>` | Removes all log files (including rotated variants, JSONL event files, frontend logs) and clears the in-memory event ring buffer. |
 | `log_frontend` | `level: String`, `message: String` | `()` | Routes a frontend log message through the Rust tracing system. Accepts levels: `"INFO"`, `"WARN"`, `"ERROR"`. Messages appear in the structured event stream with `source="frontend"`. |
 | `open_log_viewer` | _(none)_ | `Result<(), String>` | Shows and focuses the `log-viewer` window. |
+| `log_window_state_snapshot` | `reason: String` | `Result<(), String>` | Logs native state for the main, log-viewer, and overlay windows: existence, visibility, focus, minimized state, position, size, and scale factor. |
 
 ## Models (`commands/models.rs`)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -85,6 +85,8 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 | `microphone` | `string` | `'system_default'` | `'system_default'` or any device name from `list_audio_devices` | Audio input device for recording. When set to `'system_default'`, the frontend sends `null` to the backend, which uses the system default input device. Available devices are fetched via the `list_audio_devices` command when the settings panel opens. |
 | `launchAtLogin` | `boolean` | `false` | `true` / `false` | Whether the app starts automatically on macOS login. Uses `@tauri-apps/plugin-autostart` with `MacosLauncher::LaunchAgent`. On mount, the hook checks the actual OS autostart state and reconciles with the stored setting (handles the case where the user removed the login item from System Settings). |
 
+When the selected microphone, or the resolved system default input, looks like a Bluetooth headset-style input, the settings panel shows a warning. These devices can make macOS switch playback into a call-style route while Murmur records, which may make other audio sound quieter or lower quality. The recommended workaround is to select the Mac built-in microphone or a USB microphone for input while keeping Bluetooth headphones for output.
+
 ---
 
 ## Persistence and Migration

--- a/scripts/tail-macos-audio-ducking.sh
+++ b/scripts/tail-macos-audio-ducking.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="${HOME}/Library/Application Support/local-dictation/logs"
+mkdir -p "${log_dir}"
+
+stamp="$(date +%Y%m%d-%H%M%S)"
+out="${log_dir}/macos-audio-${stamp}.log"
+
+cat <<EOF
+Capturing macOS audio diagnostics to:
+  ${out}
+
+Reproduce the ducking issue now. Press Ctrl-C to stop.
+EOF
+
+predicate='process == "coreaudiod" OR process == "Murmur" OR process == "Local Dictation Dev" OR subsystem CONTAINS[c] "audio" OR category CONTAINS[c] "audio" OR eventMessage CONTAINS[c] "duck" OR eventMessage CONTAINS[c] "volume" OR eventMessage CONTAINS[c] "mute" OR eventMessage CONTAINS[c] "HAL" OR eventMessage CONTAINS[c] "AudioDevice" OR eventMessage CONTAINS[c] "AudioSession" OR eventMessage CONTAINS[c] "route"'
+
+log stream --style compact --info --predicate "${predicate}" | tee "${out}"


### PR DESCRIPTION
## Summary
- Log audio route snapshots on focus/visibility changes, recording start/stop, and transcription pipeline boundaries so ducking reports have concrete route evidence.
- Warn when the selected/default microphone looks like a Bluetooth headset input and add an Audio tab to the log viewer with a route timeline.
- Make the dev Tauri config load Vite URLs for all windows so `npm run tauri -- dev --config src-tauri/tauri.dev.conf.json` exercises current source in Computer Use.

## Test plan
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1`
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test -- settings.test.ts`
- [x] `npm run tauri -- dev --config src-tauri/tauri.dev.conf.json`; Computer Use verified the dev app loads `localhost:1420`, the Log Viewer shows the Audio tab, and a start/stop recording smoke emitted route snapshots plus capture stream start/stop events.

Closes #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Audio tab in Log Viewer with audio-route timeline, Bluetooth warning indicators, and route summaries
  * App now captures and logs audio-route snapshots and window-state diagnostics across lifecycle, recording start/stop, overlays, tray actions, and log viewer
  * Added commands to request current audio-route or window-state snapshots and a macOS helper script to tail audio ducking logs
  * Settings show Bluetooth-microphone warning when applicable

* **Documentation**
  * Docs updated with audio-tab details, commands, macOS troubleshooting, and Bluetooth ducking guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->