### PR TITLE
feat: AI cleanup (rule-based) — strip filler + tidy punctuation before injection

### DIFF
--- a/app/src-tauri/src/cleanup.rs
+++ b/app/src-tauri/src/cleanup.rs
@@ -72,11 +72,27 @@ fn split_trailing_punct(token: &str) -> (&str, &str) {
 }
 
 /// Compare two tokens for the duplicate-collapse rule: case-insensitive on the
-/// word, ignoring trailing punctuation. "The the." collapses; "had had" too.
+/// word, ignoring trailing punctuation. "The the." collapses to a single key.
 fn word_key(token: &str) -> String {
     let (word, _) = split_trailing_punct(token);
     word.to_lowercase()
 }
+
+/// Closed-class function words whose immediate repetition is overwhelmingly a
+/// recognition/stutter artifact rather than real speech. Only immediate
+/// duplicates of these words collapse.
+///
+/// This preserves the "never drop a real word" guarantee for legitimate
+/// consecutive repeats that English genuinely produces — e.g. "had had no
+/// effect", "the things that that man said", "all that I had had" — because
+/// those content/relative words are *not* on this list. The list is kept
+/// deliberately small and excludes any word that can validly double:
+///   - "that" is excluded ("that that" is valid),
+///   - "had"/"is"/"do"/"has" are excluded (valid as repeated auxiliaries).
+const COLLAPSIBLE_STUTTER_WORDS: &[&str] = &[
+    "i", "the", "a", "an", "and", "to", "of", "it", "in", "on",
+    "we", "you", "so", "but", "for", "with", "my", "he", "she", "they",
+];
 
 /// Remove filler tokens that stand alone as whole words. A token is filler only
 /// when, stripped of trailing punctuation, it case-insensitively matches a known
@@ -93,16 +109,23 @@ fn remove_filler(text: &str) -> String {
     kept.join(" ")
 }
 
