### PR TITLE
feat: overlay hover-expand with quick settings panel (dynamic resize)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Overlay hover-expand quick settings** — hovering the Dynamic Island reveals a quick-settings dropdown with global-disable, auto-paste, and settings-window controls; inline recording timer while hovering (#135)
+
 ### Fixed
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
 

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -215,6 +215,24 @@ pub fn set_overlay_expanded(app: tauri::AppHandle, state: tauri::State<'_, State
     }
 }
 
+/// Show and focus the main app window.
+///
+/// The overlay uses this instead of frontend window APIs so it does not need
+/// broad `core:window:allow-show` / `allow-set-focus` permissions.
+#[tauri::command]
+pub fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
+    match app.get_webview_window("main") {
+        Some(window) => {
+            window.show().map_err(|e| e.to_string())?;
+            window.set_focus().map_err(|e| e.to_string())
+        }
+        None => {
+            tracing::warn!(target: "system", "show_main_window: main window not found");
+            Ok(())
+        }
+    }
+}
+
 /// Hide the always-on-top overlay window.
 #[tauri::command]
 pub fn hide_overlay(app: tauri::AppHandle) -> Result<(), String> {

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -7,6 +7,10 @@ use tauri::Manager;
 const NOTCH_EXPAND: f64 = 120.0; // 60px expansion room on each side
 #[cfg(target_os = "macos")]
 const FALLBACK_OVERLAY_W: f64 = 200.0;
+#[cfg(target_os = "macos")]
+const FALLBACK_OVERLAY_H: f64 = 37.0;
+#[cfg(target_os = "macos")]
+const EXPANDED_DROP: f64 = 56.0; // extra height for the hover dropdown row
 
 #[derive(serde::Serialize, Clone)]
 pub(crate) struct NotchInfo {
@@ -168,6 +172,43 @@ pub fn show_overlay(app: tauri::AppHandle, state: tauri::State<'_, State>) -> Re
             }
             None => {
                 tracing::warn!(target: "system", "show_overlay: overlay window not found — skipping");
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Resize the overlay window for the hover-expand dropdown.
+///
+/// Grows the window height by `EXPANDED_DROP` when expanded so the dropdown row
+/// has room, and restores it to notch height when collapsed. Width is computed
+/// with the same formula as `position_overlay_default`, so the collapsed size
+/// matches what `show_overlay` set. Only the size changes — the window stays
+/// anchored at y=0, so the extra height grows downward.
+///
+/// We resize on hover rather than pre-allocating a tall window because a
+/// transparent overlay with cursor events enabled captures the mouse across its
+/// whole frame, which would create a click dead-zone below the notch when idle.
+#[tauri::command]
+pub fn set_overlay_expanded(app: tauri::AppHandle, state: tauri::State<'_, State>, expanded: bool) -> Result<(), String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (&app, &state, expanded);
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let notch = *state.notch_info.lock_or_recover();
+        match app.get_webview_window("overlay") {
+            Some(overlay) => {
+                let w = notch.map(|(w, _)| w + NOTCH_EXPAND).unwrap_or(FALLBACK_OVERLAY_W);
+                let base_h = notch.map(|(_, h)| h).unwrap_or(FALLBACK_OVERLAY_H);
+                let h = if expanded { base_h + EXPANDED_DROP } else { base_h };
+                overlay.set_size(tauri::LogicalSize::new(w, h)).map_err(|e| e.to_string())
+            }
+            None => {
+                tracing::warn!(target: "system", "set_overlay_expanded: overlay window not found — skipping");
                 Ok(())
             }
         }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -148,6 +148,7 @@ pub fn run() {
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
             commands::overlay::set_overlay_expanded,
+            commands::overlay::show_main_window,
             commands::overlay::get_notch_info,
             telemetry::get_event_history,
             telemetry::clear_event_history,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             commands::tray::update_tray_icon,
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
+            commands::overlay::set_overlay_expanded,
             commands::overlay::get_notch_info,
             telemetry::get_event_history,
             telemetry::clear_event_history,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,8 @@ import { useHoldDownToggle } from './lib/hooks/useHoldDownToggle';
 import { useDoubleTapToggle } from './lib/hooks/useDoubleTapToggle';
 import { useCombinedToggle } from './lib/hooks/useCombinedToggle';
 import { useShowAboutListener } from './lib/hooks/useShowAboutListener';
+import { useOverlaySettingsSync } from './lib/hooks/useOverlaySettingsSync';
+import { useOpenSettingsListener } from './lib/hooks/useOpenSettingsListener';
 import { useEscapeCancel } from './lib/hooks/useEscapeCancel';
 import { useAutoUpdater } from './lib/hooks/useAutoUpdater';
 import { UpdateModal } from './components/UpdateModal';
@@ -51,8 +53,11 @@ function App() {
       .catch(() => setModelReady(true)); // fail open so main UI still loads
   }, []);
 
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, applyExternalSettings } = useSettings();
   const { initialized, error: initError } = useInitialization(settings);
+
+  // Keep settings in sync when the overlay's quick controls change them.
+  useOverlaySettingsSync(applyExternalSettings);
 
   // Track accessibility permission — when it transitions false→true the
   // double-tap listener restarts automatically (rdev silently does nothing
@@ -115,6 +120,10 @@ function App() {
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [mainTab, setMainTab] = useState<'record' | 'file'>('record');
+
+  // Overlay gear button asks the main window to open the Settings panel.
+  const openSettings = useCallback(() => setIsSettingsOpen(true), []);
+  useOpenSettingsListener(openSettings);
 
   const error = initError || recordingError;
 

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -1,17 +1,58 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { listen, emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import { cursorPosition, getCurrentWindow } from '@tauri-apps/api/window';
 import { isDictationStatus } from '../lib/types';
 import type { DictationStatus } from '../lib/types';
 import { flog } from '../lib/log';
 import { STORAGE_KEY, DEFAULT_SETTINGS, loadSettings, saveSettings } from '../lib/settings';
+import type { Settings } from '../lib/settings';
+import { buildConfigureOptions } from '../lib/dictation';
 
 const BAR_COUNT = 7;
+const COLLAPSE_DELAY_MS = 300;
+const SHRINK_DELAY_MS = 380;
+const HOVER_WATCHDOG_MS = 250;
+const HOVER_BOUNDS_PADDING = 8;
 
 function formatElapsed(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function PowerIcon({ stroke }: { stroke: string }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2v10" />
+      <path d="M18.4 6.6a9 9 0 1 1-12.8 0" />
+    </svg>
+  );
+}
+
+function ClipboardPasteIcon({ stroke }: { stroke: string }) {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="8" y="2" width="8" height="4" rx="1" />
+      <path d="M16 4h2a2 2 0 0 1 2 2v4" />
+      <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h5" />
+      <path d="M16 14v6" />
+      <path d="M13 17h6" />
+    </svg>
+  );
+}
+
+function SlidersIcon({ stroke }: { stroke: string }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 7h4" />
+      <path d="M12 7h8" />
+      <circle cx="10" cy="7" r="2" />
+      <path d="M4 17h10" />
+      <path d="M18 17h2" />
+      <circle cx="16" cy="17" r="2" />
+    </svg>
+  );
 }
 
 export function OverlayWidget() {
@@ -21,13 +62,16 @@ export function OverlayWidget() {
   const [disabled, setDisabled] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [autoPaste, setAutoPaste] = useState(false);
+  const [fileOutputEnabled, setFileOutputEnabled] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const notchHeightRef = useRef(0);
   const [notchHeight, setNotchHeight] = useState(0);
   const [notchWidth, setNotchWidth] = useState(185);
+  const islandRef = useRef<HTMLDivElement | null>(null);
   const statusRef = useRef(status);
   const lockedRef = useRef(lockedMode);
   const disabledRef = useRef(disabled);
+  const expandedRef = useRef(expanded);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shrinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -37,6 +81,13 @@ export function OverlayWidget() {
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { lockedRef.current = lockedMode; }, [lockedMode]);
   useEffect(() => { disabledRef.current = disabled; }, [disabled]);
+  useEffect(() => { expandedRef.current = expanded; }, [expanded]);
+
+  const applySettingsSnapshot = useCallback((settings: Settings) => {
+    setDisabled(settings.disabled);
+    setAutoPaste(settings.autoPaste);
+    setFileOutputEnabled(settings.saveTranscript || settings.saveAudio);
+  }, []);
 
   // Log mount + fetch notch dimensions + read initial disabled state
   useEffect(() => {
@@ -54,12 +105,7 @@ export function OverlayWidget() {
       })
       .catch((e) => flog.warn('overlay', 'get_notch_info failed', { error: String(e) }));
     try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (typeof parsed.disabled === 'boolean') setDisabled(parsed.disabled);
-        if (typeof parsed.autoPaste === 'boolean') setAutoPaste(parsed.autoPaste);
-      }
+      applySettingsSnapshot(loadSettings());
     } catch { /* ignore */ }
     return () => {
       flog.info('overlay', 'unmounted');
@@ -67,7 +113,7 @@ export function OverlayWidget() {
       if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current);
       if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
     };
-  }, []);
+  }, [applySettingsSnapshot]);
 
   // Restore saved position (Rust handles default positioning)
   // TODO: re-enable after notch positioning is stable
