### PR TITLE
feat: finish v0.11 features (built-in vocab, custom voice commands, cleanup sub-toggles, per-app cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-23
+
 ### Added
 - **Overlay hover-expand quick settings** — hovering the Dynamic Island reveals a quick-settings dropdown with global-disable, auto-paste, and settings-window controls; inline recording timer while hovering (#135)
 - **Accessibility permission reset** troubleshooting button in the permissions banner — resets the app's stale TCC entry for the current bundle id (`tccutil reset Accessibility`) and reopens System Settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Accessibility permission reset** troubleshooting button in the permissions banner — resets the app's stale TCC entry for the current bundle id (`tccutil reset Accessibility`) and reopens System Settings
 - **Save dictation output to file**: optional "Save Transcript to File" (`.txt`) and "Save Audio to File" (`.wav`) toggles for live hotkey dictation, with a configurable output folder (defaults to `Documents/Murmur`). When either is enabled, text is still copied to the clipboard but auto-paste is paused (`file_output.rs`).
 - **History source badge**: each history entry now shows whether it came from live recording ("Mic") or a transcribed file ("File", with the source file name).
+- **Built-in code vocabulary** — code-aware vocabulary now works with no folder selected, biasing transcription toward a curated dev-term dictionary (`useEffect`, `kubectl`, `stderr`, …); an optional project folder layers your own identifiers on top (`vocab::builtin_terms_prompt`).
+- **Custom voice commands** — define your own spoken `phrase → replacement` pairs (applied after the built-in commands) in Settings (`voice_commands::apply_voice_commands_with_custom`).
+- **Transcript cleanup sub-toggles** — independently turn off "remove filler words" and "capitalize sentences" while keeping cleanup on.
+- **Per-app transcript-cleanup override** — per-app profiles can now force cleanup on/off per frontmost app, alongside the existing auto-paste override.
+
+### Changed
+- **Unified Vocabulary settings** — the manual Custom Vocabulary input and the Code-Aware Vocabulary controls now live together in one "Vocabulary" section (both feed the same Whisper initial prompt).
 
 ### Fixed
 - **Microphone permission banner no longer false-negatives** after a dev rebuild or app move (stale TCC, #190). The banner now reads the live 4-state `AVCaptureDevice` authorization status and treats `notDetermined`/`unknown` as transient (not a hard "denied"), so a stale TCC entry can't mislabel a working mic. Added a microphone **reset** troubleshooting button (`tccutil reset Microphone <bundle-id>`) mirroring the Accessibility reset.

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.11.0"
+version = "0.12.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -32,9 +32,13 @@ fn build_code_vocab_prompt(folder: &str) -> String {
 }
 
 /// Return the code-aware vocabulary prompt for the current settings, or an empty
-/// string when the feature is disabled. Uses the cached prompt when present;
-/// otherwise scans the folder once and caches the result so subsequent
-/// utterances don't rescan.
+/// string when the feature is disabled.
+///
+/// When enabled, the built-in dev-term dictionary always contributes so the
+/// feature works with no folder selected ("just works"). A configured project
+/// folder is scanned (and cached) and its identifiers are placed *first* — they're
+/// more specific than the generic built-ins, so they survive Whisper's prompt
+/// truncation. Folder scanning still happens at most once per folder/enable change.
 fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
     // Fast path under the lock: feature off => nothing to do.
     let (enabled, folder, cached) = {
@@ -45,19 +49,33 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
             dictation.code_vocab_prompt.clone(),
         )
     };
-    if !enabled || folder.trim().is_empty() {
+    if !enabled {
         return String::new();
     }
-    if let Some(prompt) = cached {
-        return prompt;
+
+    let builtin = crate::vocab::builtin_terms_prompt();
+
+    // Optional project scan layered on top of the built-ins.
+    let folder_prompt = if folder.trim().is_empty() {
+        String::new()
+    } else if let Some(prompt) = cached {
+        prompt
+    } else {
+        // Not yet scanned: build now and cache (only if settings still match).
+        let prompt = build_code_vocab_prompt(&folder);
+        let mut dictation = app_state.dictation.lock_or_recover();
+        if dictation.code_vocab_enabled && dictation.code_vocab_folder == folder {
+            dictation.code_vocab_prompt = Some(prompt.clone());
+        }
+        prompt
+    };
+
+    // Project identifiers first (most specific), built-in dictionary after.
+    if folder_prompt.trim().is_empty() {
+        builtin
+    } else {
+        format!("{} {}", folder_prompt.trim(), builtin)
     }
-    // Not yet scanned: build now and cache (only if settings still match).
-    let prompt = build_code_vocab_prompt(&folder);
-    let mut dictation = app_state.dictation.lock_or_recover();
-    if dictation.code_vocab_enabled && dictation.code_vocab_folder == folder {
-        dictation.code_vocab_prompt = Some(prompt.clone());
-    }
-    prompt
 }
 
 /// Merge the manual custom-vocabulary string and the code-aware vocabulary into a
@@ -148,23 +166,26 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, cleanup_enabled) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, voice_command_pairs, cleanup_enabled, cleanup_remove_filler, cleanup_capitalize) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.cleanup_enabled)
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.voice_command_pairs.clone(), dictation.cleanup_enabled, dictation.cleanup_remove_filler, dictation.cleanup_capitalize)
     };
 
