### PR TITLE
feat: live streaming transcription preview in overlay (#129)

### DIFF
--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -324,6 +324,48 @@ pub fn stop_recording() -> Result<Vec<f32>, String> {
     }
 }
 
+/// Non-destructively snapshot the audio captured **so far** in the current
+/// recording, resampled to Whisper's 16kHz mono format.
+///
+/// Used only by the optional live-preview pass (issue #129). Unlike
+/// `stop_recording`, this does NOT take or clear the buffer, does NOT touch the
+/// `active` flag or join the capture thread, and does NOT affect the
+/// authoritative final transcription in any way — it clones the current samples
+/// under the buffer lock and returns a resampled copy. Returns `None` when no
+/// recording is in progress (no buffer present).
+pub fn snapshot_samples() -> Option<Vec<f32>> {
+    let state = RECORDING_STATE.get()?;
+    let guard = state.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(target: "audio", "snapshot_samples: recording state mutex was poisoned, recovering");
+        poisoned.into_inner()
+    });
+
+    // Only snapshot while actively recording — never after stop has begun.
+    if !guard.active.load(Ordering::Relaxed) {
+        return None;
+    }
+    let buffer = guard.shared.as_ref()?;
+    let sample_rate = guard.sample_rate;
+    let raw: Vec<f32> = {
+        let samples = buffer.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(target: "audio", "snapshot_samples: samples mutex was poisoned, recovering");
+            poisoned.into_inner()
+        });
+        samples.clone()
+    };
+    // Release the recording-state lock before the (potentially larger) resample.
+    drop(guard);
+
+    if raw.is_empty() {
+        return Some(raw);
+    }
+    if sample_rate != WHISPER_SAMPLE_RATE {
+        Some(resample(&raw, sample_rate, WHISPER_SAMPLE_RATE))
+    } else {
+        Some(raw)
+    }
+}
+
 #[allow(dead_code)]
 pub fn is_recording() -> bool {
     if let Some(state) = RECORDING_STATE.get() {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1,9 +1,141 @@
 use crate::{MutexExt, State};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
+use crate::transcriber::preview;
 use crate::{audio, audio_decode, injector, keyboard, vad};
-use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Emitter;
+
+/// How often the live-preview background task runs a partial transcription.
+/// A ~1.4s cadence balances responsiveness against the CPU cost of repeated
+/// whisper passes; the task additionally *skips* a tick if the previous pass is
+/// still running, so a slow transcribe can never pile up.
+const LIVE_PREVIEW_INTERVAL_MS: u64 = 1_400;
+
+/// Spawn the optional live-preview background task for a recording session.
+///
+/// PREVIEW-ONLY: this never produces the authoritative injected text and never
+/// touches `app_state.backend`. It owns a dedicated `PreviewTranscriber`
+/// (separate whisper context/state) so it cannot race or corrupt the final
+/// one-shot pass. No-op (returns immediately) when the feature is off or the
+/// active backend isn't Whisper. The loop exits when `cancel` flips to false
+/// (set on stop/cancel) or the model can't be loaded.
+fn spawn_live_preview(
+    app_handle: tauri::AppHandle,
+    model_name: String,
+    language: String,
+    cancel: Arc<AtomicBool>,
+    recording_id: u64,
+) {
+    use tauri::Manager;
+    // True only while `cancel` is set AND this is still the active recording.
+    // Guards against a stale task from a superseded session emitting after a
+    // new recording has begun (rapid start-stop). The two tasks each own their
+    // own whisper state, so this is purely about avoiding stale UI text. The
+    // recording_id is read back through the managed `State` (the task is
+    // 'static and can't borrow `AppState`).
+    let still_current_handle = app_handle.clone();
+    let still_current = move || {
+        if !cancel.load(Ordering::Relaxed) {
+            return false;
+        }
+        still_current_handle
+            .try_state::<State>()
+            .map(|s| s.app_state.recording_id.load(Ordering::SeqCst) == recording_id)
+            .unwrap_or(false)
+    };
+    tokio::spawn(async move {
+        // Resolve the model path off the chance the model isn't present yet.
+        let model_path = match preview::preview_model_path(&model_name) {
+            Some(p) => p.to_string_lossy().to_string(),
+            None => {
+                tracing::info!(target: "preview", "live preview: model '{}' not found, skipping", model_name);
+                return;
+            }
+        };
+        let lang_param = match language.as_str() {
+            "auto" | "" => None,
+            other => Some(other.to_string()),
+        };
+
+        // Build the dedicated preview engine on a blocking thread (model load +
+        // GPU init). If it fails, silently skip preview for this session.
+        let build = tokio::task::spawn_blocking(move || preview::PreviewTranscriber::new(&model_path)).await;
+        let mut engine = match build {
+            Ok(Ok(engine)) => engine,
+            Ok(Err(e)) => {
+                tracing::info!(target: "preview", "live preview: engine init failed ({}), skipping", e);
+                return;
+            }
+            Err(e) => {
+                tracing::info!(target: "preview", "live preview: engine init task panicked ({}), skipping", e);
+                return;
+            }
+        };
+        tracing::info!(target: "preview", "live preview: engine ready");
+
+        let mut last_emitted: Option<String> = None;
+        while still_current() {
+            tokio::time::sleep(std::time::Duration::from_millis(LIVE_PREVIEW_INTERVAL_MS)).await;
+            if !still_current() {
+                break;
+            }
+
+            // Non-destructive snapshot of audio-so-far (16kHz mono).
+            let snapshot = match audio::snapshot_samples() {
+                Some(s) => s,
+                None => continue, // recording ended between checks
+            };
+            let window = match preview::select_preview_window(
+                &snapshot,
+                crate::state::WHISPER_SAMPLE_RATE,
+                preview::PREVIEW_WINDOW_SECS,
+                preview::PREVIEW_MIN_SAMPLES,
+            ) {
+                Some(w) => w.to_vec(),
+                None => continue, // not enough audio yet
+            };
+
+            // Run the (blocking) whisper pass on a dedicated thread so the async
+            // runtime isn't stalled. The engine moves in and back out so it stays
+            // owned by this loop (skip-if-running is implicit: we await here).
+            let lang = lang_param.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let out = engine.transcribe_partial(&window, lang.as_deref());
+                (engine, out)
+            })
+            .await;
+            let out = match result {
+                Ok((returned_engine, out)) => {
+                    engine = returned_engine;
+                    out
+                }
+                Err(e) => {
+                    tracing::warn!(target: "preview", "live preview: pass panicked ({})", e);
+                    continue;
+                }
+            };
+
+            if !still_current() {
+                break;
+            }
+            match out {
+                Ok(Some(text)) => {
+                    if last_emitted.as_deref() != Some(text.as_str()) {
+                        last_emitted = Some(text.clone());
+                        let _ = app_handle.emit("partial-transcript", text);
+                    }
+                }
+                Ok(None) => { /* nothing worth showing this tick */ }
+                Err(e) => {
+                    tracing::warn!(target: "preview", "live preview: pass failed ({})", e);
+                }
+            }
+        }
+        tracing::info!(target: "preview", "live preview: loop exited");
+    });
+}
 
 /// Max number of code identifiers to feed Whisper as an initial prompt. Whisper
 /// truncates the prompt to its context window anyway; this keeps the bias list