@@ -189,14 +235,13 @@ export function OverlayWidget() {
     listen('settings-changed', () => {
       try {
         const s = loadSettings();
-        setAutoPaste(s.autoPaste);
-        setDisabled(s.disabled);
+        applySettingsSnapshot(s);
       } catch { /* ignore */ }
     }).then((fn) => {
       if (cancelled) { fn(); } else { unlisten = fn; }
     });
     return () => { cancelled = true; unlisten?.(); };
-  }, []);
+  }, [applySettingsSnapshot]);
 
   // Track recording elapsed time for the inline timer (recording + hover only).
   useEffect(() => {
@@ -248,6 +293,10 @@ export function OverlayWidget() {
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
+    }
+    if (expandedRef.current) {
+      flog.info('overlay', 'double-click ignored while expanded', { status: currentStatus });
+      return;
     }
     const currentLocked = lockedRef.current;
     if (!currentLocked) {
@@ -326,50 +375,136 @@ export function OverlayWidget() {
     });
   }, []);
 
-  // Hover-expand: grow the window first, then animate the card open.
-  const handleMouseEnter = useCallback(() => {
-    if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
-    if (shrinkTimerRef.current) { clearTimeout(shrinkTimerRef.current); shrinkTimerRef.current = null; }
-    // Refresh quick-control values from localStorage (overlay has no shared settings context).
-    try {
-      const s = loadSettings();
-      setAutoPaste(s.autoPaste);
-      setDisabled(s.disabled);
-    } catch { /* ignore */ }
-    invoke('set_overlay_expanded', { expanded: true })
-      .catch((e) => flog.warn('overlay', 'set_overlay_expanded(true) failed', { error: String(e) }));
-    setExpanded(true);
+  const shrinkOverlayWindow = useCallback(() => {
+    if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
+    shrinkTimerRef.current = setTimeout(() => {
+      shrinkTimerRef.current = null;
+      invoke('set_overlay_expanded', { expanded: false })
+        .catch((e) => flog.warn('overlay', 'set_overlay_expanded(false) failed', { error: String(e) }));
+    }, SHRINK_DELAY_MS);
   }, []);
 
-  // Collapse after a 300ms hover-intent delay; shrink the window only after the
-  // close animation finishes so the dropdown isn't clipped mid-transition.
-  const handleMouseLeave = useCallback(() => {
+  const collapseOverlay = useCallback((delayMs = COLLAPSE_DELAY_MS) => {
     if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current);
     collapseTimerRef.current = setTimeout(() => {
       collapseTimerRef.current = null;
       setExpanded(false);
-      if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
-      shrinkTimerRef.current = setTimeout(() => {
-        shrinkTimerRef.current = null;
-        invoke('set_overlay_expanded', { expanded: false })
-          .catch((e) => flog.warn('overlay', 'set_overlay_expanded(false) failed', { error: String(e) }));
-      }, 380);
-    }, 300);
-  }, []);
+      shrinkOverlayWindow();
+    }, delayMs);
+  }, [shrinkOverlayWindow]);
+
+  // Hover-expand: grow the window first, then animate the card open.
+  const handleMouseEnter = useCallback(() => {
+    if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
+    if (shrinkTimerRef.current) { clearTimeout(shrinkTimerRef.current); shrinkTimerRef.current = null; }
+    if (expandedRef.current) return;
+    // Refresh quick-control values from localStorage (overlay has no shared settings context).
+    try {
+      const s = loadSettings();
+      applySettingsSnapshot(s);
+    } catch { /* ignore */ }
+    invoke('set_overlay_expanded', { expanded: true })
+      .catch((e) => flog.warn('overlay', 'set_overlay_expanded(true) failed', { error: String(e) }));
+    setExpanded(true);
+  }, [applySettingsSnapshot]);
+
+  // Collapse after a 300ms hover-intent delay; shrink the window only after the
+  // close animation finishes so the dropdown isn't clipped mid-transition.
+  const handleMouseLeave = useCallback(() => {
+    collapseOverlay();
+  }, [collapseOverlay]);
+
+  // Safety net for macOS/Tauri hover edge cases: if the native window is already
+  // expanded but a leave event is missed, collapse once the cursor is outside the
+  // actual visible island card (not merely outside the transparent window frame).
+  useEffect(() => {
+    if (!expanded) return;
+    const currentWindow = getCurrentWindow();
+    const intervalId = setInterval(async () => {
+      const island = islandRef.current;
+      if (!island || !expandedRef.current) return;
+      try {
+        const [windowPosition, cursor] = await Promise.all([
+          currentWindow.outerPosition(),
+          cursorPosition(),
+        ]);
+        const scale = window.devicePixelRatio || 1;
+        const rect = island.getBoundingClientRect();
+        const padding = HOVER_BOUNDS_PADDING * scale;
+        const left = windowPosition.x + rect.left * scale - padding;
+        const right = windowPosition.x + rect.right * scale + padding;
+        const top = windowPosition.y + rect.top * scale - padding;
+        const bottom = windowPosition.y + rect.bottom * scale + padding;
+
+        if (cursor.x < left || cursor.x > right || cursor.y < top || cursor.y > bottom) {
+          collapseOverlay(0);
+        }
+      } catch (err) {
+        flog.warn('overlay', 'hover watchdog failed', { error: String(err) });
+      }
+    }, HOVER_WATCHDOG_MS);
+    return () => clearInterval(intervalId);
+  }, [expanded, collapseOverlay]);
+
+  // The overlay is non-activating and sits above the menu bar, so macOS can miss
+  // normal DOM hover entry events. Polling the cursor against the visible island
+  // bounds keeps hover-expand reliable without widening the clickable window.
+  useEffect(() => {
+    const currentWindow = getCurrentWindow();
+    let inFlight = false;
+    const intervalId = setInterval(async () => {
+      const island = islandRef.current;
+      if (!island || expandedRef.current || inFlight) return;
+      inFlight = true;
+      try {
+        const [windowPosition, cursor] = await Promise.all([
+          currentWindow.outerPosition(),
+          cursorPosition(),
+        ]);
+        const scale = window.devicePixelRatio || 1;
+        const rect = island.getBoundingClientRect();
+        const padding = HOVER_BOUNDS_PADDING * scale;
+        const left = windowPosition.x + rect.left * scale - padding;
+        const right = windowPosition.x + rect.right * scale + padding;
+        const top = windowPosition.y + rect.top * scale - padding;
+        const bottom = windowPosition.y + rect.bottom * scale + padding;
+
+        if (cursor.x >= left && cursor.x <= right && cursor.y >= top && cursor.y <= bottom) {
+          handleMouseEnter();
+        }
+      } catch (err) {
+        flog.warn('overlay', 'hover detector failed', { error: String(err) });
+      } finally {
+        inFlight = false;
+      }
+    }, HOVER_WATCHDOG_MS);
+    return () => clearInterval(intervalId);
+  }, [handleMouseEnter]);
 
   // Quick control: auto-paste. Write localStorage + notify the main window.
