### PR TITLE
feat: Per-app profiles — frontmost app changes dictation behavior

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -79,15 +79,29 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone())
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone())
+    };
+
+    // Per-app profiles: if the frontmost app has a matching profile that sets an
+    // auto-paste override, honor it instead of the global setting. No match (or
+    // no detected app) leaves the global value untouched.
+    let profile_auto_paste = if app_profiles.is_empty() {
+        auto_paste
+    } else {
+        let bundle_id = crate::frontmost::frontmost_bundle_id();
+        let resolved = crate::frontmost::resolve_auto_paste(auto_paste, bundle_id.as_deref(), &app_profiles);
+        if resolved != auto_paste {
+            tracing::info!(target: "pipeline", "app profile override: auto_paste {} -> {} (frontmost={})", auto_paste, resolved, bundle_id.as_deref().unwrap_or("unknown"));
+        }
+        resolved
     };
 
     // When saving to a file, suppress auto-paste into the focused app. The
     // clipboard write inside `inject_text` is unconditional, so text remains
     // copyable regardless of these toggles.
-    let effective_auto_paste = auto_paste && !(save_transcript || save_audio);
+    let effective_auto_paste = profile_auto_paste && !(save_transcript || save_audio);
 
     // Pre-VAD signal level logging for mic diagnosis
     let rms = audio::compute_rms(samples);