@@ -537,6 +669,12 @@ pub async fn configure_dictation(
         dictation.cleanup_enabled = cleanup_enabled;
     }
 
+    // Live streaming preview (#129): preview-only overlay text while recording.
+    // Default-off; only honored for the Whisper backend at recording time.
+    if let Some(live_preview) = options.get("livePreviewEnabled").and_then(|v| v.as_bool()) {
+        dictation.live_preview_enabled = live_preview;
+    }
+
     // Code-aware vocabulary: a toggle plus a folder to scan for identifiers.
     // Changing either invalidates the cached prompt so the next transcription
     // (or the explicit prebuild below) rescans. Disabling clears the cache so we
@@ -659,10 +797,50 @@ pub async fn start_native_recording(
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(target: "pipeline", "start_native_recording: started");
 
+    // Live streaming preview (#129): start the optional throttled preview task.
+    // Default-off and Whisper-only; entirely separate from the final pipeline.
+    maybe_start_live_preview(&app_handle, &state.app_state);
+
     Ok(serde_json::json!({
         "type": "recording_started",
         "state": "recording"
     }))
+}
+
+/// Start the live-preview task iff the setting is on AND the active backend is
+/// Whisper. Reads the gate under the existing locks and arms the shared cancel
+/// flag before spawning. No-op otherwise — so default-off users and Parakeet
+/// users see byte-for-byte the current behavior.
+fn maybe_start_live_preview(app_handle: &tauri::AppHandle, app_state: &AppState) {
+    let (enabled, model_name, language) = {
+        let d = app_state.dictation.lock_or_recover();
+        (d.live_preview_enabled, d.model_name.clone(), d.language.clone())
+    };
+    let backend_name = {
+        let b = app_state.backend.lock_or_recover();
+        b.name().to_string()
+    };
+    if !preview::should_run_preview(enabled, &backend_name) {
+        return;
+    }
+    // Arm the cancel flag for this session, then spawn.
+    app_state.live_preview_active.store(true, Ordering::SeqCst);
+    let cancel = Arc::clone(&app_state.live_preview_active);
+    let recording_id = app_state.recording_id.load(Ordering::SeqCst);
+    tracing::info!(target: "preview", "live preview: starting (model={}, recording_id={})", model_name, recording_id);
+    spawn_live_preview(app_handle.clone(), model_name, language, cancel, recording_id);
+}
+
+/// Stop any running live-preview task and clear the overlay's preview text.
+/// Idempotent and safe to call when no preview was running.
+fn stop_live_preview(app_handle: &tauri::AppHandle, app_state: &AppState) {
+    // Only act if a preview was actually armed, so we don't emit a spurious
+    // clear event for default-off users.
+    if app_state.live_preview_active.swap(false, Ordering::SeqCst) {
+        tracing::info!(target: "preview", "live preview: stopping");
+        // Tell the overlay to drop any partial text it's showing.
+        let _ = app_handle.emit("partial-transcript", "");
+    }
 }
 
 #[tauri::command]
