### PR TITLE
fix: Microphone permission banner no longer false-negatives after a dev rebuild or app move (stale TCC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **History source badge**: each history entry now shows whether it came from live recording ("Mic") or a transcribed file ("File", with the source file name).
 
 ### Fixed
+- **Microphone permission banner no longer false-negatives** after a dev rebuild or app move (stale TCC, #190). The banner now reads the live 4-state `AVCaptureDevice` authorization status and treats `notDetermined`/`unknown` as transient (not a hard "denied"), so a stale TCC entry can't mislabel a working mic. Added a microphone **reset** troubleshooting button (`tccutil reset Microphone <bundle-id>`) mirroring the Accessibility reset.
 - Strip recording-status-changed emissions from `ensure_vad_model` to reduce event noise
 
 ## [0.8.0] - 2026-03-02

--- a/app/src-tauri/src/commands/permissions.rs
+++ b/app/src-tauri/src/commands/permissions.rs
@@ -124,6 +124,51 @@ pub fn request_microphone_permission() -> Result<(), String> {
     { Ok(()) }
 }
 
+/// Reset this app's stale macOS Microphone TCC entry, then reopen the pane.
+///
+/// Mirrors `reset_accessibility_permission` for the case where the running build
+/// still reports the microphone as denied/missing while System Settings lists the
+/// app (common after rebuilding a dev bundle or moving the .app — the binary
+/// signature changes and the TCC entry goes stale). Resets ONLY the current bundle
+/// identifier via `tccutil reset Microphone <bundle-id>` — never all apps. macOS
+/// re-prompts on next mic use afterward; this only clears the stale entry.
+#[tauri::command]
+pub fn reset_microphone_permission() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let bundle_id = current_bundle_identifier()
+            .ok_or_else(|| "Could not determine the app's bundle identifier".to_string())?;
+
+        tracing::info!(
+            target: "system",
+            "resetting Microphone TCC entry for bundle id {}",
+            bundle_id
+        );
+
+        let output = std::process::Command::new("tccutil")
+            .args(["reset", "Microphone", &bundle_id])
+            .output()
+            .map_err(|e| format!("Failed to run tccutil: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!(
+                target: "system",
+                "tccutil reset failed for {}: {}",
+                bundle_id,
+                stderr.trim()
+            );
+            return Err(format!("tccutil reset failed: {}", stderr.trim()));
+        }
+
+        return open_system_preference_pane("Privacy_Microphone");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Microphone reset is only supported on macOS".to_string())
+    }
+}
+
 /// Check microphone authorization status WITHOUT opening the device.
 ///
 /// Reads `AVCaptureDevice.authorizationStatus(for: .audio)`. This only queries
@@ -156,7 +201,105 @@ pub fn check_microphone_permission() -> bool {
     }
 }
 