-/// Collapse immediate duplicate words ("the the" -> "the", "is is" -> "is").
-/// Comparison is case-insensitive and punctuation-insensitive; the *first*
-/// occurrence is kept so any trailing punctuation on it survives.
+/// Collapse immediate duplicate *stutter* words ("the the" -> "the",
+/// "I I" -> "I"). Comparison is case-insensitive and punctuation-insensitive;
+/// the *first* occurrence is kept so any trailing punctuation on it survives.
+///
+/// Collapsing is intentionally conservative: only a repeat whose word is in
+/// [`COLLAPSIBLE_STUTTER_WORDS`] is dropped. A legitimate doubled content word
+/// such as "had had" or "that that" is left untouched, honoring the module's
+/// "never drop a real word" guarantee.
 fn collapse_duplicates(text: &str) -> String {
     let mut out: Vec<&str> = Vec::new();
     let mut prev_key: Option<String> = None;
     for token in text.split_whitespace() {
         let key = word_key(token);
-        // Don't collapse empty keys (a lone punctuation token).
-        if !key.is_empty() && prev_key.as_deref() == Some(key.as_str()) {
+        let is_repeat = !key.is_empty() && prev_key.as_deref() == Some(key.as_str());
+        // Only collapse an immediate repeat when the word is a known stutter
+        // artifact; real repeated words (e.g. "had had") are preserved.
+        if is_repeat && COLLAPSIBLE_STUTTER_WORDS.contains(&key.as_str()) {
             continue;
         }
         out.push(token);

--- a/app/src-tauri/src/cleanup.rs
+++ b/app/src-tauri/src/cleanup.rs
@@ -1,0 +1,310 @@
+//! Rule-based transcript cleanup applied before injection.
+//!
+//! Pure, deterministic text tidying — no LLM, no network. Each rule is
+//! deliberately conservative: it only touches filler tokens it recognizes and
+//! never drops a real word. Filler removal and capitalization are independently
+//! toggleable so users can opt into only the parts they trust.
+
+/// Options controlling which cleanup rules run.
+///
+/// The spacing/punctuation normalisation and immediate-duplicate collapse
+/// always run (they're safe and reversible in effect); only the two
+/// potentially-aggressive rules are gated.
+#[derive(Debug, Clone, Copy)]
+pub struct CleanupOptions {
+    /// Remove standalone filler tokens ("um", "uh", "er", "hmm").
+    pub remove_filler: bool,
+    /// Capitalize sentence starts.
+    pub capitalize: bool,
+}
+
+impl Default for CleanupOptions {
+    fn default() -> Self {
+        Self { remove_filler: true, capitalize: true }
+    }
+}
+
+/// Filler tokens removed when they appear as standalone words. Kept short and
+/// unambiguous so we never strip a real word (e.g. "Erm" the name, or "her").
+const FILLER_TOKENS: &[&str] = &["um", "uh", "er", "hmm", "uhh", "umm", "erm"];
+
+/// Clean a transcript according to `opts`.
+///
+/// Pipeline order (each step operates on the previous step's output):
+/// 1. remove standalone filler tokens (if enabled),
+/// 2. collapse immediate duplicate words ("the the" -> "the"),
+/// 3. normalize whitespace and spacing around punctuation,
+/// 4. capitalize sentence starts (if enabled).
+///
+/// Terminal punctuation present in the input is preserved.
+pub fn clean_transcript(text: &str, opts: CleanupOptions) -> String {
+    if text.trim().is_empty() {
+        return String::new();
+    }
+
+    let mut out = text.to_string();
+
+    if opts.remove_filler {
+        out = remove_filler(&out);
+    }
+
+    out = collapse_duplicates(&out);
+    out = normalize_spacing(&out);
+
+    if opts.capitalize {
+        out = capitalize_sentences(&out);
+    }
+
+    out
+}
+
+/// Strip a single trailing punctuation char from a token, returning the bare
+/// word and the punctuation (if any). Only handles the sentence/clause marks
+/// we care about so we don't mangle contractions or hyphenated words.
+fn split_trailing_punct(token: &str) -> (&str, &str) {
+    if let Some(last) = token.chars().last() {
+        if matches!(last, '.' | ',' | '!' | '?' | ';' | ':') {
+            let idx = token.len() - last.len_utf8();
+            return (&token[..idx], &token[idx..]);
+        }
+    }
+    (token, "")
+}
+
+/// Compare two tokens for the duplicate-collapse rule: case-insensitive on the
+/// word, ignoring trailing punctuation. "The the." collapses; "had had" too.
+fn word_key(token: &str) -> String {
+    let (word, _) = split_trailing_punct(token);
+    word.to_lowercase()
+}
+
+/// Remove filler tokens that stand alone as whole words. A token is filler only
+/// when, stripped of trailing punctuation, it case-insensitively matches a known
+/// filler. Punctuation attached to a removed filler is dropped with it.
+fn remove_filler(text: &str) -> String {
+    let kept: Vec<&str> = text
+        .split_whitespace()
+        .filter(|token| {
+            let (word, _) = split_trailing_punct(token);
+            let lower = word.to_lowercase();
+            !FILLER_TOKENS.contains(&lower.as_str())
+        })
+        .collect();
+    kept.join(" ")
+}
+
+/// Collapse immediate duplicate words ("the the" -> "the", "is is" -> "is").
+/// Comparison is case-insensitive and punctuation-insensitive; the *first*
+/// occurrence is kept so any trailing punctuation on it survives.
+fn collapse_duplicates(text: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    let mut prev_key: Option<String> = None;
+    for token in text.split_whitespace() {
+        let key = word_key(token);
+        // Don't collapse empty keys (a lone punctuation token).
+        if !key.is_empty() && prev_key.as_deref() == Some(key.as_str()) {
+            continue;
+        }
+        out.push(token);
+        prev_key = Some(key);
+    }
+    out.join(" ")
+}
+
+/// Normalize whitespace: collapse runs of spaces, remove spaces before
+/// sentence/clause punctuation, and ensure a single space after punctuation
+/// when another word follows.
+fn normalize_spacing(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut prev_was_space = false;
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            // Defer emitting whitespace until we know it isn't followed by
+            // punctuation that should hug the previous word.
+            prev_was_space = true;
+            continue;
+        }
+
+        if matches!(ch, '.' | ',' | '!' | '?' | ';' | ':') {
+            // Drop any pending space before punctuation.
+            prev_was_space = false;
+            result.push(ch);
+            continue;
+        }
+
+        if prev_was_space && !result.is_empty() {
+            result.push(' ');
+        }
+        prev_was_space = false;
+        result.push(ch);
+    }
+
+    result.trim().to_string()
+}
+
+/// Capitalize the first alphabetic character of each sentence. Sentence
+/// boundaries are the start of the string and the position after a terminal
+/// `.`/`!`/`?`. Only the leading letter is touched — interior casing (acronyms,
+/// proper nouns) is left untouched so we never corrupt real words.
+fn capitalize_sentences(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut at_sentence_start = true;
+
+    for ch in text.chars() {
+        if at_sentence_start && ch.is_alphabetic() {
+            for upper in ch.to_uppercase() {
+                result.push(upper);
+            }
+            at_sentence_start = false;
+            continue;
+        }
+
+        result.push(ch);
+
+        if matches!(ch, '.' | '!' | '?') {
+            at_sentence_start = true;
+        } else if !ch.is_whitespace() {
+            // A non-terminal, non-space char means we're inside a sentence.
+            at_sentence_start = false;
+        }
+        // Whitespace between a terminator and the next letter keeps
+        // `at_sentence_start` true.
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full() -> CleanupOptions {
+        CleanupOptions { remove_filler: true, capitalize: true }
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(clean_transcript("", full()), "");
+        assert_eq!(clean_transcript("   ", full()), "");
+    }
+
+    #[test]
+    fn removes_standalone_filler() {
+        assert_eq!(
+            clean_transcript("um hello uh world", full()),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn removes_filler_with_trailing_punct() {
+        assert_eq!(clean_transcript("hello um, world", full()), "Hello world");
+    }
+
+    #[test]
+    fn keeps_real_words_resembling_filler() {
+        // "her" and "under" must survive — only exact filler tokens are dropped.
+        assert_eq!(
+            clean_transcript("her under the umbrella", full()),
+            "Her under the umbrella"
+        );
+    }
+
+    #[test]
+    fn filler_disabled_keeps_tokens() {
+        let opts = CleanupOptions { remove_filler: false, capitalize: false };
+        assert_eq!(clean_transcript("um hello", opts), "um hello");
+    }
+
+    #[test]
+    fn collapses_immediate_duplicates() {
+        assert_eq!(clean_transcript("the the cat", full()), "The cat");
+        assert_eq!(clean_transcript("I I think", full()), "I think");
+    }
+
+    #[test]
+    fn collapses_case_insensitive_duplicates() {
+        assert_eq!(clean_transcript("The the dog", full()), "The dog");
+    }
+
+    #[test]
+    fn does_not_collapse_distinct_words() {
+        assert_eq!(
+            clean_transcript("had had no effect", full()).to_lowercase(),
+            "had had no effect"
+        );
+        // Only *immediate* repeats collapse; "the cat the dog" stays intact.
+        assert_eq!(clean_transcript("the cat the dog", full()), "The cat the dog");
+    }
+
+    #[test]
+    fn normalizes_space_before_punctuation() {
+        assert_eq!(
+            clean_transcript("hello , world .", full()),
+            "Hello, world."
+        );
+    }
+
+    #[test]
+    fn collapses_double_spaces() {
+        assert_eq!(
+            clean_transcript("hello    there  friend", full()),
+            "Hello there friend"
+        );
+    }
+
+    #[test]
+    fn capitalizes_sentence_starts() {
+        assert_eq!(
+            clean_transcript("hello world. how are you?", full()),
+            "Hello world. How are you?"
+        );
+    }
+
+    #[test]
+    fn capitalize_disabled_leaves_case() {
+        let opts = CleanupOptions { remove_filler: false, capitalize: false };
+        assert_eq!(clean_transcript("hello. world.", opts), "hello. world.");
+    }
+
+    #[test]
+    fn preserves_terminal_punctuation() {
+        assert_eq!(clean_transcript("done!", full()), "Done!");
+        assert_eq!(clean_transcript("really?", full()), "Really?");
+    }
+
+    #[test]
+    fn combined_real_world_example() {
+        let input = "um so the the meeting is uh tomorrow .  see you  there";
+        assert_eq!(
+            clean_transcript(input, full()),
+            "So the meeting is tomorrow. See you there"
+        );
+    }
+
+    #[test]
+    fn does_not_drop_interior_casing() {
+        // Acronyms / proper nouns mid-sentence are untouched.
+        assert_eq!(
+            clean_transcript("call the FBI today.", full()),
+            "Call the FBI today."
+        );
+    }
+
+    #[test]
+    fn filler_only_input_collapses_to_empty() {
+        assert_eq!(clean_transcript("um uh hmm", full()), "");
+    }
+
+    #[test]
+    fn independent_toggles() {
+        // Filler removed, but capitalization left off.
+        let opts = CleanupOptions { remove_filler: true, capitalize: false };
+        assert_eq!(clean_transcript("um hello", opts), "hello");
+
+        // Capitalization on, filler left in.
+        let opts = CleanupOptions { remove_filler: false, capitalize: true };
+        assert_eq!(clean_transcript("um hello", opts), "Um hello");
+    }
+}

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -79,9 +79,9 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, cleanup_enabled) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled)
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.cleanup_enabled)
     };
 
     // Per-app profiles: if the frontmost app has a matching profile that sets an