@@ -693,6 +871,9 @@ pub async fn stop_native_recording(
     };
     keyboard::set_processing(true);
     tracing::info!(target: "pipeline", "stop_native_recording: stopping");
+    // Stop the live-preview task first so it can't snapshot mid-teardown or race
+    // the authoritative final pass. No-op when preview wasn't running.
+    stop_live_preview(&app_handle, &state.app_state);
     let _ = app_handle.emit("recording-status-changed", "processing");
 
     // Guard resets status to Idle if stop_recording fails or samples are empty;
@@ -829,6 +1010,9 @@ pub async fn cancel_native_recording(
         }
         (prev, rid)
     };
+
+    // Stop any live-preview task regardless of which phase we're cancelling from.
+    stop_live_preview(&app_handle, &state.app_state);
 
     let stop_err = match prev_status {
         DictationStatus::Recording => {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -112,8 +112,11 @@ fn spawn_live_preview(
                     out
                 }
                 Err(e) => {
-                    tracing::warn!(target: "preview", "live preview: pass panicked ({})", e);
-                    continue;
+                    // The blocking closure panicked, so `engine` was consumed and
+                    // cannot be moved back out — it's gone for this session. End
+                    // the preview loop cleanly rather than reuse a lost engine.
+                    tracing::warn!(target: "preview", "live preview: pass panicked ({}), ending preview", e);
+                    break;
                 }
             };
 

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -59,6 +59,11 @@ pub struct DictationState {
     /// when the folder/enabled flag changes so we don't rescan every utterance.
     /// `None` means "not yet scanned" (build lazily on first use).
     pub code_vocab_prompt: Option<String>,
+    /// Live streaming transcription preview (issue #129). When enabled, a
+    /// throttled background pass shows partial words in the overlay *while
+    /// recording*. Preview-only — never affects the authoritative injected text.
+    /// CPU-heavy, Whisper-only, OFF by default.
+    pub live_preview_enabled: bool,
 }
 
 impl Default for DictationState {
@@ -84,6 +89,7 @@ impl Default for DictationState {
             code_vocab_enabled: false,
             code_vocab_folder: String::new(),
             code_vocab_prompt: None,
+            live_preview_enabled: false,
         }
     }
 }
@@ -102,6 +108,11 @@ pub struct AppState {
     /// transcription share one Whisper backend, so they must be mutually
     /// exclusive — this flag lets each path refuse to start over the other.
     pub file_transcribing: AtomicBool,
+    /// Cancellation flag for the optional live-preview background task (#129).
+    /// Set to `false` on recording stop/cancel so the preview loop exits
+    /// promptly. Wrapped in an `Arc` so the spawned task can hold a clone
+    /// without borrowing `AppState`.
+    pub live_preview_active: std::sync::Arc<AtomicBool>,
 }
 
 impl AppState {
@@ -131,6 +142,7 @@ impl Default for AppState {
             recording_id: AtomicU64::new(0),
             cancelled_id: AtomicU64::new(0),
             file_transcribing: AtomicBool::new(false),
+            live_preview_active: std::sync::Arc::new(AtomicBool::new(false)),
         }
     }
 }

--- a/app/src-tauri/src/transcriber/mod.rs
+++ b/app/src-tauri/src/transcriber/mod.rs
@@ -1,4 +1,5 @@
 pub mod parakeet;
+pub mod preview;
 pub mod whisper;
 
 pub use parakeet::ParakeetBackend;

