### PR TITLE
feat: add macOS Accessibility permission reset button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Accessibility permission reset** troubleshooting button in the permissions banner — resets the app's stale TCC entry for the current bundle id (`tccutil reset Accessibility`) and reopens System Settings
+
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
 

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/commands/permissions.rs
+++ b/app/src-tauri/src/commands/permissions.rs
@@ -41,6 +41,80 @@ pub fn request_accessibility_permission() -> Result<(), String> {
     { Ok(()) }
 }
 
+/// Read the running process's bundle identifier (macOS).
+///
+/// Returns the *runtime* bundle id (e.g. the dev bundle `Local Dictation Dev`),
+/// which is what TCC actually keys Accessibility entries on — not the static
+/// identifier from `tauri.conf.json`, which can be stale for rebuilt/dev bundles.
+#[cfg(target_os = "macos")]
+fn current_bundle_identifier() -> Option<String> {
+    use objc2::msg_send;
+    use objc2::runtime::{AnyClass, AnyObject};
+    use objc2_foundation::NSString;
+
+    unsafe {
+        let cls = AnyClass::get(c"NSBundle")?;
+        let bundle: *mut AnyObject = msg_send![cls, mainBundle];
+        if bundle.is_null() {
+            return None;
+        }
+        let ident: *const NSString = msg_send![bundle, bundleIdentifier];
+        if ident.is_null() {
+            return None;
+        }
+        let s = (*ident).to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+}
+
+/// Reset this app's stale macOS Accessibility TCC entry, then reopen the pane.
+///
+/// Troubleshooting action for the case where System Settings lists the app under
+/// Accessibility but the running build still reports access missing (common after
+/// rebuilding a dev bundle). Resets ONLY the current bundle identifier via
+/// `tccutil reset Accessibility <bundle-id>` — never all apps. macOS still requires
+/// the user to re-enable the app manually afterward; this only clears the stale entry.
+#[tauri::command]
+pub fn reset_accessibility_permission() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let bundle_id = current_bundle_identifier()
+            .ok_or_else(|| "Could not determine the app's bundle identifier".to_string())?;
+
+        tracing::info!(
+            target: "system",
+            "resetting Accessibility TCC entry for bundle id {}",
+            bundle_id
+        );
+
+        let output = std::process::Command::new("tccutil")
+            .args(["reset", "Accessibility", &bundle_id])
+            .output()
+            .map_err(|e| format!("Failed to run tccutil: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!(
+                target: "system",
+                "tccutil reset failed for {}: {}",
+                bundle_id,
+                stderr.trim()
+            );
+            return Err(format!("tccutil reset failed: {}", stderr.trim()));
+        }
+
+        return open_system_preference_pane("Privacy_Accessibility");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Accessibility reset is only supported on macOS".to_string())
+    }
+}
+
 /// Request microphone permission (opens System Settings on macOS)
 #[tauri::command]
 pub fn request_microphone_permission() -> Result<(), String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() {
             commands::permissions::open_system_preferences,
             commands::permissions::check_accessibility_permission,
             commands::permissions::request_accessibility_permission,
+            commands::permissions::reset_accessibility_permission,
             commands::permissions::request_microphone_permission,
             commands::permissions::check_microphone_permission,
             commands::permissions::list_audio_devices,

--- a/app/src/components/PermissionsBanner.tsx
+++ b/app/src/components/PermissionsBanner.tsx
@@ -13,6 +13,7 @@ export function PermissionsBanner() {
   });
   const [dismissed, setDismissed] = useState(false);
   const [checking, setChecking] = useState(true);
