### PR TITLE
feat: Multi-language transcription — language select + auto-detect

### DIFF
--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -56,7 +56,10 @@ impl Default for DictationState {
         Self {
             status: DictationStatus::Idle,
             model_name: "base.en".to_string(),
-            language: "en".to_string(),
+            // "auto" => whisper auto-detect (None lang param). Non-Whisper
+            // backends ignore this. The frontend persists/overrides it via
+            // configure_dictation; this is only the pre-configure fallback.
+            language: "auto".to_string(),
             auto_paste: false,
             auto_paste_delay_ms: 50,
             vad_sensitivity: 50,

--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -147,8 +147,7 @@ impl TranscriptionBackend for WhisperBackend {
         tracing::info!(target: "pipeline", "whisper: reusing cached state for transcription");
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        let lang_opt: Option<&str> = if language == "auto" { None } else { Some(language) };
-        params.set_language(lang_opt);
+        params.set_language(whisper_language_param(language));
         params.set_print_special(false);
         params.set_print_progress(false);
         params.set_print_realtime(false);
@@ -218,6 +217,18 @@ impl TranscriptionBackend for WhisperBackend {
     }
 }
 
+/// Map a frontend language setting to whisper's `set_language` argument.
+/// `"auto"` (and an empty string, as a defensive fallback) => `None`, which
+/// makes whisper auto-detect the spoken language. Any other value is passed
+/// through as an ISO code for whisper to honor. Whisper-only: other backends
+/// ignore the language entirely.
+fn whisper_language_param(language: &str) -> Option<&str> {
+    match language {
+        "auto" | "" => None,
+        other => Some(other),
+    }
+}
+
 fn strip_punctuation(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut result = String::with_capacity(input.len());
@@ -255,7 +266,26 @@ fn strip_punctuation(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_punctuation;
+    use super::{strip_punctuation, whisper_language_param};
+
+    #[test]
+    fn language_auto_maps_to_none() {
+        assert_eq!(whisper_language_param("auto"), None);
+    }
+
+    #[test]
+    fn language_empty_maps_to_none() {
+        // Defensive: an empty/unset value should fall back to auto-detect, not
+        // be passed to whisper as a bogus empty language code.
+        assert_eq!(whisper_language_param(""), None);
+    }
+
+    #[test]
+    fn language_iso_code_passes_through() {
+        assert_eq!(whisper_language_param("en"), Some("en"));
+        assert_eq!(whisper_language_param("es"), Some("es"));
+        assert_eq!(whisper_language_param("ja"), Some("ja"));
+    }
 
     #[test]
     fn strip_basic_sentence_punctuation() {

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -126,4 +126,42 @@ describe('loadSettings', () => {
     const settings = loadSettings();
     expect(settings.cleanupEnabled).toBe(true);
   });
+
+  it('defaults language to auto when absent from stored settings', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      model: 'base.en',
+      doubleTapKey: 'shift_l',
+      recordingMode: 'hold_down',
+    }));
+    const settings = loadSettings();
+    expect(settings.language).toBe(DEFAULT_SETTINGS.language);
+    expect(settings.language).toBe('auto');
+  });
+
+  it('coerces an unknown language code to default', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      language: 'klingon',
+    }));
+    const settings = loadSettings();
+    expect(settings.language).toBe(DEFAULT_SETTINGS.language);
+  });
+
+  it('coerces a non-string language to default', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      language: 42,
+    }));
+    const settings = loadSettings();
+    expect(settings.language).toBe(DEFAULT_SETTINGS.language);
+  });
+
+  it('preserves a valid non-default language code', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      language: 'nl',
+    }));
+    const settings = loadSettings();
+    expect(settings.language).toBe('nl');
+  });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -82,16 +82,24 @@ export const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
   { value: 'de', label: 'German' },
   { value: 'it', label: 'Italian' },
   { value: 'pt', label: 'Portuguese' },
+  { value: 'nl', label: 'Dutch' },
   { value: 'ja', label: 'Japanese' },