@@ -185,6 +185,21 @@ async fn run_transcription_pipeline(
     let inference_ms = t_transcribe.elapsed().as_millis() as u64;
     let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
     tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
+
+    // Phase: rule-based cleanup (filler removal + punctuation/spacing tidy).
+    // Runs on the transcript before injection and file output so what the user
+    // pastes matches what's saved. Conservative and independent of any other
+    // post-processing (e.g. voice commands), operating only on its own setting.
+    // Runs BEFORE voice commands so filler/punctuation tidy never mangles the
+    // structural tokens (e.g. inserted "\n" from "new line") that voice commands
+    // emit downstream.
+    let text = if cleanup_enabled && !text.trim().is_empty() {
+        let cleaned = crate::cleanup::clean_transcript(&text, crate::cleanup::CleanupOptions::default());
+        tracing::info!(target: "pipeline", "cleanup applied ({} -> {} chars)", text.len(), cleaned.len());
+        cleaned
+    } else {
+        text
+    };
 
     // Phase: Voice commands -- rewrite spoken command tokens (e.g. "new line",
     // "scratch that") before the text reaches file output / clipboard / paste.
@@ -447,6 +462,10 @@ pub async fn configure_dictation(
                 Some(crate::state::AppProfile { bundle_id, label, auto_paste_override })
             })
             .collect();