--- a/app/src-tauri/src/transcriber/preview.rs
+++ b/app/src-tauri/src/transcriber/preview.rs
@@ -1,0 +1,296 @@
+//! Live streaming transcription **preview** (issue #129).
+//!
+//! This module powers the optional, default-off "live preview" that shows
+//! partial words in the Dynamic Island overlay *while the user is still
+//! speaking*. It is strictly preview-only:
+//!
+//! - It NEVER produces the authoritative injected/clipboard text. The final
+//!   one-shot transcription on stop (see `commands/recording.rs`) is unchanged.
+//! - It uses its **own** dedicated `WhisperContext` + `WhisperState`, separate
+//!   from the cached backend state in `AppState::backend`. This is the same
+//!   isolation pattern VAD uses (a fresh context per run) and is the key to
+//!   concurrency safety: the preview pass and the final pass can never share or
+//!   corrupt each other's `WhisperState`.
+//! - Whisper backend only. Parakeet (and any future non-whisper backend) gets a
+//!   graceful no-op — the preview engine simply fails to build and the caller
+//!   silently skips it.
+//!
+//! The pure decision logic (trailing-window selection, preview-text gating) is
+//! split out into free functions so it can be unit-tested without whisper-rs.
+
+/// Number of trailing seconds of audio to feed each preview pass. A short window
+/// keeps each partial transcription cheap (CPU-bound) and responsive, at the
+/// cost of not re-deriving the full utterance every tick. The authoritative
+/// final pass always sees the complete audio, so this windowing only affects the
+/// throwaway preview text.
+pub const PREVIEW_WINDOW_SECS: f32 = 12.0;
+
+/// Don't bother running a preview pass until at least this many samples have
+/// accumulated. Below this, whisper tends to hallucinate on the tiny clip and
+/// the preview would just be noise.
+pub const PREVIEW_MIN_SAMPLES: usize = 8_000; // 0.5s at 16kHz
+
+/// Select the trailing window of samples to feed a preview pass.
+///
+/// Returns `None` when there isn't enough audio yet (caller should skip this
+/// tick). Otherwise returns the most-recent `window_secs` of samples (or the
+/// whole buffer when it's shorter than the window). Pure + allocation-light: it
+/// borrows a sub-slice of the input, it does not copy.
+pub fn select_preview_window(
+    samples: &[f32],
+    sample_rate: u32,
+    window_secs: f32,
+    min_samples: usize,
+) -> Option<&[f32]> {
+    if samples.len() < min_samples {
+        return None;
+    }
+    if sample_rate == 0 || window_secs <= 0.0 {
+        // Defensive: a bad rate/window means "use everything" rather than panic.
+        return Some(samples);
+    }
+    let window_len = (sample_rate as f32 * window_secs) as usize;
+    if window_len == 0 || samples.len() <= window_len {
+        Some(samples)
+    } else {
+        Some(&samples[samples.len() - window_len..])
+    }
+}
+
+/// Normalize raw whisper output into preview text suitable for the overlay.
+///
+/// Returns `None` when the result is effectively empty (so the caller can skip
+/// emitting and avoid flickering the overlay to blank). Whisper sometimes emits
+/// bracketed non-speech markers like `[BLANK_AUDIO]` or `(silence)` on a quiet
+/// trailing window; those are dropped so they never reach the UI.
+pub fn clean_preview_text(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Drop a lone bracketed marker (e.g. "[BLANK_AUDIO]", "(silence)"). These are
+    // whole-string non-speech annotations, not partial words.
+    let is_bracket_marker = (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        || (trimmed.starts_with('(') && trimmed.ends_with(')'));
+    if is_bracket_marker {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Whether a live preview pass should run at all for the given backend + setting.
+///
+/// Centralizes the gate so the on/off behavior is unit-testable and identical
+/// everywhere. Preview runs only when the user enabled it AND the active backend
+/// is whisper. `backend_name` comes from `TranscriptionBackend::name()`.
+pub fn should_run_preview(live_preview_enabled: bool, backend_name: &str) -> bool {
+    live_preview_enabled && backend_name == "whisper"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_skips_when_below_min() {
+        let samples = vec![0.0f32; 100];
+        assert!(select_preview_window(&samples, 16_000, 12.0, PREVIEW_MIN_SAMPLES).is_none());
+    }
+
+    #[test]
+    fn window_returns_all_when_shorter_than_window() {
+        let samples = vec![0.1f32; 16_000]; // 1s, window is 12s
+        let win = select_preview_window(&samples, 16_000, 12.0, 8_000).unwrap();
+        assert_eq!(win.len(), 16_000);
+    }
+
+    #[test]
+    fn window_returns_trailing_slice_when_longer() {
+        // 20s of audio at 16kHz, 12s window => last 12s = 192_000 samples.
+        let samples = vec![0.2f32; 16_000 * 20];
+        let win = select_preview_window(&samples, 16_000, 12.0, 8_000).unwrap();
+        assert_eq!(win.len(), 16_000 * 12);
+        // It must be the *trailing* slice (tail of the buffer).
+        let tail = &samples[samples.len() - 16_000 * 12..];
+        assert_eq!(win.as_ptr(), tail.as_ptr());
+    }
+
+    #[test]
+    fn window_exactly_window_len_returns_all() {
+        let samples = vec![0.3f32; 16_000 * 12];
+        let win = select_preview_window(&samples, 16_000, 12.0, 8_000).unwrap();
+        assert_eq!(win.len(), 16_000 * 12);
+    }
+
+    #[test]
+    fn window_zero_rate_uses_everything() {
+        let samples = vec![0.4f32; 10_000];
+        let win = select_preview_window(&samples, 0, 12.0, 8_000).unwrap();
+        assert_eq!(win.len(), 10_000);
+    }
+
+    #[test]
+    fn window_zero_window_secs_uses_everything() {
+        let samples = vec![0.4f32; 10_000];
+        let win = select_preview_window(&samples, 16_000, 0.0, 8_000).unwrap();
+        assert_eq!(win.len(), 10_000);
+    }
+
+    #[test]
+    fn clean_text_trims_and_keeps_words() {
+        assert_eq!(clean_preview_text("  hello world  ").as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn clean_text_drops_empty() {
+        assert!(clean_preview_text("").is_none());
+        assert!(clean_preview_text("    ").is_none());
+    }
+
+    #[test]
+    fn clean_text_drops_blank_audio_marker() {
+        assert!(clean_preview_text("[BLANK_AUDIO]").is_none());
+        assert!(clean_preview_text("  (silence) ").is_none());
+        assert!(clean_preview_text("[ Silence ]").is_none());
+    }
+
+    #[test]
+    fn clean_text_keeps_text_with_internal_brackets() {
+        // Only a *whole-string* bracket marker is dropped; real words survive.
+        assert_eq!(
+            clean_preview_text("the array[i] value").as_deref(),
+            Some("the array[i] value")
+        );
+    }
+
+    #[test]
+    fn gate_off_when_disabled() {
+        assert!(!should_run_preview(false, "whisper"));
+    }
+
+    #[test]
+    fn gate_off_for_non_whisper_backend() {
+        assert!(!should_run_preview(true, "parakeet"));
+    }
+
+    #[test]
+    fn gate_on_for_whisper_when_enabled() {
+        assert!(should_run_preview(true, "whisper"));
+    }
+}
+
+// The whisper-rs–backed preview engine. Kept below the pure logic and behind the
+// same crate so the unit tests above (run via `rustc --test`) don't need to link
+// whisper-rs. This is the only part that touches the GPU/model.
+pub use engine::PreviewTranscriber;
+
+mod engine {
+    use super::clean_preview_text;
+    use std::path::PathBuf;
+    use std::sync::Once;
+    use whisper_rs::{
+        FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
+    };
+
+    static INIT_LOGGING: Once = Once::new();
+
+    fn suppress_whisper_logs() {
+        INIT_LOGGING.call_once(|| {
+            whisper_rs::install_logging_hooks();
+        });
+    }
+
+    /// A self-contained whisper engine used ONLY for live preview. Owns its own
+    /// `WhisperState` (which internally holds an Arc-cloned context) so it can
+    /// never race or corrupt the authoritative backend's cached `WhisperState`.
+    pub struct PreviewTranscriber {
+        state: WhisperState,
+    }
+
+    impl PreviewTranscriber {
+        /// Build a preview engine for `model_path`. Returns `Err` if the model
+        /// can't be loaded — the caller treats that as "skip preview this
+        /// session" and never surfaces it to the user.
+        pub fn new(model_path: &str) -> Result<Self, String> {
+            suppress_whisper_logs();
+            let params = WhisperContextParameters::default();
+            let context = WhisperContext::new_with_params(model_path, params)
+                .map_err(|e| format!("preview: failed to load whisper model: {}", e))?;
+            // `WhisperState` keeps its own Arc clone of the context, so the local
+            // `context` binding can drop here without invalidating the state.
+            let state = context
+                .create_state()
+                .map_err(|e| format!("preview: failed to create whisper state: {}", e))?;
+            Ok(Self { state })
+        }
+
+        /// Run a single preview pass over `samples` (16kHz mono). Returns the
+        /// cleaned partial text, or `None` when there's nothing worth showing.
+        /// Best-effort: any whisper error is mapped to `Err` and the caller logs
+        /// + skips it.
+        pub fn transcribe_partial(
+            &mut self,
+            samples: &[f32],
+            language: Option<&str>,
+        ) -> Result<Option<String>, String> {
+            let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+            if let Some(lang) = language {
+                params.set_language(Some(lang));
+            }
+            params.set_print_special(false);
+            params.set_print_progress(false);
+            params.set_print_realtime(false);
+            params.set_print_timestamps(false);
+            params.set_suppress_blank(true);
+            params.set_single_segment(true);
+            params.set_debug_mode(false);
+            // Speed over accuracy for the throwaway preview pass.
+            params.set_no_context(true);
+
+            self.state
+                .full(params, samples)
+                .map_err(|e| format!("preview transcription failed: {}", e))?;
+
+            let num_segments = self.state.full_n_segments();
+            let mut text = String::new();
+            for i in 0..num_segments {
+                if let Some(segment) = self.state.get_segment(i) {
+                    if let Ok(s) = segment.to_str() {
+                        text.push_str(s);
+                    }
+                }
+            }
+            Ok(clean_preview_text(&text))
+        }
+    }
+
+    /// Resolve the on-disk path for a whisper model name, mirroring the search
+    /// paths used by the authoritative backend. Kept here (rather than reaching
+    /// into `whisper.rs` private fns) so the preview engine is self-contained.
+    pub fn preview_model_path(model_name: &str) -> Option<PathBuf> {
+        let filename = format!("ggml-{}.bin", model_name);
+        let mut dirs_to_search: Vec<PathBuf> = Vec::new();
+        if let Ok(custom) = std::env::var("WHISPER_MODEL_DIR") {
+            dirs_to_search.push(PathBuf::from(custom));
+        }
+        if let Some(data_dir) = dirs::data_dir() {
+            dirs_to_search.push(
+                ["local-dictation", "models"]
+                    .iter()
+                    .fold(data_dir.clone(), |p, s| p.join(s)),
+            );
+            dirs_to_search.push(data_dir.join("pywhispercpp").join("models"));
+        }
+        if let Some(home) = dirs::home_dir() {
+            dirs_to_search.push(home.join(".cache").join("whisper.cpp"));
+            dirs_to_search.push(home.join(".cache").join("whisper"));
+            dirs_to_search.push(home.join(".whisper").join("models"));
+        }
+        dirs_to_search
+            .into_iter()
+            .map(|d| d.join(&filename))
+            .find(|p| p.exists())
+    }
+}
+
+pub use engine::preview_model_path;

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -64,6 +64,9 @@ export function OverlayWidget() {
   const [autoPaste, setAutoPaste] = useState(false);
   const [fileOutputEnabled, setFileOutputEnabled] = useState(false);
   const [elapsed, setElapsed] = useState(0);
+  // Live streaming preview text (#129). Preview-only — this is never the
+  // authoritative pasted text; it just mirrors what Rust emits while recording.
+  const [previewText, setPreviewText] = useState('');
   const notchHeightRef = useRef(0);
   const [notchHeight, setNotchHeight] = useState(0);
   const [notchWidth, setNotchWidth] = useState(185);
@@ -213,6 +216,25 @@ export function OverlayWidget() {
     });
     return () => { cancelled = true; unlisten?.(); };
   }, []);
+
+  // Subscribe to live preview text events from Rust (#129). An empty payload
+  // clears the preview (sent on stop/cancel). Preview-only display.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<string>('partial-transcript', (event) => {
+      setPreviewText(typeof event.payload === 'string' ? event.payload : '');
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
+
+  // Clear preview text whenever we leave the recording state — defensive so a
+  // stale partial never lingers on the overlay if the clear event is missed.
+  useEffect(() => {
+    if (status !== 'recording') setPreviewText('');
+  }, [status]);
 
   // Subscribe to app-disabled-changed events from Rust
   useEffect(() => {
@@ -612,8 +634,20 @@ export function OverlayWidget() {
             </span>
           )}
 
-          {/* Spacer */}
-          <div className="flex-1" />
+          {/* Live preview text (#129) — partial words while recording. Preview
+              only; truncated to a single line so it never resizes the pill. */}
+          {status === 'recording' && previewText ? (
+            <span
+              className="flex-1 min-w-0 truncate text-white/70 text-right"
+              style={{ marginLeft: 8, marginRight: 8, fontSize: 11 }}
+              title={previewText}
+            >
+              {previewText}
+            </span>
+          ) : (
+            /* Spacer */
+            <div className="flex-1" />
+          )}
 
           {/* Right side — waveform (only when active) */}
           <div

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -637,6 +637,35 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             />
           </button>
         </div>
+
+        {/* Live Preview Toggle (#129) — partial words in the overlay while
+            speaking. Preview-only (never changes pasted text); Whisper-only. */}
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              Live Preview
+            </label>
+            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              Show partial words in the overlay while you speak. Uses more CPU; Whisper models only. The pasted text is unchanged.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.livePreviewEnabled}
+            aria-label="Live preview"
+            onClick={() => onUpdateSettings({ livePreviewEnabled: !settings.livePreviewEnabled })}
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+              settings.livePreviewEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                settings.livePreviewEnabled ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
         </SettingsSection>
 
         <SettingsSection title="Recording" subtitle="Trigger mode, shortcut key">

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -75,6 +75,7 @@ export interface ConfigureOptions {
   cleanupEnabled?: boolean;
   codeVocabEnabled?: boolean;
   codeVocabFolder?: string;
+  livePreviewEnabled?: boolean;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -104,6 +105,7 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     cleanupEnabled: s.cleanupEnabled,
     codeVocabEnabled: s.codeVocabEnabled,
     codeVocabFolder: s.codeVocabFolder,
+    livePreviewEnabled: s.livePreviewEnabled,
   };
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'cleanupEnabled' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'cleanupEnabled' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'livePreviewEnabled' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -86,6 +86,7 @@ export function useSettings() {
               cleanupEnabled: previousSettings.cleanupEnabled,
               codeVocabEnabled: previousSettings.codeVocabEnabled,
               codeVocabFolder: previousSettings.codeVocabFolder,
+              livePreviewEnabled: previousSettings.livePreviewEnabled,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -205,4 +205,34 @@ describe('loadSettings', () => {
     expect(settings.codeVocabEnabled).toBe(true);
     expect(settings.codeVocabFolder).toBe('/Users/me/project');
   });
+
+  it('defaults livePreviewEnabled to false (off) when absent', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      model: 'base.en',
+      doubleTapKey: 'shift_l',
+      language: 'en',
+      recordingMode: 'hold_down',
+    }));
+    const settings = loadSettings();
+    expect(settings.livePreviewEnabled).toBe(DEFAULT_SETTINGS.livePreviewEnabled);
+    expect(settings.livePreviewEnabled).toBe(false);
+  });
+
+  it('coerces non-boolean livePreviewEnabled to default', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      livePreviewEnabled: 'yes',
+    }));
+    const settings = loadSettings();
+    expect(settings.livePreviewEnabled).toBe(DEFAULT_SETTINGS.livePreviewEnabled);
+  });
+
+  it('preserves an explicit livePreviewEnabled value', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      livePreviewEnabled: true,
+    }));
+    const settings = loadSettings();
+    expect(settings.livePreviewEnabled).toBe(true);
+  });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -37,6 +37,12 @@ export interface Settings {
   codeVocabEnabled: boolean;
   /** Absolute path to the project folder scanned for code identifiers. */
   codeVocabFolder: string;
+  /**
+   * Show partial words in the overlay *while speaking* (live streaming preview,
+   * issue #129). Preview-only — never changes the injected/clipboard text.
+   * CPU-heavy, Whisper-only, OFF by default.
+   */
+  livePreviewEnabled: boolean;
 }
 
 export type ModelOption =
