### PR TITLE
feat: multi-file queue for Transcribe File

### DIFF
--- a/app/src/components/FileTranscriptionPanel.tsx
+++ b/app/src/components/FileTranscriptionPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
-import { useFileTranscription } from '../lib/hooks/useFileTranscription';
+import { useFileTranscription, type FileQueueItem } from '../lib/hooks/useFileTranscription';
 import { flog } from '../lib/log';
 
 interface FileTranscriptionPanelProps {
@@ -8,34 +8,114 @@ interface FileTranscriptionPanelProps {
   addEntry: (text: string, duration: number) => void;
 }
 
-export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps) {
-  const { status, result, error, fileName, isDragging, transcribe } = useFileTranscription({ addEntry });
-  const [copied, setCopied] = useState(false);
+function formatCopyAll(items: FileQueueItem[]): string {
+  return items
+    .filter((i) => i.status === 'complete')
+    .map((i) => {
+      const text = i.result?.trim() || 'No speech detected in this file.';
+      return `${i.name}\n\n${text}`;
+    })
+    .join('\n\n');
+}
 
-  const processing = status === 'processing';
+function StatusIcon({ status }: { status: FileQueueItem['status'] }) {
+  if (status === 'processing') {
+    return (
+      <svg className="w-4 h-4 animate-spin shrink-0 text-stone-500" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    );
+  }
+  if (status === 'complete') {
+    return (
+      <svg className="w-4 h-4 shrink-0 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <svg className="w-4 h-4 shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    );
+  }
+  return (
+    <span className="w-4 h-4 shrink-0 rounded-full border-2 border-stone-300 dark:border-stone-600" />
+  );
+}
+
+function statusLabel(status: FileQueueItem['status']): string {
+  switch (status) {
+    case 'pending':
+      return 'Queued';
+    case 'processing':
+      return 'Transcribing…';
+    case 'complete':
+      return 'Done';
+    case 'error':
+      return 'Failed';
+  }
+}
+
+export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps) {
+  const { items, batchWarning, isDragging, isProcessing, enqueuePaths, reset } =
+    useFileTranscription({ addEntry });
+  const [copiedIds, setCopiedIds] = useState<Set<string>>(new Set());
+  const [copyAllDone, setCopyAllDone] = useState(false);
+
+  const completeItems = items.filter((i) => i.status === 'complete');
+  const hasQueue = items.length > 0;
 
   const handlePick = async () => {
     try {
       const selected = await open({
-        multiple: false,
+        multiple: true,
         filters: [{ name: 'Audio', extensions: ['wav', 'mp3', 'm4a'] }],
       });
-      if (typeof selected === 'string') {
-        void transcribe(selected);
-      }
+      if (selected === null) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      enqueuePaths(paths);
     } catch (e) {
       flog.warn('file-transcribe', 'file dialog failed', { error: String(e) });
     }
   };
 
-  const handleCopy = async () => {
+  const handleCopyItem = async (item: FileQueueItem) => {
+    const text = item.result?.trim() || '';
+    if (!text) return;
     try {
-      await navigator.clipboard.writeText(result);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      await navigator.clipboard.writeText(text);
+      setCopiedIds((prev) => new Set(prev).add(item.id));
+      setTimeout(() => {
+        setCopiedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(item.id);
+          return next;
+        });
+      }, 2000);
     } catch (e) {
       console.error('Failed to copy:', e);
     }
+  };
+
+  const handleCopyAll = async () => {
+    const text = formatCopyAll(items);
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyAllDone(true);
+      setTimeout(() => setCopyAllDone(false), 2000);
+    } catch (e) {
+      console.error('Failed to copy:', e);
+    }
+  };
+
+  const handleReset = () => {
+    reset();
+    setCopiedIds(new Set());
+    setCopyAllDone(false);
   };
 
   return (
@@ -52,55 +132,94 @@ export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
         </svg>
         <div className="text-sm text-stone-600 dark:text-stone-400">
-          Drag an audio file here, or
+          Drag audio files here, or
         </div>
         <button
           onClick={handlePick}
-          disabled={processing}
-          className="px-4 py-2 text-sm font-medium rounded-lg bg-stone-800 text-white hover:bg-stone-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-stone-200 dark:text-stone-900 dark:hover:bg-stone-100 transition-colors"
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-stone-800 text-white hover:bg-stone-700 dark:bg-stone-200 dark:text-stone-900 dark:hover:bg-stone-100 transition-colors"
         >
-          Choose File
+          Choose Files
         </button>
         <div className="text-xs text-stone-400 dark:text-stone-500">WAV, MP3, or M4A</div>
       </div>
 
-      {/* Processing indicator */}
-      {processing && (
-        <div className="shrink-0 flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
-          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
-          <span className="truncate">Transcribing {fileName}…</span>
+      {batchWarning && (
+        <div className="shrink-0 px-4 py-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+          <p className="text-amber-800 dark:text-amber-300 text-sm">{batchWarning}</p>
         </div>
       )}
 
-      {/* Error */}
-      {error && (
-        <div className="shrink-0 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-red-600 dark:text-red-400 text-sm">{error}</p>
-        </div>
-      )}
-
-      {/* Result */}
-      {status === 'complete' && (
-        <div className="flex-1 flex flex-col overflow-hidden rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800">
-          <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b border-stone-200 dark:border-stone-700">
-            <span className="text-xs font-medium text-stone-500 dark:text-stone-400 truncate">{fileName}</span>
-            <button
-              onClick={handleCopy}
-              disabled={!result}
-              className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 disabled:opacity-50 transition-colors"
-            >
-              {copied ? (
-                <span className="text-emerald-600 dark:text-emerald-400">Copied!</span>
-              ) : (
-                'Copy'
+      {hasQueue && (
+        <div className="flex-1 flex flex-col overflow-hidden rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800 min-h-0">
+          <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b border-stone-200 dark:border-stone-700 gap-2">
+            <span className="text-xs font-medium text-stone-500 dark:text-stone-400">
+              {isProcessing
+                ? `Transcribing (${items.filter((i) => i.status === 'complete' || i.status === 'error').length}/${items.length})`
+                : `${items.length} file${items.length === 1 ? '' : 's'}`}
+            </span>
+            <div className="flex items-center gap-3">
+              {completeItems.length > 0 && (
+                <button
+                  onClick={handleCopyAll}
+                  className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
+                >
+                  {copyAllDone ? (
+                    <span className="text-emerald-600 dark:text-emerald-400">Copied all!</span>
+                  ) : (
+                    'Copy all'
+                  )}
+                </button>
               )}
-            </button>
+              <button
+                onClick={handleReset}
+                className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
+              >
+                Clear
+              </button>
+            </div>
           </div>
-          <div className="flex-1 overflow-y-auto p-4 text-sm text-stone-800 dark:text-stone-200 whitespace-pre-wrap break-words">
-            {result || <span className="text-stone-400 dark:text-stone-500">No speech detected in this file.</span>}
+
+          <div className="flex-1 overflow-y-auto divide-y divide-stone-200 dark:divide-stone-700">
+            {items.map((item) => (
+              <div key={item.id} className="px-4 py-3 flex flex-col gap-2">
+                <div className="flex items-start gap-2">
+                  <StatusIcon status={item.status} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-stone-800 dark:text-stone-200 truncate">
+                        {item.name}
+                      </span>
+                      <span className="text-xs text-stone-400 dark:text-stone-500 shrink-0">
+                        {statusLabel(item.status)}
+                      </span>
+                    </div>
+                    {item.status === 'error' && item.error && (
+                      <p className="mt-1 text-xs text-red-600 dark:text-red-400">{item.error}</p>
+                    )}
+                  </div>
+                  {item.status === 'complete' && (
+                    <button
+                      onClick={() => handleCopyItem(item)}
+                      disabled={!item.result?.trim()}
+                      className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 disabled:opacity-50 shrink-0 transition-colors"
+                    >
+                      {copiedIds.has(item.id) ? (
+                        <span className="text-emerald-600 dark:text-emerald-400">Copied!</span>
+                      ) : (
+                        'Copy'
+                      )}
+                    </button>
+                  )}
+                </div>
+                {item.status === 'complete' && (
+                  <div className="pl-6 text-sm text-stone-700 dark:text-stone-300 whitespace-pre-wrap break-words max-h-40 overflow-y-auto">
+                    {item.result?.trim() || (
+                      <span className="text-stone-400 dark:text-stone-500">No speech detected in this file.</span>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/app/src/lib/hooks/useFileTranscription.ts
+++ b/app/src/lib/hooks/useFileTranscription.ts
@@ -6,7 +6,17 @@ import { flog } from '../log';
 const AUDIO_EXTENSIONS = ['wav', 'mp3', 'm4a'];
 const UNSUPPORTED_MESSAGE = 'Unsupported file type. Use WAV, MP3, or M4A.';
 
-export type FileTranscriptionStatus = 'idle' | 'processing' | 'complete' | 'error';
+export type QueueItemStatus = 'pending' | 'processing' | 'complete' | 'error';
+
+export interface FileQueueItem {
+  id: string;
+  path: string;
+  name: string;
+  status: QueueItemStatus;
+  result?: string;
+  error?: string;
+  duration?: number;
+}
 
 function hasAudioExtension(path: string): boolean {
   const ext = path.split('.').pop()?.toLowerCase();
@@ -17,95 +27,188 @@ function baseName(path: string): string {
   return path.split(/[\\/]/).pop() || path;
 }
 
+function partitionPaths(paths: string[]): { supported: string[]; unsupportedCount: number } {
+  const supported: string[] = [];
+  let unsupportedCount = 0;
+  for (const path of paths) {
+    if (hasAudioExtension(path)) {
+      supported.push(path);
+    } else {
+      unsupportedCount += 1;
+    }
+  }
+  return { supported, unsupportedCount };
+}
+
+function unsupportedWarning(count: number): string {
+  if (count === 1) {
+    return `Skipped 1 unsupported file. ${UNSUPPORTED_MESSAGE}`;
+  }
+  return `Skipped ${count} unsupported file(s). ${UNSUPPORTED_MESSAGE}`;
+}
+
 interface UseFileTranscriptionProps {
   /** Persist completed transcriptions to shared history (no WPM stats). */
   addEntry: (text: string, duration: number) => void;
 }
 
 /**
- * Manages the file-transcription flow: invokes the Rust `transcribe_file`
- * command, tracks status/result/error, and wires window drag-and-drop (which
- * yields real filesystem paths via the Tauri webview event).
+ * Manages batch file transcription: queues paths, drains sequentially via Rust
+ * `transcribe_file`, and wires window drag-and-drop (Tauri webview paths).
  */
 export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
-  const [status, setStatus] = useState<FileTranscriptionStatus>('idle');
-  const [result, setResult] = useState('');
-  const [error, setError] = useState('');
-  const [fileName, setFileName] = useState('');
+  const [items, setItems] = useState<FileQueueItem[]>([]);
+  const [batchWarning, setBatchWarning] = useState('');
   const [isDragging, setIsDragging] = useState(false);
+  const [isDraining, setIsDraining] = useState(false);
 
-  // Ref mirror so the drag-drop listener (registered once) sees current status.
-  const statusRef = useRef(status);
-  statusRef.current = status;
+  const itemsRef = useRef<FileQueueItem[]>([]);
 
-  const transcribe = useCallback(async (path: string) => {
-    if (statusRef.current === 'processing') return;
-    if (!hasAudioExtension(path)) {
-      setError(UNSUPPORTED_MESSAGE);
-      setStatus('error');
-      return;
-    }
-    setFileName(baseName(path));
-    setResult('');
-    setError('');
-    setStatus('processing');
-    flog.info('file-transcribe', 'start', { name: baseName(path) });
-
-    const res = await transcribeFile(path);
-    if (res.type === 'error') {
-      setError(res.error || 'Transcription failed');
-      setStatus('error');
-      flog.warn('file-transcribe', 'error', { error: res.error });
-      return;
-    }
-
-    const text = res.text || '';
-    setResult(text);
-    setStatus('complete');
-    if (text.trim()) {
-      addEntry(text, res.duration ?? 0);
-    }
-    flog.info('file-transcribe', 'complete', { textLen: text.length });
-  }, [addEntry]);
-
-  const reset = useCallback(() => {
-    setStatus('idle');
-    setResult('');
-    setError('');
-    setFileName('');
+  const setItemsSynced = useCallback((updater: (prev: FileQueueItem[]) => FileQueueItem[]) => {
+    setItems((prev) => {
+      const next = updater(prev);
+      itemsRef.current = next;
+      return next;
+    });
   }, []);
 
-  // Drag-and-drop via the Tauri webview — provides absolute file paths
-  // (the plain HTML5 drop event does not, for security reasons). Drag-drop is
-  // an optional convenience; if the listener can't be registered the picker
-  // button still works, so failures degrade gracefully rather than break the UI.
+  const batchGenerationRef = useRef(0);
+  const drainingRef = useRef(false);
+
+  const isProcessing = isDraining || items.some((i) => i.status === 'processing');
+
+  const updateItem = useCallback(
+    (id: string, patch: Partial<FileQueueItem>) => {
+      setItemsSynced((prev) =>
+        prev.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+      );
+    },
+    [setItemsSynced],
+  );
+
+  const drainQueue = useCallback(
+    async (generation: number) => {
+      if (drainingRef.current) return;
+      drainingRef.current = true;
+      setIsDraining(true);
+
+      try {
+        while (batchGenerationRef.current === generation) {
+          const next = itemsRef.current.find((i) => i.status === 'pending');
+          if (!next) break;
+
+          updateItem(next.id, { status: 'processing', error: undefined, result: undefined });
+          flog.info('file-transcribe', 'start', { name: next.name });
+
+          const res = await transcribeFile(next.path);
+
+          if (batchGenerationRef.current !== generation) {
+            flog.info('file-transcribe', 'stale result ignored', { name: next.name });
+            return;
+          }
+
+          if (res.type === 'error') {
+            const err = res.error || 'Transcription failed';
+            updateItem(next.id, { status: 'error', error: err });
+            flog.warn('file-transcribe', 'error', { error: err });
+            continue;
+          }
+
+          const text = res.text || '';
+          updateItem(next.id, {
+            status: 'complete',
+            result: text,
+            duration: res.duration ?? 0,
+          });
+          if (text.trim()) {
+            addEntry(text, res.duration ?? 0);
+          }
+          flog.info('file-transcribe', 'complete', { textLen: text.length });
+        }
+      } finally {
+        drainingRef.current = false;
+        setIsDraining(false);
+        // Another enqueue may have added pending items while we were finishing.
+        if (
+          batchGenerationRef.current === generation &&
+          itemsRef.current.some((i) => i.status === 'pending')
+        ) {
+          void drainQueue(generation);
+        }
+      }
+    },
+    [addEntry, updateItem],
+  );
+
+  const enqueuePaths = useCallback(
+    (paths: string[]) => {
+      if (paths.length === 0) return;
+
+      const { supported, unsupportedCount } = partitionPaths(paths);
+      if (unsupportedCount > 0) {
+        setBatchWarning(unsupportedWarning(unsupportedCount));
+      }
+
+      if (supported.length === 0) return;
+
+      const activePaths = new Set(
+        itemsRef.current
+          .filter((i) => i.status === 'pending' || i.status === 'processing')
+          .map((i) => i.path),
+      );
+      const toAdd = supported.filter((path) => !activePaths.has(path));
+      if (toAdd.length === 0) return;
+
+      const newItems: FileQueueItem[] = toAdd.map((path) => ({
+        id: crypto.randomUUID(),
+        path,
+        name: baseName(path),
+        status: 'pending',
+      }));
+
+      setItemsSynced((prev) => [...prev, ...newItems]);
+
+      const generation = batchGenerationRef.current;
+      void drainQueue(generation);
+    },
+    [drainQueue, setItemsSynced],
+  );
+
+  const reset = useCallback(() => {
+    batchGenerationRef.current += 1;
+    drainingRef.current = false;
+    setIsDraining(false);
+    itemsRef.current = [];
+    setItems([]);
+    setBatchWarning('');
+  }, []);
+
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     let cancelled = false;
 
     try {
-      getCurrentWebview().onDragDropEvent((event) => {
-        const payload = event.payload;
-        if (payload.type === 'enter' || payload.type === 'over') {
-          setIsDragging(true);
-        } else if (payload.type === 'leave') {
-          setIsDragging(false);
-        } else if (payload.type === 'drop') {
-          setIsDragging(false);
-          const audioPath = payload.paths.find(hasAudioExtension);
-          if (audioPath) {
-            void transcribe(audioPath);
-          } else if (payload.paths.length > 0) {
-            setError(UNSUPPORTED_MESSAGE);
-            setStatus('error');
+      getCurrentWebview()
+        .onDragDropEvent((event) => {
+          const payload = event.payload;
+          if (payload.type === 'enter' || payload.type === 'over') {
+            setIsDragging(true);
+          } else if (payload.type === 'leave') {
+            setIsDragging(false);
+          } else if (payload.type === 'drop') {
+            setIsDragging(false);
+            if (payload.paths.length > 0) {
+              enqueuePaths(payload.paths);
+            }
           }
-        }
-      }).then((fn) => {
-        if (cancelled) fn();
-        else unlisten = fn;
-      }).catch((e) => {
-        flog.warn('file-transcribe', 'drag-drop listener failed', { error: String(e) });
-      });
+        })
+        .then((fn) => {
+          if (cancelled) fn();
+          else unlisten = fn;
+        })
+        .catch((e) => {
+          flog.warn('file-transcribe', 'drag-drop listener failed', { error: String(e) });
+        });
     } catch (e) {
       flog.warn('file-transcribe', 'drag-drop unavailable', { error: String(e) });
     }
@@ -114,7 +217,14 @@ export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
       cancelled = true;
       unlisten?.();
     };
-  }, [transcribe]);
+  }, [enqueuePaths]);
 
-  return { status, result, error, fileName, isDragging, transcribe, reset };
+  return {
+    items,
+    batchWarning,
+    isDragging,
+    isProcessing,
+    enqueuePaths,
+    reset,
+  };
 }


### PR DESCRIPTION
## Summary
- Queue multiple audio files from multi-select dialog and drag-and-drop; drain sequentially via existing `transcribe_file`.
- Show per-file status, transcript, and copy; batch warning for skipped unsupported types; Copy all with filename separators.
- Generation token on reset ignores stale in-flight results so cleared UI/history cannot be repopulated.

## Test plan
- [x] `cargo check` / `cargo test` / `npx tsc --noEmit`
- [ ] Native app smoke: multi-select, multi-drop, mixed supported/unsupported, Clear during processing
- [ ] Verify each success still appears in shared history with file source name

Closes #187

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File transcription now supports queuing multiple files simultaneously instead of single-file processing.
  * Added per-file status indicators to track transcription progress for each queued item.
  * Individual "Copy" buttons for transcribed results and a "Copy all" option for batch copying completed items.
  * Batch warning system alerts users to unsupported file types before processing.
  * Added "Clear" button to reset the transcription queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->