-    // Per-app profiles: if the frontmost app has a matching profile that sets an
-    // auto-paste override, honor it instead of the global setting. No match (or
-    // no detected app) leaves the global value untouched.
-    let profile_auto_paste = if app_profiles.is_empty() {
-        auto_paste
+    // Per-app profiles: if the frontmost app has a matching profile, its overrides
+    // replace the global auto-paste / cleanup settings. The frontmost app is
+    // detected once (a single osascript call) and reused for both resolutions. No
+    // profiles (or no detected app) leaves the global values untouched.
+    let (profile_auto_paste, profile_cleanup) = if app_profiles.is_empty() {
+        (auto_paste, cleanup_enabled)
     } else {
         let bundle_id = crate::frontmost::frontmost_bundle_id();
-        let resolved = crate::frontmost::resolve_auto_paste(auto_paste, bundle_id.as_deref(), &app_profiles);
-        if resolved != auto_paste {
-            tracing::info!(target: "pipeline", "app profile override: auto_paste {} -> {} (frontmost={})", auto_paste, resolved, bundle_id.as_deref().unwrap_or("unknown"));
+        let resolved_paste = crate::frontmost::resolve_auto_paste(auto_paste, bundle_id.as_deref(), &app_profiles);
+        let resolved_cleanup = crate::frontmost::resolve_cleanup(cleanup_enabled, bundle_id.as_deref(), &app_profiles);
+        if resolved_paste != auto_paste || resolved_cleanup != cleanup_enabled {
+            tracing::info!(target: "pipeline", "app profile override (frontmost={}): auto_paste {}->{}, cleanup {}->{}",
+                bundle_id.as_deref().unwrap_or("unknown"), auto_paste, resolved_paste, cleanup_enabled, resolved_cleanup);
         }
-        resolved
+        (resolved_paste, resolved_cleanup)
     };
 
     // When saving to a file, suppress auto-paste into the focused app. The
@@ -262,17 +283,27 @@ async fn run_transcription_pipeline(
     // Runs BEFORE voice commands so filler/punctuation tidy never mangles the
     // structural tokens (e.g. inserted "\n" from "new line") that voice commands
     // emit downstream.
-    let text = if cleanup_enabled && !text.trim().is_empty() {
-        let cleaned = crate::cleanup::clean_transcript(&text, crate::cleanup::CleanupOptions::default());
+    // `profile_cleanup` already folds in any per-app override of the global toggle.
+    let text = if profile_cleanup && !text.trim().is_empty() {
+        let opts = crate::cleanup::CleanupOptions {
+            remove_filler: cleanup_remove_filler,
+            capitalize: cleanup_capitalize,
+        };
+        let cleaned = crate::cleanup::clean_transcript(&text, opts);
         tracing::info!(target: "pipeline", "cleanup applied ({} -> {} chars)", text.len(), cleaned.len());
         cleaned
     } else {
         text
     };
 
-    // Phase: Voice commands -- rewrite spoken command tokens (e.g. "new line",
-    // "scratch that") before the text reaches file output / clipboard / paste.
-    let text = crate::voice_commands::apply_voice_commands(&text, voice_commands_enabled);
+    // Phase: Voice commands -- rewrite the built-in spoken tokens (e.g. "new line",
+    // "scratch that") plus any user-defined commands before the text reaches file
+    // output / clipboard / paste.
+    let custom_commands: Vec<(String, String)> = voice_command_pairs
+        .into_iter()
+        .map(|vc| (vc.phrase, vc.replacement))
+        .collect();
+    let text = crate::voice_commands::apply_voice_commands_with_custom(&text, voice_commands_enabled, &custom_commands);
 
     // Update last_transcription_at for idle timeout tracking
     *app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
@@ -498,6 +529,26 @@ pub async fn configure_dictation(
         dictation.voice_commands_enabled = vc;
     }
 
+    // User-defined voice commands: array of { phrase, replacement }. Entries with
+    // a blank phrase are skipped. Replaces the whole list when the key is present.
+    if let Some(pairs) = options.get("voiceCommands").and_then(|v| v.as_array()) {
+        dictation.voice_command_pairs = pairs
+            .iter()
+            .filter_map(|p| {
+                let phrase = p.get("phrase").and_then(|v| v.as_str())?.trim().to_string();
+                if phrase.is_empty() {
+                    return None;
+                }
+                let replacement = p
+                    .get("replacement")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some(crate::state::VoiceCommand { phrase, replacement })
+            })
+            .collect();
+    }
+
     if let Some(save_transcript) = options.get("saveTranscript").and_then(|v| v.as_bool()) {
         dictation.save_transcript = save_transcript;
     }
@@ -528,13 +579,22 @@ pub async fn configure_dictation(
                     .to_string();
                 // null/absent -> None (use global); otherwise the boolean override.
                 let auto_paste_override = p.get("autoPasteOverride").and_then(|v| v.as_bool());
-                Some(crate::state::AppProfile { bundle_id, label, auto_paste_override })
+                let cleanup_override = p.get("cleanupOverride").and_then(|v| v.as_bool());
+                Some(crate::state::AppProfile { bundle_id, label, auto_paste_override, cleanup_override })
             })
             .collect();
     }
 
     if let Some(cleanup_enabled) = options.get("cleanupEnabled").and_then(|v| v.as_bool()) {
         dictation.cleanup_enabled = cleanup_enabled;
+    }
+
+    if let Some(v) = options.get("cleanupRemoveFiller").and_then(|v| v.as_bool()) {
+        dictation.cleanup_remove_filler = v;
+    }
+
+    if let Some(v) = options.get("cleanupCapitalize").and_then(|v| v.as_bool()) {
+        dictation.cleanup_capitalize = v;
     }
 
     // Code-aware vocabulary: a toggle plus a folder to scan for identifiers.

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -62,6 +62,28 @@ pub fn resolve_auto_paste(
     auto_paste
 }
 
+/// Resolve the effective transcript-cleanup setting for the frontmost app.
+///
+/// Mirrors [`resolve_auto_paste`]: returns the override from the first matching
+/// profile that sets one, otherwise the global `cleanup` value. Pure for testing.
+pub fn resolve_cleanup(
+    cleanup: bool,
+    bundle_id: Option<&str>,
+    profiles: &[crate::state::AppProfile],
+) -> bool {
+    let Some(bundle_id) = bundle_id else {
+        return cleanup;
+    };
+    for profile in profiles {
+        if profile.bundle_id == bundle_id {
+            if let Some(override_value) = profile.cleanup_override {
+                return override_value;
+            }
+        }
+    }
+    cleanup
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,6 +94,16 @@ mod tests {
             bundle_id: bundle_id.to_string(),
             label: bundle_id.to_string(),
             auto_paste_override,
+            cleanup_override: None,
+        }
+    }
+
+    fn cleanup_profile(bundle_id: &str, cleanup_override: Option<bool>) -> AppProfile {
+        AppProfile {
+            bundle_id: bundle_id.to_string(),
+            label: bundle_id.to_string(),
+            auto_paste_override: None,
+            cleanup_override,
         }
     }
 
@@ -115,5 +147,45 @@ mod tests {
         ];
         // First profile has no override, so we fall through to the second.
         assert!(!resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
+    }
+
+    #[test]
+    fn cleanup_no_frontmost_uses_global() {
+        let profiles = vec![cleanup_profile("com.apple.Terminal", Some(false))];
+        assert!(resolve_cleanup(true, None, &profiles));
+        assert!(!resolve_cleanup(false, None, &profiles));
+    }
+
+    #[test]
+    fn cleanup_matching_profile_override_wins() {
+        // Force cleanup OFF in a code editor even though it's globally on.
+        let profiles = vec![cleanup_profile("com.microsoft.VSCode", Some(false))];
+        assert!(!resolve_cleanup(true, Some("com.microsoft.VSCode"), &profiles));
+    }
+
+    #[test]
+    fn cleanup_matching_profile_can_force_on() {
+        let profiles = vec![cleanup_profile("com.apple.mail", Some(true))];
+        assert!(resolve_cleanup(false, Some("com.apple.mail"), &profiles));
+    }
+
+    #[test]
+    fn cleanup_null_override_falls_through_to_global() {
+        let profiles = vec![cleanup_profile("com.apple.Terminal", None)];
+        assert!(resolve_cleanup(true, Some("com.apple.Terminal"), &profiles));
+        assert!(!resolve_cleanup(false, Some("com.apple.Terminal"), &profiles));
+    }
+
+    #[test]
+    fn cleanup_and_auto_paste_overrides_are_independent() {
+        // A profile can override one without touching the other.
+        let profiles = vec![AppProfile {
+            bundle_id: "com.apple.Terminal".to_string(),
+            label: "Terminal".to_string(),
+            auto_paste_override: Some(true),
+            cleanup_override: Some(false),
+        }];
+        assert!(resolve_auto_paste(false, Some("com.apple.Terminal"), &profiles));
+        assert!(!resolve_cleanup(true, Some("com.apple.Terminal"), &profiles));
     }
 }

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -21,13 +21,28 @@ impl Default for DictationStatus {
 }
 
 /// Per-app dictation profile. When the frontmost macOS app's bundle id matches
-/// `bundle_id`, `auto_paste_override` (when `Some`) replaces the global
-/// auto-paste setting at inject time. `None` means "no override — use global".
+/// `bundle_id`, each `*_override` (when `Some`) replaces the corresponding global
+/// setting at transcription time. `None` means "no override — use global".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppProfile {
     pub bundle_id: String,
     pub label: String,
+    /// Override the global auto-paste setting for this app.
     pub auto_paste_override: Option<bool>,
+    /// Override the global transcript-cleanup setting for this app (e.g. force
+    /// verbatim output in a code editor, or force cleanup in an email client).
+    #[serde(default)]
+    pub cleanup_override: Option<bool>,
+}
+
+/// A user-defined voice command: when `phrase` is spoken (matched
+/// case-insensitively on word boundaries), it is replaced by `replacement`.
+/// Applied after the built-in command set, so users can extend — not override —
+/// the defaults.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoiceCommand {
+    pub phrase: String,
+    pub replacement: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,9 +61,16 @@ pub struct DictationState {
     /// Per-app profiles that override auto-paste based on the frontmost app.
     pub app_profiles: Vec<AppProfile>,
     pub voice_commands_enabled: bool,
+    /// User-defined voice commands applied after the built-in set.
+    #[serde(default)]
+    pub voice_command_pairs: Vec<VoiceCommand>,
     /// Rule-based transcript cleanup (filler removal, spacing/capitalization)
     /// applied before injection. Off by default.
     pub cleanup_enabled: bool,
+    /// When cleanup is enabled, remove standalone filler tokens ("um", "uh").
+    pub cleanup_remove_filler: bool,
+    /// When cleanup is enabled, capitalize sentence starts.
+    pub cleanup_capitalize: bool,
     /// Code-aware vocabulary: when enabled, identifiers scanned from
     /// `code_vocab_folder` are fed to Whisper as an initial prompt to bias
     /// transcription toward the user's code terms. Whisper backend only.
@@ -80,7 +102,10 @@ impl Default for DictationState {
             output_dir: String::new(),
             app_profiles: Vec::new(),
             voice_commands_enabled: false,
+            voice_command_pairs: Vec::new(),
             cleanup_enabled: false,
+            cleanup_remove_filler: true,
+            cleanup_capitalize: true,
             code_vocab_enabled: false,
             code_vocab_folder: String::new(),
             code_vocab_prompt: None,

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -10,6 +10,40 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Built-in dictionary of common programming / tooling terms fed to Whisper as an
+/// initial-prompt bias whenever code-aware vocabulary is enabled — even with no
+/// project folder selected, so the feature "just works" out of the box. Chosen for
+/// terms Whisper tends to mangle (camelCase APIs, CLI names, abbreviations) rather
+/// than words it already knows. A project scan, when configured, layers on top of
+/// (and ranks ahead of) this list.
+pub const BUILTIN_DEV_TERMS: &[&str] = &[
+    // JS/TS framework + hooks
+    "useEffect", "useState", "useRef", "useCallback", "useMemo", "useContext",
+    "TypeScript", "JavaScript", "JSX", "TSX", "npm", "npx", "pnpm", "yarn",
+    "Node.js", "Deno", "Vite", "Webpack", "ESLint", "Prettier", "Tailwind",
+    "React", "Vue", "Svelte", "Next.js", "async", "await", "Promise", "nullable",
+    // Rust
+    "Rust", "cargo", "rustc", "clippy", "tokio", "serde", "async", "trait",
+    "enum", "struct", "impl", "Mutex", "Arc", "borrow", "lifetime", "macro",
+    "stdout", "stderr", "stdin", "dylib", "rustup", "Tauri", "whisper-rs",
+    // Python
+    "Python", "pip", "venv", "pytest", "numpy", "pandas", "asyncio", "dataclass",
+    "Django", "Flask", "FastAPI", "PyTorch", "TensorFlow",
+    // Go / other langs
+    "Golang", "goroutine", "Kotlin", "Swift", "SwiftUI", "Xcode",
+    // Web / protocols / data
+    "API", "REST", "GraphQL", "JSON", "YAML", "TOML", "HTTP", "HTTPS", "WebSocket",
+    "OAuth", "JWT", "CORS", "UUID", "regex", "stdin", "CRUD", "SQL",
+    // Databases / infra / devops
+    "Postgres", "PostgreSQL", "SQLite", "Redis", "MongoDB", "Docker", "Kubernetes",
+    "kubectl", "nginx", "Terraform", "Ansible", "GitHub", "GitLab", "CI/CD",
+    "DevOps", "Kafka", "RabbitMQ", "gRPC",
+    // General CS / build
+    "localhost", "config", "env", "boolean", "int", "struct", "endpoint",
+    "middleware", "namespace", "runtime", "stack trace", "codebase", "repo",
+    "commit", "rebase", "changelog", "metadata", "macOS", "Linux",
+];
+
 /// Skip individual files larger than this (bytes). A single huge minified bundle
 /// or vendored blob shouldn't dominate the scan or hang it.
 pub const MAX_FILE_BYTES: u64 = 512 * 1024;
@@ -29,6 +63,19 @@ pub const SOURCE_EXTENSIONS: &[&str] = &[
     "swift", "c", "h", "cc", "cpp", "hpp", "cs", "rb", "php", "scala", "sh",
     "lua", "dart", "vue", "svelte",
 ];
+
+/// Render [`BUILTIN_DEV_TERMS`] as a space-joined initial-prompt string, deduped
+/// case-insensitively (the list carries intentional cross-language repeats like
+/// "async"/"struct") while preserving the first surface form and order.
+pub fn builtin_terms_prompt() -> String {
+    let mut seen = std::collections::HashSet::new();
+    BUILTIN_DEV_TERMS
+        .iter()
+        .filter(|t| seen.insert(t.to_ascii_lowercase()))
+        .copied()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 
 /// Return true if `path` has one of the source extensions we scan (case-insensitive).
 pub fn is_source_file(path: &Path) -> bool {
@@ -479,6 +526,19 @@ mod tests {
         assert!(is_skipped_dir(".git"));
         assert!(!is_skipped_dir("src"));
         assert!(!is_skipped_dir("components"));
+    }
+
+    #[test]
+    fn builtin_prompt_is_nonempty_and_deduped() {
+        let p = builtin_terms_prompt();
+        assert!(p.contains("useEffect"));
+        assert!(p.contains("kubectl"));
+        // "async"/"struct" appear multiple times in the source list but must be
+        // deduped (case-insensitively) in the rendered prompt.
+        let count_async = p.split(' ').filter(|t| t.eq_ignore_ascii_case("async")).count();
+        assert_eq!(count_async, 1, "async should appear once, prompt={:?}", p);
+        let count_struct = p.split(' ').filter(|t| t.eq_ignore_ascii_case("struct")).count();
+        assert_eq!(count_struct, 1, "struct should appear once");
     }
 
     #[test]

--- a/app/src-tauri/src/voice_commands.rs
+++ b/app/src-tauri/src/voice_commands.rs
@@ -75,6 +75,63 @@ pub fn apply_voice_commands(text: &str, enabled: bool) -> String {
     out
 }
 
+/// Apply the built-in command map, then any user-defined `custom` commands.
+///
+/// Custom commands are literal `phrase -> replacement` substitutions, matched
+/// case-insensitively on word boundaries (same matcher as the built-ins). They run
+/// *after* the built-ins, so a user can extend the vocabulary without breaking the
+/// defaults. Blank phrases are ignored. When `enabled` is false the text is
+/// returned unchanged.
+pub fn apply_voice_commands_with_custom(
+    text: &str,
+    enabled: bool,
+    custom: &[(String, String)],
+) -> String {
+    if !enabled {
+        return text.to_string();
+    }
+    let built = apply_voice_commands(text, true);
+    if custom.is_empty() {
+        return built;
+    }
+    let mut out = built;
+    for (phrase, replacement) in custom {
+        let phrase = phrase.trim();
+        if phrase.is_empty() {
+            continue;
+        }
+        out = replace_phrase(&out, phrase, replacement);
+    }
+    out
+}
+
+/// Replace every word-boundary, case-insensitive occurrence of `phrase` in `text`
+/// with `replacement`. Mirrors the built-in matcher's lowercase-parallel scan.
+fn replace_phrase(text: &str, phrase: &str, replacement: &str) -> String {
+    let lower = text.to_lowercase();
+    let chars: Vec<char> = text.chars().collect();
+    let lower_chars: Vec<char> = lower.chars().collect();
+    let phrase_chars: Vec<char> = phrase.to_lowercase().chars().collect();
+    // Lowercasing can (rarely, for some Unicode) change length; bail to the
+    // original in that case rather than risk an index mismatch.
+    if phrase_chars.is_empty() || lower_chars.len() != chars.len() {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if matches_at(&lower_chars, i, &phrase_chars) {
+            out.push_str(replacement);
+            i += phrase_chars.len();
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
 /// How a matched command rewrites the output buffer.
 enum Command {
     /// Insert literal text (e.g. newline) verbatim.
@@ -293,5 +350,64 @@ mod tests {
     fn command_at_start_of_input() {
         // "period" at the very start has no prior word; it just emits the mark.
         assert_eq!(apply_voice_commands("period", true), ".");
+    }
+
+    fn pairs(p: &[(&str, &str)]) -> Vec<(String, String)> {
+        p.iter().map(|(a, b)| (a.to_string(), b.to_string())).collect()
+    }
+
+    #[test]
+    fn custom_disabled_returns_unchanged() {
+        let custom = pairs(&[("my email", "me@example.com")]);
+        assert_eq!(
+            apply_voice_commands_with_custom("my email", false, &custom),
+            "my email"
+        );
+    }
+
+    #[test]
+    fn custom_literal_replacement() {
+        let custom = pairs(&[("my email", "me@example.com")]);
+        assert_eq!(
+            apply_voice_commands_with_custom("send to my email please", true, &custom),
+            "send to me@example.com please"
+        );
+    }
+
+    #[test]
+    fn custom_is_case_insensitive_and_word_bounded() {
+        let custom = pairs(&[("sig", "Best, Alex")]);
+        // "sig" matches as a word, but not inside "signal".
+        assert_eq!(
+            apply_voice_commands_with_custom("SIG and signal", true, &custom),
+            "Best, Alex and signal"
+        );
+    }
+
+    #[test]
+    fn custom_runs_after_builtins() {
+        // Built-in "new line" fires first, then the custom replacement.
+        let custom = pairs(&[("ticket", "JIRA-123")]);
+        assert_eq!(
+            apply_voice_commands_with_custom("ticket new line done", true, &custom),
+            "JIRA-123\ndone"
+        );
+    }
+
+    #[test]
+    fn custom_blank_phrase_ignored() {
+        let custom = pairs(&[("   ", "x")]);
+        assert_eq!(
+            apply_voice_commands_with_custom("hello world", true, &custom),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn custom_empty_list_matches_builtin_only() {
+        assert_eq!(
+            apply_voice_commands_with_custom("done period", true, &[]),
+            "done."
+        );
     }
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -155,7 +155,7 @@ function App() {
       <StatsBar statsVersion={combinedStatsVersion} />
 
       <div className="flex-1 flex overflow-hidden">
-        <main className="flex-1 flex flex-col overflow-hidden p-4 gap-4">
+        <main className={`flex-1 flex-col overflow-hidden p-4 gap-4 ${isSettingsOpen ? 'hidden' : 'flex'}`}>
           <div className="shrink-0 flex gap-1 p-1 self-start bg-stone-100 dark:bg-stone-800 rounded-lg">
             {(['record', 'file'] as const).map((tab) => (
               <button
@@ -196,6 +196,7 @@ function App() {
           )}
         </main>
 
+        {isSettingsOpen && (
         <SettingsPanel
           isOpen={isSettingsOpen}
           onClose={() => setIsSettingsOpen(false)}
@@ -208,6 +209,7 @@ function App() {
           onCheckForUpdate={checkForUpdate}
           updateStatus={updateStatus}
         />
+        )}
       </div>
 
       <AboutModal

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -6,7 +6,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import {
   Settings, RecordingMode, DEFAULT_SETTINGS,
   MODEL_OPTIONS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
-  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, AppProfile,
+  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, AppProfile, VoiceCommand,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
@@ -146,7 +146,7 @@ function AppProfilesEditor({ profiles, onChange }: {
     }
     onChange([
       ...profiles,
-      { bundleId: trimmedId, label: label.trim(), autoPasteOverride: false },
+      { bundleId: trimmedId, label: label.trim(), autoPasteOverride: null, cleanupOverride: null },
     ]);
     setBundleId('');
     setLabel('');
@@ -156,24 +156,37 @@ function AppProfilesEditor({ profiles, onChange }: {
     onChange(profiles.filter((p) => p.bundleId !== id));
   };
 
-  // Cycle the override: Default (null) -> On (true) -> Off (false) -> Default.
-  const cycleOverride = (id: string) => {
-    onChange(profiles.map((p) => {
-      if (p.bundleId !== id) return p;
-      const next = p.autoPasteOverride === null ? true : p.autoPasteOverride === true ? false : null;
-      return { ...p, autoPasteOverride: next };
-    }));
+  // Cycle a tri-state override: Default (null) -> On (true) -> Off (false) -> Default.
+  const cycle = (value: boolean | null): boolean | null =>
+    value === null ? true : value === true ? false : null;
+
+  const cyclePaste = (id: string) => {
+    onChange(profiles.map((p) =>
+      p.bundleId === id ? { ...p, autoPasteOverride: cycle(p.autoPasteOverride) } : p));
   };
 
-  const overrideLabel = (value: boolean | null) =>
-    value === null ? 'Default' : value ? 'Paste On' : 'Paste Off';
+  const cycleCleanup = (id: string) => {
+    onChange(profiles.map((p) =>
+      p.bundleId === id ? { ...p, cleanupOverride: cycle(p.cleanupOverride) } : p));
+  };
+
+  const chipLabel = (kind: string, value: boolean | null) =>
+    value === null ? `${kind}: Default` : value ? `${kind}: On` : `${kind}: Off`;
+
+  const chipClass = (value: boolean | null) =>
+    value === null
+      ? 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-600 dark:text-stone-300'
+      : value
+        ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
+        : 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400';
 
   return (
     <div>
       <p className="mb-2 text-xs text-stone-500 dark:text-stone-400">
-        Override auto-paste for specific apps by bundle id (e.g.
-        <span className="font-mono"> com.apple.Terminal</span>). The frontmost app
-        when you finish dictating decides the behavior.
+        Override auto-paste and transcript cleanup for specific apps by bundle id
+        (e.g. <span className="font-mono">com.apple.Terminal</span>). The frontmost
+        app when you finish dictating decides the behavior. Each toggle cycles
+        Default → On → Off.
       </p>
 
       {profiles.length > 0 && (
@@ -181,42 +194,48 @@ function AppProfilesEditor({ profiles, onChange }: {
           {profiles.map((p) => (
             <li
               key={p.bundleId}
-              className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
+              className="flex flex-col gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
             >
-              <div className="min-w-0 flex-1">
-                {p.label && (
-                  <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
-                    {p.label}
+              <div className="flex items-center gap-2">
+                <div className="min-w-0 flex-1">
+                  {p.label && (
+                    <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
+                      {p.label}
+                    </div>
+                  )}
+                  <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
+                    {p.bundleId}
                   </div>
-                )}
-                <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
-                  {p.bundleId}
                 </div>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(p.bundleId)}
+                  aria-label={`Remove profile for ${p.label || p.bundleId}`}
+                  className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => cycleOverride(p.bundleId)}
-                aria-label={`Auto-paste for ${p.label || p.bundleId}: ${overrideLabel(p.autoPasteOverride)}`}
-                className={`shrink-0 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${
-                  p.autoPasteOverride === null
-                    ? 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-600 dark:text-stone-300'
-                    : p.autoPasteOverride
-                      ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
-                      : 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400'
-                }`}
-              >
-                {overrideLabel(p.autoPasteOverride)}
-              </button>
-              <button
-                type="button"
-                onClick={() => handleRemove(p.bundleId)}
-                aria-label={`Remove profile for ${p.label || p.bundleId}`}
-                className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+              <div className="flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => cyclePaste(p.bundleId)}
+                  aria-label={`Auto-paste for ${p.label || p.bundleId}: ${chipLabel('Paste', p.autoPasteOverride)}`}
+                  className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.autoPasteOverride)}`}
+                >
+                  {chipLabel('Paste', p.autoPasteOverride)}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => cycleCleanup(p.bundleId)}
+                  aria-label={`Cleanup for ${p.label || p.bundleId}: ${chipLabel('Clean', p.cleanupOverride)}`}
+                  className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cleanupOverride)}`}
+                >
+                  {chipLabel('Clean', p.cleanupOverride)}
+                </button>
+              </div>
             </li>
           ))}
         </ul>
@@ -261,6 +280,108 @@ function AppProfilesEditor({ profiles, onChange }: {
   );
 }
 
+// Custom voice commands: user-defined phrase -> replacement pairs applied after
+// the built-in command set. Simple add/remove list.
+function VoiceCommandsEditor({ commands, onChange }: {
+  commands: VoiceCommand[];
+  onChange: (next: VoiceCommand[]) => void;
+}) {
+  const [phrase, setPhrase] = useState('');
+  const [replacement, setReplacement] = useState('');
+
+  const handleAdd = () => {
+    const trimmedPhrase = phrase.trim();
+    if (!trimmedPhrase) return;
+    if (commands.some((c) => c.phrase.toLowerCase() === trimmedPhrase.toLowerCase())) {
+      setPhrase('');
+      setReplacement('');
+      return;
+    }
+    onChange([...commands, { phrase: trimmedPhrase, replacement }]);
+    setPhrase('');
+    setReplacement('');
+  };
+
+  const handleRemove = (p: string) => {
+    onChange(commands.filter((c) => c.phrase !== p));
+  };
+
+  return (
+    <div className="mt-3">
+      <p className="mb-2 text-xs text-stone-500 dark:text-stone-400">
+        Add your own spoken phrases. When you say the phrase it's replaced by the
+        text (case-insensitive). Runs after the built-in commands.
+      </p>
+
+      {commands.length > 0 && (
+        <ul className="mb-3 space-y-1.5">
+          {commands.map((c) => (
+            <li
+              key={c.phrase}
+              className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
+                  “{c.phrase}”
+                </div>
+                <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
+                  → {c.replacement || '(empty)'}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemove(c.phrase)}
+                aria-label={`Remove voice command ${c.phrase}`}
+                className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={phrase}
+          onChange={(e) => setPhrase(e.target.value)}
+          placeholder="Spoken phrase (e.g. my email)"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+        />
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={replacement}
+            onChange={(e) => setReplacement(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+            placeholder="Replacement (e.g. me@example.com)"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className="flex-1 min-w-0 px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!phrase.trim()}
+            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface SettingsPanelProps {
   isOpen: boolean;
   onClose: () => void;
@@ -274,8 +395,18 @@ interface SettingsPanelProps {
   updateStatus: UpdateStatus;
 }
 
+const SETTINGS_CATEGORIES = [
+  { id: 'transcription', label: 'Transcription' },
+  { id: 'recording', label: 'Recording' },
+  { id: 'output', label: 'Output & Paste' },
+  { id: 'profiles', label: 'Per-App Profiles' },
+  { id: 'vocab', label: 'Vocabulary' },
+  { id: 'about', label: 'About' },
+] as const;
+
 export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, accessibilityGranted, onCheckForUpdate, updateStatus }: SettingsPanelProps) {
   const [confirmReset, setConfirmReset] = useState(false);
+  const [activeCat, setActiveCat] = useState<string>('transcription');
   const [version, setVersion] = useState('');
 
   useEffect(() => { getVersion().then(setVersion); }, []);
@@ -418,27 +549,43 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
       : null;
 
   return (
-    <aside
-      className={`shrink-0 border-l border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800 transition-all duration-200 ${
-        isOpen ? 'w-[280px] overflow-y-auto' : 'w-0 overflow-hidden'
-      }`}
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-stone-200 dark:border-stone-700">
-        <h2 className="text-sm font-semibold text-stone-900 dark:text-stone-100">Settings</h2>
-        <button
-          onClick={onClose}
-          className="p-1 rounded-md hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
-        >
-          <svg className="w-4 h-4 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
+    <div className="flex-1 flex overflow-hidden bg-white dark:bg-stone-900">
+      {/* Left: category nav rail */}
+      <nav className="w-48 shrink-0 flex flex-col border-r border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800/40 overflow-y-auto">
+        <div className="flex items-center justify-between h-12 shrink-0 px-3">
+          <h2 className="text-sm font-semibold text-stone-900 dark:text-stone-100">Settings</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close settings"
+            className="p-1 rounded-md text-stone-500 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-2 pb-3 space-y-0.5">
+          {SETTINGS_CATEGORIES.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => setActiveCat(c.id)}
+              className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                activeCat === c.id
+                  ? 'bg-stone-200 dark:bg-stone-700 text-stone-900 dark:text-stone-100 font-medium'
+                  : 'text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700/50'
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </nav>
 
-      {/* Content */}
-      <div className="px-4 pt-1">
-        <SettingsSection title="Transcription" subtitle="Model, language, microphone">
+      {/* Right: active category content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl px-6 py-5">
+        <SettingsSection pageId="transcription" activePage={activeCat} title="Transcription" subtitle="Model, language, microphone">
         {/* Model Selector */}
         <div>
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
@@ -604,12 +751,6 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           </p>
         </div>
 
-        {/* Custom Vocabulary */}
-        <CustomVocabularyTextarea
-          value={settings.customVocabulary}
-          onCommit={(value) => onUpdateSettings({ customVocabulary: value })}
-        />
-
         {/* Transcript Cleanup Toggle */}
         <div className="flex items-center justify-between">
           <div>
@@ -637,9 +778,57 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             />
           </button>
         </div>
+
+        {/* Cleanup sub-options — only meaningful while cleanup is enabled. */}
+        {settings.cleanupEnabled && (
+          <div className="ml-3 pl-3 border-l border-stone-200 dark:border-stone-700 space-y-3">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-stone-600 dark:text-stone-400">
+                Remove filler words (um, uh)
+              </label>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.cleanupRemoveFiller}
+                aria-label="Remove filler words"
+                onClick={() => onUpdateSettings({ cleanupRemoveFiller: !settings.cleanupRemoveFiller })}
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                  settings.cleanupRemoveFiller ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                    settings.cleanupRemoveFiller ? 'translate-x-4' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-stone-600 dark:text-stone-400">
+                Capitalize sentences
+              </label>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.cleanupCapitalize}
+                aria-label="Capitalize sentences"
+                onClick={() => onUpdateSettings({ cleanupCapitalize: !settings.cleanupCapitalize })}
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                  settings.cleanupCapitalize ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                    settings.cleanupCapitalize ? 'translate-x-4' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+        )}
         </SettingsSection>
 
-        <SettingsSection title="Recording" subtitle="Trigger mode, shortcut key">
+        <SettingsSection pageId="recording" activePage={activeCat} title="Recording" subtitle="Trigger mode, shortcut key">
         {/* Voice Detection */}
         <div>
           <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
@@ -710,7 +899,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         </div>
         </SettingsSection>
 
-        <SettingsSection title="Output" subtitle="Auto-paste, launch at login">
+        <SettingsSection pageId="output" activePage={activeCat} title="Output" subtitle="Auto-paste, launch at login">
         {/* Auto-Paste Toggle */}
         <div>
           <div className="flex items-center justify-between">
@@ -922,16 +1111,29 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             />
           </button>
         </div>
+
+        {settings.voiceCommandsEnabled && (
+          <VoiceCommandsEditor
+            commands={settings.voiceCommands}
+            onChange={(next) => onUpdateSettings({ voiceCommands: next })}
+          />
+        )}
         </SettingsSection>
 
-        <SettingsSection title="Per-App Profiles" subtitle="Auto-paste per frontmost app" defaultExpanded={false}>
+        <SettingsSection pageId="profiles" activePage={activeCat} title="Per-App Profiles" subtitle="Auto-paste + cleanup per frontmost app">
           <AppProfilesEditor
             profiles={settings.appProfiles}
             onChange={(next) => onUpdateSettings({ appProfiles: next })}
           />
         </SettingsSection>
 
-        <SettingsSection title="Code-Aware Vocabulary" subtitle="Bias toward your code identifiers" defaultExpanded={false}>
+        <SettingsSection pageId="vocab" activePage={activeCat} title="Vocabulary" subtitle="Bias transcription toward your terms">
+        {/* Manual custom vocabulary — feeds the same initial prompt as code-aware. */}
+        <CustomVocabularyTextarea
+          value={settings.customVocabulary}
+          onCommit={(value) => onUpdateSettings({ customVocabulary: value })}
+        />
+
         {/* Code-Aware Vocabulary Toggle */}
         <div>
           <div className="flex items-center justify-between">
@@ -940,7 +1142,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 Code-Aware Vocabulary
               </label>
               <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
-                Scan a project folder for code identifiers (useEffect, tauri, stderr) and bias transcription toward them. Whisper models only.
+                Bias transcription toward common dev terms (useEffect, kubectl, stderr) — works out of the box, no folder needed. Optionally add a project folder for your own identifiers. Whisper models only.
               </p>
             </div>
             <button
@@ -964,10 +1166,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           {settings.codeVocabEnabled && (
             <div className="mt-3">
               <label className="block text-xs text-stone-600 dark:text-stone-400 mb-1">
-                Project Folder
+                Project Folder (optional)
               </label>
               <div className="px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/50 text-stone-700 dark:text-stone-300 break-all">
-                {settings.codeVocabFolder || 'No folder selected'}
+                {settings.codeVocabFolder || 'No folder — built-in dev terms only'}
               </div>
               <div className="mt-2 flex items-center gap-3">
                 <button
@@ -986,14 +1188,14 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 )}
               </div>
               <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
-                The folder is scanned once when set (dependency and build directories are skipped). Re-select to rescan after big code changes.
+                Optional. When set, the folder is scanned once for your identifiers (dependency and build directories are skipped) and layered on top of the built-in terms. Re-select to rescan after big code changes.
               </p>
             </div>
           )}
         </div>
         </SettingsSection>
 
-        <SettingsSection title="About" subtitle="Stats, logs, updates" defaultExpanded={false}>
+        <SettingsSection pageId="about" activePage={activeCat} title="About" subtitle="Stats, logs, updates">
         {/* Model Info */}
         <div>
           <div className="text-sm text-stone-600 dark:text-stone-400">
@@ -1061,7 +1263,8 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           </div>
         )}
         </SettingsSection>
+        </div>
       </div>
-    </aside>
+    </div>
   );
 }

--- a/app/src/components/settings/SettingsSection.tsx
+++ b/app/src/components/settings/SettingsSection.tsx
@@ -5,9 +5,14 @@ interface SettingsSectionProps {
   subtitle?: string;
   defaultExpanded?: boolean;
   children: React.ReactNode;
+  // Page mode: when `pageId` is set, the section renders as a flat, non-collapsible
+  // settings page (static heading + body) and is shown only when activePage === pageId.
+  // Used by the two-pane settings layout where the left nav replaces accordions.
+  pageId?: string;
+  activePage?: string;
 }
 
-export function SettingsSection({ title, subtitle, defaultExpanded = true, children }: SettingsSectionProps) {
+export function SettingsSection({ title, subtitle, defaultExpanded = true, children, pageId, activePage }: SettingsSectionProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [overflowVisible, setOverflowVisible] = useState(defaultExpanded);
   const contentId = useId();
@@ -23,6 +28,21 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
   const handleTransitionEnd = useCallback(() => {
     if (expanded) setOverflowVisible(true);
   }, [expanded]);
+
+  // Page mode: flat, always-open page gated by the active category. Hooks above
+  // still run (so order is stable) but the accordion chrome is skipped.
+  if (pageId !== undefined) {
+    if (activePage !== undefined && activePage !== pageId) return null;
+    return (
+      <div>
+        <h1 className="text-base font-semibold text-stone-900 dark:text-stone-100">{title}</h1>
+        {subtitle && (
+          <p className="mt-0.5 text-xs text-stone-400 dark:text-stone-500">{subtitle}</p>
+        )}
+        <div className="pt-4 space-y-4">{children}</div>
+      </div>
+    );
+  }
 
   return (
     <div className="border-b border-stone-200 dark:border-stone-700">

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { DEFAULT_SETTINGS, Settings, AppProfile } from './settings';
+import { DEFAULT_SETTINGS, Settings, AppProfile, VoiceCommand } from './settings';
 
 export interface DictationResponse {
   type: string;
@@ -72,7 +72,10 @@ export interface ConfigureOptions {
   outputDir?: string;
   appProfiles?: AppProfile[];
   voiceCommandsEnabled?: boolean;
+  voiceCommands?: VoiceCommand[];
   cleanupEnabled?: boolean;
+  cleanupRemoveFiller?: boolean;
+  cleanupCapitalize?: boolean;
   codeVocabEnabled?: boolean;
   codeVocabFolder?: string;
 }
@@ -101,7 +104,10 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     outputDir: s.outputDir,
     appProfiles: s.appProfiles,
     voiceCommandsEnabled: s.voiceCommandsEnabled,
+    voiceCommands: s.voiceCommands,
     cleanupEnabled: s.cleanupEnabled,
+    cleanupRemoveFiller: s.cleanupRemoveFiller,
+    cleanupCapitalize: s.cleanupCapitalize,
     codeVocabEnabled: s.codeVocabEnabled,
     codeVocabFolder: s.codeVocabFolder,
   };

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -113,8 +113,15 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
     }
   }, []);
 
-  // On mount: always check on launch, then set up 24h periodic interval
+  // On mount: always check on launch, then set up 24h periodic interval.
+  // Skip entirely in dev — a dev build auto-updating to a prod release would
+  // download+relaunch into /Applications, making `tauri dev` impossible.
   useEffect(() => {
+    if (import.meta.env.DEV) {
+      flog.info('updater', 'dev build — skipping automatic update check');
+      return;
+    }
+
     performCheck({ isBackground: true });
 
     const interval = setInterval(() => {

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'cleanupEnabled' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -83,7 +83,10 @@ export function useSettings() {
               outputDir: previousSettings.outputDir,
               appProfiles: previousSettings.appProfiles,
               voiceCommandsEnabled: previousSettings.voiceCommandsEnabled,
+              voiceCommands: previousSettings.voiceCommands,
               cleanupEnabled: previousSettings.cleanupEnabled,
+              cleanupRemoveFiller: previousSettings.cleanupRemoveFiller,
+              cleanupCapitalize: previousSettings.cleanupCapitalize,
               codeVocabEnabled: previousSettings.codeVocabEnabled,
               codeVocabFolder: previousSettings.codeVocabFolder,
             };

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -4,13 +4,24 @@ export type DoubleTapKey = 'shift_l' | 'alt_l' | 'ctrl_r';
 
 /**
  * Per-app dictation profile. When the frontmost macOS app's bundle id matches
- * `bundleId`, `autoPasteOverride` (when non-null) replaces the global auto-paste
+ * `bundleId`, each `*Override` (when non-null) replaces the corresponding global
  * setting. `null` means "no override — use the global setting".
  */
 export interface AppProfile {
   bundleId: string;
   label: string;
   autoPasteOverride: boolean | null;
+  cleanupOverride: boolean | null;
+}
+
+/**
+ * A user-defined voice command. When `phrase` is spoken it is replaced by
+ * `replacement` (case-insensitive, word-boundary). Applied after the built-in
+ * commands, so users extend rather than override the defaults.
+ */
+export interface VoiceCommand {
+  phrase: string;
+  replacement: string;
 }
 
 export interface Settings {
@@ -32,10 +43,20 @@ export interface Settings {
   outputDir: string;
   appProfiles: AppProfile[];
   voiceCommandsEnabled: boolean;
+  /** User-defined voice commands applied after the built-in set. */
+  voiceCommands: VoiceCommand[];
   cleanupEnabled: boolean;
-  /** Bias transcription toward code identifiers scanned from a project folder. */
+  /** When cleanup is on, remove filler tokens ("um", "uh"). */
+  cleanupRemoveFiller: boolean;
+  /** When cleanup is on, capitalize sentence starts. */
+  cleanupCapitalize: boolean;
+  /**
+   * Bias transcription toward code identifiers. When enabled, a built-in
+   * dev-term dictionary is always used; a project folder (optional) layers the
+   * user's own identifiers on top.
+   */
   codeVocabEnabled: boolean;
-  /** Absolute path to the project folder scanned for code identifiers. */
+  /** Optional absolute path to a project folder scanned for code identifiers. */
   codeVocabFolder: string;
 }
 
@@ -119,7 +140,10 @@ export const DEFAULT_SETTINGS: Settings = {
   outputDir: '',
   appProfiles: [],
   voiceCommandsEnabled: false,
+  voiceCommands: [],
   cleanupEnabled: false,
+  cleanupRemoveFiller: true,
+  cleanupCapitalize: true,
   codeVocabEnabled: false,
   codeVocabFolder: '',
 };
@@ -173,7 +197,31 @@ export function loadSettings(): Settings {
             label: typeof p.label === 'string' ? p.label : '',
             autoPasteOverride:
               typeof p.autoPasteOverride === 'boolean' ? p.autoPasteOverride : null,
+            cleanupOverride:
+              typeof p.cleanupOverride === 'boolean' ? p.cleanupOverride : null,
           }));
+      }
+
+      // voiceCommands: array of { phrase, replacement }. Drop malformed entries
+      // and coerce a non-array (or absent on older blobs) back to the default.
+      if (!Array.isArray(parsed.voiceCommands)) {
+        parsed.voiceCommands = DEFAULT_SETTINGS.voiceCommands;
+      } else {
+        parsed.voiceCommands = parsed.voiceCommands
+          .filter((c): c is VoiceCommand =>
+            !!c && typeof (c as VoiceCommand).phrase === 'string' && (c as VoiceCommand).phrase.trim() !== '')
+          .map((c) => ({
+            phrase: c.phrase.trim(),
+            replacement: typeof c.replacement === 'string' ? c.replacement : '',
+          }));
+      }
+
+      // cleanup sub-toggles default to on; coerce non-booleans back to the default.
+      if (typeof parsed.cleanupRemoveFiller !== 'boolean') {
+        parsed.cleanupRemoveFiller = DEFAULT_SETTINGS.cleanupRemoveFiller;
+      }
+      if (typeof parsed.cleanupCapitalize !== 'boolean') {
+        parsed.cleanupCapitalize = DEFAULT_SETTINGS.cleanupCapitalize;
       }
 
       // Voice commands gate the Rust transform — coerce non-booleans (or a


### PR DESCRIPTION
Finishes the half-wired parts of the v0.11.0 feature batch. Audited all 7 originally-flagged gaps; **2 were already complete on main** (no change needed), **5 implemented here**.

## Already done on main (verified, no change)
- **Multi-language no-op** — `SettingsPanel` already gates the language picker via `isEnglishOnlyModel` (`.en` suffix or parakeet backend): selector disabled + note "English only model — switch to Whisper Large Turbo".
- **Parakeet download** — `download_model` routes parakeet → `download_parakeet_model` (tarball + extract); `check_specific_model_exists` handles it.

## Implemented

### Code-aware vocabulary "just works" (no folder required)
A curated built-in dev-term dictionary (`vocab::BUILTIN_DEV_TERMS`, ~100 terms — `useEffect`, `kubectl`, `stderr`, …) is always applied when the feature is enabled. A project folder is now **optional** and, when set, its scanned identifiers are layered *first* (more specific → survive Whisper's prompt truncation). `resolve_code_vocab_prompt` rewired accordingly.

### Custom voice commands
User-defined `phrase → replacement` pairs applied **after** the built-in command set (`voice_commands::apply_voice_commands_with_custom`, word-boundary + case-insensitive). New Settings editor; persisted as `voiceCommands` and threaded through `configure_dictation`.

### Transcript cleanup sub-toggles
`remove_filler` / `capitalize` are now threaded through `DictationState` + `configure_dictation` instead of hardcoded `CleanupOptions::default()`. Exposed as sub-toggles under the cleanup switch.

### Per-app cleanup override
`AppProfile` gains `cleanup_override`; `frontmost::resolve_cleanup` mirrors `resolve_auto_paste`, resolved from the **same single** frontmost-app lookup (no extra osascript). UI: each profile row now has Paste + Clean tri-state chips.

### Unified Vocabulary settings
Manual Custom Vocabulary + Code-Aware Vocabulary merged into one "Vocabulary" section (both feed the same initial prompt).

## Also included
- The in-progress **two-pane Settings information-architecture refactor** (`App.tsx`, `SettingsSection.tsx` page mode, paged nav in `SettingsPanel.tsx`) — authored separately; this work builds on top of it, so it rides along.
- Settings-panel horizontal-scrollbar fix; dev-build auto-update skip.

## Tests
- `cargo test --lib -- --test-threads=1` → **190 passed** (new: vocab builtin dedupe, `resolve_cleanup`, custom voice commands).
- `npm test` (vitest) → **59 passed**.
- `npx tsc --noEmit` → clean.
- `transcription_integration` aborts in this sandbox (real whisper.cpp Metal inference, no GPU) — pre-existing, local-only test, imports none of this change.

Draft — for review before merge.