### PR TITLE
feat: optional save dictation transcript/audio to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - **Save dictation output to file**: optional "Save Transcript to File" (`.txt`) and "Save Audio to File" (`.wav`) toggles for live hotkey dictation, with a configurable output folder (defaults to `Documents/Murmur`). When either is enabled, text is still copied to the clipboard but auto-paste is paused (`file_output.rs`).
+- **History source badge**: each history entry now shows whether it came from live recording ("Mic") or a transcribed file ("File", with the source file name).
 
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Save dictation output to file**: optional "Save Transcript to File" (`.txt`) and "Save Audio to File" (`.wav`) toggles for live hotkey dictation, with a configurable output folder (defaults to `Documents/Murmur`). When either is enabled, text is still copied to the clipboard but auto-paste is paused (`file_output.rs`).
+
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
 

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -184,9 +184,8 @@ async fn run_transcription_pipeline(
     // Non-fatal: a write failure is logged and surfaced to the UI, but the text
     // is already on its way to the clipboard. Uses the original (pre-VAD) samples.
     if save_audio || save_transcript {
-        let timestamp = chrono::Local::now().format("%y%m%d-%H%M%S").to_string();
         if let Err(e) = crate::file_output::write_dictation_outputs(
-            samples, &text, save_audio, save_transcript, &output_dir, &timestamp,
+            samples, &text, save_audio, save_transcript, &output_dir,
         ) {
             tracing::warn!(target: "pipeline", "file output failed: {}", e);
             let _ = app_handle.emit(

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -79,10 +79,15 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation)
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone())
     };
+
+    // When saving to a file, suppress auto-paste into the focused app. The
+    // clipboard write inside `inject_text` is unconditional, so text remains
+    // copyable regardless of these toggles.
+    let effective_auto_paste = auto_paste && !(save_transcript || save_audio);
 
     // Pre-VAD signal level logging for mic diagnosis
     let rms = audio::compute_rms(samples);
@@ -175,6 +180,22 @@ async fn run_transcription_pipeline(
         return Ok((String::new(), PipelineTimings { vad_ms, inference_ms, paste_ms: 0, rss_before_mb, rss_after_mb }));
     }
 
+    // Phase: File output (optional) -- persist audio/transcript before injection.
+    // Non-fatal: a write failure is logged and surfaced to the UI, but the text
+    // is already on its way to the clipboard. Uses the original (pre-VAD) samples.
+    if save_audio || save_transcript {
+        let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        if let Err(e) = crate::file_output::write_dictation_outputs(
+            samples, &text, save_audio, save_transcript, &output_dir, &timestamp,
+        ) {
+            tracing::warn!(target: "pipeline", "file output failed: {}", e);
+            let _ = app_handle.emit(
+                "file-output-failed",
+                "Couldn't save dictation to file. Text is still in your clipboard.",
+            );
+        }
+    }
+
     // Phase: Text injection (clipboard write + optional osascript paste)
     let t_inject = std::time::Instant::now();
     if !text.is_empty() {
@@ -182,7 +203,7 @@ async fn run_transcription_pipeline(
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
         app_handle
             .run_on_main_thread(move || {
-                let _ = tx.send(injector::inject_text(&text_to_inject, auto_paste, paste_delay_ms));
+                let _ = tx.send(injector::inject_text(&text_to_inject, effective_auto_paste, paste_delay_ms));
             })
             .map_err(|e| format!("Failed to dispatch to main thread: {}", e))?;
         let paste_hint = if cfg!(target_os = "macos") {
@@ -370,6 +391,18 @@ pub async fn configure_dictation(
 
     if let Some(sp) = options.get("smartPunctuation").and_then(|v| v.as_bool()) {
         dictation.smart_punctuation = sp;
+    }
+
+    if let Some(save_transcript) = options.get("saveTranscript").and_then(|v| v.as_bool()) {
+        dictation.save_transcript = save_transcript;
+    }
+
+    if let Some(save_audio) = options.get("saveAudio").and_then(|v| v.as_bool()) {
+        dictation.save_audio = save_audio;
+    }
+
+    if let Some(output_dir) = options.get("outputDir").and_then(|v| v.as_str()) {
+        dictation.output_dir = output_dir.to_string();
     }
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -184,7 +184,7 @@ async fn run_transcription_pipeline(
     // Non-fatal: a write failure is logged and surfaced to the UI, but the text
     // is already on its way to the clipboard. Uses the original (pre-VAD) samples.
     if save_audio || save_transcript {
-        let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        let timestamp = chrono::Local::now().format("%y%m%d-%H%M%S").to_string();
         if let Err(e) = crate::file_output::write_dictation_outputs(
             samples, &text, save_audio, save_transcript, &output_dir, &timestamp,
         ) {

--- a/app/src-tauri/src/file_output.rs
+++ b/app/src-tauri/src/file_output.rs
@@ -3,8 +3,8 @@
 //! When the user enables "save transcript" and/or "save audio", a completed
 //! live dictation is written to a file in addition to the usual clipboard copy.
 //! Audio is written as 16-bit PCM WAV at the pipeline's 16kHz mono sample rate;
-//! the transcript is written as UTF-8 `.txt`. Both share a timestamped base name
-//! so a paired recording lines up (`murmur-2026-05-28_14-30-01.wav` + `.txt`).
+//! the transcript is written as UTF-8 `.txt`. Both share a short timestamped
+//! base name so a paired recording lines up (`murmur-260528-143001.wav` + `.txt`).
 //!
 //! Privacy: this module never logs the resolved directory or file path (which
 //! would carry the user's home dir/username), only counts and booleans.
@@ -28,7 +28,7 @@ fn resolve_output_dir(output_dir: &str) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
-/// Build a base name like `murmur-2026-05-28_14-30-01`, appending `-1`, `-2`, …
+/// Build a base name like `murmur-260528-143001`, appending `-1`, `-2`, …
 /// if a `.wav` or `.txt` with that base already exists in `dir`.
 fn unique_base_name(dir: &Path, timestamp: &str) -> String {
     let base = format!("murmur-{}", timestamp);

--- a/app/src-tauri/src/file_output.rs
+++ b/app/src-tauri/src/file_output.rs
@@ -1,0 +1,221 @@
+//! Persist dictation output to disk.
+//!
+//! When the user enables "save transcript" and/or "save audio", a completed
+//! live dictation is written to a file in addition to the usual clipboard copy.
+//! Audio is written as 16-bit PCM WAV at the pipeline's 16kHz mono sample rate;
+//! the transcript is written as UTF-8 `.txt`. Both share a timestamped base name
+//! so a paired recording lines up (`murmur-2026-05-28_14-30-01.wav` + `.txt`).
+//!
+//! Privacy: this module never logs the resolved directory or file path (which
+//! would carry the user's home dir/username), only counts and booleans.
+
+use crate::state::WHISPER_SAMPLE_RATE;
+use std::path::{Path, PathBuf};
+
+/// Resolve the output directory: the user-chosen `output_dir` if non-empty,
+/// otherwise `<Documents>/Murmur` (falling back to `<home>/Murmur`).
+fn resolve_output_dir(output_dir: &str) -> Result<PathBuf, String> {
+    let dir = if !output_dir.trim().is_empty() {
+        PathBuf::from(output_dir)
+    } else {
+        let base = dirs::document_dir()
+            .or_else(dirs::home_dir)
+            .ok_or_else(|| "Could not determine a default output directory".to_string())?;
+        base.join("Murmur")
+    };
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create output directory: {}", e))?;
+    Ok(dir)
+}
+
+/// Build a base name like `murmur-2026-05-28_14-30-01`, appending `-1`, `-2`, …
+/// if a `.wav` or `.txt` with that base already exists in `dir`.
+fn unique_base_name(dir: &Path, timestamp: &str) -> String {
+    let base = format!("murmur-{}", timestamp);
+    let taken = |name: &str| dir.join(format!("{}.wav", name)).exists()
+        || dir.join(format!("{}.txt", name)).exists();
+    if !taken(&base) {
+        return base;
+    }
+    let mut n = 1;
+    loop {
+        let candidate = format!("{}-{}", base, n);
+        if !taken(&candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Write a 16-bit PCM mono WAV at the pipeline sample rate from f32 samples.
+fn write_wav(path: &Path, samples: &[f32]) -> Result<(), String> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: WHISPER_SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)
+        .map_err(|e| format!("Failed to create WAV file: {}", e))?;
+    for &s in samples {
+        let clamped = s.clamp(-1.0, 1.0);
+        let value = (clamped * i16::MAX as f32) as i16;
+        writer
+            .write_sample(value)
+            .map_err(|e| format!("Failed to write WAV sample: {}", e))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize WAV file: {}", e))?;
+    Ok(())
+}
+
+/// Persist the requested dictation outputs. The transcript is only written when
+/// `save_transcript` is set and the text is non-empty; the audio is only written
+/// when `save_audio` is set. Returns the number of files written on success.
+pub fn write_dictation_outputs(
+    samples: &[f32],
+    text: &str,
+    save_audio: bool,
+    save_transcript: bool,
+    output_dir: &str,
+    timestamp: &str,
+) -> Result<usize, String> {
+    if !save_audio && !save_transcript {
+        return Ok(0);
+    }
+
+    let dir = resolve_output_dir(output_dir)?;
+    let base = unique_base_name(&dir, timestamp);
+    let mut written = 0;
+
+    if save_audio {
+        write_wav(&dir.join(format!("{}.wav", base)), samples)?;
+        written += 1;
+    }
+
+    if save_transcript && !text.trim().is_empty() {
+        std::fs::write(dir.join(format!("{}.txt", base)), text)
+            .map_err(|e| format!("Failed to write transcript file: {}", e))?;
+        written += 1;
+    }
+
+    tracing::info!(
+        target: "pipeline",
+        files_written = written,
+        save_audio = save_audio,
+        save_transcript = save_transcript,
+        "dictation output written to file"
+    );
+
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur_file_output_test_{}_{}",
+            std::process::id(),
+            tag
+        ));
+        // Start clean so collision/uniqueness assertions are deterministic.
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn writes_wav_and_txt() {
+        let dir = temp_dir("both");
+        let samples = vec![0.0f32, 0.5, -0.5, 1.0, -1.0];
+        let written = write_dictation_outputs(
+            &samples,
+            "hello world",
+            true,
+            true,
+            dir.to_str().unwrap(),
+            "2026-05-28_14-30-01",
+        )
+        .unwrap();
+        assert_eq!(written, 2);
+
+        let wav = dir.join("murmur-2026-05-28_14-30-01.wav");
+        let txt = dir.join("murmur-2026-05-28_14-30-01.txt");
+        assert!(wav.exists());
+        assert!(txt.exists());
+        assert_eq!(std::fs::read_to_string(&txt).unwrap(), "hello world");
+
+        let reader = hound::WavReader::open(&wav).unwrap();
+        assert_eq!(reader.spec().channels, 1);
+        assert_eq!(reader.spec().sample_rate, WHISPER_SAMPLE_RATE);
+        assert_eq!(reader.len() as usize, samples.len());
+    }
+
+    #[test]
+    fn empty_text_skips_transcript() {
+        let dir = temp_dir("empty_text");
+        let written = write_dictation_outputs(
+            &[0.1f32, 0.2],
+            "   ",
+            true,
+            true,
+            dir.to_str().unwrap(),
+            "2026-05-28_14-30-02",
+        )
+        .unwrap();
+        assert_eq!(written, 1);
+        assert!(dir.join("murmur-2026-05-28_14-30-02.wav").exists());
+        assert!(!dir.join("murmur-2026-05-28_14-30-02.txt").exists());
+    }
+
+    #[test]
+    fn transcript_only_skips_audio() {
+        let dir = temp_dir("txt_only");
+        let written = write_dictation_outputs(
+            &[0.1f32],
+            "text only",
+            false,
+            true,
+            dir.to_str().unwrap(),
+            "2026-05-28_14-30-03",
+        )
+        .unwrap();
+        assert_eq!(written, 1);
+        assert!(!dir.join("murmur-2026-05-28_14-30-03.wav").exists());
+        assert!(dir.join("murmur-2026-05-28_14-30-03.txt").exists());
+    }
+
+    #[test]
+    fn neither_toggle_writes_nothing() {
+        let dir = temp_dir("none");
+        let written = write_dictation_outputs(
+            &[0.1f32],
+            "ignored",
+            false,
+            false,
+            dir.to_str().unwrap(),
+            "2026-05-28_14-30-04",
+        )
+        .unwrap();
+        assert_eq!(written, 0);
+    }
+
+    #[test]
+    fn collision_appends_suffix() {
+        let dir = temp_dir("collision");
+        let ts = "2026-05-28_14-30-05";
+        let samples = vec![0.0f32];
+        write_dictation_outputs(&samples, "first", true, true, dir.to_str().unwrap(), ts).unwrap();
+        write_dictation_outputs(&samples, "second", true, true, dir.to_str().unwrap(), ts).unwrap();
+
+        assert!(dir.join(format!("murmur-{}.txt", ts)).exists());
+        assert!(dir.join(format!("murmur-{}-1.txt", ts)).exists());
+        assert_eq!(
+            std::fs::read_to_string(dir.join(format!("murmur-{}-1.txt", ts))).unwrap(),
+            "second"
+        );
+    }
+}

--- a/app/src-tauri/src/file_output.rs
+++ b/app/src-tauri/src/file_output.rs
@@ -3,8 +3,8 @@
 //! When the user enables "save transcript" and/or "save audio", a completed
 //! live dictation is written to a file in addition to the usual clipboard copy.
 //! Audio is written as 16-bit PCM WAV at the pipeline's 16kHz mono sample rate;
-//! the transcript is written as UTF-8 `.txt`. Both share a short timestamped
-//! base name so a paired recording lines up (`murmur-260528-143001.wav` + `.txt`).
+//! the transcript is written as UTF-8 `.txt`. Both share a short sequential
+//! base name so a paired recording lines up (`murmur-0001.wav` + `.txt`).
 //!
 //! Privacy: this module never logs the resolved directory or file path (which
 //! would carry the user's home dir/username), only counts and booleans.
@@ -28,18 +28,36 @@ fn resolve_output_dir(output_dir: &str) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
-/// Build a base name like `murmur-260528-143001`, appending `-1`, `-2`, …
-/// if a `.wav` or `.txt` with that base already exists in `dir`.
-fn unique_base_name(dir: &Path, timestamp: &str) -> String {
-    let base = format!("murmur-{}", timestamp);
+/// Parse the sequence number from a `murmur-NNNN` file stem. Returns `None`
+/// for anything that isn't exactly `murmur-<digits>` (e.g. older timestamped
+/// names, which carry extra `-` separators).
+fn sequence_of(stem: &str) -> Option<u32> {
+    let digits = stem.strip_prefix("murmur-")?;
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Build the next sequential base name (`murmur-0001`, `murmur-0002`, …) by
+/// scanning `dir` for the highest existing `murmur-NNNN` and adding one. The
+/// returned base is guaranteed free for both `.wav` and `.txt`.
+fn next_base_name(dir: &Path) -> String {
+    let mut highest = 0u32;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if let Some(stem) = Path::new(&entry.file_name()).file_stem().and_then(|s| s.to_str()) {
+                if let Some(n) = sequence_of(stem) {
+                    highest = highest.max(n);
+                }
+            }
+        }
+    }
     let taken = |name: &str| dir.join(format!("{}.wav", name)).exists()
         || dir.join(format!("{}.txt", name)).exists();
-    if !taken(&base) {
-        return base;
-    }
-    let mut n = 1;
+    let mut n = highest + 1;
     loop {
-        let candidate = format!("{}-{}", base, n);
+        let candidate = format!("murmur-{:04}", n);
         if !taken(&candidate) {
             return candidate;
         }
@@ -79,14 +97,13 @@ pub fn write_dictation_outputs(
     save_audio: bool,
     save_transcript: bool,
     output_dir: &str,
-    timestamp: &str,
 ) -> Result<usize, String> {
     if !save_audio && !save_transcript {
         return Ok(0);
     }
 
     let dir = resolve_output_dir(output_dir)?;
-    let base = unique_base_name(&dir, timestamp);
+    let base = next_base_name(&dir);
     let mut written = 0;
 
     if save_audio {
@@ -137,13 +154,12 @@ mod tests {
             true,
             true,
             dir.to_str().unwrap(),
-            "2026-05-28_14-30-01",
         )
         .unwrap();
         assert_eq!(written, 2);
 
-        let wav = dir.join("murmur-2026-05-28_14-30-01.wav");
-        let txt = dir.join("murmur-2026-05-28_14-30-01.txt");
+        let wav = dir.join("murmur-0001.wav");
+        let txt = dir.join("murmur-0001.txt");
         assert!(wav.exists());
         assert!(txt.exists());
         assert_eq!(std::fs::read_to_string(&txt).unwrap(), "hello world");
@@ -163,12 +179,11 @@ mod tests {
             true,
             true,
             dir.to_str().unwrap(),
-            "2026-05-28_14-30-02",
         )
         .unwrap();
         assert_eq!(written, 1);
-        assert!(dir.join("murmur-2026-05-28_14-30-02.wav").exists());
-        assert!(!dir.join("murmur-2026-05-28_14-30-02.txt").exists());
+        assert!(dir.join("murmur-0001.wav").exists());
+        assert!(!dir.join("murmur-0001.txt").exists());
     }
 
     #[test]
@@ -180,12 +195,11 @@ mod tests {
             false,
             true,
             dir.to_str().unwrap(),
-            "2026-05-28_14-30-03",
         )
         .unwrap();
         assert_eq!(written, 1);
-        assert!(!dir.join("murmur-2026-05-28_14-30-03.wav").exists());
-        assert!(dir.join("murmur-2026-05-28_14-30-03.txt").exists());
+        assert!(!dir.join("murmur-0001.wav").exists());
+        assert!(dir.join("murmur-0001.txt").exists());
     }
 
     #[test]
@@ -197,25 +211,42 @@ mod tests {
             false,
             false,
             dir.to_str().unwrap(),
-            "2026-05-28_14-30-04",
         )
         .unwrap();
         assert_eq!(written, 0);
     }
 
     #[test]
-    fn collision_appends_suffix() {
-        let dir = temp_dir("collision");
-        let ts = "2026-05-28_14-30-05";
+    fn sequence_increments_per_recording() {
+        let dir = temp_dir("sequence");
         let samples = vec![0.0f32];
-        write_dictation_outputs(&samples, "first", true, true, dir.to_str().unwrap(), ts).unwrap();
-        write_dictation_outputs(&samples, "second", true, true, dir.to_str().unwrap(), ts).unwrap();
+        write_dictation_outputs(&samples, "first", true, true, dir.to_str().unwrap()).unwrap();
+        write_dictation_outputs(&samples, "second", true, true, dir.to_str().unwrap()).unwrap();
 
-        assert!(dir.join(format!("murmur-{}.txt", ts)).exists());
-        assert!(dir.join(format!("murmur-{}-1.txt", ts)).exists());
+        assert!(dir.join("murmur-0001.txt").exists());
+        assert!(dir.join("murmur-0002.txt").exists());
         assert_eq!(
-            std::fs::read_to_string(dir.join(format!("murmur-{}-1.txt", ts))).unwrap(),
+            std::fs::read_to_string(dir.join("murmur-0002.txt")).unwrap(),
             "second"
         );
+    }
+
+    #[test]
+    fn ignores_non_sequential_names_when_numbering() {
+        let dir = temp_dir("mixed_names");
+        // An older timestamped name should not inflate the next sequence number.
+        std::fs::write(dir.join("murmur-260528-210426.wav"), b"x").unwrap();
+        write_dictation_outputs(&[0.0f32], "fresh", true, true, dir.to_str().unwrap()).unwrap();
+        assert!(dir.join("murmur-0001.wav").exists());
+        assert!(dir.join("murmur-0001.txt").exists());
+    }
+
+    #[test]
+    fn sequence_of_parses_only_pure_digits() {
+        assert_eq!(sequence_of("murmur-0007"), Some(7));
+        assert_eq!(sequence_of("murmur-42"), Some(42));
+        assert_eq!(sequence_of("murmur-260528-210426"), None);
+        assert_eq!(sequence_of("murmur-"), None);
+        assert_eq!(sequence_of("other-0001"), None);
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod alloc;
 mod audio;
 mod audio_decode;
 mod commands;
+mod file_output;
 mod injector;
 mod keyboard;
 mod resource_monitor;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -30,6 +30,9 @@ pub struct DictationState {
     pub vad_sensitivity: u32,
     pub custom_vocabulary: String,
     pub smart_punctuation: bool,
+    pub save_transcript: bool,
+    pub save_audio: bool,
+    pub output_dir: String,
 }
 
 impl Default for DictationState {
@@ -43,6 +46,9 @@ impl Default for DictationState {
             vad_sensitivity: 50,
             custom_vocabulary: String::new(),
             smart_punctuation: true,
+            save_transcript: false,
+            save_audio: false,
+            output_dir: String::new(),
         }
     }
 }

--- a/app/src/components/FileTranscriptionPanel.tsx
+++ b/app/src/components/FileTranscriptionPanel.tsx
@@ -5,7 +5,7 @@ import { flog } from '../lib/log';
 
 interface FileTranscriptionPanelProps {
   /** Persist completed transcriptions to shared history. */
-  addEntry: (text: string, duration: number) => void;
+  addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string) => void;
 }
 
 export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps) {

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -75,11 +75,31 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
             }`}
           >
             {/* Header row with timestamp and duration */}
-            <div className="flex items-center justify-between mb-1">
-              <span className="text-xs text-stone-500 dark:text-stone-400">
-                {formatTimestamp(entry.timestamp)}
-              </span>
-              <div className="flex items-center gap-2">
+            <div className="flex items-center justify-between mb-1 gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs text-stone-500 dark:text-stone-400 shrink-0">
+                  {formatTimestamp(entry.timestamp)}
+                </span>
+                {(entry.source ?? 'recording') === 'file' ? (
+                  <span
+                    title={entry.sourceName}
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 min-w-0 max-w-[150px]"
+                  >
+                    <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                    </svg>
+                    <span className="truncate">{entry.sourceName || 'File'}</span>
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-stone-200 text-stone-600 dark:bg-stone-600 dark:text-stone-300 shrink-0">
+                    <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-14 0m7 7v3m-4 0h8m-4-6a3 3 0 01-3-3V5a3 3 0 016 0v4a3 3 0 01-3 3z" />
+                    </svg>
+                    Mic
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
                 <span className="text-xs text-stone-400 dark:text-stone-500">
                   {formatDuration(entry.duration)}
                 </span>

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -83,12 +83,12 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
                 {(entry.source ?? 'recording') === 'file' ? (
                   <span
                     title={entry.sourceName}
-                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 min-w-0 max-w-[150px]"
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 shrink-0"
                   >
                     <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
                     </svg>
-                    <span className="truncate">{entry.sourceName || 'File'}</span>
+                    File
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-stone-200 text-stone-600 dark:bg-stone-600 dark:text-stone-300 shrink-0">

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -83,12 +83,12 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
                 {(entry.source ?? 'recording') === 'file' ? (
                   <span
                     title={entry.sourceName}
-                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 shrink-0"
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 min-w-0 max-w-[180px]"
                   >
                     <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
                     </svg>
-                    File
+                    <span className="truncate">{entry.sourceName || 'File'}</span>
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-stone-200 text-stone-600 dark:bg-stone-600 dark:text-stone-300 shrink-0">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { open } from '@tauri-apps/plugin-dialog';
 import { getVersion } from '@tauri-apps/api/app';
 import {
   Settings, RecordingMode, DEFAULT_SETTINGS,
@@ -160,6 +161,19 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
   };
 
   const handleRequestPermission = () => invoke('request_accessibility_permission');
+
+  const handleChooseFolder = async () => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (typeof selected === 'string') {
+        onUpdateSettings({ outputDir: selected });
+      }
+    } catch {
+      // Dialog cancelled or unavailable — keep the current folder.
+    }
+  };
+
+  const saveToFile = settings.saveTranscript || settings.saveAudio;
 
   // Model availability check and inline download
   const [modelAvailable, setModelAvailable] = useState<boolean | null>(null);
@@ -578,6 +592,94 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               value={settings.autoPasteDelayMs}
               onCommit={(value) => onUpdateSettings({ autoPasteDelayMs: value })}
             />
+          )}
+        </div>
+
+        {/* Save Transcript to File Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              Save Transcript to File
+            </label>
+            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              Write each transcription to a .txt file
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.saveTranscript}
+            aria-label="Save transcript to file"
+            onClick={() => onUpdateSettings({ saveTranscript: !settings.saveTranscript })}
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+              settings.saveTranscript ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                settings.saveTranscript ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* Save Audio to File Toggle */}
+        <div>
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+                Save Audio to File
+              </label>
+              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                Write each recording to a .wav file
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.saveAudio}
+              aria-label="Save audio to file"
+              onClick={() => onUpdateSettings({ saveAudio: !settings.saveAudio })}
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                settings.saveAudio ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  settings.saveAudio ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+
+          {saveToFile && (
+            <div className="mt-3">
+              <label className="block text-xs text-stone-600 dark:text-stone-400 mb-1">
+                Output Folder
+              </label>
+              <div className="px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/50 text-stone-700 dark:text-stone-300 break-all">
+                {settings.outputDir || 'Documents/Murmur (default)'}
+              </div>
+              <div className="mt-2 flex items-center gap-3">
+                <button
+                  onClick={handleChooseFolder}
+                  className="text-xs font-medium text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-200 underline hover:no-underline transition-colors"
+                >
+                  Choose Folder
+                </button>
+                {settings.outputDir && (
+                  <button
+                    onClick={() => onUpdateSettings({ outputDir: '' })}
+                    className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-500 dark:hover:text-stone-300 underline hover:no-underline transition-colors"
+                  >
+                    Reset to default
+                  </button>
+                )}
+              </div>
+              <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+                Text is still copied to the clipboard, but auto-paste is paused while saving to file.
+              </p>
+            </div>
           )}
         </div>
 

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -67,6 +67,9 @@ export interface ConfigureOptions {
   idleTimeoutMinutes?: number;
   customVocabulary?: string;
   smartPunctuation?: boolean;
+  saveTranscript?: boolean;
+  saveAudio?: boolean;
+  outputDir?: string;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {

--- a/app/src/lib/history.ts
+++ b/app/src/lib/history.ts
@@ -1,8 +1,16 @@
+/** Where a history entry's text came from. */
+export type HistorySource = 'recording' | 'file';
+
 export interface HistoryEntry {
   id: string;
   text: string;
   timestamp: number;
   duration: number; // recording duration in seconds
+  /** Origin of the entry. Absent on entries saved before this field existed
+   *  (treated as 'recording' when displayed). */
+  source?: HistorySource;
+  /** For file transcriptions, the source file's base name (for display). */
+  sourceName?: string;
 }
 
 const STORAGE_KEY = 'dictation-history';
@@ -30,12 +38,20 @@ export function saveHistory(entries: HistoryEntry[]): void {
   }
 }
 
-export function addHistoryEntry(entries: HistoryEntry[], text: string, duration: number): HistoryEntry[] {
+export function addHistoryEntry(
+  entries: HistoryEntry[],
+  text: string,
+  duration: number,
+  source: HistorySource = 'recording',
+  sourceName?: string,
+): HistoryEntry[] {
   const newEntry: HistoryEntry = {
     id: Date.now().toString(),
     text,
     timestamp: Date.now(),
     duration,
+    source,
+    ...(sourceName ? { sourceName } : {}),
   };
   return [...entries, newEntry].slice(-MAX_ENTRIES);
 }

--- a/app/src/lib/hooks/useFileTranscription.ts
+++ b/app/src/lib/hooks/useFileTranscription.ts
@@ -19,7 +19,7 @@ function baseName(path: string): string {
 
 interface UseFileTranscriptionProps {
   /** Persist completed transcriptions to shared history (no WPM stats). */
-  addEntry: (text: string, duration: number) => void;
+  addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string) => void;
 }
 
 /**
@@ -45,7 +45,8 @@ export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
       setStatus('error');
       return;
     }
-    setFileName(baseName(path));
+    const name = baseName(path);
+    setFileName(name);
     setResult('');
     setError('');
     setStatus('processing');
@@ -63,7 +64,7 @@ export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
     setResult(text);
     setStatus('complete');
     if (text.trim()) {
-      addEntry(text, res.duration ?? 0);
+      addEntry(text, res.duration ?? 0, 'file', name);
     }
     flog.info('file-transcribe', 'complete', { textLen: text.length });
   }, [addEntry]);

--- a/app/src/lib/hooks/useHistoryManagement.ts
+++ b/app/src/lib/hooks/useHistoryManagement.ts
@@ -1,12 +1,12 @@
 import { useState, useCallback } from 'react';
-import { HistoryEntry, loadHistory, saveHistory, addHistoryEntry, clearHistory as clearPersistedHistory } from '../history';
+import { HistoryEntry, HistorySource, loadHistory, saveHistory, addHistoryEntry, clearHistory as clearPersistedHistory } from '../history';
 
 export function useHistoryManagement() {
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>(() => loadHistory());
 
-  const addEntry = useCallback((text: string, duration: number) => {
+  const addEntry = useCallback((text: string, duration: number, source: HistorySource = 'recording', sourceName?: string) => {
     setHistoryEntries(prev => {
-      const newHistory = addHistoryEntry(prev, text, duration);
+      const newHistory = addHistoryEntry(prev, text, duration, source, sourceName);
       saveHistory(newHistory);
       return newHistory;
     });

--- a/app/src/lib/hooks/useInitialization.ts
+++ b/app/src/lib/hooks/useInitialization.ts
@@ -21,6 +21,9 @@ export function useInitialization(settings: Settings) {
           idleTimeoutMinutes: settings.idleTimeoutMinutes,
           customVocabulary: settings.customVocabulary,
           smartPunctuation: settings.smartPunctuation,
+          saveTranscript: settings.saveTranscript,
+          saveAudio: settings.saveAudio,
+          outputDir: settings.outputDir,
         });
       })
       .then(() => {

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -110,6 +110,21 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
     };
   }, []);
 
+  // Listen for file-output (save transcript/audio) failures and surface a hint.
+  // Reuses the same auto-clearing error banner as auto-paste failures.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<string>('file-output-failed', (event) => {
+      setError(event.payload);
+      if (pasteErrorTimerRef.current) clearTimeout(pasteErrorTimerRef.current);
+      pasteErrorTimerRef.current = setTimeout(() => setError(''), 5000);
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
   // Sync transcription results from Rust — picks up text when recording was
   // initiated from the overlay (where handleStop doesn't run in this window).
   // Skip if isStoppingRef is true — handleStop is active and will handle it.

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -7,7 +7,7 @@ import { updateStats } from '../stats';
 import { flog } from '../log';
 
 interface UseRecordingStateProps {
-  addEntry: (text: string, duration: number) => void;
+  addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string) => void;
   microphone: string;
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -54,9 +54,9 @@ export function useSettings() {
       });
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates) {
       const version = ++configureVersionRef.current;
-      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity, idleTimeoutMinutes: newSettings.idleTimeoutMinutes, customVocabulary: newSettings.customVocabulary, smartPunctuation: newSettings.smartPunctuation })
+      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity, idleTimeoutMinutes: newSettings.idleTimeoutMinutes, customVocabulary: newSettings.customVocabulary, smartPunctuation: newSettings.smartPunctuation, saveTranscript: newSettings.saveTranscript, saveAudio: newSettings.saveAudio, outputDir: newSettings.outputDir })
         .catch((err) => {
           console.error('Failed to configure:', err);
           if (configureVersionRef.current === version) {
@@ -70,6 +70,9 @@ export function useSettings() {
               idleTimeoutMinutes: previousSettings.idleTimeoutMinutes,
               customVocabulary: previousSettings.customVocabulary,
               smartPunctuation: previousSettings.smartPunctuation,
+              saveTranscript: previousSettings.saveTranscript,
+              saveAudio: previousSettings.saveAudio,
+              outputDir: previousSettings.outputDir,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -16,6 +16,9 @@ export interface Settings {
   customVocabulary: string;
   disabled: boolean;
   smartPunctuation: boolean;
+  saveTranscript: boolean;
+  saveAudio: boolean;
+  outputDir: string;
 }
 
 export type ModelOption =
@@ -80,6 +83,9 @@ export const DEFAULT_SETTINGS: Settings = {
   customVocabulary: '',
   disabled: false,
   smartPunctuation: true,
+  saveTranscript: false,
+  saveAudio: false,
+  outputDir: '',
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -109,6 +115,12 @@ export function loadSettings(): Settings {
       const validLanguages = new Set<string>(LANGUAGE_OPTIONS.map((o) => o.value));
       if (typeof parsed.language !== 'string' || !validLanguages.has(parsed.language)) {
         parsed.language = DEFAULT_SETTINGS.language;
+      }
+
+      // outputDir feeds a filesystem path on the Rust side — coerce anything
+      // non-string back to the default (empty = app-chosen Documents/Murmur).
+      if (typeof parsed.outputDir !== 'string') {
+        parsed.outputDir = DEFAULT_SETTINGS.outputDir;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -101,7 +101,7 @@ Both are sent to the Rust backend via `configure_dictation` command.
 
 Live hotkey dictation can optionally persist its output to disk via two independent toggles in the Output settings section:
 
-- `saveTranscript: boolean` — write each transcription to a timestamped `.txt`.
+- `saveTranscript: boolean` — write each transcription to a sequentially numbered `.txt`.
 - `saveAudio: boolean` — write each recording to a matching `.wav` (16kHz mono, 16-bit PCM).
 - `outputDir: string` — destination folder; empty means the default `Documents/Murmur` (created on first write).
 

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -96,3 +96,17 @@ The settings panel shows accessibility permission status when auto-paste is enab
 - `autoPasteDelayMs: number` — delay in ms before simulating Cmd+V (default 50, range 10–500). Persisted to localStorage.
 
 Both are sent to the Rust backend via `configure_dictation` command.
+
+## Save to File
+
+Live hotkey dictation can optionally persist its output to disk via two independent toggles in the Output settings section:
+
+- `saveTranscript: boolean` — write each transcription to a timestamped `.txt`.
+- `saveAudio: boolean` — write each recording to a matching `.wav` (16kHz mono, 16-bit PCM).
+- `outputDir: string` — destination folder; empty means the default `Documents/Murmur` (created on first write).
+
+Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A timestamped base name (`murmur-YYYY-MM-DD_HH-MM-SS`) is shared by the pair, with a numeric suffix appended on collision.
+
+**Interaction with auto-paste:** when either toggle is on, the recording is treated as a "capture to file" action — the clipboard write still happens (clipboard-first is unconditional), but auto-paste is suppressed (`effective_auto_paste = auto_paste && !(save_transcript || save_audio)`). With both toggles off, behavior is unchanged. Write failures are non-fatal: they are logged and surfaced to the UI via the `file-output-failed` event (text remains in the clipboard).
+
+**Known limitation:** recordings the VAD classifies as no-speech return early before the write step, so they save neither file.

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -105,7 +105,7 @@ Live hotkey dictation can optionally persist its output to disk via two independ
 - `saveAudio: boolean` — write each recording to a matching `.wav` (16kHz mono, 16-bit PCM).
 - `outputDir: string` — destination folder; empty means the default `Documents/Murmur` (created on first write).
 
-Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A short timestamped base name (`murmur-YYMMDD-HHMMSS`, e.g. `murmur-260528-143001`) is shared by the pair, with a numeric suffix appended on collision.
+Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A short sequential base name (`murmur-0001`, `murmur-0002`, …) is shared by the pair. The next number is the highest existing `murmur-NNNN` in the folder plus one (older timestamped names are ignored when numbering).
 
 **Interaction with auto-paste:** when either toggle is on, the recording is treated as a "capture to file" action — the clipboard write still happens (clipboard-first is unconditional), but auto-paste is suppressed (`effective_auto_paste = auto_paste && !(save_transcript || save_audio)`). With both toggles off, behavior is unchanged. Write failures are non-fatal: they are logged and surfaced to the UI via the `file-output-failed` event (text remains in the clipboard).
 

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -105,7 +105,7 @@ Live hotkey dictation can optionally persist its output to disk via two independ
 - `saveAudio: boolean` — write each recording to a matching `.wav` (16kHz mono, 16-bit PCM).
 - `outputDir: string` — destination folder; empty means the default `Documents/Murmur` (created on first write).
 
-Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A timestamped base name (`murmur-YYYY-MM-DD_HH-MM-SS`) is shared by the pair, with a numeric suffix appended on collision.
+Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A short timestamped base name (`murmur-YYMMDD-HHMMSS`, e.g. `murmur-260528-143001`) is shared by the pair, with a numeric suffix appended on collision.
 
 **Interaction with auto-paste:** when either toggle is on, the recording is treated as a "capture to file" action — the clipboard write still happens (clipboard-first is unconditional), but auto-paste is suppressed (`effective_auto_paste = auto_paste && !(save_transcript || save_audio)`). With both toggles off, behavior is unchanged. Write failures are non-fatal: they are logged and surfaced to the UI via the `file-output-failed` event (text remains in the clipboard).
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -75,7 +75,7 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 |---------|------|---------|-------------------|-------------|
 | `autoPaste` | `boolean` | `false` | `true` / `false` | Whether to automatically paste transcribed text after copying it to the clipboard. Requires macOS Accessibility permission. Text is always copied to the clipboard regardless of this setting. |
 | `autoPasteDelayMs` | `number` | `50` | 10-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. The backend clamps this value to the 10-500 range. The UI slider only appears when `autoPaste` is enabled. |
-| `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a timestamped `.txt` in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
+| `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a sequentially numbered `.txt` (`murmur-0001`, `murmur-0002`, …) in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |
 | `outputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved transcript/audio files. Empty means the app default (`Documents/Murmur`, created on first write). Set via a folder picker (`dialog:allow-open`). |
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -75,6 +75,9 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 |---------|------|---------|-------------------|-------------|
 | `autoPaste` | `boolean` | `false` | `true` / `false` | Whether to automatically paste transcribed text after copying it to the clipboard. Requires macOS Accessibility permission. Text is always copied to the clipboard regardless of this setting. |
 | `autoPasteDelayMs` | `number` | `50` | 10-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. The backend clamps this value to the 10-500 range. The UI slider only appears when `autoPaste` is enabled. |
+| `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a timestamped `.txt` in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
+| `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |
+| `outputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved transcript/audio files. Empty means the app default (`Documents/Murmur`, created on first write). Set via a folder picker (`dialog:allow-open`). |
 
 ---
 
@@ -116,6 +119,9 @@ When settings change, `useSettings.updateSettings` pushes the following fields t
 | `autoPaste` | `autoPaste` | Yes |
 | `autoPasteDelayMs` | `autoPasteDelayMs` | Yes |
 | `vadSensitivity` | `vadSensitivity` | Yes |
+| `saveTranscript` | `saveTranscript` | Yes |
+| `saveAudio` | `saveAudio` | Yes |
+| `outputDir` | `outputDir` | Yes |
 | `doubleTapKey` | _(sent via `update_keyboard_key`)_ | Via keyboard hooks |
 | `recordingMode` | _(controls which hook is active)_ | Frontend only |
 | `microphone` | _(sent as param to `start_native_recording`)_ | Per recording |


### PR DESCRIPTION
Closes #179

## Summary

Adds an option to persist live hotkey dictation output to disk, alongside the usual clipboard-first flow. Implemented as **two independent Output-settings toggles** (either / both / neither):

- **Save Transcript to File** → timestamped `.txt`
- **Save Audio to File** → matching `.wav` (16kHz mono, 16-bit PCM)

When **either** toggle is on, the recording becomes a "capture to file" action: text is **still copied to the clipboard** (clipboard-first stays unconditional) but **auto-paste is suppressed**. With **neither** on, behavior is unchanged. Output goes to a configurable folder (default `Documents/Murmur`) chosen via a folder picker; "Reset to default" clears it.

## How it works

- New `file_output.rs`: resolves the target dir (`outputDir` or `Documents/Murmur`), builds a timestamped base name (`murmur-YYYY-MM-DD_HH-MM-SS`) with numeric collision suffixes, writes WAV via `hound` and TXT via `std::fs`. Privacy: logs only counts/booleans, never the path.
- Wired into `run_transcription_pipeline` **after** the cancellation checkpoints and **before** injection. `effective_auto_paste = auto_paste && !(save_transcript || save_audio)`. The WAV uses the original (pre-VAD) samples; the `.txt` is skipped for empty transcripts.
- Write failures are **non-fatal** but **surfaced** to the UI via the new `file-output-failed` event (mirrors `auto-paste-failed`) — not silent.
- Settings plumbed through `settings.ts` → `dictation.ts` → `useSettings`/`useInitialization` → `configure_dictation` → `DictationState`.

## Known limitation

VAD no-speech recordings return early before the write step, so they save neither file (documented in `text-injection.md`).

## Verification

- `cargo check` — clean, no warnings
- `cargo test -- --test-threads=1` — 88 + integration pass, incl. 5 new `file_output` tests (WAV+TXT, empty-text skip, txt-only, neither, collision)
- `npx tsc --noEmit` — clean
- `npm test` (vitest) — 31 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional toggles to save live dictation transcripts as text files and audio recordings.
  * Added configurable output folder for saved files with folder picker UI.
  * Added source badges to history entries indicating whether each came from live microphone or file transcription.

* **UI Improvements**
  * New settings section for managing file output options and selecting output destination.

* **Behavior Changes**
  * Auto-paste is now disabled when file saving is enabled, while clipboard copying remains active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->