@@ -122,6 +128,7 @@ export const DEFAULT_SETTINGS: Settings = {
   cleanupEnabled: false,
   codeVocabEnabled: false,
   codeVocabFolder: '',
+  livePreviewEnabled: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -198,6 +205,12 @@ export function loadSettings(): Settings {
       // anything non-string back to the empty default.
       if (typeof parsed.codeVocabFolder !== 'string') {
         parsed.codeVocabFolder = DEFAULT_SETTINGS.codeVocabFolder;
+      }
+
+      // livePreviewEnabled gates the CPU-heavy preview pass — coerce non-booleans
+      // (or a missing field on pre-feature stored settings) back to the default.
+      if (typeof parsed.livePreviewEnabled !== 'boolean') {
+        parsed.livePreviewEnabled = DEFAULT_SETTINGS.livePreviewEnabled;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -155,5 +155,6 @@ The observer is intentionally leaked (`std::mem::forget`) for app-lifetime obser
 | `app-disabled-changed` | Boolean | Global-disable state changed (updates the top-bar mic + speaker-slash) |
 | `settings-changed` | (none) | Auto-paste/disable changed in another window; listeners re-read localStorage |
 | `open-settings` | (none) | Overlay gear asks the main window to open the Settings panel |
+| `partial-transcript` | String | Live preview text while recording (#129). Empty string clears the preview. Only emitted when Live Preview is enabled (default off) and the Whisper backend is active. |
 
 The entire overlay surface is a Tauri drag region (`data-tauri-drag-region`), allowing the user to reposition it. Overlay position save/restore is currently disabled (TODO: re-enable after notch positioning is stable).

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -80,3 +80,22 @@ Status is managed in `DictationState` behind a `Mutex` with poison recovery (`Mu
 - `lib/dictation.ts` has `startRecording()` and `stopRecording()` wrappers around Tauri `invoke()`
 - `useRecordingState` hook manages status, transcription text, recording duration timer, and error state
 - `toggleRecording()` checks current status via ref and calls start or stop accordingly
+
+## Live Streaming Preview (optional, #129)
+
+A default-off setting (`livePreviewEnabled`) shows partial words in the Dynamic Island overlay *while the user is still speaking*. It is strictly **preview-only**:
+
+- The authoritative injected/clipboard text is always the existing full-audio one-shot transcription produced on stop. The preview pass never changes it.
+- **Whisper backend only.** Parakeet (and any future non-whisper backend) gets a graceful no-op via `preview::should_run_preview`.
+- **Isolated whisper context.** The preview pass owns its *own* `WhisperContext` + `WhisperState` (`transcriber/preview.rs` → `PreviewTranscriber`), separate from the cached backend state in `AppState::backend`. This is the same isolation pattern VAD uses and is the key to concurrency safety: the preview pass and the final pass can never share or corrupt each other's `WhisperState`.
+
+### Flow
+
+1. `start_native_recording` calls `maybe_start_live_preview`, which checks the gate (setting on AND backend is whisper) and spawns a throttled background task. `live_preview_active` (an `Arc<AtomicBool>` in `AppState`) is the cancel token.
+2. Every ~1.4s the task takes a non-destructive `audio::snapshot_samples()` (clones the in-progress buffer, resampled to 16kHz — never touches the final capture), selects a trailing window (`select_preview_window`, default 12s), runs a partial whisper pass on a blocking thread, and emits the cleaned text as a `partial-transcript` Tauri event.
+3. Because the loop `await`s each blocking pass before sleeping again, a slow transcribe can never pile up (skip-if-running is implicit).
+4. `stop_native_recording` and `cancel_native_recording` flip the cancel flag (`stop_live_preview`) and emit an empty `partial-transcript` to clear the overlay, *before* the authoritative final pass runs.
+
+The pure decision logic (window selection, preview-text cleaning, the on/off gate) is unit-tested in `transcriber/preview.rs`.
+
+> **Runtime note:** whether partial words actually appear while speaking cannot be verified in CI or a headless worktree (no live audio/overlay). It requires a built `.app`. See the PR's "Runtime verification REQUIRED" section.


### PR DESCRIPTION
## Summary

Adds an optional, **default-off** live preview that shows partial words in the Dynamic Island overlay **while the user is still speaking**, instead of only after they stop.

This is strictly **preview-only**. The authoritative injected/clipboard text remains the existing full-audio one-shot transcription produced on stop — it is never changed, re-ordered, or replaced by this feature.

## Design constraints honored

- **Authoritative output untouched.** The final pass in `run_transcription_pipeline` is completely unchanged. The preview pass only emits a `partial-transcript` Tauri event consumed by the overlay; it never writes the clipboard, never pastes, never feeds the history/stats path.
- **Default-off.** New `livePreviewEnabled` setting defaults to `false` everywhere (TS `DEFAULT_SETTINGS`, Rust `DictationState::default`). When off, behavior is byte-for-byte the current behavior — `stop_live_preview` even no-ops its overlay-clear emit unless a preview was actually armed.
- **Whisper backend only.** `preview::should_run_preview` gates on `backend.name() == "whisper"`, so Parakeet (and any future backend) gets a graceful no-op — nothing spawns, nothing errors.
- **Append-only plumbing.** All settings changes are additive (new field + new coercion branch + new configure key), matching the existing `cleanupEnabled` / `codeVocab*` patterns.

## How it works

1. `start_native_recording` calls `maybe_start_live_preview`, which checks the gate and spawns a throttled `tokio` task. A shared `Arc<AtomicBool>` (`live_preview_active`) in `AppState` is the cancel token.
2. Every ~1.4s the task takes a **non-destructive** `audio::snapshot_samples()` (clones the in-progress buffer, resampled to 16kHz — never touches the final capture, the `active` flag, or the capture thread), selects a trailing window (default 12s), runs a partial whisper pass on a blocking thread, and emits the cleaned text.
3. Because the loop `await`s each blocking pass before sleeping again, a slow transcribe can never pile up (**skip-if-running is implicit**).
4. `stop_native_recording` / `cancel_native_recording` flip the cancel flag and emit an empty `partial-transcript` to clear the overlay, **before** the authoritative final pass runs.
5. A `recording_id` generation guard prevents a superseded session's in-flight pass from emitting stale text on rapid start-stop.

## WhisperState concurrency decision (highest-risk area)

The transcription backend stores a single cached `WhisperState` behind `AppState::backend` (`Mutex<Box<dyn TranscriptionBackend>>`). Running a preview pass concurrently with the final pass on that **same** `WhisperState` would corrupt results (`WhisperState::full` mutates internal buffers).

**Decision: the preview pass owns its OWN dedicated `WhisperContext` + `WhisperState`** (`transcriber/preview.rs` → `PreviewTranscriber`), entirely separate from the cached backend state and never reachable through `AppState::backend`. This is the same isolation pattern VAD already uses (a fresh `WhisperVadContext` per run). Consequences:

- The preview pass and the final pass can **never** share or corrupt each other's `WhisperState` — they are different objects.
- In whisper-rs 0.15.1, `WhisperState` holds its own Arc-cloned context and is `unsafe impl Send`, so `PreviewTranscriber` moves cleanly across `spawn_blocking` boundaries.
- Trade-off: extra memory + a model load for the preview engine. Acceptable because the feature is default-off and CPU-heavy by nature. Even in the rapid start-stop window where an old and new preview task briefly overlap, each owns its own state, so the only consequence is wasted work (already bounded by the cancel flag + `recording_id` guard).

## Tests

- **Rust pure logic** (`transcriber/preview.rs`, `#[cfg(test)]`): trailing-window selection (below-min skip, shorter-than-window, trailing slice, zero-rate/zero-window fallbacks), preview-text cleaning (trim, empty drop, `[BLANK_AUDIO]`/`(silence)` marker drop, internal-bracket preservation), and the on/off + backend gate. Verified green via `rustc --test` on a /tmp copy (13/13). CI compiles+runs them under `cargo test --lib`.
- **Frontend** (`settings.test.ts`): default-off, non-boolean coercion, explicit-value preservation for `livePreviewEnabled`. `npx tsc --noEmit` clean; `npm test` 62/62 green.

## Runtime verification REQUIRED

The actual streaming behavior **cannot** be verified in CI or this headless worktree — there is no live microphone audio and no rendered overlay. A human must run a **built `.app`** (`cd app && npm run tauri build`) and confirm:

1. **Default-off is invisible.** Fresh install / untouched settings: record + stop as today. Confirm no overlay preview text ever appears and the pasted/clipboard text is exactly as before.
2. **Toggle on → partial words appear.** Settings → Transcription → enable **Live Preview** (Whisper model selected, e.g. `base.en`). Start recording and speak a long sentence. Confirm partial words appear in the Dynamic Island **while still speaking**, updating roughly every ~1.4s.
3. **Final injected text is unchanged.** Stop. Confirm the pasted/clipboard text is the full, authoritative transcription (identical to preview-off) — NOT the last partial preview string.
4. **CPU acceptable.** Watch Activity Monitor / the in-app resource monitor during a long preview-on recording. Confirm CPU is within an acceptable range and recovers after stop.
5. **No crash/hang on rapid start-stop.** Rapidly start/stop/cancel recordings (keyboard and overlay double-click) with preview on. Confirm no crash, no hung "Processing" state, no stale preview text lingering from a previous recording, and the overlay clears to idle each time.
6. **Parakeet no-op.** Switch to the Parakeet model with Live Preview still on. Confirm recording works normally and no preview appears (graceful no-op, no error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional live transcription preview that displays partial text in the overlay while recording (disabled by default).
  * Live preview is exclusive to the Whisper backend and can be toggled in Transcription settings.
  * Preview text is for visualization only; final injected text remains unchanged.

* **Documentation**
  * Updated overlay and transcription feature documentation to explain the new live preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->