-  { value: 'zh', label: 'Chinese' },
   { value: 'ko', label: 'Korean' },
+  { value: 'zh', label: 'Chinese' },
+  { value: 'ru', label: 'Russian' },
+  { value: 'pl', label: 'Polish' },
+  { value: 'tr', label: 'Turkish' },
+  { value: 'hi', label: 'Hindi' },
+  { value: 'ar', label: 'Arabic' },
 ];
 
 export const DEFAULT_SETTINGS: Settings = {
   // Parakeet fp16 is the default transcription model (faster; English-only).
   model: 'parakeet-tdt-0.6b-v2-fp16',
   doubleTapKey: 'shift_l',
-  language: 'en',
+  // 'auto' lets Whisper auto-detect the spoken language ("just works"); the
+  // default Parakeet model is English-only and ignores this value.
+  language: 'auto',
   autoPaste: false,
   autoPasteDelayMs: 50,
   recordingMode: 'hold_down',


### PR DESCRIPTION
## Summary

Lets users pick the transcription language (or auto-detect) for the Whisper backend.

The core language selector, settings plumbing, and Whisper param wiring already landed on `main` (PR #142). This change completes and improves that feature to the spec:

- **Default to `auto`** — `DEFAULT_SETTINGS.language` (`settings.ts`) and `DictationState::default()` (`state.rs`) now default to `'auto'` (Whisper auto-detect) instead of `'en'`, so multilingual dictation "just works" out of the box. The default Parakeet model is English-only and ignores the value, so the default install behavior is unchanged.
- **Expanded language list** — added Dutch (`nl`), Russian (`ru`), Polish (`pl`), Turkish (`tr`), Hindi (`hi`), Arabic (`ar`) to `LANGUAGE_OPTIONS`, alongside the existing auto/en/es/fr/de/it/pt/ja/ko/zh.
- **Whisper param mapping** — factored the inline `language == "auto" ? None : Some(...)` into a pure `whisper_language_param()` helper in `transcriber/whisper.rs` and unit-tested it (`auto`/empty => None, ISO codes pass through). Empty string now also maps to None as a defensive fallback.
- **Graceful no-op for other backends** — Parakeet already ignores `_language`; unchanged. Only the Whisper backend honors the setting.
- **Migration tests** — added `settings.test.ts` cases: defaults to `auto` when absent, coerces an unknown code (`klingon`) and a non-string (`42`) to default, and preserves a valid non-default code (`nl`). The existing `loadSettings` allow-list coercion already drives this.

Existing plumbing confirmed intact end-to-end: `configure_dictation` parses `language` and stores it on `DictationState`; the live + file pipelines pass `&language` to `backend.transcribe()`; `dictation.ts` (`ConfigureOptions` + `buildConfigureOptions`) and `useSettings.ts` (configure trigger + revert) already carry `language`.

## Verification

- **Rust (pure logic, standalone `rustc --test`)** — extracted `whisper_language_param` + `strip_punctuation` into `/tmp/whisper_lang_logic.rs` and ran `rustc --test`: **4 passed, 0 failed** (`language_auto_maps_to_none`, `language_empty_maps_to_none`, `language_iso_code_passes_through`, `strip_basic_sentence_punctuation`). The added tests live in the real module's `#[cfg(test)]` block; CI's full Rust suite (`ci.yml`) exercises them in-crate.
- **TypeScript** — `cd app && npx tsc --noEmit`: **clean (exit 0)**.
- **Frontend tests** — `cd app && npm test --silent`: **38 passed (3 files)**, including the 4 new language migration cases in `settings.test.ts`. (The `Failed to load settings: SyntaxError` line in stderr is the expected log from the existing invalid-JSON test, which passes.)

The full `cargo build`/`cargo test` (whisper-rs + Metal) was **not** run locally — it runs in CI on this PR. The native runtime was **not** exercised; smoke-test the built `.app` (pick a non-English Whisper model, e.g. Large Turbo, set a language and Auto Detect) before release.