### PR TITLE
feat: Multi-file drag-and-drop for Transcribe File

### DIFF
--- a/app/src/components/FileTranscriptionPanel.tsx
+++ b/app/src/components/FileTranscriptionPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useFileTranscription } from '../lib/hooks/useFileTranscription';
+import type { QueueItem } from '../lib/hooks/useFileTranscription';
 import { flog } from '../lib/log';
 
 interface FileTranscriptionPanelProps {
@@ -8,39 +9,62 @@ interface FileTranscriptionPanelProps {
   addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string) => void;
 }
 
-export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps) {
-  const { status, result, error, fileName, isDragging, transcribe } = useFileTranscription({ addEntry });
-  const [copied, setCopied] = useState(false);
+/** Per-file status pill in the queue list. */
+function StatusBadge({ item }: { item: QueueItem }) {
+  switch (item.status) {
+    case 'queued':
+      return <span className="text-xs text-stone-400 dark:text-stone-500">Queued</span>;
+    case 'transcribing':
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-300">
+          <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Transcribing
+        </span>
+      );
+    case 'done':
+      return <span className="text-xs text-emerald-600 dark:text-emerald-400">Done</span>;
+    case 'error':
+      return <span className="text-xs text-red-600 dark:text-red-400">Error</span>;
+  }
+}
 