+/// Map a raw macOS `AVAuthorizationStatus` value to a banner-state string.
+///
+/// Pure helper so the status-enum -> banner-state mapping is unit-testable
+/// without a live TCC database. The returned string is consumed by the frontend
+/// permissions banner, which distinguishes a hard "denied" (show red, offer the
+/// reset path) from a transient "notDetermined"/"unknown" state (do NOT show a
+/// hard denied banner — see issue #190, false-negatives after a dev rebuild or
+/// app move when TCC drops the entry and the status reads not-determined).
+///
+/// `AVAuthorizationStatus` (AVFoundation):
+///   0 = notDetermined, 1 = restricted, 2 = denied, 3 = authorized.
+/// Any unexpected value (e.g. a future/probe-failure sentinel) maps to "unknown"
+/// rather than "denied" so a transient probe glitch never hard-fails the banner.
+fn mic_status_to_banner_state(status: isize) -> &'static str {
+    match status {
+        3 => "granted",
+        2 | 1 => "denied",
+        0 => "notDetermined",
+        _ => "unknown",
+    }
+}
+
+/// Read the *current* microphone authorization status as a banner-state string.
+///
+/// Queries `AVCaptureDevice.authorizationStatus(for: .audio)` live at call-time
+/// (never a cached value) and maps it via [`mic_status_to_banner_state`]. Unlike
+/// the boolean [`check_microphone_permission`], this preserves the distinction
+/// between a genuine "denied" and a transient "notDetermined"/"unknown" state so
+/// the banner doesn't false-negative after a rebuild/move (issue #190).
+///
+/// Returns one of: "granted" | "denied" | "notDetermined" | "unknown".
+/// Like the bool probe, this only reads TCC state — it never opens the device,
+/// so it cannot duck other apps' audio (issue #177).
+#[tauri::command]
+pub fn check_microphone_permission_status() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2::msg_send;
+        use objc2::runtime::AnyClass;
+        use objc2_foundation::NSString;
+
+        unsafe {
+            let Some(cls) = AnyClass::get(c"AVCaptureDevice") else {
+                // Class lookup failed: a probe glitch, not a real denial.
+                return "unknown".to_string();
+            };
+            // AVMediaTypeAudio == @"soun"
+            let media = NSString::from_str("soun");
+            let status: isize = msg_send![cls, authorizationStatusForMediaType: &*media];
+            mic_status_to_banner_state(status).to_string()
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "granted".to_string()
+    }
+}
+
 #[tauri::command]
 pub fn list_audio_devices() -> Result<Vec<String>, String> {
     audio::list_input_devices()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mic_status_to_banner_state;
+
+    #[test]
+    fn authorized_status_maps_to_granted() {
+        // AVAuthorizationStatusAuthorized
+        assert_eq!(mic_status_to_banner_state(3), "granted");
+    }
+
+    #[test]
+    fn denied_and_restricted_map_to_denied() {
+        // AVAuthorizationStatusDenied
+        assert_eq!(mic_status_to_banner_state(2), "denied");
+        // AVAuthorizationStatusRestricted (e.g. MDM/parental controls) — still a
+        // genuine block, so it must read as denied, not a transient state.
+        assert_eq!(mic_status_to_banner_state(1), "denied");
+    }
+
+    #[test]
+    fn not_determined_is_not_a_hard_denial() {
+        // AVAuthorizationStatusNotDetermined: TCC has no entry yet (common right
+        // after a rebuild/move). Must NOT collapse to "denied" (issue #190).
+        let state = mic_status_to_banner_state(0);
+        assert_eq!(state, "notDetermined");
+        assert_ne!(state, "denied");
+    }
+
+    #[test]
+    fn unexpected_values_map_to_unknown_not_denied() {
+        // Any future/sentinel value from a probe glitch must degrade to "unknown",
+        // never a hard "denied" — we never want to false-negative the banner.
+        for v in [-1isize, 4, 99, isize::MAX, isize::MIN] {
+            let state = mic_status_to_banner_state(v);
+            assert_eq!(state, "unknown", "value {v} should map to unknown");
+            assert_ne!(state, "denied", "value {v} must not map to denied");
+        }
+    }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -134,6 +134,8 @@ pub fn run() {
             commands::permissions::reset_accessibility_permission,
             commands::permissions::request_microphone_permission,
             commands::permissions::check_microphone_permission,
+            commands::permissions::check_microphone_permission_status,
+            commands::permissions::reset_microphone_permission,
             commands::permissions::list_audio_devices,
             commands::keyboard::start_keyboard_listener,
             commands::keyboard::stop_keyboard_listener,

--- a/app/src/components/PermissionsBanner.tsx
+++ b/app/src/components/PermissionsBanner.tsx
@@ -1,10 +1,25 @@
 import { useCallback, useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { resetAccessibilityPermission } from '../lib/dictation';
+import {
+  checkMicrophonePermissionStatus,
+  resetAccessibilityPermission,
+  resetMicrophonePermission,
+  type MicPermissionStatus,
+} from '../lib/dictation';
 
 interface PermissionStatus {
-  microphone: 'unknown' | 'granted' | 'denied';
+  microphone: MicPermissionStatus;
   accessibility: 'unknown' | 'granted' | 'denied';
+}
+
+/**
+ * Whether a microphone status should render as a hard "denied" banner. Only a
+ * genuine TCC denial (or restriction) blocks recording; "notDetermined" (no TCC
+ * entry yet, common after a rebuild/move) and "unknown" (a transient probe
+ * glitch) must NOT false-negative as denied (issue #190).
+ */
+function isMicHardDenied(status: MicPermissionStatus): boolean {
+  return status === 'denied';
 }
 
 export function PermissionsBanner() {
@@ -15,6 +30,7 @@ export function PermissionsBanner() {
   const [dismissed, setDismissed] = useState(false);
   const [checking, setChecking] = useState(true);
   const [resetError, setResetError] = useState<string | null>(null);
+  const [micResetError, setMicResetError] = useState<string | null>(null);
 
   const checkPermissions = useCallback(async () => {
     setChecking(true);
@@ -25,15 +41,19 @@ export function PermissionsBanner() {
       // Check microphone via native TCC status query (issue #177).
       // Must NOT use getUserMedia here: opening the mic spins up voice-processing
       // I/O, which ducks all other system audio on every window focus.
-      let hasMicrophone = false;
+      //
+      // Use the 4-state status (not the bool probe) so a transient
+      // "notDetermined"/"unknown" never collapses to a hard "denied" banner
+      // after a dev rebuild or app move (issue #190).
+      let micStatus: MicPermissionStatus = 'unknown';
       try {
-        hasMicrophone = await invoke<boolean>('check_microphone_permission');
+        micStatus = await checkMicrophonePermissionStatus();
       } catch {
-        hasMicrophone = false;
+        micStatus = 'unknown';
       }
 
       setPermissions({
-        microphone: hasMicrophone ? 'granted' : 'denied',
+        microphone: micStatus,
         accessibility: hasAccessibility ? 'granted' : 'denied',
       });
     } catch (error) {
@@ -75,7 +95,27 @@ export function PermissionsBanner() {
     }
   };
 
-  const allGranted = permissions.microphone === 'granted' && permissions.accessibility === 'granted';
+  const handleResetMicrophone = async () => {
+    setMicResetError(null);
+    try {
+      await resetMicrophonePermission();
+    } catch (error) {
+      console.error('Failed to reset microphone permission:', error);
+      setMicResetError(
+        typeof error === 'string'
+          ? error
+          : "Couldn't reset the Microphone entry. Check the logs for details.",
+      );
+    } finally {
+      checkPermissions();
+    }
+  };
+
+  const micDenied = isMicHardDenied(permissions.microphone);
+  // Only a genuine denial blocks recording; treat notDetermined/unknown as "fine
+  // for now" so the banner doesn't surface a false-negative (issue #190).
+  const micOk = !micDenied;
+  const allGranted = micOk && permissions.accessibility === 'granted';
 
   if (dismissed || allGranted || checking) {
     return null;
@@ -92,14 +132,12 @@ export function PermissionsBanner() {
             {/* Microphone Permission */}
             <div className="flex items-center gap-2">
               <span className={`w-2 h-2 rounded-full ${
-                permissions.microphone === 'granted'
-                  ? 'bg-emerald-500'
-                  : 'bg-red-500'
+                micOk ? 'bg-emerald-500' : 'bg-red-500'
               }`} />
               <span className="text-sm text-amber-700 dark:text-amber-300">
-                Microphone: {permissions.microphone === 'granted' ? 'Granted' : 'Required for recording'}
+                Microphone: {micOk ? 'Granted' : 'Required for recording'}
               </span>
-              {permissions.microphone !== 'granted' && (
+              {micDenied && (
                 <button
                   onClick={handleOpenMicrophone}
                   className="text-xs text-amber-600 dark:text-amber-400 underline hover:no-underline"
@@ -108,6 +146,27 @@ export function PermissionsBanner() {
                 </button>
               )}
             </div>
+
+            {/* Microphone troubleshooting: reset a stale TCC entry */}
+            {micDenied && (
+              <div className="ml-4 space-y-1">
+                <button
+                  onClick={handleResetMicrophone}
+                  className="text-xs text-amber-600/80 dark:text-amber-400/80 underline hover:no-underline"
+                >
+                  Still not working? Reset &amp; Open Settings
+                </button>
+                <p className="text-xs text-amber-600/70 dark:text-amber-400/70">
+                  Clears Murmur's stale Microphone entry, then opens System Settings.
+                  macOS will re-prompt the next time you record.
+                </p>
+                {micResetError && (
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    {micResetError}
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* Accessibility Permission */}
             <div className="flex items-center gap-2">

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -134,3 +134,24 @@ export async function transcribeFile(filePath: string): Promise<DictationRespons
 export async function resetAccessibilityPermission(): Promise<void> {
   return await invoke('reset_accessibility_permission');
 }
+
+/** Live microphone authorization state, mirroring the Rust banner-state mapping. */
+export type MicPermissionStatus = 'granted' | 'denied' | 'notDetermined' | 'unknown';
+
+/**
+ * Query the *current* microphone authorization status (never cached). Unlike the
+ * boolean `check_microphone_permission`, this preserves the distinction between a
+ * genuine "denied" and a transient "notDetermined"/"unknown" state, so the banner
+ * doesn't false-negative after a dev rebuild or app move (issue #190).
+ */
+export async function checkMicrophonePermissionStatus(): Promise<MicPermissionStatus> {
+  return await invoke('check_microphone_permission_status');
+}
+
+/**
+ * Reset this app's stale macOS Microphone TCC entry, then reopen the Microphone
+ * settings pane. Rejects if the reset fails (see Rust `reset_microphone_permission`).
+ */
+export async function resetMicrophonePermission(): Promise<void> {
+  return await invoke('reset_microphone_permission');
+}


### PR DESCRIPTION
## Problem (#190)

After a **dev rebuild or moving the .app**, the binary's code signature changes and macOS can drop or stale the Microphone TCC entry. The live authorization status then reads `AVAuthorizationStatusNotDetermined`, even though recording still works (macOS just re-prompts on next use). The permissions banner read mic status through the boolean `check_microphone_permission` command, which maps **everything except `authorized` to `false`**. The frontend rendered that `false` as a hard **"Microphone: Required for recording"** banner — a false-negative for a mic that's actually fine. A transient probe glitch (class lookup failure) had the same effect.

## Root cause

A 4-state native status (`notDetermined`/`restricted`/`denied`/`authorized`) was being squashed into a single boolean before it reached the UI, so the UI could not tell a **genuine denial** apart from a **transient/not-yet-determined** state and defaulted both to "denied".

## The fix (conservative, mirrors the existing Accessibility pattern)

**Rust — `commands/permissions.rs`**
- New `check_microphone_permission_status()` command returns the **live** `AVCaptureDevice.authorizationStatus(for: .audio)` (queried at call-time, never cached) as a string: `granted | denied | notDetermined | unknown`.
- Pure, unit-tested helper `mic_status_to_banner_state(isize) -> &str` does the enum→banner-state mapping. `denied (2)` and `restricted (1)` → `denied`; `notDetermined (0)` → `notDetermined`; **any unexpected/sentinel value → `unknown`, never `denied`**. A class-lookup/probe failure also degrades to `unknown`.
- New `reset_microphone_permission()` command mirrors `reset_accessibility_permission` exactly: `tccutil reset Microphone <runtime-bundle-id>` (current bundle id only, never all apps), then reopens System Settings → Privacy → Microphone. Reuses the existing `current_bundle_identifier()` helper.
- The existing boolean `check_microphone_permission` command is left **intact** (backward compatible / append-only).

**Frontend — `PermissionsBanner.tsx`, `lib/dictation.ts`**
- Banner now reads mic state via `check_microphone_permission_status`. Only a genuine `denied` renders the hard red "required" banner + Open Settings; `notDetermined`/`unknown` are treated as "fine for now" so the banner no longer false-negatives.
- Added a microphone **"Still not working? Reset & Open Settings"** troubleshooting button + helper text, mirroring the Accessibility reset block (same structure, copy, and error handling).

**`lib.rs`** — registered the two new commands (append-only).

A genuine `denied`/`restricted` signal is **unchanged** — this only fixes the false-negative/stale case and adds the recovery path.

## Verification

Tested in this PR:
- **Pure Rust helper** `mic_status_to_banner_state` — extracted to `/tmp` and run with `rustc --test`: 4/4 pass (authorized→granted, denied & restricted→denied, notDetermined→not-denied, and a sweep of unexpected values incl. negatives / `isize::MAX`/`MIN`→unknown, never denied). The same `#[cfg(test)] mod tests` ships in `permissions.rs` and will run in `cargo test` on CI.
- **Frontend**: `npm ci` then `npx tsc --noEmit` → exit 0; `npm test --silent` → **59/59 pass**, including the issue-#177 `no-mic-probe` regression guard (the new banner path uses the native Tauri command, never `getUserMedia`).
- Did **not** run the full `cargo` suite locally (slow) — `ci.yml` runs the Rust suite on this PR.

**Still requires a real built-.app smoke test before release** (cannot be reproduced in `tauri dev` or a fresh worktree — needs real TCC state and a focused UI):
1. Build the .app, grant mic, confirm banner clears.
2. Rebuild / move the .app to force a stale/`notDetermined` TCC entry; confirm the banner does **not** show a red "Microphone required" false-negative, and recording still prompts/works.
3. Deny mic in System Settings; confirm the banner **does** show the hard "required" state (genuine denial preserved).
4. Click the new mic **Reset & Open Settings** button; confirm `tccutil reset Microphone <bundle>` runs, System Settings → Privacy → Microphone opens, and macOS re-prompts on next record.