-  const handleToggleAutoPaste = useCallback((e: React.MouseEvent) => {
+  const handleToggleAutoPaste = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
       const s = loadSettings();
       const next = !s.autoPaste;
-      saveSettings({ ...s, autoPaste: next });
-      setAutoPaste(next);
+      const nextSettings = { ...s, autoPaste: next };
+      saveSettings(nextSettings);
+      applySettingsSnapshot(nextSettings);
+      try {
+        await invoke('configure_dictation', { options: buildConfigureOptions(nextSettings) });
+      } catch (err) {
+        saveSettings(s);
+        applySettingsSnapshot(s);
+        throw err;
+      }
       emit('settings-changed').catch((err) => flog.warn('overlay', 'emit settings-changed failed', { error: String(err) }));
     } catch (err) {
       flog.error('overlay', 'toggle autoPaste failed', { error: String(err) });
+      try {
+        applySettingsSnapshot(loadSettings());
+      } catch { /* ignore */ }
     }
-  }, []);
+  }, [applySettingsSnapshot]);
 
   // Quick control: global disable. Gate the backend immediately, then notify.
   const handleToggleDisabled = useCallback(async (e: React.MouseEvent) => {
@@ -398,6 +533,23 @@ export function OverlayWidget() {
   }, []);
 
   const topH = notchHeight || 37;
+  const effectiveAutoPaste = autoPaste && !fileOutputEnabled;
+  const autoPastePaused = autoPaste && fileOutputEnabled;
+  const autoPasteLabel = autoPastePaused
+    ? 'Auto-paste paused while saving files'
+    : effectiveAutoPaste
+      ? 'Disable auto-paste'
+      : 'Enable auto-paste';
+  const autoPasteColor = effectiveAutoPaste
+    ? '#10b981'
+    : autoPastePaused
+      ? '#f59e0b'
+      : 'rgba(255,255,255,0.85)';
+  const autoPasteBackground = effectiveAutoPaste
+    ? 'rgba(16,185,129,0.16)'
+    : autoPastePaused
+      ? 'rgba(245,158,11,0.14)'
+      : 'rgba(255,255,255,0.06)';
 
   return (
     <div
@@ -407,13 +559,19 @@ export function OverlayWidget() {
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onMouseMove={handleMouseEnter}
+      onMouseOver={handleMouseEnter}
     >
       {/* Dynamic Island: top bar matches notch height; hover expands it downward
           to reveal the quick-settings dropdown. Idle/recording only changes the
           top bar — the dropdown row is identical. */}
       <div
+        ref={islandRef}
         className="cursor-pointer select-none overflow-hidden"
+        onMouseEnter={handleMouseEnter}
+        onMouseMove={handleMouseEnter}
+        onMouseOver={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         style={{
           borderRadius: '0 0 12px 12px',
           width: (expanded || isActive) ? notchWidth + 68 : notchWidth + 28,
@@ -490,38 +648,32 @@ export function OverlayWidget() {
             transitionDelay: expanded ? '100ms' : '0ms',
           }}
         >
-          {/* Global disable (speaker-slash) */}
+          {/* Global disable */}
           <button
             type="button"
-            aria-label="Disable Murmur"
+            aria-label={disabled ? 'Enable Murmur' : 'Disable Murmur'}
             onClick={handleToggleDisabled}
             className="shrink-0 flex items-center justify-center cursor-pointer rounded-[9px] transition-colors"
             style={{ width: 30, height: 30, background: disabled ? 'rgba(239,68,68,0.12)' : 'rgba(255,255,255,0.06)' }}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={disabled ? '#ef4444' : 'rgba(255,255,255,0.85)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-              <line x1="23" y1="9" x2="17" y2="15" />
-              <line x1="17" y1="9" x2="23" y2="15" />
-            </svg>
+            <PowerIcon stroke={disabled ? '#ef4444' : 'rgba(255,255,255,0.85)'} />
           </button>
 
-          {/* Auto-paste toggle */}
+          {/* Auto-paste */}
           <button
             type="button"
             role="switch"
-            aria-checked={autoPaste}
-            aria-label="Auto paste"
+            aria-checked={effectiveAutoPaste}
+            aria-label={autoPasteLabel}
+            title={autoPasteLabel}
             onClick={handleToggleAutoPaste}
-            className="relative shrink-0 cursor-pointer rounded-full transition-colors"
-            style={{ width: 34, height: 18, opacity: disabled ? 0.35 : 1, background: autoPaste ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.18)' }}
+            className="shrink-0 flex items-center justify-center cursor-pointer rounded-[9px] transition-colors"
+            style={{ width: 30, height: 30, opacity: disabled ? 0.35 : 1, background: autoPasteBackground }}
           >
-            <span
-              className="absolute rounded-full transition-transform"
-              style={{ top: 2, left: 2, width: 14, height: 14, background: autoPaste ? '#14141a' : '#fff', transform: autoPaste ? 'translateX(16px)' : 'translateX(0)' }}
-            />
+            <ClipboardPasteIcon stroke={autoPasteColor} />
           </button>
 
-          {/* Open settings (gear) */}
+          {/* Open settings */}
           <button
             type="button"
             aria-label="Open settings"
@@ -529,10 +681,7 @@ export function OverlayWidget() {
             className="shrink-0 flex items-center justify-center cursor-pointer rounded-[9px] transition-colors"
             style={{ width: 30, height: 30, background: 'rgba(255,255,255,0.06)' }}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.85)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
+            <SlidersIcon stroke="rgba(255,255,255,0.85)" />
           </button>
         </div>
       </div>

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { listen, emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
-import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isDictationStatus } from '../lib/types';
 import type { DictationStatus } from '../lib/types';
 import { flog } from '../lib/log';
@@ -391,10 +390,8 @@ export function OverlayWidget() {
   const handleOpenSettings = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
-      emit('open-settings').catch(() => {});
-      const main = await WebviewWindow.getByLabel('main');
-      await main?.show();
-      await main?.setFocus();
+      await invoke('show_main_window');
+      await emit('open-settings');
     } catch (err) {
       flog.error('overlay', 'open settings failed', { error: String(err) });
     }

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -1,24 +1,37 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { listen } from '@tauri-apps/api/event';
+import { listen, emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isDictationStatus } from '../lib/types';
 import type { DictationStatus } from '../lib/types';
 import { flog } from '../lib/log';
-import { STORAGE_KEY, DEFAULT_SETTINGS } from '../lib/settings';
+import { STORAGE_KEY, DEFAULT_SETTINGS, loadSettings, saveSettings } from '../lib/settings';
 
 const BAR_COUNT = 7;
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
 
 export function OverlayWidget() {
   const [status, setStatus] = useState<DictationStatus>('idle');
   const [showCancelled, setShowCancelled] = useState(false);
   const [lockedMode, setLockedMode] = useState(false);
   const [disabled, setDisabled] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [autoPaste, setAutoPaste] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
   const notchHeightRef = useRef(0);
+  const [notchHeight, setNotchHeight] = useState(0);
   const [notchWidth, setNotchWidth] = useState(185);
   const statusRef = useRef(status);
   const lockedRef = useRef(lockedMode);
   const disabledRef = useRef(disabled);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shrinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const audioLevelRef = useRef(0);
   const barRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -34,6 +47,7 @@ export function OverlayWidget() {
         if (info) {
           flog.info('overlay', 'notch info', { notch_width: info.notch_width, notch_height: info.notch_height });
           notchHeightRef.current = info.notch_height;
+          setNotchHeight(info.notch_height);
           setNotchWidth(info.notch_width);
         } else {
           flog.info('overlay', 'no notch detected');
@@ -45,11 +59,14 @@ export function OverlayWidget() {
       if (stored) {
         const parsed = JSON.parse(stored);
         if (typeof parsed.disabled === 'boolean') setDisabled(parsed.disabled);
+        if (typeof parsed.autoPaste === 'boolean') setAutoPaste(parsed.autoPaste);
       }
     } catch { /* ignore */ }
     return () => {
       flog.info('overlay', 'unmounted');
       if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+      if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current);
+      if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
     };
   }, []);
 
@@ -120,13 +137,18 @@ export function OverlayWidget() {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
     listen<{ notch_width: number; notch_height: number } | null>('notch-info-changed', (event) => {
+      // Rust resizes the window back to collapsed dimensions on display change,
+      // so reset the expanded UI state to stay in sync.
+      setExpanded(false);
       if (event.payload) {
         flog.info('overlay', 'notch info changed', { notch_width: event.payload.notch_width, notch_height: event.payload.notch_height });
         notchHeightRef.current = event.payload.notch_height;
+        setNotchHeight(event.payload.notch_height);
         setNotchWidth(event.payload.notch_width);
       } else {
         flog.info('overlay', 'notch removed (no notch on new display)');
         notchHeightRef.current = 0;
+        setNotchHeight(0);
         setNotchWidth(140);
       }
     }).then((fn) => {
@@ -159,6 +181,32 @@ export function OverlayWidget() {
     });
     return () => { cancelled = true; unlisten?.(); };
   }, []);
+
+  // Subscribe to settings-changed (emitted by the main window) so the quick
+  // controls reflect changes made there, even while already expanded.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen('settings-changed', () => {
+      try {
+        const s = loadSettings();
+        setAutoPaste(s.autoPaste);
+        setDisabled(s.disabled);
+      } catch { /* ignore */ }
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
+  // Track recording elapsed time for the inline timer (recording + hover only).
+  useEffect(() => {
+    if (status !== 'recording') { setElapsed(0); return; }
+    const start = Date.now();
+    setElapsed(0);
+    const id = setInterval(() => setElapsed(Math.floor((Date.now() - start) / 1000)), 250);
+    return () => clearInterval(id);
+  }, [status]);
 
   // Animate waveform bars via rAF (direct DOM updates, no React reconciliation)
   useEffect(() => {
@@ -279,31 +327,109 @@ export function OverlayWidget() {
     });
   }, []);
 
+  // Hover-expand: grow the window first, then animate the card open.
+  const handleMouseEnter = useCallback(() => {
+    if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
+    if (shrinkTimerRef.current) { clearTimeout(shrinkTimerRef.current); shrinkTimerRef.current = null; }
+    // Refresh quick-control values from localStorage (overlay has no shared settings context).
+    try {
+      const s = loadSettings();
+      setAutoPaste(s.autoPaste);
+      setDisabled(s.disabled);
+    } catch { /* ignore */ }
+    invoke('set_overlay_expanded', { expanded: true })
+      .catch((e) => flog.warn('overlay', 'set_overlay_expanded(true) failed', { error: String(e) }));
+    setExpanded(true);
+  }, []);
+
+  // Collapse after a 300ms hover-intent delay; shrink the window only after the
+  // close animation finishes so the dropdown isn't clipped mid-transition.
+  const handleMouseLeave = useCallback(() => {
+    if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = setTimeout(() => {
+      collapseTimerRef.current = null;
+      setExpanded(false);
+      if (shrinkTimerRef.current) clearTimeout(shrinkTimerRef.current);
+      shrinkTimerRef.current = setTimeout(() => {
+        shrinkTimerRef.current = null;
+        invoke('set_overlay_expanded', { expanded: false })
+          .catch((e) => flog.warn('overlay', 'set_overlay_expanded(false) failed', { error: String(e) }));
+      }, 380);
+    }, 300);
+  }, []);
+
+  // Quick control: auto-paste. Write localStorage + notify the main window.
+  const handleToggleAutoPaste = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      const s = loadSettings();
+      const next = !s.autoPaste;
+      saveSettings({ ...s, autoPaste: next });
+      setAutoPaste(next);
+      emit('settings-changed').catch((err) => flog.warn('overlay', 'emit settings-changed failed', { error: String(err) }));
+    } catch (err) {
+      flog.error('overlay', 'toggle autoPaste failed', { error: String(err) });
+    }
+  }, []);
+
+  // Quick control: global disable. Gate the backend immediately, then notify.
+  const handleToggleDisabled = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      const s = loadSettings();
+      const next = !s.disabled;
+      await invoke('set_app_disabled', { disabled: next });
+      saveSettings({ ...s, disabled: next });
+      setDisabled(next);
+      emit('settings-changed').catch((err) => flog.warn('overlay', 'emit settings-changed failed', { error: String(err) }));
+    } catch (err) {
+      flog.error('overlay', 'toggle disabled failed', { error: String(err) });
+    }
+  }, []);
+
+  // Quick control: open the main window's Settings panel.
+  const handleOpenSettings = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      emit('open-settings').catch(() => {});
+      const main = await WebviewWindow.getByLabel('main');
+      await main?.show();
+      await main?.setFocus();
+    } catch (err) {
+      flog.error('overlay', 'open settings failed', { error: String(err) });
+    }
+  }, []);
+
+  const topH = notchHeight || 37;
+
   return (
     <div
-      data-tauri-drag-region
       className="w-full h-full flex"
       style={{ background: 'transparent' }}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
-      {/* Dynamic Island: same height as notch, expands horizontally.
-          Idle = small icon on the left showing app is alive.
-          Active = expands with red dot on left, waveform on right. */}
+      {/* Dynamic Island: top bar matches notch height; hover expands it downward
+          to reveal the quick-settings dropdown. Idle/recording only changes the
+          top bar — the dropdown row is identical. */}
       <div
-        className="cursor-pointer select-none overflow-hidden transition-all duration-[500ms] ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+        className="cursor-pointer select-none overflow-hidden"
         style={{
           borderRadius: '0 0 12px 12px',
-          width: isActive ? notchWidth + 68 : notchWidth + 28,
+          width: (expanded || isActive) ? notchWidth + 68 : notchWidth + 28,
+          height: expanded ? topH + 56 : topH,
           marginLeft: 32,
-          height: '100%',
           background: 'rgba(20, 20, 20, 0.92)',
           backdropFilter: 'blur(40px)',
           WebkitBackdropFilter: 'blur(40px)',
+          transition: 'width 400ms cubic-bezier(0.34,1.56,0.64,1), height 360ms cubic-bezier(0.34,1.56,0.64,1)',
         }}
       >
-        <div className="flex items-center h-full" style={{ paddingLeft: 10, paddingRight: 10 }}>
+        {/* Top bar — the only draggable surface (keeps the dropdown buttons clickable) */}
+        <div data-tauri-drag-region className="flex items-center" style={{ height: topH, paddingLeft: 10, paddingRight: 10 }}>
           {/* Left side — mic icon (idle) or red dot (recording) or spinner (processing) or red X (cancelled), all same position */}
           <div className="shrink-0 w-3 h-3 flex items-center justify-center">
             {showCancelled ? (
@@ -323,6 +449,13 @@ export function OverlayWidget() {
               </svg>
             )}
           </div>
+
+          {/* Inline timer — recording + hover only */}
+          {status === 'recording' && expanded && (
+            <span className="shrink-0 text-white/60 tabular-nums" style={{ marginLeft: 7, fontSize: 11 }}>
+              {formatElapsed(elapsed)}
+            </span>
+          )}
 
           {/* Spacer */}
           <div className="flex-1" />
@@ -346,6 +479,64 @@ export function OverlayWidget() {
               />
             ))}
           </div>