-  const processing = status === 'processing';
+export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps) {
+  const { queue, summary, error, isDragging, isRunning, enqueue, reset } = useFileTranscription({ addEntry });
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const handlePick = async () => {
     try {
       const selected = await open({
-        multiple: false,
+        multiple: true,
         filters: [{ name: 'Audio', extensions: ['wav', 'mp3', 'm4a'] }],
       });
-      if (typeof selected === 'string') {
-        void transcribe(selected);
-      }
+      // With `multiple: true` the dialog returns string[] | null.
+      const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
+      if (paths.length > 0) enqueue(paths);
     } catch (e) {
       flog.warn('file-transcribe', 'file dialog failed', { error: String(e) });
     }
   };
 
-  const handleCopy = async () => {
+  const handleCopy = async (item: QueueItem) => {
+    if (!item.text) return;
     try {
-      await navigator.clipboard.writeText(result);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      await navigator.clipboard.writeText(item.text);
+      setCopiedId(item.id);
+      setTimeout(() => setCopiedId((id) => (id === item.id ? null : id)), 2000);
     } catch (e) {
       console.error('Failed to copy:', e);
     }
   };
 
+  const hasQueue = queue.length > 0;
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden gap-4">
-      {/* Drop zone + picker */}
+      {/* Drop zone + multi-select picker */}
       <div
         className={`shrink-0 rounded-xl border-2 border-dashed p-8 flex flex-col items-center justify-center text-center gap-3 transition-colors ${
           isDragging
@@ -52,55 +76,77 @@ export function FileTranscriptionPanel({ addEntry }: FileTranscriptionPanelProps
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
         </svg>
         <div className="text-sm text-stone-600 dark:text-stone-400">
-          Drag an audio file here, or
+          Drag audio files here, or
         </div>
         <button
           onClick={handlePick}
-          disabled={processing}
           className="px-4 py-2 text-sm font-medium rounded-lg bg-stone-800 text-white hover:bg-stone-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-stone-200 dark:text-stone-900 dark:hover:bg-stone-100 transition-colors"
         >
-          Choose File
+          Choose Files
         </button>
-        <div className="text-xs text-stone-400 dark:text-stone-500">WAV, MP3, or M4A</div>
+        <div className="text-xs text-stone-400 dark:text-stone-500">WAV, MP3, or M4A — multiple files supported</div>
       </div>
 
-      {/* Processing indicator */}
-      {processing && (
-        <div className="shrink-0 flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
-          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
-          <span className="truncate">Transcribing {fileName}…</span>
-        </div>
-      )}
-
-      {/* Error */}
+      {/* Unsupported-type / dialog error (queue-level, not per-file) */}
       {error && (
         <div className="shrink-0 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
           <p className="text-red-600 dark:text-red-400 text-sm">{error}</p>
         </div>
       )}
 
-      {/* Result */}
-      {status === 'complete' && (
+      {/* Queue list with per-file status + results */}
+      {hasQueue && (
         <div className="flex-1 flex flex-col overflow-hidden rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800">
           <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b border-stone-200 dark:border-stone-700">
-            <span className="text-xs font-medium text-stone-500 dark:text-stone-400 truncate">{fileName}</span>
-            <button
-              onClick={handleCopy}
-              disabled={!result}
-              className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 disabled:opacity-50 transition-colors"
-            >
-              {copied ? (
-                <span className="text-emerald-600 dark:text-emerald-400">Copied!</span>
-              ) : (
-                'Copy'
-              )}
-            </button>
+            <span className="text-xs font-medium text-stone-500 dark:text-stone-400">
+              {summary.finished
+                ? `Finished — ${summary.done} done${summary.error > 0 ? `, ${summary.error} error${summary.error > 1 ? 's' : ''}` : ''}`
+                : `Transcribing ${summary.done + summary.error} of ${summary.total}…`}
+            </span>
+            {summary.finished && !isRunning && (
+              <button
+                onClick={reset}
+                className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
+              >
+                Clear
+              </button>
+            )}
           </div>
-          <div className="flex-1 overflow-y-auto p-4 text-sm text-stone-800 dark:text-stone-200 whitespace-pre-wrap break-words">
-            {result || <span className="text-stone-400 dark:text-stone-500">No speech detected in this file.</span>}
+          <div className="flex-1 overflow-y-auto divide-y divide-stone-100 dark:divide-stone-700/60">
+            {queue.map((item) => (
+              <div key={item.id} className="px-4 py-3 flex flex-col gap-1.5">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-stone-800 dark:text-stone-200 truncate" title={item.name}>
+                    {item.name}
+                  </span>
+                  <div className="shrink-0 flex items-center gap-3">
+                    <StatusBadge item={item} />
+                    {item.status === 'done' && item.text && item.text.trim() && (
+                      <button
+                        onClick={() => handleCopy(item)}
+                        className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
+                      >
+                        {copiedId === item.id ? (
+                          <span className="text-emerald-600 dark:text-emerald-400">Copied!</span>
+                        ) : (
+                          'Copy'
+                        )}
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {item.status === 'done' && (
+                  <p className="text-sm text-stone-600 dark:text-stone-300 whitespace-pre-wrap break-words">
+                    {item.text && item.text.trim()
+                      ? item.text
+                      : <span className="text-stone-400 dark:text-stone-500">No speech detected in this file.</span>}
+                  </p>
+                )}
+                {item.status === 'error' && item.error && (
+                  <p className="text-sm text-red-600 dark:text-red-400 break-words">{item.error}</p>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/app/src/lib/fileQueue.test.ts
+++ b/app/src/lib/fileQueue.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasAudioExtension,
+  baseName,
+  buildQueueItems,
+  updateItem,
+  nextQueued,
+  summarize,
+  hasAnyAudio,
+  QueueItem,
+} from './fileQueue';
+
+describe('hasAudioExtension', () => {
+  it('accepts supported audio extensions (case-insensitive)', () => {
+    expect(hasAudioExtension('/a/b.wav')).toBe(true);
+    expect(hasAudioExtension('/a/b.mp3')).toBe(true);
+    expect(hasAudioExtension('/a/b.m4a')).toBe(true);
+    expect(hasAudioExtension('/a/b.M4A')).toBe(true);
+    expect(hasAudioExtension('CLIP.WAV')).toBe(true);
+  });
+
+  it('rejects unsupported or extension-less paths', () => {
+    expect(hasAudioExtension('/a/b.txt')).toBe(false);
+    expect(hasAudioExtension('/a/b.flac')).toBe(false);
+    expect(hasAudioExtension('/a/noext')).toBe(false);
+    expect(hasAudioExtension('')).toBe(false);
+  });
+});
+
+describe('baseName', () => {
+  it('returns the final segment for posix and windows paths', () => {
+    expect(baseName('/Users/x/clip.wav')).toBe('clip.wav');
+    expect(baseName('C:\\sounds\\clip.mp3')).toBe('clip.mp3');
+    expect(baseName('clip.m4a')).toBe('clip.m4a');
+  });
+});
+
+describe('buildQueueItems', () => {
+  it('builds queued items only for supported audio files', () => {
+    const items = buildQueueItems(['/a/one.wav', '/a/note.txt', '/a/two.mp3']);
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.name)).toEqual(['one.wav', 'two.mp3']);
+    expect(items.every((i) => i.status === 'queued')).toBe(true);
+  });
+
+  it('assigns unique ids even for duplicate basenames in different dirs', () => {
+    const items = buildQueueItems(['/a/clip.wav', '/b/clip.wav']);
+    expect(items).toHaveLength(2);
+    expect(items[0].id).not.toBe(items[1].id);
+  });
+
+  it('dedupes against existing items and within the new batch', () => {
+    const existing = buildQueueItems(['/a/one.wav']);
+    const merged = buildQueueItems(['/a/one.wav', '/a/two.wav', '/a/two.wav'], existing);
+    // /a/one.wav already queued -> skipped; /a/two.wav added once.
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe('two.wav');
+    // ordinal continues past existing length, keeping ids distinct.
+    expect(merged[0].id).not.toBe(existing[0].id);
+  });
+
+  it('returns an empty list when no audio files are present', () => {
+    expect(buildQueueItems(['/a/note.txt', '/a/img.png'])).toEqual([]);
+  });
+});
+
+describe('updateItem', () => {
+  it('patches only the targeted item immutably', () => {
+    const queue = buildQueueItems(['/a/one.wav', '/a/two.wav']);
+    const next = updateItem(queue, queue[0].id, { status: 'done', text: 'hi' });
+    expect(next[0]).toMatchObject({ status: 'done', text: 'hi' });
+    expect(next[1].status).toBe('queued');
+    // original untouched
+    expect(queue[0].status).toBe('queued');
+    expect(next).not.toBe(queue);
+  });
+
+  it('is a no-op for an unknown id', () => {
+    const queue = buildQueueItems(['/a/one.wav']);
+    const next = updateItem(queue, 'missing', { status: 'error' });
+    expect(next[0].status).toBe('queued');
+  });
+});
+
+describe('nextQueued', () => {
+  it('returns the first queued item', () => {
+    let queue = buildQueueItems(['/a/one.wav', '/a/two.wav', '/a/three.wav']);
+    queue = updateItem(queue, queue[0].id, { status: 'done' });
+    const next = nextQueued(queue);
+    expect(next?.name).toBe('two.wav');
+  });
+
+  it('returns null when nothing is queued', () => {
+    let queue = buildQueueItems(['/a/one.wav']);
+    queue = updateItem(queue, queue[0].id, { status: 'error', error: 'boom' });
+    expect(nextQueued(queue)).toBeNull();
+    expect(nextQueued([])).toBeNull();
+  });
+
+  it('skips an item currently transcribing', () => {
+    let queue = buildQueueItems(['/a/one.wav', '/a/two.wav']);
+    queue = updateItem(queue, queue[0].id, { status: 'transcribing' });
+    expect(nextQueued(queue)?.name).toBe('two.wav');
+  });
+});
+
+describe('summarize', () => {
+  it('counts statuses and reports unfinished while work remains', () => {
+    let queue = buildQueueItems(['/a/one.wav', '/a/two.wav', '/a/three.wav']);
+    queue = updateItem(queue, queue[0].id, { status: 'done' });
+    queue = updateItem(queue, queue[1].id, { status: 'transcribing' });
+    const s = summarize(queue);
+    expect(s).toMatchObject({ total: 3, queued: 1, transcribing: 1, done: 1, error: 0 });
+    expect(s.finished).toBe(false);
+  });
+
+  it('is finished once nothing is queued or transcribing', () => {
+    let queue = buildQueueItems(['/a/one.wav', '/a/two.wav']);
+    queue = updateItem(queue, queue[0].id, { status: 'done' });
+    queue = updateItem(queue, queue[1].id, { status: 'error', error: 'x' });
+    const s = summarize(queue);
+    expect(s.finished).toBe(true);
+    expect(s.done).toBe(1);
+    expect(s.error).toBe(1);
+  });
+
+  it('reports not finished for an empty queue', () => {
+    expect(summarize([]).finished).toBe(false);
+  });
+
+  it('handles a queue with one item per status', () => {
+    const queue: QueueItem[] = [
+      { id: '0', path: '/a.wav', name: 'a.wav', status: 'queued' },
+      { id: '1', path: '/b.wav', name: 'b.wav', status: 'transcribing' },
+      { id: '2', path: '/c.wav', name: 'c.wav', status: 'done', text: 't' },
+      { id: '3', path: '/d.wav', name: 'd.wav', status: 'error', error: 'e' },
+    ];
+    expect(summarize(queue)).toMatchObject({
+      total: 4,
+      queued: 1,
+      transcribing: 1,
+      done: 1,
+      error: 1,
+      finished: false,
+    });
+  });
+});
+
+describe('hasAnyAudio', () => {
+  it('detects at least one audio path', () => {
+    expect(hasAnyAudio(['/a/note.txt', '/a/clip.mp3'])).toBe(true);
+    expect(hasAnyAudio(['/a/note.txt', '/a/img.png'])).toBe(false);
+    expect(hasAnyAudio([])).toBe(false);
+  });
+});

--- a/app/src/lib/fileQueue.ts
+++ b/app/src/lib/fileQueue.ts
@@ -1,0 +1,102 @@
+//! Pure queue-state helpers for multi-file transcription.
+//!
+//! The hook (`useFileTranscription`) drives the actual Rust calls; this module
+//! holds only the side-effect-free list math so it can be unit-tested in
+//! isolation (no Tauri, no React). A queue is an ordered list of items, each
+//! carrying its own per-file status so one file's failure never aborts the rest.
+
+const AUDIO_EXTENSIONS = ['wav', 'mp3', 'm4a'] as const;
+
+export const UNSUPPORTED_MESSAGE = 'Unsupported file type. Use WAV, MP3, or M4A.';
+
+export type QueueItemStatus = 'queued' | 'transcribing' | 'done' | 'error';
+
+export interface QueueItem {
+  /** Stable id for React keys and targeted updates (path + ordinal). */
+  id: string;
+  /** Absolute filesystem path passed to the Rust `transcribe_file` command. */
+  path: string;
+  /** Display name (basename of the path). */
+  name: string;
+  status: QueueItemStatus;
+  /** Transcribed text once `done` (empty string allowed = no speech). */
+  text?: string;
+  /** Failure reason once `error`. */
+  error?: string;
+}
+
+/** True when `path` ends in a supported audio extension (case-insensitive). */
+export function hasAudioExtension(path: string): boolean {
+  const ext = path.split('.').pop()?.toLowerCase();
+  return !!ext && (AUDIO_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+/** Last path segment, tolerant of both `/` and `\` separators. */
+export function baseName(path: string): string {
+  return path.split(/[\\/]/).pop() || path;
+}
+
+/**
+ * Build queue items for the audio paths in `paths`, skipping non-audio files and
+ * any path already present in `existing` (dedupe across repeated drops/picks).
+ * Ids are derived from the path plus a monotonic ordinal so duplicate basenames
+ * across directories still get distinct React keys.
+ */
+export function buildQueueItems(paths: string[], existing: QueueItem[] = []): QueueItem[] {
+  const seen = new Set(existing.map((i) => i.path));
+  const items: QueueItem[] = [];
+  let ordinal = existing.length;
+  for (const path of paths) {
+    if (!hasAudioExtension(path)) continue;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    items.push({
+      id: `${ordinal}:${path}`,
+      path,
+      name: baseName(path),
+      status: 'queued',
+    });
+    ordinal += 1;
+  }
+  return items;
+}
+
+/** Return a new queue with the item at `id` patched (immutable update). */
+export function updateItem(
+  queue: QueueItem[],
+  id: string,
+  patch: Partial<QueueItem>,
+): QueueItem[] {
+  return queue.map((item) => (item.id === id ? { ...item, ...patch } : item));
+}
+
+/** The first still-`queued` item, or `null` when the queue is fully processed. */
+export function nextQueued(queue: QueueItem[]): QueueItem | null {
+  return queue.find((item) => item.status === 'queued') ?? null;
+}
+
+/** Counts by status, useful for the summary line ("3 of 5 done, 1 error"). */
+export interface QueueSummary {
+  total: number;
+  queued: number;
+  transcribing: number;
+  done: number;
+  error: number;
+  /** True when nothing is left queued or in-flight. */
+  finished: boolean;
+}
+
+export function summarize(queue: QueueItem[]): QueueSummary {
+  const counts = { queued: 0, transcribing: 0, done: 0, error: 0 };
+  for (const item of queue) counts[item.status] += 1;
+  return {
+    total: queue.length,
+    ...counts,
+    finished: queue.length > 0 && counts.queued === 0 && counts.transcribing === 0,
+  };
+}
+
+/** True when at least one supported audio file appears in `paths`. */
+export function hasAnyAudio(paths: string[]): boolean {
+  return paths.some(hasAudioExtension);
+}

--- a/app/src/lib/hooks/useFileTranscription.ts
+++ b/app/src/lib/hooks/useFileTranscription.ts
@@ -2,20 +2,17 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { transcribeFile } from '../dictation';
 import { flog } from '../log';
+import {
+  QueueItem,
+  UNSUPPORTED_MESSAGE,
+  buildQueueItems,
+  updateItem,
+  nextQueued,
+  summarize,
+  hasAnyAudio,
+} from '../fileQueue';
 
-const AUDIO_EXTENSIONS = ['wav', 'mp3', 'm4a'];
-const UNSUPPORTED_MESSAGE = 'Unsupported file type. Use WAV, MP3, or M4A.';
-
-export type FileTranscriptionStatus = 'idle' | 'processing' | 'complete' | 'error';
-
-function hasAudioExtension(path: string): boolean {
-  const ext = path.split('.').pop()?.toLowerCase();
-  return !!ext && AUDIO_EXTENSIONS.includes(ext);
-}
-
-function baseName(path: string): string {
-  return path.split(/[\\/]/).pop() || path;
-}
+export type { QueueItem, QueueItemStatus } from '../fileQueue';
 
 interface UseFileTranscriptionProps {
   /** Persist completed transcriptions to shared history (no WPM stats). */
@@ -23,62 +20,102 @@ interface UseFileTranscriptionProps {
 }
 
 /**
- * Manages the file-transcription flow: invokes the Rust `transcribe_file`
- * command, tracks status/result/error, and wires window drag-and-drop (which
- * yields real filesystem paths via the Tauri webview event).
+ * Manages the multi-file transcription flow: maintains a queue of audio files,
+ * invokes the Rust `transcribe_file` command for each one **sequentially** (one
+ * at a time keeps memory/CPU sane — the backend is shared with live dictation),
+ * tracks per-file status, and appends each completed result to shared history.
+ *
+ * A single file's failure is recorded on its own item and does not abort the
+ * remaining queue. Drag-and-drop via the Tauri webview yields real filesystem
+ * paths (the plain HTML5 drop event does not, for security reasons); the
+ * multi-select file picker in the panel supplies paths the same way.
  */
 export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
-  const [status, setStatus] = useState<FileTranscriptionStatus>('idle');
-  const [result, setResult] = useState('');
+  const [queue, setQueue] = useState<QueueItem[]>([]);
   const [error, setError] = useState('');
-  const [fileName, setFileName] = useState('');
   const [isDragging, setIsDragging] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
 
-  // Ref mirror so the drag-drop listener (registered once) sees current status.
-  const statusRef = useRef(status);
-  statusRef.current = status;
+  // Refs mirror state so the once-registered drag-drop listener and the async
+  // drain loop always see current values without re-subscribing.
+  const runningRef = useRef(false);
+  runningRef.current = isRunning;
+  const queueRef = useRef(queue);
+  queueRef.current = queue;
+  const addEntryRef = useRef(addEntry);
+  addEntryRef.current = addEntry;
 
-  const transcribe = useCallback(async (path: string) => {
-    if (statusRef.current === 'processing') return;
-    if (!hasAudioExtension(path)) {
-      setError(UNSUPPORTED_MESSAGE);
-      setStatus('error');
-      return;
+  // Sequentially process every still-`queued` item. Re-entrancy is guarded by
+  // `runningRef`; the loop re-reads `queueRef` each pass so items enqueued mid-run
+  // are picked up. Per-file errors are captured on the item, never thrown.
+  const drain = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setIsRunning(true);
+
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const item = nextQueued(queueRef.current);
+        if (!item) break;
+
+        setQueue((q) => updateItem(q, item.id, { status: 'transcribing' }));
+        flog.info('file-transcribe', 'start', { name: item.name });
+
+        const res = await transcribeFile(item.path);
+
+        if (res.type === 'error') {
+          const message = res.error || 'Transcription failed';
+          setQueue((q) => updateItem(q, item.id, { status: 'error', error: message }));
+          flog.warn('file-transcribe', 'error', { error: message });
+          continue;
+        }
+
+        const text = res.text || '';
+        setQueue((q) => updateItem(q, item.id, { status: 'done', text }));
+        if (text.trim()) {
+          addEntryRef.current(text, res.duration ?? 0, 'file', item.name);
+        }
+        flog.info('file-transcribe', 'complete', { textLen: text.length });
+      }
+    } finally {
+      runningRef.current = false;
+      setIsRunning(false);
     }
-    const name = baseName(path);
-    setFileName(name);
-    setResult('');
-    setError('');
-    setStatus('processing');
-    flog.info('file-transcribe', 'start', { name: baseName(path) });
-
-    const res = await transcribeFile(path);
-    if (res.type === 'error') {
-      setError(res.error || 'Transcription failed');
-      setStatus('error');
-      flog.warn('file-transcribe', 'error', { error: res.error });
-      return;
-    }
-
-    const text = res.text || '';
-    setResult(text);
-    setStatus('complete');
-    if (text.trim()) {
-      addEntry(text, res.duration ?? 0, 'file', name);
-    }
-    flog.info('file-transcribe', 'complete', { textLen: text.length });
-  }, [addEntry]);
-
-  const reset = useCallback(() => {
-    setStatus('idle');
-    setResult('');
-    setError('');
-    setFileName('');
   }, []);
 
-  // Drag-and-drop via the Tauri webview — provides absolute file paths
-  // (the plain HTML5 drop event does not, for security reasons). Drag-drop is
-  // an optional convenience; if the listener can't be registered the picker
+  // Add audio paths to the queue (deduped) and kick off the drain loop. Reports
+  // an unsupported-type error only when *none* of the dropped/picked files are
+  // audio, so a mixed selection still queues the valid files.
+  const enqueue = useCallback((paths: string[]) => {
+    if (paths.length === 0) return;
+    if (!hasAnyAudio(paths)) {
+      setError(UNSUPPORTED_MESSAGE);
+      return;
+    }
+    setError('');
+    setQueue((prev) => {
+      const added = buildQueueItems(paths, prev);
+      const next = added.length > 0 ? [...prev, ...added] : prev;
+      queueRef.current = next;
+      return next;
+    });
+    void drain();
+  }, [drain]);
+
+  /** Backwards-compatible single-path entry point (wraps `enqueue`). */
+  const transcribe = useCallback((path: string) => {
+    enqueue([path]);
+  }, [enqueue]);
+
+  const reset = useCallback(() => {
+    if (runningRef.current) return;
+    setQueue([]);
+    setError('');
+  }, []);
+
+  // Drag-and-drop via the Tauri webview — provides absolute file paths. Drag-drop
+  // is an optional convenience; if the listener can't be registered the picker
   // button still works, so failures degrade gracefully rather than break the UI.
   useEffect(() => {
     let unlisten: (() => void) | null = null;
@@ -93,12 +130,8 @@ export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
           setIsDragging(false);
         } else if (payload.type === 'drop') {
           setIsDragging(false);
-          const audioPath = payload.paths.find(hasAudioExtension);
-          if (audioPath) {
-            void transcribe(audioPath);
-          } else if (payload.paths.length > 0) {
-            setError(UNSUPPORTED_MESSAGE);
-            setStatus('error');
+          if (payload.paths.length > 0) {
+            enqueue(payload.paths);
           }
         }
       }).then((fn) => {
@@ -115,7 +148,18 @@ export function useFileTranscription({ addEntry }: UseFileTranscriptionProps) {
       cancelled = true;
       unlisten?.();
     };
-  }, [transcribe]);
+  }, [enqueue]);
 
-  return { status, result, error, fileName, isDragging, transcribe, reset };
+  const summary = summarize(queue);
+
+  return {
+    queue,
+    summary,
+    error,
+    isDragging,
+    isRunning,
+    enqueue,
+    transcribe,
+    reset,
+  };
 }


### PR DESCRIPTION
## Summary

Extends the existing single-file "Transcribe File" flow to a multi-file queue. Users can drag-drop several audio files at once or pick multiple via the file dialog; files transcribe **sequentially** (one at a time to keep memory/CPU sane — the backend is shared with live dictation), and each result is appended to history with the existing `File` source badge.

### Changes
- **`app/src/lib/fileQueue.ts`** (new) — pure, side-effect-free queue-state helpers (`buildQueueItems`, `updateItem`, `nextQueued`, `summarize`, `hasAudioExtension`, dedupe). No Tauri/React deps so it is unit-testable in isolation.
- **`app/src/lib/hooks/useFileTranscription.ts`** — now drives a queue with per-file status (`queued`/`transcribing`/`done`/`error`). Sequential drain loop reuses the existing `transcribe_file` command per file; a single file's error is recorded on its own item and does **not** abort the rest. Keeps a backwards-compatible single-path `transcribe(path)` entry point.
- **`app/src/components/FileTranscriptionPanel.tsx`** — multi-select picker (`multiple: true`), multi-file drop, queue list UI with per-file status pills, per-file copy, and a summary/clear line.

### Design notes
- No new Rust command: the existing `transcribe_file` already enforces mutual exclusion via its `file_transcribing` guard, so looping on the frontend serializes naturally and avoids touching shared Rust files.
- No `settings.ts` / `state.rs` changes (lowest conflict footprint).

## Verification
- `npm ci` — clean install in fresh worktree.
- `npx tsc --noEmit` — exit 0 (no type errors).
- `npm test` (vitest) — exit 0, **51 passed** (4 files), including the **17 new cases** in `src/lib/fileQueue.test.ts` covering audio-extension matching, dedupe across batches, immutable item updates, sequential `nextQueued` ordering, and status summarization.

Native runtime was **NOT** exercised here (no full `cargo build` / `.app` — per repo guidance, GitHub CI runs the full Rust suite). Please smoke-test the built `.app` before release: drag-drop multiple WAV/MP3/M4A files and a mixed selection (incl. a non-audio file) to confirm sequential transcription, per-file error isolation, and history entries with the File badge.