### PR TITLE
feat: Usage dashboard — heatmap, WPM trend, dictation streak

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,7 @@ import { UpdateModal } from './components/UpdateModal';
 import type { UpdateStatus } from './lib/updater';
 import { StatsBar } from './components/StatsBar';
 const ResourceMonitor = lazy(() => import('./components/ResourceMonitor').then(m => ({ default: m.ResourceMonitor })));
+const UsageDashboard = lazy(() => import('./components/UsageDashboard').then(m => ({ default: m.UsageDashboard })));
 import { resetStats } from './lib/stats';
 import { ModelDownloader } from './components/ModelDownloader';
 
@@ -185,6 +186,8 @@ function App() {
               )}
 
               <RecordingControls status={status} initialized={initialized} onStart={handleStart} onStop={handleStop} />
+
+              <Suspense fallback={null}><UsageDashboard statsVersion={combinedStatsVersion} /></Suspense>
 
               {import.meta.env.DEV && <Suspense fallback={null}><ResourceMonitor /></Suspense>}
             </>

--- a/app/src/components/UsageDashboard.tsx
+++ b/app/src/components/UsageDashboard.tsx
@@ -1,0 +1,267 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  loadStats,
+  getRecentDays,
+  getHeatmapWeeks,
+  getCurrentStreak,
+  type DaySummary,
+} from '../lib/stats';
+
+const STORAGE_KEY = 'usage-dashboard-collapsed';
+const HEATMAP_WEEKS = 8;
+const RECENT_DAYS = 7;
+
+// Heatmap geometry (SVG user units; viewBox scales to container width).
+const CELL = 12;
+const GAP = 3;
+const STEP = CELL + GAP;
+
+// Bar/line chart geometry.
+const CHART_W = 100;
+const CHART_H = 40;
+
+const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function loadCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// GitHub-style intensity: 0 = empty, 1..4 scaled against the busiest day shown.
+function intensity(words: number, max: number): number {
+  if (words <= 0) return 0;
+  if (max <= 0) return 1;
+  const ratio = words / max;
+  if (ratio > 0.66) return 4;
+  if (ratio > 0.33) return 3;
+  return 2;
+}
+
+const HEAT_FILL: Record<number, string> = {
+  0: 'var(--heat-0)',
+  1: 'var(--heat-1)',
+  2: 'var(--heat-2)',
+  3: 'var(--heat-3)',
+  4: 'var(--heat-4)',
+};
+
+function shortDay(d: Date): string {
+  return DOW[d.getDay()].slice(0, 1);
+}
+
+interface UsageDashboardProps {
+  // Bumped by App when a recording finishes (or stats reset) — forces a re-read.
+  statsVersion: number;
+}
+
+export function UsageDashboard({ statsVersion }: UsageDashboardProps) {
+  const [isCollapsed, setIsCollapsed] = useState(loadCollapsed);
+  const [version, setVersion] = useState(0);
+
+  // Re-read stats whenever localStorage changes from another window/tab, and
+  // when the panel is expanded so it reflects recordings made while collapsed.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'dictation-stats') setVersion(v => v + 1);
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  // Re-read on expand, on every storage bump, and when App signals new stats;
+  // memoized so the derived charts don't recompute on unrelated re-renders.
+  const stats = useMemo(
+    () => (isCollapsed ? null : loadStats()),
+    [isCollapsed, version, statsVersion],
+  );
+
+  const streak = stats ? getCurrentStreak(stats) : 0;
+  const weeks = stats ? getHeatmapWeeks(stats, HEATMAP_WEEKS) : [];
+  const recent = stats ? getRecentDays(stats, RECENT_DAYS) : [];
+
+  const maxHeat = Math.max(0, ...weeks.flat().map(d => d.words));
+  const maxWords = Math.max(1, ...recent.map(d => d.words));
+  const maxWpm = Math.max(1, ...recent.map(d => d.wpm));
+
+  const toggle = () => {
+    const next = !isCollapsed;
+    setIsCollapsed(next);
+    if (!next) setVersion(v => v + 1); // refresh on expand
+    try { localStorage.setItem(STORAGE_KEY, String(next)); } catch { /* ignore */ }
+  };
+
+  const heatW = HEATMAP_WEEKS * STEP - GAP;
+  const heatH = 7 * STEP - GAP;
+
+  return (
+    // Stone/amber palette. CSS vars drive SVG fills/strokes so they track dark mode.
+    <div className="shrink-0 rounded-lg border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800/50 overflow-hidden [--heat-0:#e7e5e4] dark:[--heat-0:#292524] [--heat-1:#fde68a] dark:[--heat-1:#78350f] [--heat-2:#fcd34d] dark:[--heat-2:#b45309] [--heat-3:#f59e0b] dark:[--heat-3:#d97706] [--heat-4:#d97706] dark:[--heat-4:#fbbf24] [--bar-fill:#f59e0b] dark:[--bar-fill:#fbbf24] [--wpm-stroke:#57534e] dark:[--wpm-stroke:#a8a29e]">
+      {/* Header row */}
+      <button
+        onClick={toggle}
+        className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-stone-100 dark:hover:bg-stone-700/50 transition-colors"
+      >
+        <span className="text-xs font-medium text-stone-500 dark:text-stone-400 uppercase tracking-wider">
+          Insights
+        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-stone-500 dark:text-stone-400">
+            <span className="text-amber-600 dark:text-amber-400 font-medium">Streak</span>
+            {' '}{streak} {streak === 1 ? 'day' : 'days'}
+          </span>
+          <svg
+            className={`w-3.5 h-3.5 text-stone-400 transition-transform duration-200 ${isCollapsed ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+          </svg>
+        </div>
+      </button>
+
+      {!isCollapsed && stats && (
+        <div className="px-3 pb-3 flex flex-col gap-4">
+          {/* Heatmap — last ~8 weeks of words/day */}
+          <Section title={`Activity · last ${HEATMAP_WEEKS} weeks`}>
+            <svg
+              viewBox={`0 0 ${heatW} ${heatH}`}
+              className="w-full max-w-[260px] h-auto"
+              role="img"
+              aria-label="Words per day heatmap"
+            >
+              {weeks.map((col, w) =>
+                col.map((day, d) => (
+                  <rect
+                    key={day.key}
+                    x={w * STEP}
+                    y={d * STEP}
+                    width={CELL}
+                    height={CELL}
+                    rx={2}
+                    fill={HEAT_FILL[intensity(day.words, maxHeat)]}
+                  >
+                    <title>{`${day.key}: ${day.words} words, ${day.recordings} recordings`}</title>
+                  </rect>
+                )),
+              )}
+            </svg>
+            <div className="flex items-center gap-1.5 mt-1.5 text-[10px] text-stone-500 dark:text-stone-400">
+              <span>Less</span>
+              {[0, 1, 2, 3, 4].map(level => (
+                <span
+                  key={level}
+                  className="inline-block w-2.5 h-2.5 rounded-[2px]"
+                  style={{ background: HEAT_FILL[level] }}
+                />
+              ))}
+              <span>More</span>
+            </div>
+          </Section>
+
+          {/* Words/day bar chart — last 7 days */}
+          <Section title="Words per day · last 7 days">
+            <svg
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              preserveAspectRatio="none"
+              className="w-full h-16"
+              role="img"
+              aria-label="Words per day bar chart"
+            >
+              {recent.map((day, i) => {
+                const bw = CHART_W / RECENT_DAYS;
+                const inset = bw * 0.18;
+                const h = (day.words / maxWords) * CHART_H;
+                return (
+                  <rect
+                    key={day.key}
+                    x={i * bw + inset}
+                    y={CHART_H - h}
+                    width={bw - inset * 2}
+                    height={h}
+                    rx={1}
+                    fill="var(--bar-fill)"
+                  >
+                    <title>{`${day.key}: ${day.words} words`}</title>
+                  </rect>
+                );
+              })}
+            </svg>
+            <DayAxis days={recent} />
+          </Section>
+
+          {/* WPM trend line — last 7 days */}
+          <Section title="WPM trend · last 7 days">
+            <svg
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              preserveAspectRatio="none"
+              className="w-full h-16"
+              role="img"
+              aria-label="Words-per-minute trend line"
+            >
+              {[0.5].map(p => (
+                <line
+                  key={p}
+                  x1={0} y1={CHART_H * (1 - p)}
+                  x2={CHART_W} y2={CHART_H * (1 - p)}
+                  stroke="currentColor"
+                  strokeWidth="0.5"
+                  className="text-stone-200 dark:text-stone-700"
+                  strokeDasharray="2,2"
+                />
+              ))}
+              <polyline
+                points={wpmPoints(recent, maxWpm)}
+                fill="none"
+                stroke="var(--wpm-stroke)"
+                strokeWidth="1.2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            </svg>
+            <DayAxis days={recent} />
+          </Section>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function wpmPoints(days: DaySummary[], maxWpm: number): string {
+  if (days.length === 0) return '';
+  return days
+    .map((day, i) => {
+      const x = (i / (RECENT_DAYS - 1)) * CHART_W;
+      const y = (1 - day.wpm / maxWpm) * CHART_H;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[10px] font-medium text-stone-400 dark:text-stone-500 uppercase tracking-wider mb-1.5">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function DayAxis({ days }: { days: DaySummary[] }) {
+  return (
+    <div className="flex justify-between mt-1 px-0.5">
+      {days.map(day => (
+        <span key={day.key} className="text-[9px] text-stone-400 dark:text-stone-500 tabular-nums">
+          {shortDay(day.date)}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/app/src/lib/stats.ts
+++ b/app/src/lib/stats.ts
@@ -1,8 +1,20 @@
+// Per-day usage bucket, keyed by 'YYYY-MM-DD' (local time) in `dailyBuckets`.
+export interface DayBucket {
+  words: number;
+  recordings: number;
+  recordingSeconds: number;
+}
+
+export type DailyBuckets = Record<string, DayBucket>;
+
 export interface DictationStats {
   totalWords: number;
   totalRecordings: number;
   totalDurationSeconds: number;
   wpmSamples: number[];
+  // Per-day breakdown for the usage dashboard. Absent on stats saved before
+  // this map existed — back-filled to {} on load (see loadStats).
+  dailyBuckets: DailyBuckets;
 }
 
 const DEFAULT_STATS: DictationStats = {
@@ -10,7 +22,38 @@ const DEFAULT_STATS: DictationStats = {
   totalRecordings: 0,
   totalDurationSeconds: 0,
   wpmSamples: [],
+  dailyBuckets: {},
 };
+
+const EMPTY_BUCKET: DayBucket = { words: 0, recordings: 0, recordingSeconds: 0 };
+
+// Local-time 'YYYY-MM-DD' key for a date (defaults to now). Local — so a day's
+// bucket aligns with the user's calendar, not UTC.
+export function dayKey(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function isValidBucket(b: unknown): b is DayBucket {
+  if (!b || typeof b !== 'object') return false;
+  const r = b as Record<string, unknown>;
+  return (
+    typeof r.words === 'number' && isFinite(r.words) &&
+    typeof r.recordings === 'number' && isFinite(r.recordings) &&
+    typeof r.recordingSeconds === 'number' && isFinite(r.recordingSeconds)
+  );
+}
+
+function sanitizeBuckets(raw: unknown): DailyBuckets {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: DailyBuckets = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (isValidBucket(value)) out[key] = value;
+  }
+  return out;
+}
 
 const STORAGE_KEY = 'dictation-stats';
 const MAX_WPM_SAMPLES = 100;
@@ -26,6 +69,9 @@ export function loadStats(): DictationStats {
       ) {
         parsed.wpmSamples = DEFAULT_STATS.wpmSamples;
       }
+      // Back-compat: stats saved before dailyBuckets existed have no map; the
+      // sanitizer turns `undefined` into {} so older installs migrate cleanly.
+      parsed.dailyBuckets = sanitizeBuckets(parsed.dailyBuckets);
       return { ...DEFAULT_STATS, ...parsed };
     }
   } catch (e) {
@@ -55,11 +101,25 @@ export function updateStats(text: string, durationSeconds: number): void {
       }
     }
 
+    // Fold this recording into today's bucket (recordings increments even for
+    // empty transcriptions, mirroring totalRecordings — drives the streak).
+    const key = dayKey();
+    const prev = stats.dailyBuckets[key] ?? EMPTY_BUCKET;
+    const dailyBuckets: DailyBuckets = {
+      ...stats.dailyBuckets,
+      [key]: {
+        words: prev.words + wordCount,
+        recordings: prev.recordings + 1,
+        recordingSeconds: prev.recordingSeconds + durationSeconds,
+      },
+    };
+
     saveStats({
       totalWords: stats.totalWords + wordCount,
       totalRecordings: stats.totalRecordings + 1,
       totalDurationSeconds: stats.totalDurationSeconds + durationSeconds,
       wpmSamples: newSamples,
+      dailyBuckets,
     });
   } catch (e) {
     console.error('Failed to update stats:', e);
@@ -82,4 +142,84 @@ export function getWPM(stats: DictationStats): number {
 
 export function getApproxTokens(stats: DictationStats): number {
   return Math.round(stats.totalWords * 1.3);
+}
+
+// --- Daily-bucket derivations for the usage dashboard ---
+
+export interface DaySummary extends DayBucket {
+  key: string;   // 'YYYY-MM-DD'
+  date: Date;    // local midnight of that day
+  wpm: number;   // words per minute over the day (0 when no audio)
+}
+
+function bucketFor(buckets: DailyBuckets, key: string): DayBucket {
+  return buckets[key] ?? EMPTY_BUCKET;
+}
+
+function summaryFor(buckets: DailyBuckets, date: Date): DaySummary {
+  const key = dayKey(date);
+  const b = bucketFor(buckets, key);
+  const minutes = b.recordingSeconds / 60;
+  return {
+    key,
+    date: new Date(date.getFullYear(), date.getMonth(), date.getDate()),
+    words: b.words,
+    recordings: b.recordings,
+    recordingSeconds: b.recordingSeconds,
+    wpm: minutes > 0 ? Math.round(b.words / minutes) : 0,
+  };
+}
+
+// Ordered oldest→newest list of the last `days` calendar days ending today.
+export function getRecentDays(stats: DictationStats, days: number): DaySummary[] {
+  const out: DaySummary[] = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - i);
+    out.push(summaryFor(stats.dailyBuckets, d));
+  }
+  return out;
+}
+
+// Heatmap grid: `weeks` columns of 7 rows (Sun→Sat), aligned so the last column
+// ends on today. Cells before the user's first day still render (empty buckets).
+export function getHeatmapWeeks(stats: DictationStats, weeks: number): DaySummary[][] {
+  const today = new Date();
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  // Walk back to the Sunday that starts the earliest visible week.
+  const start = new Date(todayMidnight);
+  start.setDate(start.getDate() - today.getDay() - (weeks - 1) * 7);
+
+  const cols: DaySummary[][] = [];
+  for (let w = 0; w < weeks; w++) {
+    const col: DaySummary[] = [];
+    for (let day = 0; day < 7; day++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + w * 7 + day);
+      // Days in the future (this week, after today) are omitted as empty cells.
+      col.push(d > todayMidnight ? summaryFor({}, d) : summaryFor(stats.dailyBuckets, d));
+    }
+    cols.push(col);
+  }
+  return cols;
+}
+
+// Consecutive days with >=1 recording, counting back from today. If today has
+// no recordings yet the streak still counts from yesterday so it isn't lost
+// mid-day before the first recording.
+export function getCurrentStreak(stats: DictationStats): number {
+  const buckets = stats.dailyBuckets;
+  const today = new Date();
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  let streak = 0;
+  // Start at today, or yesterday if today is still empty.
+  let cursor = new Date(todayMidnight);
+  if (bucketFor(buckets, dayKey(cursor)).recordings === 0) {
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  while (bucketFor(buckets, dayKey(cursor)).recordings > 0) {
+    streak++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return streak;
 }


### PR DESCRIPTION
Adds a flashy, frontend-only **Insights** section to the main app.

## What's included
- **stats.ts (extended, back-compat):** persists a per-day bucket map in localStorage — `{ 'YYYY-MM-DD': { words, recordings, recordingSeconds } }`. Cumulative stats keep working; if the new map is absent it initializes to `{}` (sanitizer migration on load). `updateStats(text, durationSeconds)` now also writes today's bucket. New derivations: `getRecentDays`, `getHeatmapWeeks`, `getCurrentStreak`, `dayKey`.
- **UsageDashboard.tsx (new):** collapsible (chevron), collapse state persisted under its own localStorage key (`usage-dashboard-collapsed`, **not** settings.ts). No external chart library — inline SVG only, matching the ResourceMonitor pattern. Renders:
  - a 7×8 GitHub-style word **heatmap** of the last ~8 weeks (intensity squares),
  - a **words/day bar** chart for the last 7 days,
  - a **WPM trend line** for the last 7 days,
  - the **current streak** = consecutive days up to today with ≥1 recording.
- **App.tsx:** renders `<UsageDashboard />` in the record-tab main content area; refreshes via the existing `combinedStatsVersion`.

Stone/amber palette (CSS vars for dark-mode-aware SVG fills/strokes) to match existing components. Does **not** touch settings.ts / SettingsPanel.

## Verification
- `npx tsc --noEmit` passes; `npm test` (vitest) — 31 tests pass.
- The native runtime was **NOT** exercised in this automated build. Smoke-test the built `.app` before release: record a few clips, confirm the heatmap/bar/line render and the streak increments, and confirm an install with pre-existing `dictation-stats` migrates without losing cumulative totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a usage dashboard with collapsible insights panel in the record tab
  * Dashboard displays daily dictation statistics including current streak, activity heatmap, and word count/WPM trend visualizations
  * Dashboard state persists across sessions and syncs across browser tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->