+        </div>
+
+        {/* Quick-settings dropdown — revealed on hover (identical in idle/recording) */}
+        <div
+          className="flex items-center justify-center gap-4"
+          style={{
+            height: 56,
+            padding: '0 12px 8px',
+            opacity: expanded ? 1 : 0,
+            pointerEvents: expanded ? 'auto' : 'none',
+            transition: 'opacity 200ms ease',
+            transitionDelay: expanded ? '100ms' : '0ms',
+          }}
+        >
+          {/* Global disable (speaker-slash) */}
+          <button
+            type="button"
+            aria-label="Disable Murmur"
+            onClick={handleToggleDisabled}
+            className="shrink-0 flex items-center justify-center cursor-pointer rounded-[9px] transition-colors"
+            style={{ width: 30, height: 30, background: disabled ? 'rgba(239,68,68,0.12)' : 'rgba(255,255,255,0.06)' }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={disabled ? '#ef4444' : 'rgba(255,255,255,0.85)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+              <line x1="23" y1="9" x2="17" y2="15" />
+              <line x1="17" y1="9" x2="23" y2="15" />
+            </svg>
+          </button>
+
+          {/* Auto-paste toggle */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={autoPaste}
+            aria-label="Auto paste"
+            onClick={handleToggleAutoPaste}
+            className="relative shrink-0 cursor-pointer rounded-full transition-colors"
+            style={{ width: 34, height: 18, opacity: disabled ? 0.35 : 1, background: autoPaste ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.18)' }}
+          >
+            <span
+              className="absolute rounded-full transition-transform"
+              style={{ top: 2, left: 2, width: 14, height: 14, background: autoPaste ? '#14141a' : '#fff', transform: autoPaste ? 'translateX(16px)' : 'translateX(0)' }}
+            />
+          </button>
+
+          {/* Open settings (gear) */}
+          <button
+            type="button"
+            aria-label="Open settings"
+            onClick={handleOpenSettings}
+            className="shrink-0 flex items-center justify-center cursor-pointer rounded-[9px] transition-colors"
+            style={{ width: 30, height: 30, background: 'rgba(255,255,255,0.06)' }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.85)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
         </div>
       </div>
     </div>

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -587,6 +587,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               )}
             </div>
           )}