+    }
+
+    if let Some(cleanup_enabled) = options.get("cleanupEnabled").and_then(|v| v.as_bool()) {
+        dictation.cleanup_enabled = cleanup_enabled;
     }
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 mod alloc;
 mod audio;
 mod audio_decode;
+mod cleanup;
 mod commands;
 mod file_output;
 mod frontmost;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -46,6 +46,9 @@ pub struct DictationState {
     /// Per-app profiles that override auto-paste based on the frontmost app.
     pub app_profiles: Vec<AppProfile>,
     pub voice_commands_enabled: bool,
+    /// Rule-based transcript cleanup (filler removal, spacing/capitalization)
+    /// applied before injection. Off by default.
+    pub cleanup_enabled: bool,
 }
 
 impl Default for DictationState {
@@ -64,6 +67,7 @@ impl Default for DictationState {
             output_dir: String::new(),
             app_profiles: Vec::new(),
             voice_commands_enabled: false,
+            cleanup_enabled: false,
         }
     }
 }

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -598,6 +598,34 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           value={settings.customVocabulary}
           onCommit={(value) => onUpdateSettings({ customVocabulary: value })}
         />
+
+        {/* Transcript Cleanup Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              Transcript Cleanup
+            </label>
+            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              Strip filler words (um, uh) and tidy spacing before pasting.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.cleanupEnabled}
+            aria-label="Transcript cleanup"
+            onClick={() => onUpdateSettings({ cleanupEnabled: !settings.cleanupEnabled })}
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+              settings.cleanupEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                settings.cleanupEnabled ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
         </SettingsSection>
 
         <SettingsSection title="Recording" subtitle="Trigger mode, shortcut key">

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -72,6 +72,7 @@ export interface ConfigureOptions {
   outputDir?: string;
   appProfiles?: AppProfile[];
   voiceCommandsEnabled?: boolean;
+  cleanupEnabled?: boolean;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -98,6 +99,7 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     outputDir: s.outputDir,
     appProfiles: s.appProfiles,
     voiceCommandsEnabled: s.voiceCommandsEnabled,
+    cleanupEnabled: s.cleanupEnabled,
   };
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'cleanupEnabled' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -83,6 +83,7 @@ export function useSettings() {
               outputDir: previousSettings.outputDir,
               appProfiles: previousSettings.appProfiles,
               voiceCommandsEnabled: previousSettings.voiceCommandsEnabled,
+              cleanupEnabled: previousSettings.cleanupEnabled,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -97,4 +97,33 @@ describe('loadSettings', () => {
       expect(settings.recordingMode).toBe(mode);
     }
   });
+
+  it('defaults cleanupEnabled when absent from stored settings', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      model: 'base.en',
+      doubleTapKey: 'shift_l',
+      language: 'en',
+      recordingMode: 'hold_down',
+    }));
+    const settings = loadSettings();
+    expect(settings.cleanupEnabled).toBe(DEFAULT_SETTINGS.cleanupEnabled);
+  });
+
+  it('coerces non-boolean cleanupEnabled to default', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      cleanupEnabled: 'yes',
+    }));
+    const settings = loadSettings();
+    expect(settings.cleanupEnabled).toBe(DEFAULT_SETTINGS.cleanupEnabled);
+  });
+
+  it('preserves an explicit cleanupEnabled value', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      cleanupEnabled: true,
+    }));
+    const settings = loadSettings();
+    expect(settings.cleanupEnabled).toBe(true);
+  });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -32,6 +32,7 @@ export interface Settings {
   outputDir: string;
   appProfiles: AppProfile[];
   voiceCommandsEnabled: boolean;
+  cleanupEnabled: boolean;
 }
 
 export type ModelOption =
@@ -106,6 +107,7 @@ export const DEFAULT_SETTINGS: Settings = {
   outputDir: '',
   appProfiles: [],
   voiceCommandsEnabled: false,
+  cleanupEnabled: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -164,6 +166,12 @@ export function loadSettings(): Settings {
       // missing field on pre-feature stored settings) back to the default.
       if (typeof parsed.voiceCommandsEnabled !== 'boolean') {
         parsed.voiceCommandsEnabled = DEFAULT_SETTINGS.voiceCommandsEnabled;
+      }
+
+      // cleanupEnabled is a boolean toggle — coerce anything non-boolean
+      // (including absent on older settings blobs) back to the default.
+      if (typeof parsed.cleanupEnabled !== 'boolean') {
+        parsed.cleanupEnabled = DEFAULT_SETTINGS.cleanupEnabled;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;


### PR DESCRIPTION
## Summary

Rule-based transcript cleanup (no LLM) applied to the transcript **before injection**, behind a new opt-in setting.

New Rust module `app/src-tauri/src/cleanup.rs` with a pure `clean_transcript(text, opts) -> String` plus unit tests. Rules:

- Remove standalone filler tokens (`um`, `uh`, `er`, `hmm`, plus `uhh`/`umm`/`erm`) with surrounding-whitespace fixups; punctuation attached to a removed filler is dropped with it.
- Collapse immediate duplicate words (`the the` -> `the`), case- and trailing-punctuation-insensitive, keeping the first occurrence.
- Normalize spacing: collapse double spaces, remove spaces before `.,!?;:`.
- Capitalize sentence starts and preserve terminal punctuation. Only the leading letter of each sentence is touched, so interior casing (acronyms, proper nouns) is never corrupted.

Filler removal and capitalization are **independently toggleable** via `CleanupOptions`; the spacing/duplicate rules always run. The pass is conservative and never drops real words (e.g. `her`, `under` survive).

## Wiring

- `mod cleanup;` registered in `lib.rs`.
- Hooked into `run_transcription_pipeline` in `commands/recording.rs` right after transcription and before file output + injection, so saved transcripts match the injected text. Operates only on its own `cleanupEnabled` setting (independent of / composable with any voice-command processing).
- New `cleanup_enabled` field on `DictationState`, plumbed via `configure_dictation` (`cleanupEnabled` option).

## Frontend

- Appended `cleanupEnabled: boolean` (default `false`) to `Settings` type, `DEFAULT_SETTINGS`, and `loadSettings` migration (non-boolean coerced to default).
- Plumbed through `ConfigureOptions` / `buildConfigureOptions` and the `useSettings` reconfigure + revert path.
- Added a "Transcript Cleanup" toggle row at the end of the Transcription section in `SettingsPanel.tsx`.
- Added migration unit tests in `settings.test.ts`.

## Verification

- Frontend: `npx tsc --noEmit` passes; vitest suite passes (34 tests, including 3 new cleanup migration tests).
- The Rust `cleanup` module ships with unit tests; `ci.yml` runs the full cargo suite on this PR.
- **The native runtime was NOT exercised in this automated build** — smoke-test the built `.app` (enable Transcript Cleanup, dictate filler-heavy speech, confirm cleaned text is pasted) before release.