### PR TITLE
feat: Smart Correction — post-model vocabulary correction on every engine (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Smart Correction** — vocabulary is now applied to the transcript *after* recognition, on **every** engine (including the default Parakeet, which ignores Whisper's prompt). Tier 1 is an exact spoken→written map (Aho-Corasick, single pass) that turns "use effect" into `useEffect`; Tier 2 is opt-out "sounds-like" matching (phonetic key + edit distance, fires only near your vocabulary) that recovers close mishearings like "red pivot" → `rePivot`. Built once on settings-change, runs inline in well under a millisecond (logged as a `correction_ms` telemetry phase). Common dev abbreviations (e.g. "standard error" → `stderr`) are included when Code-Aware Vocabulary is on. Settings: Vocabulary → Smart Correction (on by default) + Sounds-like matching sub-toggle (`correction.rs`).
+
+### Changed
+- Code-Aware Vocabulary now also corrects the transcript on every backend via Smart Correction, not just Whisper's prompt.
+
+### Deferred
+- **Tier 3 (local-LLM context correction)** — deferred to a sidecar-process design. An in-process LLM is impossible here: `llama-cpp-2` and `whisper-rs` each vendor their own `ggml` and crash (SIGSEGV) when linked together. See `docs/decisions/DECISIONS.md`.
+
 ## [0.12.0] - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-23
+
 ### Added
 - **Smart Correction** — vocabulary is now applied to the transcript *after* recognition, on **every** engine (including the default Parakeet, which ignores Whisper's prompt). Tier 1 is an exact spoken→written map (Aho-Corasick, single pass) that turns "use effect" into `useEffect`; Tier 2 is opt-out "sounds-like" matching (phonetic key + edit distance, fires only near your vocabulary) that recovers close mishearings like "red pivot" → `rePivot`. Built once on settings-change, runs inline in well under a millisecond (logged as a `correction_ms` telemetry phase). Common dev abbreviations (e.g. "standard error" → `stderr`) are included when Code-Aware Vocabulary is on. Settings: Vocabulary → Smart Correction (on by default) + Sounds-like matching sub-toggle (`correction.rs`).
 
 ### Changed
 - Code-Aware Vocabulary now also corrects the transcript on every backend via Smart Correction, not just Whisper's prompt.
-
-### Deferred
-- **Tier 3 (local-LLM context correction)** — deferred to a sidecar-process design. An in-process LLM is impossible here: `llama-cpp-2` and `whisper-rs` each vendor their own `ggml` and crash (SIGSEGV) when linked together. See `docs/decisions/DECISIONS.md`.
 
 ## [0.12.0] - 2026-06-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Read these before working on a feature:
 - **[docs/features/log-viewer.md](docs/features/log-viewer.md)** — Structured event system and log viewer
 - **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
 - **[docs/features/models.md](docs/features/models.md)** — Model management and download
+- **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map
 

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5800,6 +5800,7 @@ dependencies = [
 name = "ui"
 version = "0.12.0"
 dependencies = [
+ "aho-corasick",
  "arboard",
  "base64 0.22.1",
  "block2",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -327,7 +327,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -544,14 +544,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -4499,6 +4499,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "fmt"] }
 tracing-appender = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+aho-corasick = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["metal"] }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.12.0"
+version = "0.13.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -702,12 +702,6 @@ pub async fn configure_dictation(
     if let Some(v) = options.get("correctionFuzzy").and_then(|v| v.as_bool()) {
         dictation.correction_fuzzy = v;
     }
-    if let Some(v) = options.get("correctionModelEnabled").and_then(|v| v.as_bool()) {
-        dictation.correction_model_enabled = v;
-    }
-    if let Some(v) = options.get("correctionModelFast").and_then(|v| v.as_bool()) {
-        dictation.correction_model_fast = v;
-    }
 
     // Rebuild the correction matcher from the (now-updated) unified vocab +
     // correction settings. Built here on settings-change, never per-utterance.

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -92,6 +92,49 @@ fn combine_prompts(custom: &str, code: &str) -> Option<String> {
     }
 }
 
+/// Split the free-text custom-vocabulary field into individual written terms.
+/// Entries are separated by commas or newlines (not spaces) so multi-word terms
+/// like "API Gateway" survive as one entry. Blank entries are dropped.
+fn parse_vocab_terms(s: &str) -> Vec<String> {
+    s.split(|c| c == ',' || c == '\n' || c == '\r')
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Rebuild the post-model correction matcher from the current dictation settings
+/// and store it in `app_state.correction_matcher`. Called on settings-change (in
+/// `configure_dictation`) — never per-utterance. `dictation` is the already-held
+/// lock guard; the matcher is stored under a separate leaf mutex.
+fn rebuild_correction_matcher(
+    app_state: &AppState,
+    dictation: &crate::state::DictationState,
+) {
+    let code_enabled = dictation.code_vocab_enabled;
+    let mut terms = parse_vocab_terms(&dictation.custom_vocabulary);
+    if code_enabled {
+        // Built-in dev dictionary + any cached project scan become correction
+        // terms (their spoken forms are auto-derived: "useEffect" -> "use effect").
+        for t in crate::vocab::builtin_terms_prompt().split_whitespace() {
+            terms.push(t.to_string());
+        }
+        if let Some(folder_prompt) = &dictation.code_vocab_prompt {
+            for t in folder_prompt.split_whitespace() {
+                terms.push(t.to_string());
+            }
+        }
+    }
+    let matcher = crate::correction::CorrectionMatcher::build(
+        &terms,
+        &[],
+        dictation.correction_fuzzy,
+        // Gate the std* abbrev builtins on the dev-context (code-vocab) signal.
+        code_enabled,
+    );
+    *app_state.correction_matcher.lock_or_recover() = Some(std::sync::Arc::new(matcher));
+}
+
 /// RAII guard that resets dictation status to Idle on drop,
 /// ensuring status is restored on any early return or error path.
 ///
@@ -147,6 +190,7 @@ impl Drop for FileTranscribeGuard<'_> {
 pub(crate) struct PipelineTimings {
     pub vad_ms: u64,
     pub inference_ms: u64,
+    pub correction_ms: u64,
     pub paste_ms: u64,
     pub rss_before_mb: u64,
     pub rss_after_mb: u64,
@@ -166,9 +210,9 @@ async fn run_transcription_pipeline(
     let _guard = IdleGuard::new(app_state, recording_id);
 
     // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, voice_command_pairs, cleanup_enabled, cleanup_remove_filler, cleanup_capitalize) = {
+    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, voice_command_pairs, cleanup_enabled, cleanup_remove_filler, cleanup_capitalize, correction_enabled) = {
         let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.voice_command_pairs.clone(), dictation.cleanup_enabled, dictation.cleanup_remove_filler, dictation.cleanup_capitalize)
+        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.voice_command_pairs.clone(), dictation.cleanup_enabled, dictation.cleanup_remove_filler, dictation.cleanup_capitalize, dictation.correction_enabled)
     };
 
     // Per-app profiles: if the frontmost app has a matching profile, its overrides
@@ -202,7 +246,7 @@ async fn run_transcription_pipeline(
     // Checkpoint 1: cancelled before VAD?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before VAD (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms: 0, inference_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
+        return Ok((String::new(), PipelineTimings { vad_ms: 0, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
     }
 
     // Phase: VAD -- filter out silence to prevent Whisper hallucination loops
@@ -224,7 +268,7 @@ async fn run_transcription_pipeline(
                 Ok(vad::VadResult::NoSpeech) => {
                     tracing::info!(target: "pipeline", "VAD detected no speech ({} samples, {:?}), skipping transcription",
                         samples.len(), t_vad.elapsed());
-                    return Ok((String::new(), PipelineTimings { vad_ms: t_vad.elapsed().as_millis() as u64, inference_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
+                    return Ok((String::new(), PipelineTimings { vad_ms: t_vad.elapsed().as_millis() as u64, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
                 }
                 Ok(vad::VadResult::Speech(trimmed)) => {
                     tracing::info!(target: "pipeline", "VAD trimmed {} -> {} samples ({:.0}% speech, {:?})",
@@ -255,7 +299,7 @@ async fn run_transcription_pipeline(
     // Checkpoint 2: cancelled before transcription?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
+        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
     }
 
     // Phase: Transcription (includes lazy model load on first run)
@@ -305,12 +349,34 @@ async fn run_transcription_pipeline(
         .collect();
     let text = crate::voice_commands::apply_voice_commands_with_custom(&text, voice_commands_enabled, &custom_commands);
 
+    // Phase: post-model correction (Tier 1 exact map + Tier 2 sounds-like). Applies
+    // the unified vocabulary to the transcript on EVERY backend — this is what makes
+    // vocab work on the default Parakeet engine (which ignores Whisper's prompt).
+    // The matcher is prebuilt on settings-change; this is a couple of linear passes.
+    let t_correction = std::time::Instant::now();
+    let text = if correction_enabled && !text.trim().is_empty() {
+        let matcher = app_state.correction_matcher.lock_or_recover().clone();
+        match matcher {
+            Some(m) if !m.is_empty() => {
+                let corrected = m.apply(&text);
+                if corrected != text {
+                    tracing::info!(target: "pipeline", "correction applied ({} -> {} chars)", text.len(), corrected.len());
+                }
+                corrected
+            }
+            _ => text,
+        }
+    } else {
+        text
+    };
+    let correction_ms = t_correction.elapsed().as_millis() as u64;
+
     // Update last_transcription_at for idle timeout tracking
     *app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
     // Checkpoint 3: cancelled before text injection?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before injection (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms, paste_ms: 0, rss_before_mb, rss_after_mb }));
+        return Ok((String::new(), PipelineTimings { vad_ms, inference_ms, correction_ms, paste_ms: 0, rss_before_mb, rss_after_mb }));
     }
 
     // Phase: File output (optional) -- persist audio/transcript before injection.
@@ -362,7 +428,7 @@ async fn run_transcription_pipeline(
     let paste_ms = t_inject.elapsed().as_millis() as u64;
     tracing::info!(target: "pipeline", "inject (clipboard + paste): {:?}", t_inject.elapsed());
 
-    Ok((text, PipelineTimings { vad_ms, inference_ms, paste_ms, rss_before_mb, rss_after_mb }))
+    Ok((text, PipelineTimings { vad_ms, inference_ms, correction_ms, paste_ms, rss_before_mb, rss_after_mb }))
     // _guard drops here, setting status to Idle
 }
 
@@ -449,6 +515,7 @@ pub async fn process_audio(
         target: "pipeline",
         vad_ms = timings.vad_ms,
         inference_ms = timings.inference_ms,
+        correction_ms = timings.correction_ms,
         paste_ms = timings.paste_ms,
         total_ms = total_ms,
         audio_secs = audio_secs,
@@ -627,6 +694,24 @@ pub async fn configure_dictation(
             dictation.code_vocab_prompt = None;
         }
     }
+
+    // Post-model correction toggles.
+    if let Some(v) = options.get("correctionEnabled").and_then(|v| v.as_bool()) {
+        dictation.correction_enabled = v;
+    }
+    if let Some(v) = options.get("correctionFuzzy").and_then(|v| v.as_bool()) {
+        dictation.correction_fuzzy = v;
+    }
+    if let Some(v) = options.get("correctionModelEnabled").and_then(|v| v.as_bool()) {
+        dictation.correction_model_enabled = v;
+    }
+    if let Some(v) = options.get("correctionModelFast").and_then(|v| v.as_bool()) {
+        dictation.correction_model_fast = v;
+    }
+
+    // Rebuild the correction matcher from the (now-updated) unified vocab +
+    // correction settings. Built here on settings-change, never per-utterance.
+    rebuild_correction_matcher(&state.app_state, &dictation);
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {
         let normalized = match idle_timeout {
@@ -836,6 +921,7 @@ pub async fn stop_native_recording(
         target: "pipeline",
         vad_ms = timings.vad_ms,
         inference_ms = timings.inference_ms,
+        correction_ms = timings.correction_ms,
         paste_ms = timings.paste_ms,
         total_ms = total_ms,
         audio_secs = audio_secs,

--- a/app/src-tauri/src/correction.rs
+++ b/app/src-tauri/src/correction.rs
@@ -42,6 +42,13 @@ pub const BUILTIN_ABBREVS: &[(&str, &str)] = &[
 /// phonetic keys match. Kept tight to avoid "correcting" real English.
 const FUZZY_MAX_DIST: usize = 2;
 
+/// Minimum length for Tier-2 fuzzy matching (applies to both the candidate phrase
+/// and the vocab term's spoken form). Short words collide far too easily — e.g.
+/// "get" and "git" share a phonetic key and are 1 edit apart, so without this floor
+/// a "git" vocab entry would rewrite every spoken "get". Short terms still match
+/// exactly via Tier 1; Tier 2 only kicks in for longer, lower-collision words.
+const MIN_FUZZY_LEN: usize = 5;
+
 /// A single vocab entry: the written form the user wants, and the lowercase
 /// spoken form we expect the ASR to emit for it.
 #[derive(Debug, Clone)]
@@ -255,11 +262,19 @@ impl CorrectionMatcher {
         if self.written_lower.contains(&lower) {
             return None;
         }
+        // Short phrases collide too easily — skip them (Tier 1 still does exact).
+        if lower.len() < MIN_FUZZY_LEN {
+            return None;
+        }
         let phrase_key = phonetic_key_phrase(&lower);
         let mut best: Option<(usize, &Term)> = None; // (distance, term)
         for term in &self.terms {
             // Exact spoken match is Tier 1's job; skip here.
             if term.spoken == lower {
+                continue;
+            }
+            // Don't fuzzy-match against short vocab terms (same collision risk).
+            if term.spoken.len() < MIN_FUZZY_LEN {
                 continue;
             }
             // Cutoff scales with the term length so short words need a near-exact
@@ -501,6 +516,14 @@ mod tests {
         let m = matcher(&["rePivot"]);
         // ASR misheard "re pivot" as "red pivot"; phonetic + edit-distance recovers it.
         assert_eq!(m.apply("then red pivot the layout"), "then rePivot the layout");
+    }
+
+    #[test]
+    fn tier2_short_words_not_over_corrected() {
+        // "git" in vocab must NOT rewrite the common word "get" (both 3 chars,
+        // 1 edit apart, same phonetic key) — the length floor protects this.
+        let m = matcher(&["git"]);
+        assert_eq!(m.apply("please get the file"), "please get the file");
     }
 
     #[test]

--- a/app/src-tauri/src/correction.rs
+++ b/app/src-tauri/src/correction.rs
@@ -1,0 +1,573 @@
+//! Post-model text correction (Tiers 1–2): backend-agnostic vocabulary correction.
+//!
+//! Speech engines (Parakeet/sherpa, Whisper) emit ordinary words: "use effect",
+//! "standard error", "red pivot". This layer rewrites those into the intended
+//! written forms ("useEffect", "stderr", "rePivot") *after* transcription, so it
+//! works on every backend — unlike the old Whisper-only `initial_prompt` vocab
+//! bias, which is a silent no-op on the default Parakeet engine.
+//!
+//! Two tiers, both no-LLM and fully local:
+//!   - **Tier 1 — exact map.** A spoken→written phrase table compiled into a
+//!     single Aho-Corasick automaton; one pass over the text replaces every
+//!     word-boundary match. Catches the forms we can enumerate ("use effect").
+//!   - **Tier 2 — sounds-like.** For tokens that Tier 1 didn't fix, a phonetic
+//!     key + edit-distance check against the same vocab catches *mishearings* of
+//!     those terms ("red pivot" ≈ "re pivot" → "rePivot"). Fires only when a
+//!     vocab term is phonetically close, so ordinary English is left alone.
+//!
+//! The expensive part — compiling the automaton and the phonetic index — happens
+//! once in [`CorrectionMatcher::build`] (called on settings-change), not per
+//! transcription. [`CorrectionMatcher::apply`] is the hot path and is a couple of
+//! linear passes over a short transcript.
+
+use aho_corasick::{AhoCorasick, MatchKind};
+use std::collections::HashMap;
+
+/// Common dev abbreviations whose written form can't be derived from how they're
+/// spoken (you say "standard error", you write "stderr"). Only loaded when the
+/// caller opts into dev-context builtins (the code-vocab signal), since these are
+/// literal substitutions that would misfire on prose ("the standard error of the
+/// mean"). Kept deliberately small, unambiguous, and dev-specific — no semantic
+/// guesses like "kubernetes"→"kubectl" (different things). Spoken form lowercase.
+pub const BUILTIN_ABBREVS: &[(&str, &str)] = &[
+    ("standard error", "stderr"),
+    ("standard out", "stdout"),
+    ("standard output", "stdout"),
+    ("standard in", "stdin"),
+    ("standard input", "stdin"),
+];
+
+/// Tier-2 edit-distance ceiling. A token is only rewritten to a vocab term if the
+/// (lowercased) edit distance to that term's spoken form is `<=` this *and* their
+/// phonetic keys match. Kept tight to avoid "correcting" real English.
+const FUZZY_MAX_DIST: usize = 2;
+
+/// A single vocab entry: the written form the user wants, and the lowercase
+/// spoken form we expect the ASR to emit for it.
+#[derive(Debug, Clone)]
+struct Term {
+    written: String,
+    spoken: String,
+}
+
+/// A compiled, reusable correction matcher. Build once on settings-change, then
+/// call [`apply`](Self::apply) per transcription.
+pub struct CorrectionMatcher {
+    /// Tier-1 automaton over spoken phrases (case-insensitive, leftmost-longest).
+    ac: Option<AhoCorasick>,
+    /// Written replacement for each Tier-1 pattern, parallel to the automaton's
+    /// pattern ids.
+    replacements: Vec<String>,
+    /// Whether Tier 2 (fuzzy) is enabled.
+    fuzzy: bool,
+    /// All terms, for Tier-2 distance checks.
+    terms: Vec<Term>,
+    /// Lowercased written forms, so Tier 2 never "corrects" an already-correct token.
+    written_lower: std::collections::HashSet<String>,
+}
+
+impl CorrectionMatcher {
+    /// Build a matcher from the unified vocab list.
+    ///
+    /// `terms` are written forms (e.g. `useEffect`, `kubectl`, `rePivot`) — the
+    /// same identifiers the vocab feature already collects. Their spoken forms are
+    /// auto-derived by splitting camelCase / snake_case / digit boundaries. `pairs`
+    /// are explicit spoken→written overrides (e.g. from custom vocabulary entries
+    /// containing a `=`), layered on top. The built-in abbreviation table is always
+    /// included. `fuzzy` toggles Tier 2.
+    ///
+    /// `include_builtins` loads [`BUILTIN_ABBREVS`] (gate on the dev-context /
+    /// code-vocab signal so they don't misfire on prose).
+    ///
+    /// Returns an empty (no-op) matcher when there is nothing to correct.
+    pub fn build(
+        terms: &[String],
+        pairs: &[(String, String)],
+        fuzzy: bool,
+        include_builtins: bool,
+    ) -> Self {
+        // spoken(lowercased) -> written. Later inserts win, so ordering is:
+        // builtin abbrevs < derived-from-terms < explicit pairs (most specific).
+        let mut map: HashMap<String, String> = HashMap::new();
+
+        if include_builtins {
+            for (spoken, written) in BUILTIN_ABBREVS {
+                map.insert(spoken.to_string(), written.to_string());
+            }
+        }
+        for written in terms {
+            let written = written.trim();
+            if written.is_empty() {
+                continue;
+            }
+            let spoken = derive_spoken_form(written);
+            // Only useful when the spoken form differs from the written one;
+            // "kubectl" -> "kubectl" is a no-op for Tier 1 but still seeds Tier 2.
+            if !spoken.is_empty() {
+                map.entry(spoken).or_insert_with(|| written.to_string());
+            }
+        }
+        for (spoken, written) in pairs {
+            let spoken = spoken.trim().to_lowercase();
+            let written = written.trim();
+            if spoken.is_empty() || written.is_empty() {
+                continue;
+            }
+            map.insert(spoken, written.to_string());
+        }
+
+        // Tier-1 automaton: patterns are spoken forms that actually rewrite to
+        // something different. Identical spoken==written pairs are skipped here
+        // (nothing to replace) but kept for Tier-2 below.
+        let mut patterns: Vec<String> = Vec::new();
+        let mut replacements: Vec<String> = Vec::new();
+        for (spoken, written) in &map {
+            if !spoken.eq_ignore_ascii_case(written) {
+                patterns.push(spoken.clone());
+                replacements.push(written.clone());
+            }
+        }
+        let ac = if patterns.is_empty() {
+            None
+        } else {
+            AhoCorasick::builder()
+                .match_kind(MatchKind::LeftmostLongest)
+                .ascii_case_insensitive(true)
+                .build(&patterns)
+                .ok()
+        };
+
+        // Tier-2 term list. Vocab is small (personal lists / capped code scans), so
+        // a direct bounded scan per token is sub-millisecond and avoids the recall
+        // gap of an exact-phonetic-key index (a 1-edit mishear changes the key).
+        let mut terms: Vec<Term> = Vec::new();
+        let mut written_lower = std::collections::HashSet::new();
+        for (spoken, written) in &map {
+            written_lower.insert(written.to_lowercase());
+            terms.push(Term {
+                written: written.clone(),
+                spoken: spoken.clone(),
+            });
+        }
+
+        CorrectionMatcher {
+            ac,
+            replacements,
+            fuzzy,
+            terms,
+            written_lower,
+        }
+    }
+
+    /// True when this matcher has no patterns and no fuzzy terms — the pipeline can
+    /// skip the stage entirely.
+    pub fn is_empty(&self) -> bool {
+        self.ac.is_none() && (!self.fuzzy || self.terms.is_empty())
+    }
+
+    /// Apply Tier 1 then (if enabled) Tier 2 to `text`, returning the corrected
+    /// string. Hot path: two linear scans over a short transcript.
+    pub fn apply(&self, text: &str) -> String {
+        let t1 = self.apply_tier1(text);
+        if self.fuzzy {
+            self.apply_tier2(&t1)
+        } else {
+            t1
+        }
+    }
+
+    /// Tier 1: single Aho-Corasick pass, replacing only word-boundary matches.
+    fn apply_tier1(&self, text: &str) -> String {
+        let ac = match &self.ac {
+            Some(ac) => ac,
+            None => return text.to_string(),
+        };
+        let bytes = text.as_bytes();
+        let mut out = String::with_capacity(text.len());
+        let mut last = 0usize;
+        for m in ac.find_iter(text) {
+            let (s, e) = (m.start(), m.end());
+            // Word-boundary guard: char before/after the match must not be an
+            // ASCII alphanumeric, so "use effect" doesn't fire inside "abuse
+            // effective". Spoken forms can contain internal spaces, which is fine.
+            let before_ok = s == 0 || !bytes[s - 1].is_ascii_alphanumeric();
+            let after_ok = e == bytes.len() || !bytes[e].is_ascii_alphanumeric();
+            if before_ok && after_ok {
+                out.push_str(&text[last..s]);
+                out.push_str(&self.replacements[m.pattern().as_usize()]);
+                last = e;
+            }
+        }
+        out.push_str(&text[last..]);
+        out
+    }
+
+    /// Tier 2: for each 1- and 2-word window, if it phonetically matches a vocab
+    /// term within the edit-distance cutoff (and isn't already a written form),
+    /// rewrite it. Single left-to-right pass; longer (2-word) windows win.
+    fn apply_tier2(&self, text: &str) -> String {
+        // Tokenize into (word, byte_start, byte_end), splitting on non-alphanumeric
+        // so punctuation is preserved in the gaps.
+        let tokens = tokenize(text);
+        if tokens.is_empty() {
+            return text.to_string();
+        }
+
+        let mut out = String::with_capacity(text.len());
+        let mut last = 0usize; // byte cursor into `text`
+        let mut i = 0usize;
+        while i < tokens.len() {
+            // Try a 2-word window first, then a 1-word window.
+            let mut applied = false;
+            for span in [2usize, 1] {
+                if i + span > tokens.len() {
+                    continue;
+                }
+                let start = tokens[i].1;
+                let end = tokens[i + span - 1].2;
+                let phrase = &text[start..end];
+                if let Some(written) = self.fuzzy_lookup(phrase) {
+                    out.push_str(&text[last..start]);
+                    out.push_str(&written);
+                    last = end;
+                    i += span;
+                    applied = true;
+                    break;
+                }
+            }
+            if !applied {
+                i += 1;
+            }
+        }
+        out.push_str(&text[last..]);
+        out
+    }
+
+    /// Return the written form if `phrase` is a sounds-like match for a vocab term.
+    ///
+    /// A direct bounded scan: skip terms whose length already exceeds the edit
+    /// cutoff, then accept a term only when it is within the cutoff AND either the
+    /// edit is tiny (≤1) or the phonetic keys agree — the phonetic gate keeps real
+    /// English (which won't sound like the vocab term) from being rewritten.
+    fn fuzzy_lookup(&self, phrase: &str) -> Option<String> {
+        let lower = phrase.to_lowercase();
+        // Never touch a token that is already a written form (case-insensitive).
+        if self.written_lower.contains(&lower) {
+            return None;
+        }
+        let phrase_key = phonetic_key_phrase(&lower);
+        let mut best: Option<(usize, &Term)> = None; // (distance, term)
+        for term in &self.terms {
+            // Exact spoken match is Tier 1's job; skip here.
+            if term.spoken == lower {
+                continue;
+            }
+            // Cutoff scales with the term length so short words need a near-exact
+            // match while longer phrases tolerate up to FUZZY_MAX_DIST edits.
+            let cutoff = FUZZY_MAX_DIST.min(1 + term.spoken.len() / 4);
+            if lower.len().abs_diff(term.spoken.len()) > cutoff {
+                continue;
+            }
+            let dist = levenshtein(&lower, &term.spoken);
+            if dist > cutoff {
+                continue;
+            }
+            let phonetic_ok = dist <= 1 || phrase_key == phonetic_key_phrase(&term.spoken);
+            if phonetic_ok && best.map_or(true, |(d, _)| dist < d) {
+                best = Some((dist, term));
+            }
+        }
+        best.map(|(_, t)| t.written.clone())
+    }
+}
+
+/// Phonetic key for a (possibly multi-word) phrase: per-token keys joined by
+/// spaces, so "re pivot" and "red pivot" stay comparable token-by-token.
+fn phonetic_key_phrase(phrase: &str) -> String {
+    phrase
+        .split_whitespace()
+        .map(phonetic_key)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Split a written identifier into its likely spoken form: lowercase words joined
+/// by spaces. Handles camelCase, PascalCase, snake_case, kebab-case, and
+/// letter↔digit boundaries. `useEffect` → "use effect", `rePivot` → "re pivot",
+/// `parse_wav` → "parse wav", `large_v3` → "large v 3".
+pub fn derive_spoken_form(written: &str) -> String {
+    let mut words: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let chars: Vec<char> = written.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' || c == '-' || c == ' ' || c == '.' || c == '/' {
+            if !cur.is_empty() {
+                words.push(std::mem::take(&mut cur));
+            }
+            continue;
+        }
+        if i > 0 && !cur.is_empty() {
+            let prev = chars[i - 1];
+            // Boundary on lower→Upper (camelCase) or letter↔digit transitions.
+            let upper_after_lower = c.is_ascii_uppercase() && prev.is_ascii_lowercase();
+            let digit_boundary = c.is_ascii_digit() != prev.is_ascii_digit();
+            // Boundary on Upper→Upper→lower run (e.g. "JSONParser" -> "JSON Parser").
+            let acronym_end = c.is_ascii_lowercase()
+                && prev.is_ascii_uppercase()
+                && i >= 2
+                && chars[i - 2].is_ascii_uppercase();
+            if upper_after_lower || digit_boundary || acronym_end {
+                if acronym_end {
+                    // Move the last char (start of new word) out of `cur`.
+                    let last = cur.pop().unwrap();
+                    words.push(std::mem::take(&mut cur));
+                    cur.push(last);
+                } else {
+                    words.push(std::mem::take(&mut cur));
+                }
+            }
+        }
+        cur.push(c.to_ascii_lowercase());
+    }
+    if !cur.is_empty() {
+        words.push(cur);
+    }
+    words.retain(|w| !w.is_empty());
+    words.join(" ")
+}
+
+/// Split text into alphanumeric word tokens with their byte spans. Punctuation and
+/// whitespace become the gaps between tokens.
+fn tokenize(text: &str) -> Vec<(&str, usize, usize)> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_alphanumeric() {
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
+                i += 1;
+            }
+            out.push((&text[start..i], start, i));
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// A compact phonetic key for sounds-like matching. Not full Metaphone — a
+/// pragmatic encoding that collapses common homophones: lowercased, vowels after
+/// the first letter dropped, voiced/unvoiced and near-equivalent consonant groups
+/// merged, doubles collapsed. "red"→"RT", "re"→"R", "pivot"→"PFT", "fone"→"FN",
+/// "phone"→"FN". Empty for non-alphabetic input.
+pub fn phonetic_key(word: &str) -> String {
+    let w: Vec<char> = word
+        .chars()
+        .filter(|c| c.is_ascii_alphabetic())
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    if w.is_empty() {
+        return String::new();
+    }
+    let code = |c: char| -> char {
+        match c {
+            'b' | 'p' | 'f' | 'v' => 'F',
+            'c' | 'g' | 'j' | 'k' | 'q' | 'x' | 'z' | 's' => 'S',
+            'd' | 't' => 'T',
+            'l' => 'L',
+            'm' | 'n' => 'N',
+            'r' => 'R',
+            // h/w/y are near-silent for homophone purposes ("phone"=="fone",
+            // "rite"=="write") — treat them like vowels and drop them.
+            _ => '_', // vowels + h/w/y
+        }
+    };
+    let mut out = String::new();
+    // Keep the first letter's class (or the vowel itself, uppercased) as an anchor.
+    let first = w[0];
+    out.push(if "aeiou".contains(first) {
+        first.to_ascii_uppercase()
+    } else {
+        code(first)
+    });
+    let mut prev = out.chars().next().unwrap();
+    for &c in &w[1..] {
+        let k = code(c);
+        if k == '_' {
+            // drop interior vowels
+            prev = '_';
+            continue;
+        }
+        if k != prev {
+            out.push(k);
+        }
+        prev = k;
+    }
+    out
+}
+
+/// Classic Levenshtein edit distance (two-row DP). Used on short tokens only.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matcher(terms: &[&str]) -> CorrectionMatcher {
+        let terms: Vec<String> = terms.iter().map(|s| s.to_string()).collect();
+        // include_builtins = true so the abbrev tests (stderr/stdin) exercise them.
+        CorrectionMatcher::build(&terms, &[], true, true)
+    }
+
+    // ---- derive_spoken_form ----
+
+    #[test]
+    fn derive_camel_case() {
+        assert_eq!(derive_spoken_form("useEffect"), "use effect");
+        assert_eq!(derive_spoken_form("rePivot"), "re pivot");
+        assert_eq!(derive_spoken_form("getElementById"), "get element by id");
+    }
+
+    #[test]
+    fn derive_snake_and_kebab() {
+        assert_eq!(derive_spoken_form("parse_wav"), "parse wav");
+        assert_eq!(derive_spoken_form("code-aware"), "code aware");
+    }
+
+    #[test]
+    fn derive_digit_boundary() {
+        assert_eq!(derive_spoken_form("large_v3"), "large v 3");
+        assert_eq!(derive_spoken_form("utf8"), "utf 8");
+    }
+
+    #[test]
+    fn derive_acronym_run() {
+        assert_eq!(derive_spoken_form("JSONParser"), "json parser");
+    }
+
+    // ---- Tier 1 (exact) ----
+
+    #[test]
+    fn tier1_camel_case_fix() {
+        let m = matcher(&["useEffect"]);
+        assert_eq!(m.apply("call use effect here"), "call useEffect here");
+    }
+
+    #[test]
+    fn tier1_builtin_abbrev() {
+        let m = matcher(&[]);
+        assert_eq!(m.apply("write to standard error"), "write to stderr");
+    }
+
+    #[test]
+    fn tier1_respects_word_boundary() {
+        let m = matcher(&["useEffect"]);
+        // "use effect" inside a larger word must not fire.
+        assert_eq!(m.apply("abuse effective tactics"), "abuse effective tactics");
+    }
+
+    #[test]
+    fn tier1_longest_match_wins() {
+        let m = matcher(&["stdin"]);
+        // builtin "standard input" (2 words) beats "standard in" overlap.
+        assert_eq!(m.apply("read from standard input now"), "read from stdin now");
+    }
+
+    // ---- Tier 2 (sounds-like) ----
+
+    #[test]
+    fn tier2_phonetic_mishear() {
+        let m = matcher(&["rePivot"]);
+        // ASR misheard "re pivot" as "red pivot"; phonetic + edit-distance recovers it.
+        assert_eq!(m.apply("then red pivot the layout"), "then rePivot the layout");
+    }
+
+    #[test]
+    fn tier2_leaves_plain_english_alone() {
+        let m = matcher(&["rePivot"]);
+        // No vocab term near "the red car" -> untouched.
+        assert_eq!(m.apply("the red car drove"), "the red car drove");
+    }
+
+    #[test]
+    fn tier2_single_word_mishear() {
+        let m = matcher(&["kubectl"]);
+        // "cube cuddle" -> phonetic-ish near "kubectl"? Use a closer mishear.
+        // "kubectl" spoken-form derives to "kubectl"; a near homophone within
+        // edit distance should map. "kubecto" (1 edit) qualifies.
+        assert_eq!(m.apply("run kubecto apply"), "run kubectl apply");
+    }
+
+    #[test]
+    fn fuzzy_disabled_skips_tier2() {
+        let terms = vec!["rePivot".to_string()];
+        let m = CorrectionMatcher::build(&terms, &[], false, true);
+        assert_eq!(m.apply("then red pivot now"), "then red pivot now");
+    }
+
+    // ---- explicit pairs + empties ----
+
+    #[test]
+    fn explicit_pair_overrides() {
+        let pairs = vec![("the thing".to_string(), "TheThing".to_string())];
+        let m = CorrectionMatcher::build(&[], &pairs, true, false);
+        assert_eq!(m.apply("use the thing today"), "use TheThing today");
+    }
+
+    #[test]
+    fn empty_matcher_is_noop() {
+        // No terms, no pairs, no builtins -> genuinely empty.
+        let m = CorrectionMatcher::build(&[], &[], true, false);
+        assert!(m.is_empty());
+        assert_eq!(m.apply("nothing to do here"), "nothing to do here");
+    }
+
+    #[test]
+    fn builtins_gated_off_when_not_dev_context() {
+        // Without include_builtins, "standard error" stays as prose.
+        let m = CorrectionMatcher::build(&[], &[], true, false);
+        assert_eq!(m.apply("the standard error of the mean"), "the standard error of the mean");
+    }
+
+    #[test]
+    fn preserves_surrounding_punctuation() {
+        let m = matcher(&["useEffect"]);
+        assert_eq!(m.apply("(use effect)"), "(useEffect)");
+    }
+
+    // ---- phonetic + levenshtein primitives ----
+
+    #[test]
+    fn phonetic_collapses_homophones() {
+        assert_eq!(phonetic_key("phone"), phonetic_key("fone"));
+        assert_eq!(phonetic_key("red"), phonetic_key("read").to_string());
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("same", "same"), 0);
+        assert_eq!(levenshtein("", "abc"), 3);
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod audio;
 mod audio_decode;
 mod cleanup;
 mod commands;
+mod correction;
 mod file_output;
 mod frontmost;
 mod injector;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -88,10 +88,6 @@ pub struct DictationState {
     /// Tier 2 phonetic / edit-distance "sounds-like" matching. Gated under
     /// `correction_enabled`.
     pub correction_fuzzy: bool,
-    /// Tier 3 local-LLM cleanup pass. Opt-in, default off.
-    pub correction_model_enabled: bool,
-    /// Tier 3 "fast mode": use the smaller, faster local model variant.
-    pub correction_model_fast: bool,
 }
 
 impl Default for DictationState {
@@ -124,8 +120,6 @@ impl Default for DictationState {
             // actually work on the default Parakeet engine. No-op without vocab.
             correction_enabled: true,
             correction_fuzzy: true,
-            correction_model_enabled: false,
-            correction_model_fast: false,
         }
     }
 }

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -81,6 +81,17 @@ pub struct DictationState {
     /// when the folder/enabled flag changes so we don't rescan every utterance.
     /// `None` means "not yet scanned" (build lazily on first use).
     pub code_vocab_prompt: Option<String>,
+    /// Post-model correction (Tier 1 exact map + Tier 2 sounds-like). Applies the
+    /// vocabulary to the text *output* of every backend (not just Whisper's
+    /// prompt), so the default Parakeet engine benefits too.
+    pub correction_enabled: bool,
+    /// Tier 2 phonetic / edit-distance "sounds-like" matching. Gated under
+    /// `correction_enabled`.
+    pub correction_fuzzy: bool,
+    /// Tier 3 local-LLM cleanup pass. Opt-in, default off.
+    pub correction_model_enabled: bool,
+    /// Tier 3 "fast mode": use the smaller, faster local model variant.
+    pub correction_model_fast: bool,
 }
 
 impl Default for DictationState {
@@ -109,6 +120,12 @@ impl Default for DictationState {
             code_vocab_enabled: false,
             code_vocab_folder: String::new(),
             code_vocab_prompt: None,
+            // Post-model correction on by default: it's the fix that makes vocab
+            // actually work on the default Parakeet engine. No-op without vocab.
+            correction_enabled: true,
+            correction_fuzzy: true,
+            correction_model_enabled: false,
+            correction_model_fast: false,
         }
     }
 }
@@ -127,6 +144,10 @@ pub struct AppState {
     /// transcription share one Whisper backend, so they must be mutually
     /// exclusive — this flag lets each path refuse to start over the other.
     pub file_transcribing: AtomicBool,
+    /// Compiled post-model correction matcher, rebuilt on settings-change in
+    /// `configure_dictation`. Lives outside `DictationState` because the compiled
+    /// Aho-Corasick automaton isn't serializable.
+    pub correction_matcher: Mutex<Option<std::sync::Arc<crate::correction::CorrectionMatcher>>>,
 }
 
 impl AppState {
@@ -156,6 +177,7 @@ impl Default for AppState {
             recording_id: AtomicU64::new(0),
             cancelled_id: AtomicU64::new(0),
             file_transcribing: AtomicBool::new(false),
+            correction_matcher: Mutex::new(None),
         }
     }
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -1142,7 +1142,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 Code-Aware Vocabulary
               </label>
               <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
-                Bias transcription toward common dev terms (useEffect, kubectl, stderr) — works out of the box, no folder needed. Optionally add a project folder for your own identifiers. Whisper models only.
+                Bias transcription toward common dev terms (useEffect, kubectl, stderr) — works out of the box, no folder needed. Optionally add a project folder for your own identifiers. With Smart Correction on (below), these terms are also fixed in the transcript on every model, including Parakeet.
               </p>
             </div>
             <button
@@ -1190,6 +1190,65 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
                 Optional. When set, the folder is scanned once for your identifiers (dependency and build directories are skipped) and layered on top of the built-in terms. Re-select to rescan after big code changes.
               </p>
+            </div>
+          )}
+        </div>
+
+        {/* Smart Correction — post-model, applies vocab on every backend (Tiers 1-2). */}
+        <div>
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+                Smart Correction
+              </label>
+              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                Fix vocabulary in the transcript after recognition, on every model (including the default Parakeet). Turns "use effect" into useEffect and, with Code-Aware on, "standard error" into stderr.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.correctionEnabled}
+              aria-label="Smart correction"
+              onClick={() => onUpdateSettings({ correctionEnabled: !settings.correctionEnabled })}
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                settings.correctionEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  settings.correctionEnabled ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+
+          {settings.correctionEnabled && (
+            <div className="mt-3 flex items-center justify-between gap-4">
+              <div>
+                <label className="block text-xs font-medium text-stone-700 dark:text-stone-300">
+                  Sounds-like matching
+                </label>
+                <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                  Also recover close mishearings near your vocabulary (e.g. "red pivot" → "rePivot"). Turn off if you see unwanted swaps.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.correctionFuzzy}
+                aria-label="Sounds-like matching"
+                onClick={() => onUpdateSettings({ correctionFuzzy: !settings.correctionFuzzy })}
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
+                  settings.correctionFuzzy ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                    settings.correctionFuzzy ? 'translate-x-4' : 'translate-x-1'
+                  }`}
+                />
+              </button>
             </div>
           )}
         </div>

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -80,8 +80,6 @@ export interface ConfigureOptions {
   codeVocabFolder?: string;
   correctionEnabled?: boolean;
   correctionFuzzy?: boolean;
-  correctionModelEnabled?: boolean;
-  correctionModelFast?: boolean;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -116,8 +114,6 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     codeVocabFolder: s.codeVocabFolder,
     correctionEnabled: s.correctionEnabled,
     correctionFuzzy: s.correctionFuzzy,
-    correctionModelEnabled: s.correctionModelEnabled,
-    correctionModelFast: s.correctionModelFast,
   };
 }
 

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -78,6 +78,10 @@ export interface ConfigureOptions {
   cleanupCapitalize?: boolean;
   codeVocabEnabled?: boolean;
   codeVocabFolder?: string;
+  correctionEnabled?: boolean;
+  correctionFuzzy?: boolean;
+  correctionModelEnabled?: boolean;
+  correctionModelFast?: boolean;
 }
 
 export async function configure(options: ConfigureOptions): Promise<DictationResponse> {
@@ -110,6 +114,10 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     cleanupCapitalize: s.cleanupCapitalize,
     codeVocabEnabled: s.codeVocabEnabled,
     codeVocabFolder: s.codeVocabFolder,
+    correctionEnabled: s.correctionEnabled,
+    correctionFuzzy: s.correctionFuzzy,
+    correctionModelEnabled: s.correctionModelEnabled,
+    correctionModelFast: s.correctionModelFast,
   };
 }
 

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates || 'correctionModelEnabled' in updates || 'correctionModelFast' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -91,8 +91,6 @@ export function useSettings() {
               codeVocabFolder: previousSettings.codeVocabFolder,
               correctionEnabled: previousSettings.correctionEnabled,
               correctionFuzzy: previousSettings.correctionFuzzy,
-              correctionModelEnabled: previousSettings.correctionModelEnabled,
-              correctionModelFast: previousSettings.correctionModelFast,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -62,7 +62,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates || 'correctionModelEnabled' in updates || 'correctionModelFast' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -89,6 +89,10 @@ export function useSettings() {
               cleanupCapitalize: previousSettings.cleanupCapitalize,
               codeVocabEnabled: previousSettings.codeVocabEnabled,
               codeVocabFolder: previousSettings.codeVocabFolder,
+              correctionEnabled: previousSettings.correctionEnabled,
+              correctionFuzzy: previousSettings.correctionFuzzy,
+              correctionModelEnabled: previousSettings.correctionModelEnabled,
+              correctionModelFast: previousSettings.correctionModelFast,
             };
             settingsRef.current = reverted;
             setSettings(reverted);

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -205,4 +205,49 @@ describe('loadSettings', () => {
     expect(settings.codeVocabEnabled).toBe(true);
     expect(settings.codeVocabFolder).toBe('/Users/me/project');
   });
+
+  it('opts pre-feature settings into correction (correctionEnabled defaults on)', () => {
+    // An older blob predating the correction feature should migrate to ON.
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      model: 'base.en',
+      doubleTapKey: 'shift_l',
+      language: 'en',
+      recordingMode: 'hold_down',
+    }));
+    const settings = loadSettings();
+    expect(settings.correctionEnabled).toBe(true);
+    expect(settings.correctionFuzzy).toBe(true);
+    expect(settings.correctionModelEnabled).toBe(false);
+    expect(settings.correctionModelFast).toBe(false);
+  });
+
+  it('coerces non-boolean correction toggles to defaults', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      correctionEnabled: 'yes',
+      correctionFuzzy: 1,
+      correctionModelEnabled: 'true',
+      correctionModelFast: null,
+    }));
+    const settings = loadSettings();
+    expect(settings.correctionEnabled).toBe(DEFAULT_SETTINGS.correctionEnabled);
+    expect(settings.correctionFuzzy).toBe(DEFAULT_SETTINGS.correctionFuzzy);
+    expect(settings.correctionModelEnabled).toBe(DEFAULT_SETTINGS.correctionModelEnabled);
+    expect(settings.correctionModelFast).toBe(DEFAULT_SETTINGS.correctionModelFast);
+  });
+
+  it('preserves explicit correction settings', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      correctionEnabled: false,
+      correctionFuzzy: false,
+      correctionModelEnabled: true,
+      correctionModelFast: true,
+    }));
+    const settings = loadSettings();
+    expect(settings.correctionEnabled).toBe(false);
+    expect(settings.correctionFuzzy).toBe(false);
+    expect(settings.correctionModelEnabled).toBe(true);
+    expect(settings.correctionModelFast).toBe(true);
+  });
 });

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -217,8 +217,6 @@ describe('loadSettings', () => {
     const settings = loadSettings();
     expect(settings.correctionEnabled).toBe(true);
     expect(settings.correctionFuzzy).toBe(true);
-    expect(settings.correctionModelEnabled).toBe(false);
-    expect(settings.correctionModelFast).toBe(false);
   });
 
   it('coerces non-boolean correction toggles to defaults', () => {
@@ -226,14 +224,10 @@ describe('loadSettings', () => {
       ...DEFAULT_SETTINGS,
       correctionEnabled: 'yes',
       correctionFuzzy: 1,
-      correctionModelEnabled: 'true',
-      correctionModelFast: null,
     }));
     const settings = loadSettings();
     expect(settings.correctionEnabled).toBe(DEFAULT_SETTINGS.correctionEnabled);
     expect(settings.correctionFuzzy).toBe(DEFAULT_SETTINGS.correctionFuzzy);
-    expect(settings.correctionModelEnabled).toBe(DEFAULT_SETTINGS.correctionModelEnabled);
-    expect(settings.correctionModelFast).toBe(DEFAULT_SETTINGS.correctionModelFast);
   });
 
   it('preserves explicit correction settings', () => {
@@ -241,13 +235,9 @@ describe('loadSettings', () => {
       ...DEFAULT_SETTINGS,
       correctionEnabled: false,
       correctionFuzzy: false,
-      correctionModelEnabled: true,
-      correctionModelFast: true,
     }));
     const settings = loadSettings();
     expect(settings.correctionEnabled).toBe(false);
     expect(settings.correctionFuzzy).toBe(false);
-    expect(settings.correctionModelEnabled).toBe(true);
-    expect(settings.correctionModelFast).toBe(true);
   });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -66,10 +66,6 @@ export interface Settings {
   correctionEnabled: boolean;
   /** Tier 2 phonetic "sounds-like" matching. Gated under correctionEnabled. */
   correctionFuzzy: boolean;
-  /** Tier 3 local-LLM cleanup pass for context mishears. Opt-in, default off. */
-  correctionModelEnabled: boolean;
-  /** Tier 3 "fast mode": the smaller, faster local model variant. */
-  correctionModelFast: boolean;
 }
 
 export type ModelOption =
@@ -162,8 +158,6 @@ export const DEFAULT_SETTINGS: Settings = {
   // default Parakeet engine. A no-op when there's no vocabulary configured.
   correctionEnabled: true,
   correctionFuzzy: true,
-  correctionModelEnabled: false,
-  correctionModelFast: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -274,12 +268,6 @@ export function loadSettings(): Settings {
       }
       if (typeof parsed.correctionFuzzy !== 'boolean') {
         parsed.correctionFuzzy = DEFAULT_SETTINGS.correctionFuzzy;
-      }
-      if (typeof parsed.correctionModelEnabled !== 'boolean') {
-        parsed.correctionModelEnabled = DEFAULT_SETTINGS.correctionModelEnabled;
-      }
-      if (typeof parsed.correctionModelFast !== 'boolean') {
-        parsed.correctionModelFast = DEFAULT_SETTINGS.correctionModelFast;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -58,6 +58,18 @@ export interface Settings {
   codeVocabEnabled: boolean;
   /** Optional absolute path to a project folder scanned for code identifiers. */
   codeVocabFolder: string;
+  /**
+   * Post-model correction: apply the vocabulary to the transcript *output* of every
+   * backend (Tier 1 exact map + Tier 2 sounds-like). On by default — it's what makes
+   * vocab work on the default Parakeet engine, which ignores Whisper's prompt.
+   */
+  correctionEnabled: boolean;
+  /** Tier 2 phonetic "sounds-like" matching. Gated under correctionEnabled. */
+  correctionFuzzy: boolean;
+  /** Tier 3 local-LLM cleanup pass for context mishears. Opt-in, default off. */
+  correctionModelEnabled: boolean;
+  /** Tier 3 "fast mode": the smaller, faster local model variant. */
+  correctionModelFast: boolean;
 }
 
 export type ModelOption =
@@ -146,6 +158,12 @@ export const DEFAULT_SETTINGS: Settings = {
   cleanupCapitalize: true,
   codeVocabEnabled: false,
   codeVocabFolder: '',
+  // Correction on by default: it's the fix that makes vocab actually apply on the
+  // default Parakeet engine. A no-op when there's no vocabulary configured.
+  correctionEnabled: true,
+  correctionFuzzy: true,
+  correctionModelEnabled: false,
+  correctionModelFast: false,
 };
 
 export const STORAGE_KEY = 'dictation-settings';
@@ -246,6 +264,22 @@ export function loadSettings(): Settings {
       // anything non-string back to the empty default.
       if (typeof parsed.codeVocabFolder !== 'string') {
         parsed.codeVocabFolder = DEFAULT_SETTINGS.codeVocabFolder;
+      }
+
+      // Correction toggles — coerce non-booleans (or absent on pre-feature blobs)
+      // back to defaults. correctionEnabled defaults ON, so an older settings blob
+      // that predates this field opts into correction (the intended migration).
+      if (typeof parsed.correctionEnabled !== 'boolean') {
+        parsed.correctionEnabled = DEFAULT_SETTINGS.correctionEnabled;
+      }
+      if (typeof parsed.correctionFuzzy !== 'boolean') {
+        parsed.correctionFuzzy = DEFAULT_SETTINGS.correctionFuzzy;
+      }
+      if (typeof parsed.correctionModelEnabled !== 'boolean') {
+        parsed.correctionModelEnabled = DEFAULT_SETTINGS.correctionModelEnabled;
+      }
+      if (typeof parsed.correctionModelFast !== 'boolean') {
+        parsed.correctionModelFast = DEFAULT_SETTINGS.correctionModelFast;
       }
 
       return { ...DEFAULT_SETTINGS, ...parsed } as Settings;

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -1,0 +1,19 @@
+# Decisions Log
+
+Running log of architectural, scope, and process decisions for this project. Newest entries at the top. Each entry is short — for deep rationale on a single locked decision, write an ADR alongside in `docs/decisions/YYYY-MM-DD-*.md` and reference it here.
+
+Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md` for the entry format and invocation rules.
+
+---
+
+## 2026-06-23: Post-model correction layer — 3 tiers, local-only Tier 3, no routing
+
+**Decision:** Add a post-model TEXT correction layer that runs on every ASR backend, beside the existing cleanup + voice-command passes. Tier 1 = exact spoken→written term map (Aho-Corasick, single pass). Tier 2 = sounds-like match (Metaphone phonetic key + edit-distance, confidence cutoff, fires only near vocab). Both no-LLM, built on settings-change, target <1ms, logged as a `correction_ms` telemetry phase; one unified vocab config feeds both. Tier 3 = optional model cleanup using a **100% local** model only: Qwen2.5-1.5B-Instruct (Q4_K_M GGUF) via `llama-cpp-2` + Metal (Apache-2.0), with Qwen2.5-0.5B-Instruct as an optional "fast mode." The Tier 3 backend is a trait so a future BYO-OpenAI-compatible cloud option can plug in if approved. Smart per-input routing is dropped in favor of a single configurable backend.
+
+**Rationale:** Vocab previously fed Whisper's `initial_prompt`, a silent no-op on the default Parakeet/sherpa engine (parakeet.rs:208) — moving correction post-model fixes it for every engine and is the only place that can do camelCase/abbrev orthography. Cursor "Composer 2.5 Fast" was the only permitted cloud model, but live probing of `api.cursor.com` with a valid Admin-scoped key confirmed there is NO headless chat/completions endpoint: `/v1/me`, `/v1/models`, `/v0/agents` return 200 but only expose account/model-metadata/repo-bound Cloud Agents; every inference verb (`/v1/chat/completions`, `/v1/responses`, `/v1/completions`, `/v1/chat`, `/v1/messages`, `/v1/generate`) 404s. Composer has "no external API." Per the "no substitute" directive, cloud is dropped (kept as a trait seam). Routing was dropped because its "large input → bigger model = faster" premise only held for cloud; locally a bigger model is *slower* on long input and multiple resident models waste RAM. Mitigations: optional 0.5B fast-mode + a length-guard that skips Tier 3 on very long inputs.
+
+**Status:** active
+
+**References:** branch `feat/post-model-correction`; parakeet.rs:208; recording.rs (post-transcription pipeline, insertion after voice_commands); Qwen2.5 GGUF (Apache-2.0) via `llama-cpp-2`; Cursor probe — `/v1/me`,`/v1/models`,`/v0/agents` = 200, all inference verbs = 404.
+
+---

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,7 +6,21 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-06-23: In-process Tier 3 abandoned (ggml ABI clash); deferred to a sidecar
+
+**Decision:** Tiers 1–2 (no-LLM post-model correction) ship as planned. Tier 3 (local-LLM cleanup) is NOT shipped in-process — the `llama-cpp-2` integration and dormant settings/module were removed from the app crate. Tier 3 is deferred to a future sidecar-process design. This supersedes the Tier-3 portion of the entry below (Tiers 1–2 portion still stands).
+
+**Rationale:** `whisper-rs` and `llama-cpp-2` each statically vendor their own `ggml`. They link (matching symbol names) but **SIGSEGV at runtime** — an ABI mismatch between two ggml versions in one process — reproduced in both CPU (`MURMUR_T3_GPU_LAYERS=0`) and Metal modes during model load. Proven by isolation: a standalone binary linking only `llama-cpp-2` loads the GGUF and generates text fine (`MODEL LOADED OK`); the same code inside the app (which also links whisper) crashes. The only viable local-LLM path is a separate sidecar process (proven to run in isolation), which is a substantial new subsystem (persistent helper binary, IPC, lifecycle, Tauri `externalBin` bundling + codesign, model-download UX) with a CI signing/bundling path that can't be validated locally before pushing — too much risk for this release. A secondary finding: the 0.5B model wrapped its output in a ```` ```php ```` code fence (weak instruction-following), so Tier 3 would also need the 1.5B variant + output sanitization + prompt tuning. Working inference code is parked for the sidecar effort.
+
+**Status:** active
+
+**References:** branch `feat/post-model-correction`; commit removing in-process Tier 3; scratchpad `t3probe` (standalone proof) + `correction_model.rs.sidecar-ref` (parked impl).
+
+---
+
 ## 2026-06-23: Post-model correction layer — 3 tiers, local-only Tier 3, no routing
+
+**Status (Tier 3 portion):** superseded by 2026-06-23 (in-process Tier 3 abandoned). Tiers 1–2 portion active.
 
 **Decision:** Add a post-model TEXT correction layer that runs on every ASR backend, beside the existing cleanup + voice-command passes. Tier 1 = exact spoken→written term map (Aho-Corasick, single pass). Tier 2 = sounds-like match (Metaphone phonetic key + edit-distance, confidence cutoff, fires only near vocab). Both no-LLM, built on settings-change, target <1ms, logged as a `correction_ms` telemetry phase; one unified vocab config feeds both. Tier 3 = optional model cleanup using a **100% local** model only: Qwen2.5-1.5B-Instruct (Q4_K_M GGUF) via `llama-cpp-2` + Metal (Apache-2.0), with Qwen2.5-0.5B-Instruct as an optional "fast mode." The Tier 3 backend is a trait so a future BYO-OpenAI-compatible cloud option can plug in if approved. Smart per-input routing is dropped in favor of a single configurable backend.
 


### PR DESCRIPTION
## What

Moves vocabulary out of Whisper's prompt (a silent no-op on the default Parakeet engine) into a **post-model text-correction layer** that runs on every backend, beside the existing cleanup + voice-command passes.

- **Tier 1 — exact map**: spoken→written via a single Aho-Corasick pass. `use effect` → `useEffect`. Word-boundary aware.
- **Tier 2 — sounds-like**: phonetic key + edit distance, fires only near your vocabulary, with a length floor so common words aren't touched (`get` is never rewritten to a `git` vocab entry). Recovers mishearings like `red pivot` → `rePivot`.
- One unified vocab config (custom vocabulary + code-aware terms) drives both. Built once on settings-change; runs inline in well under 1ms (new `correction_ms` telemetry phase).
- Common dev abbreviations (`standard error` → `stderr`) included when Code-Aware Vocabulary is on (gated to dev context to avoid prose misfires).
- Settings: Vocabulary → **Smart Correction** (on by default) + **Sounds-like matching** sub-toggle.

## Tests
- `correction.rs`: 20 unit tests (exact, phonetic, boundaries, over-correction guard).
- Full suite green: 209 Rust, 62 vitest, tsc clean. Settings migration covered (existing `customVocabulary`/`codeVocab` preserved; older blobs opt into correction).

## Not included: Tier 3 (local LLM)
A local-LLM context-correction pass was researched and prototyped but **shelved**. In-process is impossible — `llama-cpp-2` and `whisper-rs` each vendor their own `ggml` and crash (SIGSEGV) when linked together (proven: standalone llama works, in-app crashes). The Cursor cloud option was also a dead end (no public inference API). Full record in `docs/decisions/DECISIONS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Smart Correction: Post-transcription text correction using vocabulary-based exact and optional sounds-like matching, applied across all transcription engines.

* **Updates**
  * Code-Aware Vocabulary now applies corrections uniformly on all backends via Smart Correction.

* **Chores**
  * Version bumped to 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->