+          {settings.autoPaste && saveToFile && (
+            <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
+              <span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />
+              <span>Paused while saving audio or transcripts to file</span>
+            </div>
+          )}
           {settings.autoPaste && (
             <PasteDelaySlider
               value={settings.autoPasteDelayMs}

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { DEFAULT_SETTINGS } from './settings';
+import { DEFAULT_SETTINGS, Settings } from './settings';
 
 export interface DictationResponse {
   type: string;
@@ -71,6 +71,24 @@ export interface ConfigureOptions {
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
   return await invoke('configure_dictation', { options });
+}
+
+/**
+ * Extract only the backend-configurable fields from a Settings object. Keeps
+ * UI-only fields (disabled, launchAtLogin, recordingMode, microphone, etc.) out
+ * of the `configure_dictation` payload so callers can't accidentally send them.
+ */
+export function buildConfigureOptions(s: Settings): ConfigureOptions {
+  return {
+    model: s.model,
+    language: s.language,
+    autoPaste: s.autoPaste,
+    autoPasteDelayMs: s.autoPasteDelayMs,
+    vadSensitivity: s.vadSensitivity,
+    idleTimeoutMinutes: s.idleTimeoutMinutes,
+    customVocabulary: s.customVocabulary,
+    smartPunctuation: s.smartPunctuation,
+  };
 }
 
 export async function countVocabTokens(text: string): Promise<number | null> {

--- a/app/src/lib/hooks/useInitialization.ts
+++ b/app/src/lib/hooks/useInitialization.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { initDictation, configure } from '../dictation';
+import { initDictation, configure, buildConfigureOptions } from '../dictation';
 import { Settings } from '../settings';
 
 export function useInitialization(settings: Settings) {
@@ -12,16 +12,7 @@ export function useInitialization(settings: Settings) {
     initDictation()
       .then(() => {
         if (cancelled) return;
-        return configure({
-          model: settings.model,
-          language: settings.language,
-          autoPaste: settings.autoPaste,
-          autoPasteDelayMs: settings.autoPasteDelayMs,
-          vadSensitivity: settings.vadSensitivity,
-          idleTimeoutMinutes: settings.idleTimeoutMinutes,
-          customVocabulary: settings.customVocabulary,
-          smartPunctuation: settings.smartPunctuation,
-        });
+        return configure(buildConfigureOptions(settings));
       })
       .then(() => {
         if (cancelled) return;

--- a/app/src/lib/hooks/useOpenSettingsListener.ts
+++ b/app/src/lib/hooks/useOpenSettingsListener.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { listen } from '@tauri-apps/api/event';
+
+/**
+ * Listens for the `open-settings` event emitted by the overlay's gear button and
+ * invokes `onOpen` to reveal the Settings panel. Showing/focusing the main window
+ * alone is not enough — the panel's open state is local React state in App.tsx.
+ */
+export function useOpenSettingsListener(onOpen: () => void) {
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen('open-settings', () => {
+      if (!cancelled) onOpen();
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, [onOpen]);
+}

--- a/app/src/lib/hooks/useOverlaySettingsSync.ts
+++ b/app/src/lib/hooks/useOverlaySettingsSync.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { Settings, loadSettings } from '../settings';
+
+/**
+ * Listens for the `settings-changed` event emitted by the overlay window's
+ * quick-settings controls (auto-paste / global disable) and applies the latest
+ * persisted settings via `apply`. The overlay runs in a separate Tauri window
+ * with no shared React context, so this event is the bridge back to the main
+ * window's settings state and backend configuration.
+ */
+export function useOverlaySettingsSync(apply: (fresh: Settings) => void) {
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen('settings-changed', () => {
+      if (!cancelled) apply(loadSettings());
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, [apply]);
+}

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -55,7 +55,7 @@ export function useSettings() {
       });
     }
 
-    if ('autoPaste' in updates || 'disabled' in updates) {
+    if ('autoPaste' in updates || 'disabled' in updates || 'saveTranscript' in updates || 'saveAudio' in updates) {
       // Notify the overlay window (separate React context) so its quick-settings
       // controls reflect changes made here. The diff-guard in applyExternalSettings
       // prevents this window from re-applying its own change.

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { emit } from '@tauri-apps/api/event';
 import { Settings, loadSettings, saveSettings } from '../settings';
-import { configure } from '../dictation';
+import { configure, buildConfigureOptions } from '../dictation';
 import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
 
 let lastAutostartOp: Promise<void> = Promise.resolve();
@@ -54,9 +55,16 @@ export function useSettings() {
       });
     }
 
+    if ('autoPaste' in updates || 'disabled' in updates) {
+      // Notify the overlay window (separate React context) so its quick-settings
+      // controls reflect changes made here. The diff-guard in applyExternalSettings
+      // prevents this window from re-applying its own change.
+      emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
+    }
+
     if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates) {
       const version = ++configureVersionRef.current;
-      configure({ model: newSettings.model, language: newSettings.language, autoPaste: newSettings.autoPaste, autoPasteDelayMs: newSettings.autoPasteDelayMs, vadSensitivity: newSettings.vadSensitivity, idleTimeoutMinutes: newSettings.idleTimeoutMinutes, customVocabulary: newSettings.customVocabulary, smartPunctuation: newSettings.smartPunctuation })
+      configure(buildConfigureOptions(newSettings))
         .catch((err) => {
           console.error('Failed to configure:', err);
           if (configureVersionRef.current === version) {
@@ -79,5 +87,31 @@ export function useSettings() {
     }
   };
 
-  return { settings, updateSettings };
+  // Ingest a settings change made by another window (the overlay's quick controls).
+  // Diffs against the current value so a window applying its own emitted change is a
+  // no-op — this is what breaks the settings-changed echo loop.
+  const applyExternalSettings = useCallback((fresh: Settings) => {
+    const prev = settingsRef.current;
+    const disabledChanged = fresh.disabled !== prev.disabled;
+    const autoPasteChanged = fresh.autoPaste !== prev.autoPaste;
+    if (!disabledChanged && !autoPasteChanged) return;
+
+    settingsRef.current = fresh;
+    setSettings(fresh);
+    saveSettings(fresh);
+
+    if (disabledChanged) {
+      // Idempotent: the overlay also calls this directly for a snappy gate.
+      invoke('set_app_disabled', { disabled: fresh.disabled }).catch((err) => {
+        console.error('Failed to sync disabled state:', err);
+      });
+    }
+    if (autoPasteChanged) {
+      configure(buildConfigureOptions(fresh)).catch((err) => {
+        console.error('Failed to configure:', err);
+      });
+    }
+  }, []);
+
+  return { settings, updateSettings, applyExternalSettings };
 }

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -39,18 +39,41 @@ Tauri's `focusable: false` configuration disables mouse events on macOS. The `sh
 
 ## Sizing
 
-Overlay width adjusts based on recording state:
+The visible pill width adjusts based on recording state and hover:
 
 | State | Width | Notes |
 |-------|-------|-------|
-| Idle | `notchWidth + 28` | Compact, shows only the mic icon |
-| Recording / Processing | `notchWidth + 68` | Expanded, shows waveform and status indicators |
+| Idle (no hover) | `notchWidth + 28` | Compact, shows only the mic icon |
+| Recording / Processing | `notchWidth + 68` | Shows waveform and status indicators |
+| Hover (idle or recording) | `notchWidth + 68` | Wide enough for the quick-settings dropdown |
 
 The full overlay window width is `notchWidth + 120` (60px expansion per side), with the visible content area sized within that.
 
-Height matches the menu bar height from notch detection. The overlay is horizontally centered at the top of the screen (y=0).
+Height matches the menu bar height from notch detection. On hover the window grows by `EXPANDED_DROP` (56px) downward to reveal the dropdown (see Hover-Expand below). The overlay is horizontally centered at the top of the screen (y=0).
 
-The width transition uses a spring-like animation: `cubic-bezier(0.34, 1.56, 0.64, 1)` over 500ms.
+Width transitions over 400ms and height over 360ms, both using the spring curve `cubic-bezier(0.34, 1.56, 0.64, 1)`.
+
+## Hover-Expand & Quick Settings
+
+Hovering the pill expands it downward into a quick-settings dropdown. The dropdown is identical regardless of state — only the top bar differs.
+
+- **Expand** on `mouseEnter`; **collapse** 300ms after `mouseLeave` (hover-intent delay to avoid flicker during cursor movement).
+- Because a transparent overlay with cursor events enabled captures the mouse across its whole frame, the window is **dynamically resized** rather than pre-allocated tall — otherwise the idle overlay would create a click dead-zone below the notch. Expand grows the window first, then the card animates open; collapse animates the card closed, then shrinks the window ~380ms later so the dropdown is never clipped mid-transition.
+- Only the **top bar** is a drag region (`data-tauri-drag-region`); the dropdown buttons are not, so they stay clickable.
+
+### Dropdown controls
+
+| Control | Action |
+|---------|--------|
+| Speaker-slash | Toggles global disable. Calls `set_app_disabled` directly for an immediate gate. When disabled: red icon (`#ef4444`) on `rgba(239,68,68,0.12)`, auto-paste dims to 35%, top-bar mic fades to 15%. |
+| Auto-paste toggle | Reads/writes the `autoPaste` setting in localStorage. |
+| Gear | Emits `open-settings` and shows/focuses the main window (`WebviewWindow.getByLabel('main')`). |
+
+During recording + hover, an inline `m:ss` timer appears next to the red dot (top bar only; never shown when collapsed).
+
+### Cross-window settings sync
+
+The overlay runs in a separate window with no shared React context. Writes go to localStorage plus an `emit('settings-changed')`; the main window listens and applies the change (`configure` for auto-paste, `set_app_disabled` for disable) with a diff-guard that prevents an echo loop. The main window also emits `settings-changed` on its own auto-paste/disable changes so an already-expanded overlay updates live.
 
 ## Visual States
 
@@ -119,6 +142,7 @@ The observer is intentionally leaked (`std::mem::forget`) for app-lifetime obser
 |---------|-------------|
 | `show_overlay` | Positions, sizes, and shows the overlay window. Re-enables mouse events. |
 | `hide_overlay` | Hides the overlay window. Gracefully handles missing window. |
+| `set_overlay_expanded` | Resizes the overlay height for hover-expand (`base_h + EXPANDED_DROP` when expanded, notch height when collapsed). Width unchanged, top anchored. |
 | `get_notch_info` | Returns cached `{ notch_width, notch_height }` or `null`. |
 
 ## Events
@@ -128,5 +152,8 @@ The observer is intentionally leaked (`std::mem::forget`) for app-lifetime obser
 | `recording-status-changed` | String | Drives visual state transitions |
 | `audio-level` | Number (RMS 0.0-1.0) | Real-time audio level for waveform |
 | `notch-info-changed` | `{ notch_width, notch_height }` or `null` | Display configuration changed |
+| `app-disabled-changed` | Boolean | Global-disable state changed (updates the top-bar mic + speaker-slash) |
+| `settings-changed` | (none) | Auto-paste/disable changed in another window; listeners re-read localStorage |
+| `open-settings` | (none) | Overlay gear asks the main window to open the Settings panel |
 
 The entire overlay surface is a Tauri drag region (`data-tauri-drag-region`), allowing the user to reposition it. Overlay position save/restore is currently disabled (TODO: re-enable after notch positioning is stable).


### PR DESCRIPTION
Closes #135

Alternative implementation to #138, rebuilt on current `main` (0.9.1). #138 is left untouched for comparison.

## Key differences vs #138
- **Dynamic window resize on hover** (`set_overlay_expanded`) instead of a pre-allocated tall window. A transparent Tauri window with cursor events enabled captures clicks across its whole frame, so a permanently-tall window would create a click dead-zone below the notch when idle. Grow window → animate open; animate closed → shrink window so the dropdown is never clipped.
- **Reuses the already-merged global-disable backend** (`set_app_disabled` / `APP_DISABLED`) — speaker-slash gates hotkeys + recording end-to-end (no settings.ts change needed; `disabled` already exists).
- **Gear opens the actual Settings panel** via an `open-settings` event, not just showing the window (panel open state is local React state in App.tsx).
- **Two-way `settings-changed` sync** with a diff-guard so a window applying its own change is a no-op (no echo loop); an expanded overlay reflects main-window changes live.
- **Drag region scoped to the top bar** so the dropdown buttons stay clickable.
- Inline `m:ss` recording timer in the top bar during recording + hover.

## Files
- `commands/overlay.rs` + `lib.rs` — `set_overlay_expanded` command.
- `OverlayWidget.tsx` — hover-intent expand/collapse, dropdown controls, timer, cross-window sync.
- `useSettings.ts` (+`applyExternalSettings`), new `useOverlaySettingsSync` / `useOpenSettingsListener` hooks, `dictation.ts` `buildConfigureOptions` helper.
- `docs/features/overlay.md`, `CHANGELOG.md`.

## Verification
- `cargo check` clean (no warnings); `cargo test -- --test-threads=1` → 84 passed.
- `tsc --noEmit` clean.
- Rendered the overlay dev entry and confirmed the dropdown layout + auto-paste toggle on/off.

Native smoke on a notched Mac still recommended: hover expand (no flicker / no click dead-zone when collapsed), gear opens Settings, speaker-slash gates hotkeys, auto-paste syncs both ways, inline timer while recording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hover-expand overlay quick-settings dropdown with global disable toggle, auto-paste control, and direct settings access.
  * Inline recording timer displayed in overlay during active recording sessions.
  * Warning banner alerting users when auto-paste is paused due to active file saving.

* **Documentation**
  * Updated overlay feature documentation with new interaction behavior and settings controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->