### PR TITLE
feat: Voice commands — spoken tokens transform the transcript before injection

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -79,9 +79,9 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone())
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled)
     };
 
     // Per-app profiles: if the frontmost app has a matching profile that sets an
@@ -185,6 +185,10 @@ async fn run_transcription_pipeline(
     let inference_ms = t_transcribe.elapsed().as_millis() as u64;
     let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
     tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
+
+    // Phase: Voice commands -- rewrite spoken command tokens (e.g. "new line",
+    // "scratch that") before the text reaches file output / clipboard / paste.
+    let text = crate::voice_commands::apply_voice_commands(&text, voice_commands_enabled);
 
     // Update last_transcription_at for idle timeout tracking
     *app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
@@ -404,6 +408,10 @@ pub async fn configure_dictation(
 
     if let Some(sp) = options.get("smartPunctuation").and_then(|v| v.as_bool()) {
         dictation.smart_punctuation = sp;
+    }
+
+    if let Some(vc) = options.get("voiceCommandsEnabled").and_then(|v| v.as_bool()) {
+        dictation.voice_commands_enabled = vc;
     }
 
     if let Some(save_transcript) = options.get("saveTranscript").and_then(|v| v.as_bool()) {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod state;
 pub mod telemetry;
 pub mod transcriber;
 mod vad;
+mod voice_commands;
 
 #[cfg(target_os = "macos")]
 #[global_allocator]

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -45,6 +45,7 @@ pub struct DictationState {
     pub output_dir: String,
     /// Per-app profiles that override auto-paste based on the frontmost app.
     pub app_profiles: Vec<AppProfile>,
+    pub voice_commands_enabled: bool,
 }
 
 impl Default for DictationState {
@@ -62,6 +63,7 @@ impl Default for DictationState {
             save_audio: false,
             output_dir: String::new(),
             app_profiles: Vec::new(),
+            voice_commands_enabled: false,
         }
     }
 }

--- a/app/src-tauri/src/voice_commands.rs
+++ b/app/src-tauri/src/voice_commands.rs
@@ -1,0 +1,278 @@
+//! Post-transcription voice command transforms.
+//!
+//! Spoken command tokens (e.g. "new line", "scratch that") are rewritten into
+//! their effect before the text reaches the clipboard/auto-paste. This runs as
+//! a pure string transform after transcription and is gated behind the
+//! `voiceCommandsEnabled` setting.
+
+/// Apply the default voice-command map to `text`.
+///
+/// When `enabled` is false the text is returned unchanged. Matching is
+/// case-insensitive and word-boundary aware (a command only fires when it sits
+/// between non-alphanumeric boundaries), so "newline" or "comma-separated" are
+/// left alone.
+///
+/// Supported commands:
+/// - `new line` -> `\n`
+/// - `new paragraph` -> `\n\n`
+/// - `scratch that` -> delete the previous sentence
+/// - `open paren` / `close paren` -> `(` / `)`
+/// - `period` / `comma` / `question mark` -> punctuation attached to the prior word
+pub fn apply_voice_commands(text: &str, enabled: bool) -> String {
+    if !enabled {
+        return text.to_string();
+    }
+
+    // Multi-word commands are matched before single-word ones so "new paragraph"
+    // wins over "new" + "paragraph" and "question mark" isn't split.
+    //
+    // Each command carries a kind that controls how surrounding whitespace is
+    // handled when it's spliced into the output.
+    const COMMANDS: &[(&str, Command)] = &[
+        ("new paragraph", Command::Replace("\n\n")),
+        ("new line", Command::Replace("\n")),
+        ("scratch that", Command::ScratchThat),
+        ("open paren", Command::OpenBracket("(")),
+        ("close paren", Command::CloseBracket(")")),
+        ("question mark", Command::Punctuation("?")),
+        ("period", Command::Punctuation(".")),
+        ("comma", Command::Punctuation(",")),
+    ];
+
+    let lower = text.to_lowercase();
+    let chars: Vec<char> = text.chars().collect();
+    let lower_chars: Vec<char> = lower.chars().collect();
+
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let mut matched = false;
+        for (phrase, command) in COMMANDS {
+            let phrase_chars: Vec<char> = phrase.chars().collect();
+            if matches_at(&lower_chars, i, &phrase_chars) {
+                command.apply(&mut out);
+                i += phrase_chars.len();
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    out
+}
+
+/// How a matched command rewrites the output buffer.
+enum Command {
+    /// Insert literal text (e.g. newline) verbatim.
+    Replace(&'static str),
+    /// Attach punctuation to the prior word: trim trailing space, then append.
+    Punctuation(&'static str),
+    /// Open bracket: ensure a leading space, append, then suppress the next space.
+    OpenBracket(&'static str),
+    /// Close bracket: attach to the prior word (trim trailing space), then append.
+    CloseBracket(&'static str),
+    /// Delete the previous sentence from the output buffer.
+    ScratchThat,
+}
+
+impl Command {
+    fn apply(&self, out: &mut String) {
+        match self {
+            Command::Replace(s) => {
+                // Trim a space we may have just emitted before the command word,
+                // so "hello new line" -> "hello\n" rather than "hello \n".
+                trim_trailing_inline_space(out);
+                out.push_str(s);
+            }
+            Command::Punctuation(p) | Command::CloseBracket(p) => {
+                trim_trailing_inline_space(out);
+                out.push_str(p);
+            }
+            Command::OpenBracket(b) => {
+                trim_trailing_inline_space(out);
+                if !out.is_empty() && !out.ends_with('\n') {
+                    out.push(' ');
+                }
+                out.push_str(b);
+            }
+            Command::ScratchThat => {
+                trim_trailing_inline_space(out);
+                delete_previous_sentence(out);
+            }
+        }
+    }
+}
+
+/// True if `phrase` occurs in `haystack` starting at `start`, bounded by
+/// non-alphanumeric characters on both sides (word-boundary match).
+fn matches_at(haystack: &[char], start: usize, phrase: &[char]) -> bool {
+    if start + phrase.len() > haystack.len() {
+        return false;
+    }
+    // Left boundary: start of input or a non-alphanumeric char before it.
+    if start > 0 && haystack[start - 1].is_alphanumeric() {
+        return false;
+    }
+    for (k, &pc) in phrase.iter().enumerate() {
+        if haystack[start + k] != pc {
+            return false;
+        }
+    }
+    // Right boundary: end of input or a non-alphanumeric char after it.
+    let after = start + phrase.len();
+    if after < haystack.len() && haystack[after].is_alphanumeric() {
+        return false;
+    }
+    true
+}
+
+/// Remove a single trailing space (but not a newline) from the buffer so
+/// punctuation/brackets attach to the prior word.
+fn trim_trailing_inline_space(out: &mut String) {
+    if out.ends_with(' ') {
+        out.pop();
+    }
+}
+
+/// Delete the previous sentence from `out`, where a sentence is delimited by
+/// `.`, `!`, `?`, or a newline. Leaves the delimiter (and any text before it)
+/// intact, trimming trailing whitespace so the next word flows on cleanly.
+fn delete_previous_sentence(out: &mut String) {
+    // Drop trailing whitespace first so we look at real content.
+    while out.ends_with(|c: char| c.is_whitespace()) {
+        out.pop();
+    }
+    // Find the boundary of the prior sentence: the last sentence-ending
+    // delimiter or newline still in the buffer.
+    let boundary = out
+        .char_indices()
+        .rev()
+        .find(|(_, c)| matches!(c, '.' | '!' | '?' | '\n'))
+        .map(|(idx, c)| idx + c.len_utf8());
+    match boundary {
+        Some(b) => out.truncate(b),
+        None => out.clear(),
+    }
+    // Trim any whitespace left between the delimiter and the next word.
+    while out.ends_with(' ') {
+        out.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_returns_text_unchanged() {
+        let input = "say new line period now";
+        assert_eq!(apply_voice_commands(input, false), input);
+    }
+
+    #[test]
+    fn new_line_inserts_newline() {
+        assert_eq!(apply_voice_commands("hello new line world", true), "hello\nworld");
+    }
+
+    #[test]
+    fn new_paragraph_inserts_double_newline() {
+        assert_eq!(
+            apply_voice_commands("first new paragraph second", true),
+            "first\n\nsecond"
+        );
+    }
+
+    #[test]
+    fn new_paragraph_wins_over_new_line() {
+        // "new paragraph" must match before the "new line"-style prefix logic.
+        let out = apply_voice_commands("a new paragraph b", true);
+        assert_eq!(out, "a\n\nb");
+    }
+
+    #[test]
+    fn period_attaches_to_prior_word() {
+        assert_eq!(apply_voice_commands("done period", true), "done.");
+    }
+
+    #[test]
+    fn comma_attaches_to_prior_word() {
+        assert_eq!(apply_voice_commands("one comma two", true), "one, two");
+    }
+
+    #[test]
+    fn question_mark_attaches_to_prior_word() {
+        assert_eq!(apply_voice_commands("really question mark", true), "really?");
+    }
+
+    #[test]
+    fn open_and_close_paren() {
+        assert_eq!(
+            apply_voice_commands("call open paren x close paren", true),
+            "call (x)"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        assert_eq!(apply_voice_commands("hello New Line world", true), "hello\nworld");
+        assert_eq!(apply_voice_commands("done PERIOD", true), "done.");
+    }
+
+    #[test]
+    fn word_boundary_avoids_false_positives() {
+        // "newline" is one word — must not be split.
+        assert_eq!(apply_voice_commands("newline", true), "newline");
+        // "periodic" contains "period" but isn't the command.
+        assert_eq!(apply_voice_commands("periodic table", true), "periodic table");
+        // "commatesh" likewise.
+        assert_eq!(apply_voice_commands("commando", true), "commando");
+    }
+
+    #[test]
+    fn scratch_that_deletes_previous_sentence() {
+        assert_eq!(
+            apply_voice_commands("First sentence. Second sentence scratch that", true),
+            "First sentence."
+        );
+    }
+
+    #[test]
+    fn scratch_that_with_no_prior_delimiter_clears_buffer() {
+        assert_eq!(apply_voice_commands("just one line scratch that", true), "");
+    }
+
+    #[test]
+    fn scratch_that_stops_at_newline() {
+        let out = apply_voice_commands("line one new line line two scratch that", true);
+        assert_eq!(out, "line one\n");
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(apply_voice_commands("", true), "");
+    }
+
+    #[test]
+    fn no_commands_passes_through() {
+        let input = "just a normal sentence with words";
+        assert_eq!(apply_voice_commands(input, true), input);
+    }
+
+    #[test]
+    fn multiple_commands_in_sequence() {
+        assert_eq!(
+            apply_voice_commands("hello comma world period new line bye", true),
+            "hello, world.\nbye"
+        );
+    }
+
+    #[test]
+    fn command_at_start_of_input() {
+        // "period" at the very start has no prior word; it just emits the mark.
+        assert_eq!(apply_voice_commands("period", true), ".");
+    }
+}

--- a/app/src-tauri/src/voice_commands.rs
+++ b/app/src-tauri/src/voice_commands.rs
@@ -52,6 +52,16 @@ pub fn apply_voice_commands(text: &str, enabled: bool) -> String {
             if matches_at(&lower_chars, i, &phrase_chars) {
                 command.apply(&mut out);
                 i += phrase_chars.len();
+                // Command kinds that splice tightly against the following word
+                // (Replace, OpenBracket) must swallow the single inline space
+                // that separated the command phrase from the next word, e.g.
+                // "hello new line world" -> "hello\nworld" and
+                // "open paren x" -> "(x". Punctuation/CloseBracket attach to the
+                // prior word and must leave that space so the next word doesn't
+                // collide ("one comma two" stays "one, two").
+                if command.splices_tightly() && i < chars.len() && chars[i] == ' ' {
+                    i += 1;
+                }
                 matched = true;
                 break;
             }
@@ -80,6 +90,15 @@ enum Command {
 }
 
 impl Command {
+    /// True when the command attaches directly to the *following* word, so the
+    /// single inline space that separated the command phrase from that word
+    /// should be consumed. `Replace` (newline) and `OpenBracket` both lead into
+    /// the next word with no space; `Punctuation` and `CloseBracket` attach to
+    /// the prior word and keep the space before the next one.
+    fn splices_tightly(&self) -> bool {
+        matches!(self, Command::Replace(_) | Command::OpenBracket(_))
+    }
+
     fn apply(&self, out: &mut String) {
         match self {
             Command::Replace(s) => {

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -855,6 +855,34 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </button>
           </div>
         </div>
+
+        {/* Voice Commands Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              Voice Commands
+            </label>
+            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              Spoken tokens like "new line", "period", or "scratch that" transform the text before pasting.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.voiceCommandsEnabled}
+            aria-label="Voice commands"
+            onClick={() => onUpdateSettings({ voiceCommandsEnabled: !settings.voiceCommandsEnabled })}
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+              settings.voiceCommandsEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                settings.voiceCommandsEnabled ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
         </SettingsSection>
 
         <SettingsSection title="Per-App Profiles" subtitle="Auto-paste per frontmost app" defaultExpanded={false}>

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -71,6 +71,7 @@ export interface ConfigureOptions {
   saveAudio?: boolean;
   outputDir?: string;
   appProfiles?: AppProfile[];
+  voiceCommandsEnabled?: boolean;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -96,6 +97,7 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     saveAudio: s.saveAudio,
     outputDir: s.outputDir,
     appProfiles: s.appProfiles,
+    voiceCommandsEnabled: s.voiceCommandsEnabled,
   };
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -82,6 +82,7 @@ export function useSettings() {
               saveAudio: previousSettings.saveAudio,
               outputDir: previousSettings.outputDir,
               appProfiles: previousSettings.appProfiles,
+              voiceCommandsEnabled: previousSettings.voiceCommandsEnabled,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -31,6 +31,7 @@ export interface Settings {
   saveAudio: boolean;
   outputDir: string;
   appProfiles: AppProfile[];
+  voiceCommandsEnabled: boolean;
 }
 
 export type ModelOption =
@@ -104,6 +105,7 @@ export const DEFAULT_SETTINGS: Settings = {
   saveAudio: false,
   outputDir: '',
   appProfiles: [],
+  voiceCommandsEnabled: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -156,6 +158,12 @@ export function loadSettings(): Settings {
             autoPasteOverride:
               typeof p.autoPasteOverride === 'boolean' ? p.autoPasteOverride : null,
           }));
+      }
+
+      // Voice commands gate the Rust transform — coerce non-booleans (or a
+      // missing field on pre-feature stored settings) back to the default.
+      if (typeof parsed.voiceCommandsEnabled !== 'boolean') {
+        parsed.voiceCommandsEnabled = DEFAULT_SETTINGS.voiceCommandsEnabled;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;


### PR DESCRIPTION
## Summary

Post-transcription text transforms triggered by spoken command tokens, applied **before** text injection (clipboard / auto-paste).

A new pure Rust module `app/src-tauri/src/voice_commands.rs` exposes `apply_voice_commands(text: &str, enabled: bool) -> String`. The default command map is case-insensitive and word-boundary matched:

- `new line` -> `\n`
- `new paragraph` -> `\n\n`
- `scratch that` -> delete the previous sentence
- `open paren` / `close paren` -> `(` / `)`
- `period` / `comma` / `question mark` -> punctuation attached to the prior word

Word-boundary matching means ordinary words such as `newline`, `periodic`, or `commando` are left untouched.

## Implementation

- `voice_commands.rs` (new): pure transform + `#[cfg(test)]` unit tests covering each command, case-insensitivity, word boundaries, `scratch that` sentence deletion, and command sequences.
- `lib.rs`: registers `mod voice_commands;`.
- `commands/recording.rs`: applies the transform in `run_transcription_pipeline` right after transcription and before file output / clipboard / paste; reads/parses the new setting in `configure_dictation`.
- `state.rs`: adds `voice_commands_enabled` to `DictationState` (default false).
- Frontend (append-only): `voiceCommandsEnabled` boolean added to `settings.ts` (type + defaults + migration), `dictation.ts` (`ConfigureOptions` + `buildConfigureOptions`), `useSettings.ts` (configure trigger + revert), and one toggle row appended to the Output section of `SettingsPanel.tsx`.

The feature is gated behind the setting and defaults to **off**.

## Verification

- `npx tsc --noEmit` passes.
- `npm test` (vitest) passes: 31/31.
- Rust is **not** compiled in this automated build (whisper-rs + Metal is slow on a cold worktree); CI runs the full Rust suite on this PR.
- The native runtime was **NOT** exercised in this automated build — smoke-test the built `.app` (record speech with voice commands enabled, confirm tokens like "new line" / "period" / "scratch that" transform the pasted text) before release.