+  const [resetError, setResetError] = useState<string | null>(null);
 
   const checkPermissions = useCallback(async () => {
     setChecking(true);
@@ -58,10 +59,16 @@ export function PermissionsBanner() {
   };
 
   const handleResetAccessibility = async () => {
+    setResetError(null);
     try {
       await invoke('reset_accessibility_permission');
     } catch (error) {
       console.error('Failed to reset accessibility permission:', error);
+      setResetError(
+        typeof error === 'string'
+          ? error
+          : "Couldn't reset the Accessibility entry. Check the logs for details.",
+      );
     } finally {
       checkPermissions();
     }
@@ -134,6 +141,11 @@ export function PermissionsBanner() {
                   Clears Murmur's stale Accessibility entry, then opens System Settings.
                   You'll still need to turn Murmur back on manually.
                 </p>
+                {resetError && (
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    {resetError}
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/app/src/components/PermissionsBanner.tsx
+++ b/app/src/components/PermissionsBanner.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { resetAccessibilityPermission } from '../lib/dictation';
 
 interface PermissionStatus {
   microphone: 'unknown' | 'granted' | 'denied';
@@ -61,7 +62,7 @@ export function PermissionsBanner() {
   const handleResetAccessibility = async () => {
     setResetError(null);
     try {
-      await invoke('reset_accessibility_permission');
+      await resetAccessibilityPermission();
     } catch (error) {
       console.error('Failed to reset accessibility permission:', error);
       setResetError(

--- a/app/src/components/PermissionsBanner.tsx
+++ b/app/src/components/PermissionsBanner.tsx
@@ -57,6 +57,16 @@ export function PermissionsBanner() {
     await invoke('request_microphone_permission');
   };
 
+  const handleResetAccessibility = async () => {
+    try {
+      await invoke('reset_accessibility_permission');
+    } catch (error) {
+      console.error('Failed to reset accessibility permission:', error);
+    } finally {
+      checkPermissions();
+    }
+  };
+
   const allGranted = permissions.microphone === 'granted' && permissions.accessibility === 'granted';
 
   if (dismissed || allGranted || checking) {
@@ -110,6 +120,22 @@ export function PermissionsBanner() {
                 </button>
               )}
             </div>
+
+            {/* Accessibility troubleshooting: reset a stale TCC entry */}
+            {permissions.accessibility !== 'granted' && (
+              <div className="ml-4 space-y-1">
+                <button
+                  onClick={handleResetAccessibility}
+                  className="text-xs text-amber-600/80 dark:text-amber-400/80 underline hover:no-underline"
+                >
+                  Still not working? Reset &amp; Open Settings
+                </button>
+                <p className="text-xs text-amber-600/70 dark:text-amber-400/70">
+                  Clears Murmur's stale Accessibility entry, then opens System Settings.
+                  You'll still need to turn Murmur back on manually.
+                </p>
+              </div>
+            )}
           </div>
 
           <button

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -91,3 +91,12 @@ export async function transcribeFile(filePath: string): Promise<DictationRespons
     };
   }
 }
+
+/**
+ * Reset this app's stale macOS Accessibility TCC entry, then reopen the
+ * Accessibility settings pane. Rejects if the reset fails (see Rust
+ * `reset_accessibility_permission`).
+ */
+export async function resetAccessibilityPermission(): Promise<void> {
+  return await invoke('reset_accessibility_permission');
+}


### PR DESCRIPTION
Closes #176

## What

Adds a troubleshooting action for the confusing macOS Accessibility state where System Settings lists the app under Privacy & Security > Accessibility, but the running build still reports access missing (common after rebuilding a dev Tauri bundle, e.g. `Local Dictation Dev`).

## Changes

- **`commands/permissions.rs`**: new `reset_accessibility_permission` command. Reads the *runtime* bundle id via `NSBundle.mainBundle.bundleIdentifier` (not the static `tauri.conf.json` value, which is stale for dev bundles), runs `tccutil reset Accessibility <bundle-id>`, then reopens the Accessibility pane via the existing `open_system_preference_pane` helper. macOS-only; errors surfaced to the UI.
- **`lib.rs`**: registers the new command.
- **`PermissionsBanner.tsx`**: secondary "Still not working? Reset & Open Settings" button shown only when Accessibility is missing, plus helper copy clarifying the entry is cleared and the user must re-enable Murmur manually. Refreshes permission status after invoking.
- **`CHANGELOG.md`**: entry under Unreleased > Added.

## Acceptance criteria

- Visible troubleshooting action when Accessibility is missing
- Opens the correct System Settings pane afterward
- Resets only Murmur's current bundle id (never all apps)
- UI copy does not imply one-click granting

## Verification

- `cd app/src-tauri && cargo check` — clean
- `cd app/src-tauri && cargo test -- --test-threads=1` — 64 passed
- `cd app && npx tsc --noEmit` — clean
- Native smoke test left to manual QA (running it live would `tccutil reset` the real machine's permission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS Accessibility troubleshooting: A new "Reset & Open Settings" button appears in the permissions banner when Accessibility is not granted, allowing users to reset stale permission entries and reopen System Settings to re-enable access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->