@@ -402,6 +416,29 @@ pub async fn configure_dictation(
 
     if let Some(output_dir) = options.get("outputDir").and_then(|v| v.as_str()) {
         dictation.output_dir = output_dir.to_string();
+    }
+
+    // Per-app profiles: array of { bundleId, label, autoPasteOverride }. A
+    // missing/null autoPasteOverride means "no override". Entries without a
+    // bundleId are skipped. Replaces the whole list when the key is present.
+    if let Some(profiles) = options.get("appProfiles").and_then(|v| v.as_array()) {
+        dictation.app_profiles = profiles
+            .iter()
+            .filter_map(|p| {
+                let bundle_id = p.get("bundleId").and_then(|v| v.as_str())?.trim().to_string();
+                if bundle_id.is_empty() {
+                    return None;
+                }
+                let label = p
+                    .get("label")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // null/absent -> None (use global); otherwise the boolean override.
+                let auto_paste_override = p.get("autoPasteOverride").and_then(|v| v.as_bool());
+                Some(crate::state::AppProfile { bundle_id, label, auto_paste_override })
+            })
+            .collect();
     }
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -1,0 +1,119 @@
+//! Frontmost-app detection used by per-app dictation profiles.
+//!
+//! Reuses the osascript approach from `injector.rs` to ask System Events for
+//! the bundle identifier of whatever app currently owns the keyboard focus.
+//! Detection is best-effort: any failure (osascript missing, permission denied,
+//! empty result) returns `None` so callers fall back to global behaviour.
+
+/// Return the bundle identifier of the frontmost macOS app, e.g.
+/// `"com.apple.Terminal"`. Returns `None` on any failure so the caller can fall
+/// back to the global auto-paste setting.
+#[cfg(target_os = "macos")]
+pub fn frontmost_bundle_id() -> Option<String> {
+    use std::process::Command;
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(target: "pipeline", "frontmost_bundle_id: osascript failed: {}", stderr.trim());
+        return None;
+    }
+
+    let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if bundle_id.is_empty() {
+        None
+    } else {
+        Some(bundle_id)
+    }
+}
+
+/// Non-macOS platforms have no frontmost-app concept here; profiles are a no-op.
+#[cfg(not(target_os = "macos"))]
+pub fn frontmost_bundle_id() -> Option<String> {
+    None
+}
+
+/// Resolve the effective auto-paste setting for the frontmost app.
+///
+/// Given the global `auto_paste` value, the detected frontmost `bundle_id`
+/// (if any), and the configured profiles, returns the override from the first
+/// matching profile that sets one, otherwise the global value. Kept pure so it
+/// can be unit-tested without invoking osascript.
+pub fn resolve_auto_paste(
+    auto_paste: bool,
+    bundle_id: Option<&str>,
+    profiles: &[crate::state::AppProfile],
+) -> bool {
+    let Some(bundle_id) = bundle_id else {
+        return auto_paste;
+    };
+    for profile in profiles {
+        if profile.bundle_id == bundle_id {
+            if let Some(override_value) = profile.auto_paste_override {
+                return override_value;
+            }
+        }
+    }
+    auto_paste
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppProfile;
+
+    fn profile(bundle_id: &str, auto_paste_override: Option<bool>) -> AppProfile {
+        AppProfile {
+            bundle_id: bundle_id.to_string(),
+            label: bundle_id.to_string(),
+            auto_paste_override,
+        }
+    }
+
+    #[test]
+    fn no_frontmost_uses_global() {
+        let profiles = vec![profile("com.apple.Terminal", Some(false))];
+        assert!(resolve_auto_paste(true, None, &profiles));
+        assert!(!resolve_auto_paste(false, None, &profiles));
+    }
+
+    #[test]
+    fn unmatched_app_uses_global() {
+        let profiles = vec![profile("com.apple.Terminal", Some(false))];
+        assert!(resolve_auto_paste(true, Some("com.apple.Safari"), &profiles));
+    }
+
+    #[test]
+    fn matching_profile_override_wins() {
+        let profiles = vec![profile("com.apple.Terminal", Some(false))];
+        assert!(!resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
+    }
+
+    #[test]
+    fn matching_profile_can_force_on() {
+        let profiles = vec![profile("com.googlecode.iterm2", Some(true))];
+        assert!(resolve_auto_paste(false, Some("com.googlecode.iterm2"), &profiles));
+    }
+
+    #[test]
+    fn null_override_falls_through_to_global() {
+        let profiles = vec![profile("com.apple.Terminal", None)];
+        assert!(resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
+        assert!(!resolve_auto_paste(false, Some("com.apple.Terminal"), &profiles));
+    }
+
+    #[test]
+    fn first_matching_override_wins() {
+        let profiles = vec![
+            profile("com.apple.Terminal", None),
+            profile("com.apple.Terminal", Some(false)),
+        ];
+        // First profile has no override, so we fall through to the second.
+        assert!(!resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod audio;
 mod audio_decode;
 mod commands;
 mod file_output;
+mod frontmost;
 mod injector;
 mod keyboard;
 mod resource_monitor;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -20,6 +20,16 @@ impl Default for DictationStatus {
     }
 }
 
+/// Per-app dictation profile. When the frontmost macOS app's bundle id matches
+/// `bundle_id`, `auto_paste_override` (when `Some`) replaces the global
+/// auto-paste setting at inject time. `None` means "no override — use global".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppProfile {
+    pub bundle_id: String,
+    pub label: String,
+    pub auto_paste_override: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DictationState {
     pub status: DictationStatus,
@@ -33,6 +43,8 @@ pub struct DictationState {
     pub save_transcript: bool,
     pub save_audio: bool,
     pub output_dir: String,
+    /// Per-app profiles that override auto-paste based on the frontmost app.
+    pub app_profiles: Vec<AppProfile>,
 }
 
 impl Default for DictationState {
@@ -49,6 +61,7 @@ impl Default for DictationState {
             save_transcript: false,
             save_audio: false,
             output_dir: String::new(),
+            app_profiles: Vec::new(),
         }
     }
 }

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -6,7 +6,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import {
   Settings, RecordingMode, DEFAULT_SETTINGS,
   MODEL_OPTIONS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
-  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS,
+  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, AppProfile,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
@@ -121,6 +121,142 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
         Higher = keeps more audio. Lower = trims silence more aggressively.
       </p>
+    </div>
+  );
+}
+
+// Per-app profiles: simple add/remove list mapping a macOS bundle id to an
+// auto-paste override. The override cycles Default -> On -> Off so the whole
+// control fits in one tap-through button.
+function AppProfilesEditor({ profiles, onChange }: {
+  profiles: AppProfile[];
+  onChange: (next: AppProfile[]) => void;
+}) {
+  const [bundleId, setBundleId] = useState('');
+  const [label, setLabel] = useState('');
+
+  const handleAdd = () => {
+    const trimmedId = bundleId.trim();
+    if (!trimmedId) return;
+    if (profiles.some((p) => p.bundleId === trimmedId)) {
+      // Already have a profile for this app — clear the inputs and bail.
+      setBundleId('');
+      setLabel('');
+      return;
+    }
+    onChange([
+      ...profiles,
+      { bundleId: trimmedId, label: label.trim(), autoPasteOverride: false },
+    ]);
+    setBundleId('');
+    setLabel('');
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(profiles.filter((p) => p.bundleId !== id));
+  };
+
+  // Cycle the override: Default (null) -> On (true) -> Off (false) -> Default.
+  const cycleOverride = (id: string) => {
+    onChange(profiles.map((p) => {
+      if (p.bundleId !== id) return p;
+      const next = p.autoPasteOverride === null ? true : p.autoPasteOverride === true ? false : null;
+      return { ...p, autoPasteOverride: next };
+    }));
+  };
+
+  const overrideLabel = (value: boolean | null) =>
+    value === null ? 'Default' : value ? 'Paste On' : 'Paste Off';
+
+  return (
+    <div>
+      <p className="mb-2 text-xs text-stone-500 dark:text-stone-400">
+        Override auto-paste for specific apps by bundle id (e.g.
+        <span className="font-mono"> com.apple.Terminal</span>). The frontmost app
+        when you finish dictating decides the behavior.
+      </p>
+
+      {profiles.length > 0 && (
+        <ul className="mb-3 space-y-1.5">
+          {profiles.map((p) => (
+            <li
+              key={p.bundleId}
+              className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
+            >
+              <div className="min-w-0 flex-1">
+                {p.label && (
+                  <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
+                    {p.label}
+                  </div>
+                )}
+                <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
+                  {p.bundleId}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => cycleOverride(p.bundleId)}
+                aria-label={`Auto-paste for ${p.label || p.bundleId}: ${overrideLabel(p.autoPasteOverride)}`}
+                className={`shrink-0 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${
+                  p.autoPasteOverride === null
+                    ? 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-600 dark:text-stone-300'
+                    : p.autoPasteOverride
+                      ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
+                      : 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400'
+                }`}
+              >
+                {overrideLabel(p.autoPasteOverride)}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRemove(p.bundleId)}
+                aria-label={`Remove profile for ${p.label || p.bundleId}`}
+                className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Label (optional, e.g. Terminal)"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+        />
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={bundleId}
+            onChange={(e) => setBundleId(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+            placeholder="com.apple.Terminal"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className="flex-1 min-w-0 px-3 py-2 text-xs font-mono rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!bundleId.trim()}
+            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Add
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -719,6 +855,13 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </button>
           </div>
         </div>
+        </SettingsSection>
+
+        <SettingsSection title="Per-App Profiles" subtitle="Auto-paste per frontmost app" defaultExpanded={false}>
+          <AppProfilesEditor
+            profiles={settings.appProfiles}
+            onChange={(next) => onUpdateSettings({ appProfiles: next })}
+          />
         </SettingsSection>
 
         <SettingsSection title="About" subtitle="Stats, logs, updates" defaultExpanded={false}>

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { DEFAULT_SETTINGS, Settings } from './settings';
+import { DEFAULT_SETTINGS, Settings, AppProfile } from './settings';
 
 export interface DictationResponse {
   type: string;
@@ -70,6 +70,7 @@ export interface ConfigureOptions {
   saveTranscript?: boolean;
   saveAudio?: boolean;
   outputDir?: string;
+  appProfiles?: AppProfile[];
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -94,6 +95,7 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     saveTranscript: s.saveTranscript,
     saveAudio: s.saveAudio,
     outputDir: s.outputDir,
+    appProfiles: s.appProfiles,
   };
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -81,6 +81,7 @@ export function useSettings() {
               saveTranscript: previousSettings.saveTranscript,
               saveAudio: previousSettings.saveAudio,
               outputDir: previousSettings.outputDir,
+              appProfiles: previousSettings.appProfiles,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -2,6 +2,17 @@ export type RecordingMode = 'hold_down' | 'double_tap' | 'both';
 
 export type DoubleTapKey = 'shift_l' | 'alt_l' | 'ctrl_r';
 
+/**
+ * Per-app dictation profile. When the frontmost macOS app's bundle id matches
+ * `bundleId`, `autoPasteOverride` (when non-null) replaces the global auto-paste
+ * setting. `null` means "no override — use the global setting".
+ */
+export interface AppProfile {
+  bundleId: string;
+  label: string;
+  autoPasteOverride: boolean | null;
+}
+
 export interface Settings {
   model: ModelOption;
   doubleTapKey: DoubleTapKey;
@@ -19,6 +30,7 @@ export interface Settings {
   saveTranscript: boolean;
   saveAudio: boolean;
   outputDir: string;
+  appProfiles: AppProfile[];
 }
 
 export type ModelOption =
@@ -91,6 +103,7 @@ export const DEFAULT_SETTINGS: Settings = {
   saveTranscript: false,
   saveAudio: false,
   outputDir: '',
+  appProfiles: [],
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -126,6 +139,23 @@ export function loadSettings(): Settings {
       // non-string back to the default (empty = app-chosen Documents/Murmur).
       if (typeof parsed.outputDir !== 'string') {
         parsed.outputDir = DEFAULT_SETTINGS.outputDir;
+      }
+
+      // appProfiles drives per-app auto-paste overrides. Drop malformed entries
+      // and coerce a non-array back to the empty default so the Rust side and UI
+      // never see a bad shape.
+      if (!Array.isArray(parsed.appProfiles)) {
+        parsed.appProfiles = DEFAULT_SETTINGS.appProfiles;
+      } else {
+        parsed.appProfiles = parsed.appProfiles
+          .filter((p): p is AppProfile =>
+            !!p && typeof (p as AppProfile).bundleId === 'string' && (p as AppProfile).bundleId.trim() !== '')
+          .map((p) => ({
+            bundleId: p.bundleId.trim(),
+            label: typeof p.label === 'string' ? p.label : '',
+            autoPasteOverride:
+              typeof p.autoPasteOverride === 'boolean' ? p.autoPasteOverride : null,
+          }));
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;


### PR DESCRIPTION
## Summary

Make dictation behavior depend on the frontmost macOS app. The first use case is auto-paste: turn it OFF in Terminal/iTerm (where a stray paste can run a command) while leaving it ON everywhere else.

## How it works

- **Frontmost detection** (`app/src-tauri/src/frontmost.rs`): a small helper reuses the osascript pattern from `injector.rs` —
  `osascript -e 'tell application "System Events" to get bundle identifier of first process whose frontmost is true'` —
  returning `Option<String>`. Any failure (osascript missing, permission denied, empty result) returns `None`, so the caller falls back to global behavior. Non-macOS targets are a no-op (`None`).
- **Settings** (`app/src/lib/settings.ts`, append-only): adds an `appProfiles` array of `{ bundleId, label, autoPasteOverride: boolean | null }`, default `[]`, plus load-time coercion that drops malformed entries.
- **UI** (`SettingsPanel.tsx`, appended section): a minimal "Per-App Profiles" add/remove list. Each row shows the bundle id and a tap-through override (Default → Paste On → Paste Off).
- **Inject time** (`commands/recording.rs`): when any profiles are configured, the pipeline resolves the frontmost bundle id once and, if a matching profile sets an override, honors it instead of the global `autoPaste`. No match (or no detected app) leaves global behavior unchanged. File-save still suppresses paste as before.
- New `frontmost` module registered in `lib.rs`; `appProfiles` plumbed through `configure_dictation`, `dictation.ts`, and `useSettings.ts`.

The pure resolution logic (`resolve_auto_paste`) is unit-tested in `frontmost.rs` (no-match, override-on, override-off, null-fallthrough, no-frontmost).

## Verification

- `npx tsc --noEmit` passes (against the real local TypeScript compiler, not the worktree stub).
- `npm test` (vitest): 31 tests pass, including the existing settings suite.
- The native Rust path was **NOT** exercised in this automated build (no cargo build/test in the worktree — CI runs the full Rust suite). Smoke-test the built `.app` before release: add a Terminal profile with auto-paste off, dictate while Terminal is frontmost, and confirm text lands in the clipboard only (no auto-paste), while other apps still auto-paste per the global setting.