### PR TITLE
Code-aware vocabulary: live scan feedback, decoupled budgets, view-all terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-24
+
+### Added
+- **Live code-vocabulary scan feedback** — choosing a project folder now shows a live scan strip: a breadth-first walk streams files and skipped directories as it indexes, with running counts, a cap warning when the walk truncates, and the top terms found. Replaces the previous silent, feedback-free scan (`VocabScanStrip`, `useVocabScan`, `scan_code_vocab`).
+- **View-all scanned terms pop-out** — a searchable, sortable modal listing every kept identifier with its frequency, split into the top-96 that feed Whisper's prompt and the remainder that feed Smart Correction (`VocabTermsModal`).
+- **Decoupled vocabulary budgets** — Whisper's initial prompt stays token-bound at the top 96 terms, while Smart Correction now consumes the top 500 (no token limit) — a large recall win for post-recognition correction on every engine.
+
+### Changed
+- **Breadth-first folder scan** — the walk now samples across sibling projects (FIFO, name-sorted) instead of depth-diving the first subdirectory, so a parent folder like `~/code` indexes fairly. Walk caps raised to 1000 files / 32 MB (per-file 512 KB unchanged).
+- **Bounded scan memory** — identifiers are extracted per file during the walk and the contents dropped, so memory is bounded by the unique-term count rather than total bytes scanned.
+- Whisper's initial prompt is now deduplicated across folder-scan, built-in, and custom sources so a term never burns two slots of the token budget.
+
+### Fixed
+- **Smart Correction no longer re-fragments its own output** — Tier-2 fuzzy tokenization treats `_` as a word character, so a snake_case form produced by Tier 1 (e.g. `error_message`) is no longer split and a sub-token fuzzy-rewritten (`error` → `Errorf`).
+- **Tier-2 fuzzy over-correction** — only structured identifiers (camelCase / snake_case / digit) are fuzzy-eligible; plain words (`Errorf`, `Record`, `kubectl`) are exact-match only, so dictating ordinary English no longer flips to a scanned identifier.
+- Smart Correction rebuilds with folder terms on the lazy path after restart (previously stayed built-in-only until an unrelated settings change).
+
 ## [0.13.0] - 2026-06-23
 
 ### Added

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.13.0"
+version = "0.14.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -5,12 +5,25 @@ use crate::{audio, audio_decode, injector, keyboard, vad};
 use std::sync::atomic::Ordering;
 use tauri::Emitter;
 
-/// Max number of code identifiers to feed Whisper as an initial prompt. Whisper
-/// truncates the prompt to its context window anyway; this keeps the bias list
-/// focused on the most frequent (most useful) terms.
-const MAX_CODE_VOCAB_TERMS: usize = 96;
+/// Max number of code identifiers fed to Whisper as an initial prompt. Whisper
+/// truncates the prompt to its ~224-token context window anyway, so this keeps
+/// the bias list focused on the most frequent (most useful) terms. This budget is
+/// intentionally *smaller* than [`CORRECTION_TERMS`]: the Whisper prompt is
+/// token-bound, while Smart Correction is not (see [`CORRECTION_TERMS`]).
+const WHISPER_PROMPT_TERMS: usize = 96;
 
-/// Scan `folder` for code identifiers and build a Whisper initial-prompt string.
+/// Max number of code identifiers fed to the Smart Correction matcher
+/// (`correction.rs` Tier 1/2). Unlike the Whisper initial prompt this path has no
+/// token budget — it's a couple of linear passes over the transcript — so a far
+/// larger term list is a pure recall win. The folder scan ranks ALL identifiers
+/// once; the top [`CORRECTION_TERMS`] feed correction and the top
+/// [`WHISPER_PROMPT_TERMS`] (a rank-prefix of them) feed Whisper.
+const CORRECTION_TERMS: usize = 500;
+
+/// Scan `folder` for code identifiers and build the cached folder-scan prompt
+/// string, ranked by descending frequency and capped at [`CORRECTION_TERMS`].
+/// The cache holds the larger (top-500) list; the Whisper path takes its
+/// [`WHISPER_PROMPT_TERMS`] rank-prefix at use time (see [`whisper_prefix`]).
 /// Empty/blank folder returns an empty string. Delegates to the guarded,
 /// pure-logic `vocab` module (file count / size caps live there).
 fn build_code_vocab_prompt(folder: &str) -> String {
@@ -20,7 +33,7 @@ fn build_code_vocab_prompt(folder: &str) -> String {
     }
     let prompt = crate::vocab::build_vocab_prompt_from_dir(
         std::path::Path::new(folder),
-        MAX_CODE_VOCAB_TERMS,
+        CORRECTION_TERMS,
     );
     tracing::info!(
         target: "pipeline",
@@ -29,6 +42,19 @@ fn build_code_vocab_prompt(folder: &str) -> String {
         prompt.len()
     );
     prompt
+}
+
+/// Take the top [`WHISPER_PROMPT_TERMS`] space-separated terms of a ranked
+/// folder-scan prompt. The cached prompt holds the top-[`CORRECTION_TERMS`] list
+/// ranked by descending frequency, so its first 96 words ARE the top-96 terms.
+/// This is what keeps the Whisper budget decoupled from the (larger) correction
+/// budget without a second walk or a second cache field.
+fn whisper_prefix(prompt: &str) -> String {
+    prompt
+        .split_whitespace()
+        .take(WHISPER_PROMPT_TERMS)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Return the code-aware vocabulary prompt for the current settings, or an empty
@@ -55,19 +81,31 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
 
     let builtin = crate::vocab::builtin_terms_prompt();
 
-    // Optional project scan layered on top of the built-ins.
+    // Optional project scan layered on top of the built-ins. The cache holds the
+    // top-CORRECTION_TERMS (500) ranked list; Whisper's token-bound prompt takes
+    // only its top-WHISPER_PROMPT_TERMS (96) rank-prefix here.
     let folder_prompt = if folder.trim().is_empty() {
         String::new()
     } else if let Some(prompt) = cached {
-        prompt
+        whisper_prefix(&prompt)
     } else {
-        // Not yet scanned: build now and cache (only if settings still match).
+        // Not yet scanned: build now and cache the full (top-500) list (only if
+        // settings still match), then feed Whisper its top-96 prefix.
         let prompt = build_code_vocab_prompt(&folder);
         let mut dictation = app_state.dictation.lock_or_recover();
         if dictation.code_vocab_enabled && dictation.code_vocab_folder == folder {
             dictation.code_vocab_prompt = Some(prompt.clone());
+            // Refresh the correction matcher so Smart Correction picks up this
+            // folder's top-500 terms now, not just on the next settings change.
+            // configure_dictation no longer prebuilds the prompt, so on the common
+            // restart-with-persisted-folder path the matcher would otherwise stay
+            // builtin-only for the whole session (it's rebuilt only here, in
+            // configure_dictation, and in scan_code_vocab — and the transcription
+            // path hits none of the other two). rebuild_correction_matcher writes a
+            // separate leaf mutex, so there's no deadlock with the held guard.
+            rebuild_correction_matcher(app_state, &dictation);
         }
-        prompt
+        whisper_prefix(&prompt)
     };
 
     // Project identifiers first (most specific), built-in dictionary after.
@@ -81,15 +119,37 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
 /// Merge the manual custom-vocabulary string and the code-aware vocabulary into a
 /// single Whisper initial prompt. Returns `None` when both are blank so the
 /// backend skips setting a prompt entirely.
+///
+/// `code` carries the folder-scan terms ahead of the built-in dictionary (see
+/// [`resolve_code_vocab_prompt`]). The hand-typed `custom` list is concatenated
+/// FIRST so user-entered terms keep precedence: Whisper truncates the initial
+/// prompt to ~224 tokens keeping the START, so a large code-scan prompt must not
+/// crowd out terms the user explicitly typed. Order is therefore custom, then
+/// folder, then builtin — and the whole thing is deduped case-insensitively so the
+/// same term never burns two slots of the budget (the Smart Correction matcher
+/// dedupes separately).
 fn combine_prompts(custom: &str, code: &str) -> Option<String> {
     let custom = custom.trim();
     let code = code.trim();
     match (custom.is_empty(), code.is_empty()) {
         (true, true) => None,
-        (false, true) => Some(custom.to_string()),
-        (true, false) => Some(code.to_string()),
-        (false, false) => Some(format!("{} {}", custom, code)),
+        (false, true) => Some(dedupe_prompt_terms(custom)),
+        (true, false) => Some(dedupe_prompt_terms(code)),
+        (false, false) => Some(dedupe_prompt_terms(&format!("{} {}", custom, code))),
     }
+}
+
+/// Collapse a space-joined prompt to its first occurrence of each term,
+/// case-insensitively, preserving order and the first surface form. Used at the
+/// combine step so cross-source repeats (folder scan vs. built-in dictionary vs.
+/// custom vocabulary) don't waste Whisper's limited prompt budget.
+fn dedupe_prompt_terms(prompt: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    prompt
+        .split_whitespace()
+        .filter(|t| seen.insert(t.to_ascii_lowercase()))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Split the free-text custom-vocabulary field into individual written terms.
@@ -119,6 +179,10 @@ fn rebuild_correction_matcher(
         for t in crate::vocab::builtin_terms_prompt().split_whitespace() {
             terms.push(t.to_string());
         }
+        // The cached folder prompt holds the top-CORRECTION_TERMS (500) ranked
+        // identifiers. Unlike the Whisper prompt path (which takes only the top-96
+        // rank-prefix because it's token-bound), Smart Correction has no token
+        // budget, so it consumes the full cached list — a big recall win.
         if let Some(folder_prompt) = &dictation.code_vocab_prompt {
             for t in folder_prompt.split_whitespace() {
                 terms.push(t.to_string());
@@ -682,17 +746,14 @@ pub async fn configure_dictation(
         }
     }
     if code_vocab_dirty {
-        if dictation.code_vocab_enabled && !dictation.code_vocab_folder.trim().is_empty() {
-            // Prebuild the prompt now (on the configure call) so the first
-            // utterance isn't slowed by a directory walk. configure is rare and
-            // the scan is guarded (file count / size caps), so doing it under the
-            // lock here is acceptable.
-            let prompt = build_code_vocab_prompt(&dictation.code_vocab_folder);
-            dictation.code_vocab_prompt = Some(prompt);
-        } else {
-            // Disabled or no folder: clear any stale cached prompt.
-            dictation.code_vocab_prompt = None;
-        }
+        // Invalidate the cached prompt; do NOT walk the tree synchronously here.
+        // The explicit `scan_code_vocab` command owns the (single) walk for a
+        // folder pick and caches the result, so prebuilding under the lock here
+        // would just duplicate that walk — and choosing a folder fires both this
+        // configure path and a scan concurrently. If no scan ever runs (folder set
+        // programmatically), `resolve_code_vocab_prompt` lazily builds + caches the
+        // prompt on the first transcription. Net: exactly one walk per folder.
+        dictation.code_vocab_prompt = None;
     }
 
     // Post-model correction toggles.
@@ -740,6 +801,260 @@ pub async fn configure_dictation(
     Ok(serde_json::json!({
         "type": "configured"
     }))
+}
+
+/// Live progress emitted (throttled) while [`scan_code_vocab`] walks a folder.
+/// Field names are part of the frontend contract — do not rename.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VocabScanProgress {
+    current_path: String,
+    files_read: usize,
+    dirs_skipped: usize,
+    terms_so_far: usize,
+    done: bool,
+}
+
+/// One ranked vocabulary term surfaced to the frontend pop-out: the written form
+/// plus how many times it appeared across the scan. Serialized camelCase (already
+/// single-word, so `term`/`freq` are unchanged). Rank is the array index + 1.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RankedTermJson {
+    term: String,
+    freq: u32,
+}
+
+/// Result of a [`scan_code_vocab`] run, returned to the frontend. Field names are
+/// part of the frontend contract — do not rename.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VocabScanSummary {
+    files: usize,
+    skipped: usize,
+    terms: usize,
+    bytes: u64,
+    capped: bool,
+    ms: u64,
+    /// Top ~12 written forms — a preview of what the scan biases toward.
+    sample_terms: Vec<String>,
+    /// Full ranked list of terms actually kept (<= [`CORRECTION_TERMS`]), ordered
+    /// by descending frequency. Rank = array index + 1. Powers the "all scanned
+    /// terms" pop-out and is the exact list fed to Smart Correction.
+    ranked_terms: Vec<RankedTermJson>,
+    /// How many of `ranked_terms` feed Whisper's initial prompt =
+    /// min([`WHISPER_PROMPT_TERMS`], ranked_terms.len()). The first `whisper_count`
+    /// entries are the Whisper budget; the rest are correction-only.
+    whisper_count: usize,
+}
+
+/// Emit a throttled `vocab-scan-progress` tick carrying the live running counts
+/// and the path being read/skipped. `force` bypasses the throttle (used for skip
+/// rows so struck-through dependency/build dirs always render live). Updates
+/// `*last_emit` when it fires. A free fn (not a closure) so both walk callbacks
+/// can call it without one capturing the other and tripping the borrow checker.
+#[allow(clippy::too_many_arguments)]
+fn emit_scan_progress(
+    handle: &tauri::AppHandle,
+    last_emit: &mut std::time::Instant,
+    current_path: String,
+    files_read: usize,
+    dirs_skipped: usize,
+    terms_so_far: usize,
+    force: bool,
+) {
+    if force
+        || last_emit.elapsed().as_millis() >= VOCAB_PROGRESS_INTERVAL_MS
+        || files_read.is_multiple_of(VOCAB_PROGRESS_EVERY_FILES)
+    {
+        *last_emit = std::time::Instant::now();
+        let _ = handle.emit(
+            "vocab-scan-progress",
+            VocabScanProgress {
+                current_path,
+                files_read,
+                dirs_skipped,
+                terms_so_far,
+                done: false,
+            },
+        );
+    }
+}
+
+/// Number of top written forms surfaced in [`VocabScanSummary::sample_terms`].
+const VOCAB_SAMPLE_TERMS: usize = 12;
+/// Emit a progress event at most this often (alongside the per-N-files gate) so a
+/// fast walk doesn't flood the event channel.
+const VOCAB_PROGRESS_INTERVAL_MS: u128 = 50;
+/// Also emit progress every this many files, so a slow-but-steady walk still
+/// reports even within one throttle window.
+const VOCAB_PROGRESS_EVERY_FILES: usize = 10;
+
+/// Scan `folder` for code identifiers off the UI thread, emitting throttled
+/// `vocab-scan-progress` events as it walks, and return a [`VocabScanSummary`].
+///
+/// On a non-empty result this also adopts the scan: it stores the folder, enables
+/// code-aware vocabulary, caches the built prompt, and rebuilds the correction
+/// matcher — mirroring `configure_dictation` so the scan takes effect immediately
+/// without a second round-trip. The filesystem walk and prompt build run inside
+/// `spawn_blocking`; no std mutex is held across an `.await`.
+#[tauri::command]
+pub async fn scan_code_vocab(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, State>,
+    folder: String,
+) -> Result<VocabScanSummary, String> {
+    let folder_trimmed = folder.trim().to_string();
+    if folder_trimmed.is_empty() {
+        return Err("No folder selected to scan.".to_string());
+    }
+
+    tracing::info!(target: "pipeline", "scan_code_vocab: start");
+
+    // Walk + prompt build are blocking (filesystem + CPU). Run them off the async
+    // runtime; the closure emits throttled progress as files are read.
+    let emit_handle = app_handle.clone();
+    let scan_folder = folder_trimmed.clone();
+    let t_start = std::time::Instant::now();
+    let (prompt, summary) = tokio::task::spawn_blocking(move || {
+        let path = std::path::Path::new(&scan_folder);
+
+        // Running scan counters shared across the file and skip callbacks. Interior
+        // mutability (Cell/RefCell) lets BOTH `FnMut` closures capture the same
+        // state by shared reference — two closures can't each capture the same
+        // locals by `&mut`, which is why this isn't plain `let mut`.
+        let files_read = std::cell::Cell::new(0usize);
+        let dirs_skipped = std::cell::Cell::new(0usize);
+        let last_emit = std::cell::Cell::new(std::time::Instant::now());
+        // Running distinct-term count (case-insensitive) surfaced by the walk's
+        // accumulator, so the live `terms_so_far` count tracks the eventual prompt
+        // size instead of sitting at zero until the walk finishes. The walk already
+        // folds each file in, so we read this count rather than re-extracting (which
+        // would double the tokenization CPU across a 1000-file/32MB scan).
+        let terms_so_far = std::cell::Cell::new(0usize);
+        let walk_start = std::time::Instant::now();
+
+        // Throttled emit reading the shared counters; `force` bypasses the throttle.
+        let emit = |current_path: String, force: bool| {
+            let mut le = last_emit.get();
+            emit_scan_progress(
+                &emit_handle,
+                &mut le,
+                current_path,
+                files_read.get(),
+                dirs_skipped.get(),
+                terms_so_far.get(),
+                force,
+            );
+            last_emit.set(le);
+        };
+
+        let outcome = crate::vocab::collect_source_files(
+            path,
+            |file_path, distinct_terms| {
+                files_read.set(files_read.get() + 1);
+                // Track the live distinct-term tally the walker already computed
+                // (no second extraction). Clamp it to CORRECTION_TERMS — the same
+                // ceiling the final summary.terms is capped at — so the live counter
+                // and the settled "done" total share one ceiling and the number
+                // never visibly drops from e.g. "1,832 terms" back to "500 terms"
+                // at completion. This is only the live counter; the authoritative
+                // ranked term count still comes from the summary.
+                terms_so_far.set(distinct_terms.min(CORRECTION_TERMS));
+                // Throttle: emit on a time window OR every N files, never per-file.
+                emit(file_path.to_string_lossy().to_string(), false);
+            },
+            |skip_path| {
+                dirs_skipped.set(dirs_skipped.get() + 1);
+                // Force-emit skip rows so the struck-through dependency/build dirs
+                // (node_modules, target, .git) always render live, even between
+                // file reads — that live skip stream is the point of the feature.
+                emit(skip_path.to_string_lossy().to_string(), true);
+            },
+        );
+
+        // Rank the folded accumulator ONCE at the larger correction budget. The
+        // walk dropped each file's contents as it read it, so this ranking is the
+        // only term-level data we keep — bounded by unique-term count, not bytes.
+        let ranked = outcome.vocab.ranked(CORRECTION_TERMS);
+        // The cached prompt string IS this ranked list joined; Whisper later takes
+        // its top-WHISPER_PROMPT_TERMS prefix, correction consumes the whole thing.
+        let prompt = crate::vocab::ranked_terms_to_prompt(&ranked);
+        // Preview: top written forms (ranking is descending-frequency, so the
+        // first VOCAB_SAMPLE_TERMS ARE the strip's preview chips).
+        let sample_terms: Vec<String> = ranked
+            .iter()
+            .take(VOCAB_SAMPLE_TERMS)
+            .map(|r| r.term.clone())
+            .collect();
+        // Full ranked list for the pop-out (<= CORRECTION_TERMS), plus how many of
+        // them feed Whisper (min(96, kept)).
+        let ranked_terms: Vec<RankedTermJson> = ranked
+            .iter()
+            .map(|r| RankedTermJson { term: r.term.clone(), freq: r.freq })
+            .collect();
+        let whisper_count = ranked_terms.len().min(WHISPER_PROMPT_TERMS);
+        let terms = ranked_terms.len();
+
+        let summary = VocabScanSummary {
+            files: outcome.files_read,
+            skipped: outcome.dirs_skipped,
+            terms,
+            bytes: outcome.total_bytes,
+            capped: outcome.capped,
+            ms: walk_start.elapsed().as_millis() as u64,
+            sample_terms,
+            ranked_terms,
+            whisper_count,
+        };
+        (prompt, summary)
+    })
+    .await
+    .map_err(|e| format!("Vocab scan task panicked: {}", e))?;
+
+    // Final progress tick so the UI lands on a settled "done" state.
+    let _ = app_handle.emit(
+        "vocab-scan-progress",
+        VocabScanProgress {
+            current_path: String::new(),
+            files_read: summary.files,
+            dirs_skipped: summary.skipped,
+            terms_so_far: summary.terms,
+            done: true,
+        },
+    );
+
+    // Adopt the scan: cache the built prompt and rebuild the correction matcher
+    // under the lock — but ONLY if the current settings still point at the folder
+    // we just walked with code-vocab enabled. The walk runs concurrently with
+    // configure_dictation (both fire on the same folder pick), and a large repo
+    // can take long enough for the user to toggle code-vocab OFF or clear/change
+    // the folder mid-walk. configure_dictation owns code_vocab_enabled +
+    // code_vocab_folder; if it has since cleared them, dropping this stale result
+    // is correct — re-enabling here would silently re-inject the code prompt while
+    // the frontend toggle reads OFF (last-writer-wins divergence). Mirrors the
+    // lazy path's guard in resolve_code_vocab_prompt. The lock is taken AFTER all
+    // awaits, scoped, and released before returning — never held across an `.await`.
+    {
+        let mut dictation = state.app_state.dictation.lock_or_recover();
+        if dictation.code_vocab_enabled && dictation.code_vocab_folder == folder_trimmed {
+            dictation.code_vocab_prompt = Some(prompt);
+            rebuild_correction_matcher(&state.app_state, &dictation);
+        }
+    }
+
+    tracing::info!(
+        target: "pipeline",
+        files = summary.files,
+        skipped = summary.skipped,
+        terms = summary.terms,
+        bytes = summary.bytes,
+        capped = summary.capped,
+        ms = t_start.elapsed().as_millis() as u64,
+        "scan_code_vocab: complete"
+    );
+
+    Ok(summary)
 }
 
 #[tauri::command]
@@ -1143,6 +1458,104 @@ pub async fn transcribe_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dedupe_prompt_drops_case_insensitive_repeats() {
+        // "Tauri"/"tauri" collapse to the first surface form; order preserved.
+        let out = dedupe_prompt_terms("Tauri useEffect tauri useState USEEFFECT");
+        assert_eq!(out, "Tauri useEffect useState");
+    }
+
+    #[test]
+    fn dedupe_prompt_is_noop_when_unique() {
+        let out = dedupe_prompt_terms("alpha beta gamma");
+        assert_eq!(out, "alpha beta gamma");
+    }
+
+    #[test]
+    fn combine_prompts_dedupes_across_sources() {
+        // Cross-source overlap: the folder/builtin `code` carries "Tauri" and the
+        // custom list repeats it (different case). It must appear exactly once,
+        // and order keeps the user-typed custom list first (precedence under
+        // Whisper's start-keeping prompt truncation), then folder/builtin (code).
+        let code = "Tauri serde useEffect";
+        let custom = "tauri myProject SERDE";
+        let combined = combine_prompts(custom, code).unwrap();
+        assert_eq!(combined, "tauri myProject SERDE useEffect");
+        // Each shared term appears exactly once (case-insensitively).
+        let n_tauri = combined.split(' ').filter(|t| t.eq_ignore_ascii_case("tauri")).count();
+        assert_eq!(n_tauri, 1, "combined={:?}", combined);
+        let n_serde = combined.split(' ').filter(|t| t.eq_ignore_ascii_case("serde")).count();
+        assert_eq!(n_serde, 1, "combined={:?}", combined);
+    }
+
+    #[test]
+    fn combine_prompts_handles_single_and_empty_sources() {
+        assert_eq!(combine_prompts("", ""), None);
+        assert_eq!(combine_prompts("custom dupCustom", "").as_deref(), Some("custom dupCustom"));
+        assert_eq!(combine_prompts("", "code dupe Dupe").as_deref(), Some("code dupe"));
+    }
+
+    #[test]
+    fn budget_constants_decoupled_96_and_500() {
+        // The two budgets are intentionally distinct; Whisper's is the smaller.
+        assert_eq!(WHISPER_PROMPT_TERMS, 96);
+        assert_eq!(CORRECTION_TERMS, 500);
+        assert!(WHISPER_PROMPT_TERMS < CORRECTION_TERMS);
+    }
+
+    #[test]
+    fn whisper_prefix_takes_top_96_of_ranked_prompt() {
+        // A ranked prompt longer than the Whisper budget is truncated to its first
+        // WHISPER_PROMPT_TERMS terms (which, given descending-frequency ranking,
+        // are the top-96). The full string is what correction consumes.
+        let full: String = (0..200)
+            .map(|i| format!("term{:03}", i))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let prefix = whisper_prefix(&full);
+        let words: Vec<&str> = prefix.split_whitespace().collect();
+        assert_eq!(words.len(), WHISPER_PROMPT_TERMS, "Whisper budget caps at 96");
+        // Prefix is the leading slice of the full ranked list.
+        assert_eq!(words[0], "term000");
+        assert_eq!(words[WHISPER_PROMPT_TERMS - 1], format!("term{:03}", WHISPER_PROMPT_TERMS - 1));
+        // Shorter-than-budget prompt passes through unchanged.
+        assert_eq!(whisper_prefix("alpha beta gamma"), "alpha beta gamma");
+        assert_eq!(whisper_prefix(""), "");
+    }
+
+    #[test]
+    fn summary_serializes_ranked_terms_and_whisper_count_camel_case() {
+        // rankedTerms / whisperCount must serialize camelCase per the frontend
+        // contract; each ranked entry is { term, freq }.
+        let summary = VocabScanSummary {
+            files: 3,
+            skipped: 1,
+            terms: 2,
+            bytes: 42,
+            capped: false,
+            ms: 7,
+            sample_terms: vec!["fooBar".into()],
+            ranked_terms: vec![
+                RankedTermJson { term: "fooBar".into(), freq: 5 },
+                RankedTermJson { term: "barBaz".into(), freq: 2 },
+            ],
+            whisper_count: 2,
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        // New camelCase keys present; snake_case absent.
+        assert!(v.get("rankedTerms").is_some(), "rankedTerms missing: {v}");
+        assert!(v.get("whisperCount").is_some(), "whisperCount missing: {v}");
+        assert!(v.get("ranked_terms").is_none(), "snake_case leaked: {v}");
+        assert!(v.get("whisper_count").is_none(), "snake_case leaked: {v}");
+        assert_eq!(v["whisperCount"], 2);
+        // sampleTerms (existing field) stays camelCase too.
+        assert!(v.get("sampleTerms").is_some(), "sampleTerms missing: {v}");
+        // Each ranked entry carries term + freq.
+        let first = &v["rankedTerms"][0];
+        assert_eq!(first["term"], "fooBar");
+        assert_eq!(first["freq"], 5);
+    }
 
     #[test]
     fn idle_guard_resets_status_on_drop() {

--- a/app/src-tauri/src/correction.rs
+++ b/app/src-tauri/src/correction.rs
@@ -364,17 +364,22 @@ pub fn derive_spoken_form(written: &str) -> String {
 }
 
 /// A written form is eligible for Tier-2 fuzzy matching only when it carries code
-/// *structure*: an internal uppercase (camelCase/PascalCase), an underscore, or a
-/// digit. Plain words ("Errorf", "Record", "kubectl", "NOOP") are exact-only — their
-/// spoken forms collide with ordinary English a single edit away (say "error", get
-/// "Errorf"), so fuzzy-matching them over-corrects. Structured identifiers derive to
-/// distinctive multi-word spoken forms and are safe to fuzzy-match.
+/// *structure*: a camelCase boundary (a lowercase immediately followed by an
+/// uppercase), an underscore, or a digit. Plain words ("Errorf", "Record",
+/// "kubectl") AND all-caps acronyms ("NOOP", "HTTP") are exact-only — they derive to
+/// single-word spoken forms that sit one edit from ordinary English (say "error",
+/// get "Errorf"), so fuzzy-matching them over-corrects. Structured identifiers derive
+/// to distinctive multi-word spoken forms and are safe to fuzzy-match.
+///
+/// Note: "uppercase anywhere after the first char" is NOT enough — an all-caps
+/// acronym satisfies it but has no real word boundary, so we require lower→upper.
 fn is_fuzzy_eligible(written: &str) -> bool {
     let has_underscore = written.contains('_');
     let has_digit = written.bytes().any(|c| c.is_ascii_digit());
-    // Uppercase anywhere after the first char => camelCase/PascalCase/acronym shape.
-    let has_internal_upper = written.bytes().skip(1).any(|c| c.is_ascii_uppercase());
-    has_underscore || has_digit || has_internal_upper
+    let b = written.as_bytes();
+    let has_camel_boundary =
+        (1..b.len()).any(|i| b[i].is_ascii_uppercase() && b[i - 1].is_ascii_lowercase());
+    has_underscore || has_digit || has_camel_boundary
 }
 
 /// Split text into word tokens with their byte spans. Punctuation and whitespace
@@ -609,14 +614,16 @@ mod tests {
 
     #[test]
     fn is_fuzzy_eligible_classifies_structure() {
-        assert!(is_fuzzy_eligible("rePivot"));        // internal upper
+        assert!(is_fuzzy_eligible("rePivot"));        // camel boundary
         assert!(is_fuzzy_eligible("variable_name"));  // underscore
         assert!(is_fuzzy_eligible("large_v3"));       // digit
-        assert!(is_fuzzy_eligible("XCTAssertEqual")); // internal upper
+        assert!(is_fuzzy_eligible("XCTAssertEqual")); // camel boundary (t->E)
         assert!(!is_fuzzy_eligible("Errorf"));        // leading cap only
         assert!(!is_fuzzy_eligible("kubectl"));       // plain lowercase
         assert!(!is_fuzzy_eligible("Record"));        // leading cap only
         assert!(!is_fuzzy_eligible("noop"));          // plain
+        assert!(!is_fuzzy_eligible("NOOP"));          // all-caps acronym, no lower->upper
+        assert!(!is_fuzzy_eligible("HTTP"));          // all-caps acronym
     }
 
     #[test]

--- a/app/src-tauri/src/correction.rs
+++ b/app/src-tauri/src/correction.rs
@@ -55,6 +55,9 @@ const MIN_FUZZY_LEN: usize = 5;
 struct Term {
     written: String,
     spoken: String,
+    /// Whether this term may be matched by Tier-2 fuzzy. Only *structured*
+    /// identifiers qualify (see [`is_fuzzy_eligible`]); plain words are exact-only.
+    fuzzy_eligible: bool,
 }
 
 /// A compiled, reusable correction matcher. Build once on settings-change, then
@@ -154,6 +157,7 @@ impl CorrectionMatcher {
             terms.push(Term {
                 written: written.clone(),
                 spoken: spoken.clone(),
+                fuzzy_eligible: is_fuzzy_eligible(written),
             });
         }
 
@@ -273,6 +277,14 @@ impl CorrectionMatcher {
             if term.spoken == lower {
                 continue;
             }
+            // Only structured identifiers are fuzzy-eligible. Plain words (e.g.
+            // "Errorf", "kubectl") are exact-only: their spoken forms sit one edit
+            // from ordinary English ("error", "cube cuddle"), so fuzzy-matching them
+            // over-corrects. Structured terms (camelCase/snake_case/digit) derive to
+            // multi-word spoken forms that don't collide with single English words.
+            if !term.fuzzy_eligible {
+                continue;
+            }
             // Don't fuzzy-match against short vocab terms (same collision risk).
             if term.spoken.len() < MIN_FUZZY_LEN {
                 continue;
@@ -351,16 +363,35 @@ pub fn derive_spoken_form(written: &str) -> String {
     words.join(" ")
 }
 
-/// Split text into alphanumeric word tokens with their byte spans. Punctuation and
-/// whitespace become the gaps between tokens.
+/// A written form is eligible for Tier-2 fuzzy matching only when it carries code
+/// *structure*: an internal uppercase (camelCase/PascalCase), an underscore, or a
+/// digit. Plain words ("Errorf", "Record", "kubectl", "NOOP") are exact-only — their
+/// spoken forms collide with ordinary English a single edit away (say "error", get
+/// "Errorf"), so fuzzy-matching them over-corrects. Structured identifiers derive to
+/// distinctive multi-word spoken forms and are safe to fuzzy-match.
+fn is_fuzzy_eligible(written: &str) -> bool {
+    let has_underscore = written.contains('_');
+    let has_digit = written.bytes().any(|c| c.is_ascii_digit());
+    // Uppercase anywhere after the first char => camelCase/PascalCase/acronym shape.
+    let has_internal_upper = written.bytes().skip(1).any(|c| c.is_ascii_uppercase());
+    has_underscore || has_digit || has_internal_upper
+}
+
+/// Split text into word tokens with their byte spans. Punctuation and whitespace
+/// become the gaps between tokens. An underscore counts as a word char, so a
+/// snake_case identifier stays a single token — this keeps Tier 2 from
+/// re-fragmenting a written form that Tier 1 already produced (e.g. `error_message`)
+/// and fuzzy-rewriting one of its bare sub-tokens (`error` -> `Errorf`). Whole
+/// snake_case tokens fall through to the `written_lower` guard in [`fuzzy_lookup`].
 fn tokenize(text: &str) -> Vec<(&str, usize, usize)> {
+    let is_word = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
     let mut out = Vec::new();
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i].is_ascii_alphanumeric() {
+        if is_word(bytes[i]) {
             let start = i;
-            while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
+            while i < bytes.len() && is_word(bytes[i]) {
                 i += 1;
             }
             out.push((&text[start..i], start, i));
@@ -534,12 +565,58 @@ mod tests {
     }
 
     #[test]
-    fn tier2_single_word_mishear() {
+    fn tier2_does_not_refragment_tier1_snake_case() {
+        // Tier 1 turns "error message" -> error_message. Tier 2 must NOT then split
+        // on the underscore and fuzzy-rewrite the bare "error" into the near vocab
+        // term "Errorf" (1 edit away) — which previously produced "Errorf_message".
+        // The whole snake_case token now hits the written_lower guard and is left alone.
+        let m = CorrectionMatcher::build(
+            &["error_message".to_string(), "Errorf".to_string()],
+            &[],
+            true,  // fuzzy on
+            false,
+        );
+        assert_eq!(m.apply("log the error message now"), "log the error_message now");
+    }
+
+    #[test]
+    fn tier2_unstructured_term_is_exact_only() {
+        // Plain lowercase identifiers (no camelCase / underscore / digit) are NOT
+        // fuzzy-eligible. "kubectl" still exact-matches via Tier 1, but a mishear
+        // "kubecto" is left alone — the precision trade that kills "error"->"Errorf".
         let m = matcher(&["kubectl"]);
-        // "cube cuddle" -> phonetic-ish near "kubectl"? Use a closer mishear.
-        // "kubectl" spoken-form derives to "kubectl"; a near homophone within
-        // edit distance should map. "kubecto" (1 edit) qualifies.
-        assert_eq!(m.apply("run kubecto apply"), "run kubectl apply");
+        assert_eq!(m.apply("run kubecto apply"), "run kubecto apply");
+        // Exact spoken form still corrects (Tier 1 path is unaffected).
+        assert_eq!(m.apply("run kubectl apply"), "run kubectl apply");
+    }
+
+    #[test]
+    fn tier2_unstructured_term_does_not_overcorrect_english() {
+        // The real-world bug: vocab term "Errorf" (Go's Errorf, no structure) sits one
+        // edit from the common word "error". Unstructured terms are exact-only now, so
+        // dictating "error" is left as English instead of flipping to "Errorf".
+        let m = CorrectionMatcher::build(&["Errorf".to_string()], &[], true, false);
+        assert_eq!(m.apply("log the error now"), "log the error now");
+    }
+
+    #[test]
+    fn tier2_structured_term_still_fuzzes() {
+        // Structured identifiers remain fuzzy-eligible: a multi-word mishear of a
+        // camelCase term is still recovered.
+        let m = matcher(&["rePivot"]);
+        assert_eq!(m.apply("then red pivot now"), "then rePivot now");
+    }
+
+    #[test]
+    fn is_fuzzy_eligible_classifies_structure() {
+        assert!(is_fuzzy_eligible("rePivot"));        // internal upper
+        assert!(is_fuzzy_eligible("variable_name"));  // underscore
+        assert!(is_fuzzy_eligible("large_v3"));       // digit
+        assert!(is_fuzzy_eligible("XCTAssertEqual")); // internal upper
+        assert!(!is_fuzzy_eligible("Errorf"));        // leading cap only
+        assert!(!is_fuzzy_eligible("kubectl"));       // plain lowercase
+        assert!(!is_fuzzy_eligible("Record"));        // leading cap only
+        assert!(!is_fuzzy_eligible("noop"));          // plain
     }
 
     #[test]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -129,6 +129,7 @@ pub fn run() {
             commands::recording::cancel_native_recording,
             commands::recording::count_vocab_tokens,
             commands::recording::transcribe_file,
+            commands::recording::scan_code_vocab,
             commands::permissions::open_system_preferences,
             commands::permissions::check_accessibility_permission,
             commands::permissions::request_accessibility_permission,

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -421,13 +421,13 @@ pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
     queue.push_back(folder.to_path_buf());
 
     'walk: while let Some(dir) = queue.pop_front() {
-        // Stop once a guard is hit, but do NOT mark `capped` here: popping another
-        // queued dir at/after the cap doesn't prove readable content was skipped
-        // (the remaining dirs may be empty/non-source). `capped` is set only at the
-        // inner break below, where a guard actually blocks reading a candidate
-        // source file — so it never raises a false "hit the cap" warning on a scan
-        // that read exactly MAX_FILES and had nothing left to read.
+        // We just popped a directory but a guard blocks processing it, so this
+        // subtree (and anything else still queued) goes un-indexed — a real
+        // truncation. Mark `capped`. NOTE: when the tree is genuinely exhausted the
+        // `while let` ends on an empty queue *without* reaching this break, so a scan
+        // that read everything (even exactly MAX_FILES) still reports capped=false.
         if files_read >= MAX_FILES || total_bytes >= MAX_TOTAL_BYTES {
+            capped = true;
             break;
         }
         let entries = match std::fs::read_dir(&dir) {

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -50,11 +50,11 @@ pub const MAX_FILE_BYTES: u64 = 512 * 1024;
 
 /// Cap on the number of files we read in one scan, so a giant repo can't hang
 /// the pipeline. Files are visited in directory-walk order until the cap is hit.
-pub const MAX_FILES: usize = 200;
+pub const MAX_FILES: usize = 1000;
 
 /// Total bytes we will read across all files in one scan. A second guard on top
 /// of the per-file and file-count caps.
-pub const MAX_TOTAL_BYTES: u64 = 8 * 1024 * 1024;
+pub const MAX_TOTAL_BYTES: u64 = 32 * 1024 * 1024;
 
 /// Source file extensions we scan. Kept to common code formats so we don't pull
 /// identifiers out of, say, lockfiles or binary assets.
@@ -226,49 +226,132 @@ fn is_candidate(token: &str) -> bool {
     true
 }
 
-/// Build a Whisper initial-prompt string from in-memory file contents.
+/// A ranked vocabulary term and the number of times it was seen across the scan.
+/// `term` is the first surface form encountered (e.g. `useEffect`), `freq` its
+/// total occurrence count. Returned by [`VocabAccumulator::ranked`] /
+/// [`ranked_vocab_terms`] ordered by descending frequency, ties broken by
+/// first-seen order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankedTerm {
+    pub term: String,
+    pub freq: u32,
+}
+
+/// Streaming frequency accumulator for identifiers. Fold one file's contents in
+/// at a time via [`VocabAccumulator::add_source`]; the file's `String` can be
+/// dropped immediately after, so peak memory is bounded by the number of unique
+/// terms (not the total bytes read). [`VocabAccumulator::ranked`] then produces a
+/// deterministic descending-frequency ranking.
+#[derive(Default)]
+pub struct VocabAccumulator {
+    /// lowercased key -> occurrence count.
+    freq: HashMap<String, u32>,
+    /// lowercased key -> first surface form seen (preserves original casing).
+    surface: HashMap<String, String>,
+    /// lowercased key -> first-seen ordinal (for stable tie-breaks).
+    order: HashMap<String, usize>,
+    next_order: usize,
+}
+
+impl VocabAccumulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Extract identifiers from `source` and fold their counts into the running
+    /// tallies. The caller may drop `source` immediately afterward — nothing from
+    /// it is retained beyond the per-term bookkeeping above.
+    pub fn add_source(&mut self, source: &str) {
+        for ident in extract_identifiers(source) {
+            self.add_identifier(&ident);
+        }
+    }
+
+    /// Fold a single already-extracted identifier into the tallies.
+    fn add_identifier(&mut self, ident: &str) {
+        let key = ident.to_ascii_lowercase();
+        *self.freq.entry(key.clone()).or_insert(0) += 1;
+        self.surface.entry(key.clone()).or_insert_with(|| ident.to_string());
+        let next = &mut self.next_order;
+        self.order.entry(key).or_insert_with(|| {
+            let o = *next;
+            *next += 1;
+            o
+        });
+    }
+
+    /// Number of distinct (case-insensitive) terms accumulated so far. The walk
+    /// hands this to the `on_file` callback so the live UI counter never has to
+    /// re-extract identifiers from already-folded file contents.
+    pub fn len(&self) -> usize {
+        self.freq.len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.freq.is_empty()
+    }
+
+    /// Produce the deterministic ranking: descending frequency, ties broken by
+    /// ascending first-seen order, truncated to `max_terms`. `max_terms == 0`
+    /// yields an empty vector.
+    pub fn ranked(&self, max_terms: usize) -> Vec<RankedTerm> {
+        if max_terms == 0 {
+            return Vec::new();
+        }
+        let mut ranked: Vec<(&String, u32)> = self.freq.iter().map(|(k, v)| (k, *v)).collect();
+        // Sort by descending frequency, then ascending first-seen order for stable ties.
+        ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| self.order[a.0].cmp(&self.order[b.0])));
+        ranked
+            .into_iter()
+            .take(max_terms)
+            .map(|(k, freq)| RankedTerm {
+                term: self.surface[k].clone(),
+                freq,
+            })
+            .collect()
+    }
+}
+
+/// Rank identifiers across in-memory file contents into `(term, freq)` pairs.
 ///
 /// Pure: takes `(label, contents)` pairs (the label is only used for ordering
 /// stability and is otherwise ignored), extracts identifiers from every file,
 /// dedupes case-insensitively, ranks by descending frequency (ties broken by
-/// first-seen order for determinism), and returns the top `max_terms` joined by
-/// spaces — directly usable as `params.set_initial_prompt(...)`.
-pub fn build_vocab_prompt<S: AsRef<str>>(files: &[(S, S)], max_terms: usize) -> String {
-    if max_terms == 0 {
-        return String::new();
-    }
-
-    // frequency by lowercased key; remember the first surface form and first-seen
-    // order so ranking is deterministic across runs.
-    let mut freq: HashMap<String, u32> = HashMap::new();
-    let mut surface: HashMap<String, String> = HashMap::new();
-    let mut order: HashMap<String, usize> = HashMap::new();
-    let mut next_order = 0usize;
-
+/// first-seen order for determinism), and returns the top `max_terms`. The
+/// joined-string [`build_vocab_prompt`] is a thin wrapper over this.
+///
+/// Retained as a pure, unit-tested reference for the ranking contract; the live
+/// directory scan folds per-file via [`VocabAccumulator`] (which this delegates
+/// to) so it never needs every file's contents resident at once.
+#[allow(dead_code)]
+pub fn ranked_vocab_terms<S: AsRef<str>>(files: &[(S, S)], max_terms: usize) -> Vec<RankedTerm> {
+    let mut acc = VocabAccumulator::new();
     for (_label, contents) in files {
-        for ident in extract_identifiers(contents.as_ref()) {
-            let key = ident.to_ascii_lowercase();
-            *freq.entry(key.clone()).or_insert(0) += 1;
-            surface.entry(key.clone()).or_insert_with(|| ident.clone());
-            order.entry(key.clone()).or_insert_with(|| {
-                let o = next_order;
-                next_order += 1;
-                o
-            });
-        }
+        acc.add_source(contents.as_ref());
     }
+    acc.ranked(max_terms)
+}
 
-    let mut ranked: Vec<(&String, u32)> = freq.iter().map(|(k, v)| (k, *v)).collect();
-    // Sort by descending frequency, then ascending first-seen order for stable ties.
-    ranked.sort_by(|a, b| {
-        b.1.cmp(&a.1)
-            .then_with(|| order[a.0].cmp(&order[b.0]))
-    });
+/// Build a Whisper initial-prompt string from in-memory file contents.
+///
+/// Pure: ranks identifiers via [`ranked_vocab_terms`] and joins the top
+/// `max_terms` surface forms by spaces — directly usable as
+/// `params.set_initial_prompt(...)`. Retained as the in-memory convenience entry
+/// (and ranking-contract reference) used by tests; the live scan path joins via
+/// [`ranked_terms_to_prompt`] on the streamed [`VocabAccumulator`] ranking.
+#[allow(dead_code)]
+pub fn build_vocab_prompt<S: AsRef<str>>(files: &[(S, S)], max_terms: usize) -> String {
+    ranked_terms_to_prompt(&ranked_vocab_terms(files, max_terms))
+}
 
+/// Join a ranked term list into a space-separated Whisper initial prompt,
+/// preserving rank order. Shared by [`build_vocab_prompt`] and the directory
+/// scan so the prompt string and the ranked list never drift out of sync.
+pub fn ranked_terms_to_prompt(ranked: &[RankedTerm]) -> String {
     ranked
-        .into_iter()
-        .take(max_terms)
-        .map(|(k, _)| surface[k].clone())
+        .iter()
+        .map(|r| r.term.as_str())
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -278,32 +361,73 @@ pub fn build_vocab_prompt<S: AsRef<str>>(files: &[(S, S)], max_terms: usize) -> 
 // this just walks a directory, applies the size/count guards, and reads files.
 // ---------------------------------------------------------------------------
 
+/// Result of walking a project folder: the folded frequency [`VocabAccumulator`]
+/// (identifiers ranked on demand — file contents are *not* retained, so memory is
+/// bounded by unique-term count, not bytes read), how many files were read, how
+/// many directories we declined to descend into, the total bytes read, and
+/// whether the walk stopped *early* on a guard (MAX_FILES / MAX_TOTAL_BYTES)
+/// before the tree was exhausted. `capped` is what the UI surfaces to explain a
+/// partial scan; it is `false` when the walk simply ran dry.
+pub struct ScanOutcome {
+    pub vocab: VocabAccumulator,
+    pub files_read: usize,
+    pub dirs_skipped: usize,
+    pub total_bytes: u64,
+    pub capped: bool,
+}
+
 /// Walk `folder`, read up to the guarded number/size of source files, and build
 /// a vocabulary prompt of at most `max_terms` identifiers. Unreadable files are
 /// logged and skipped. Returns an empty string if nothing usable is found.
 ///
 /// This function is deliberately not unit-tested (it touches the filesystem);
 /// all of its non-trivial logic delegates to the pure functions above.
-#[allow(dead_code)]
 pub fn build_vocab_prompt_from_dir(folder: &Path, max_terms: usize) -> String {
-    let files = collect_source_files(folder);
-    if files.is_empty() {
-        return String::new();
-    }
-    build_vocab_prompt(&files, max_terms)
+    let outcome = collect_source_files(folder, |_, _| {}, |_| {});
+    ranked_terms_to_prompt(&outcome.vocab.ranked(max_terms))
 }
 
-/// Iteratively walk `folder` (no recursion to bound stack), honoring the file
-/// count, per-file size, total-byte, extension, and skip-dir guards. Returns
-/// `(path_string, contents)` pairs ready for [`build_vocab_prompt`].
-#[allow(dead_code)]
-fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
-    let mut files: Vec<(String, String)> = Vec::new();
+/// Iteratively walk `folder` **breadth-first** (FIFO queue, no recursion to
+/// bound stack), honoring the file count, per-file size, total-byte, extension,
+/// and skip-dir guards. Breadth-first so a parent folder (e.g. `~/code`) samples
+/// fairly across its child projects instead of exhausting the file budget by
+/// depth-diving the first subdirectory it finds.
+///
+/// `on_file` is invoked once per source file successfully read, with the file's
+/// path and the running distinct-term count after that file was folded in (so a
+/// caller can surface a live term tally *without* re-extracting identifiers — the
+/// walk already folds each file into the accumulator). `on_skip` is invoked once
+/// per dependency/build/hidden dir declined, with that dir's path. Callers use
+/// both to surface a live scan stream (file rows and struck-through skip rows)
+/// with running counts. Returns a [`ScanOutcome`] recording the files,
+/// skipped-dir count, bytes read, and whether a guard cut the walk short
+/// (`capped`).
+pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
+    folder: &Path,
+    mut on_file: F,
+    mut on_skip: G,
+) -> ScanOutcome {
+    // Fold each file's identifiers in as we read it, then drop the contents — so
+    // peak memory is bounded by the unique-term count, not the bytes scanned.
+    let mut vocab = VocabAccumulator::new();
+    let mut files_read: usize = 0;
     let mut total_bytes: u64 = 0;
-    let mut stack: Vec<std::path::PathBuf> = vec![folder.to_path_buf()];
+    let mut dirs_skipped: usize = 0;
+    let mut capped = false;
+    // FIFO queue (breadth-first): dirs are processed in the order discovered, so
+    // the file budget spreads across sibling subtrees rather than the first one.
+    let mut queue: std::collections::VecDeque<std::path::PathBuf> =
+        std::collections::VecDeque::new();
+    queue.push_back(folder.to_path_buf());
 
-    while let Some(dir) = stack.pop() {
-        if files.len() >= MAX_FILES || total_bytes >= MAX_TOTAL_BYTES {
+    'walk: while let Some(dir) = queue.pop_front() {
+        // Stop once a guard is hit, but do NOT mark `capped` here: popping another
+        // queued dir at/after the cap doesn't prove readable content was skipped
+        // (the remaining dirs may be empty/non-source). `capped` is set only at the
+        // inner break below, where a guard actually blocks reading a candidate
+        // source file — so it never raises a false "hit the cap" warning on a scan
+        // that read exactly MAX_FILES and had nothing left to read.
+        if files_read >= MAX_FILES || total_bytes >= MAX_TOTAL_BYTES {
             break;
         }
         let entries = match std::fs::read_dir(&dir) {
@@ -316,7 +440,12 @@ fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
             }
         };
 
-        for entry in entries.flatten() {
+        // Sort entries by name so repeat scans of the same tree are stable
+        // (read_dir order is filesystem-dependent).
+        let mut sorted: Vec<std::fs::DirEntry> = entries.flatten().collect();
+        sorted.sort_by_key(|e| e.file_name());
+
+        for entry in sorted {
             let path = entry.path();
             let file_type = match entry.file_type() {
                 Ok(t) => t,
@@ -329,9 +458,11 @@ fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
                 // Skip well-known dependency/build dirs and any hidden dir
                 // (leading dot) — both are noise for a vocabulary scan.
                 if name.starts_with('.') || is_skipped_dir(&name) {
+                    dirs_skipped += 1;
+                    on_skip(&path);
                     continue;
                 }
-                stack.push(path);
+                queue.push_back(path);
                 continue;
             }
 
@@ -339,8 +470,9 @@ fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
                 continue;
             }
 
-            if files.len() >= MAX_FILES || total_bytes >= MAX_TOTAL_BYTES {
-                break;
+            if files_read >= MAX_FILES || total_bytes >= MAX_TOTAL_BYTES {
+                capped = true;
+                break 'walk;
             }
 
             // Per-file size guard before reading.
@@ -353,7 +485,14 @@ fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
             match std::fs::read_to_string(&path) {
                 Ok(contents) => {
                     total_bytes += contents.len() as u64;
-                    files.push((path.to_string_lossy().to_string(), contents));
+                    files_read += 1;
+                    // Fold the file's identifiers into the accumulator and drop the
+                    // contents — nothing keeps the `String` alive past this
+                    // iteration. Then hand the callback the running distinct-term
+                    // count so it never has to re-extract (which would double the
+                    // tokenization CPU on a large walk).
+                    vocab.add_source(&contents);
+                    on_file(&path, vocab.len());
                 }
                 Err(e) => {
                     #[cfg(not(test))]
@@ -364,7 +503,7 @@ fn collect_source_files(folder: &Path) -> Vec<(String, String)> {
         }
     }
 
-    files
+    ScanOutcome { vocab, files_read, dirs_skipped, total_bytes, capped }
 }
 
 #[cfg(test)]
@@ -509,6 +648,108 @@ mod tests {
         assert_eq!(prompt, "fooBar");
     }
 
+    // ---- Ranked (term, freq) pairs + budget split ----
+
+    #[test]
+    fn ranked_terms_returns_freq_and_rank_order() {
+        // barBaz 3x, fooBar 1x => barBaz first with freq 3, fooBar second freq 1.
+        let files = vec![("a.rs", "fooBar barBaz barBaz barBaz")];
+        let ranked = ranked_vocab_terms(&files, 10);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0], RankedTerm { term: "barBaz".into(), freq: 3 });
+        assert_eq!(ranked[1], RankedTerm { term: "fooBar".into(), freq: 1 });
+    }
+
+    #[test]
+    fn ranked_terms_respects_max_and_zero() {
+        let files = vec![("a.rs", "oneTwo threeFour fiveSix")];
+        assert_eq!(ranked_vocab_terms(&files, 2).len(), 2);
+        assert!(ranked_vocab_terms(&files, 0).is_empty());
+    }
+
+    #[test]
+    fn ranked_terms_drives_prompt_string() {
+        // build_vocab_prompt must equal the ranked list joined by spaces — the two
+        // share ranked_terms_to_prompt so the prompt and the ranked list can't drift.
+        let files = vec![("a.rs", "alphaOne betaTwo alphaOne")];
+        let ranked = ranked_vocab_terms(&files, 10);
+        assert_eq!(ranked_terms_to_prompt(&ranked), build_vocab_prompt(&files, 10));
+        assert_eq!(ranked[0].term, "alphaOne", "ranked={:?}", ranked);
+    }
+
+    #[test]
+    fn budget_split_top96_is_prefix_of_top500() {
+        // The Whisper budget (96) is the rank-prefix of the correction budget (500):
+        // both come from the same descending-frequency ranking, so the top 96 are
+        // exactly the first 96 of the top 500. Synthesize >96 distinct terms with
+        // strictly descending frequency so order is unambiguous.
+        let mut src = String::new();
+        for i in 0..150 {
+            // term i repeats (150 - i) times => strictly descending frequency.
+            for _ in 0..(150 - i) {
+                src.push_str(&format!("term{:03}X ", i));
+            }
+        }
+        let files = vec![("a.rs", src.as_str())];
+        let top500 = ranked_vocab_terms(&files, 500);
+        let top96 = ranked_vocab_terms(&files, 96);
+        assert_eq!(top500.len(), 150, "all 150 distinct terms fit under 500");
+        assert_eq!(top96.len(), 96, "Whisper budget truncates to 96");
+        // top96 is a strict prefix of top500 (same ranking, just truncated).
+        assert_eq!(&top500[..96], &top96[..]);
+        // whisperCount semantics: min(96, kept) == 96 here.
+        assert_eq!(top96.len().min(96), 96);
+    }
+
+    #[test]
+    fn budget_split_whisper_count_clamps_to_kept() {
+        // Fewer than 96 distinct terms => Whisper budget == kept count, not 96.
+        let files = vec![("a.rs", "alphaOne betaTwo gammaThree")];
+        let kept = ranked_vocab_terms(&files, 500);
+        assert_eq!(kept.len(), 3);
+        assert_eq!(kept.len().min(96), 3, "whisperCount clamps below 96");
+    }
+
+    // ---- Per-file streaming accumulator (bounded memory) ----
+
+    #[test]
+    fn accumulator_folds_per_file_without_retaining_contents() {
+        // Fold three files one String at a time, dropping each before the next —
+        // proving the ranking does NOT need all file contents resident at once.
+        let mut acc = VocabAccumulator::new();
+        {
+            let f1 = String::from("fooBar barBaz");
+            acc.add_source(&f1);
+            // f1 dropped here; nothing in `acc` borrows it.
+        }
+        {
+            let f2 = String::from("fooBar fooBar");
+            acc.add_source(&f2);
+        }
+        {
+            let f3 = String::from("quxQuux");
+            acc.add_source(&f3);
+        }
+        // fooBar seen 3x total across files => ranks first.
+        let ranked = acc.ranked(10);
+        assert_eq!(ranked[0], RankedTerm { term: "fooBar".into(), freq: 3 });
+        assert_eq!(acc.len(), 3, "fooBar, barBaz, quxQuux");
+        // Folding files one at a time matches ranking them all together.
+        let batch = ranked_vocab_terms(
+            &[("a", "fooBar barBaz"), ("b", "fooBar fooBar"), ("c", "quxQuux")],
+            10,
+        );
+        assert_eq!(ranked, batch, "streaming fold == batch ranking");
+    }
+
+    #[test]
+    fn accumulator_empty_is_empty() {
+        let acc = VocabAccumulator::new();
+        assert!(acc.is_empty());
+        assert_eq!(acc.len(), 0);
+        assert!(acc.ranked(10).is_empty());
+    }
+
     #[test]
     fn is_source_file_matches_extensions() {
         assert!(is_source_file(&PathBuf::from("a/b/c.rs")));
@@ -548,6 +789,119 @@ mod tests {
         assert!(MAX_FILES > 0);
         assert!(MAX_TOTAL_BYTES >= MAX_FILE_BYTES);
         assert!(!SOURCE_EXTENSIONS.is_empty());
+        // Caps were raised to accommodate the decoupled correction budget (top
+        // 500 terms) without scanning unbounded repos: 1000 files / 32MB total /
+        // 512KB per file. Pin the new values so an accidental downgrade is caught.
+        assert_eq!(MAX_FILES, 1000);
+        assert_eq!(MAX_TOTAL_BYTES, 32 * 1024 * 1024);
+        assert_eq!(MAX_FILE_BYTES, 512 * 1024);
+    }
+
+    // ---- Filesystem walk (breadth-first, guards, progress) ----
+
+    /// Create a unique scratch dir under the OS temp dir for a walk test.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        p.push(format!("murmur_vocab_test_{}_{}", tag, nanos));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn walk_reads_source_files_and_reports_progress() {
+        let dir = scratch_dir("read");
+        std::fs::write(dir.join("a.rs"), "let fooBar = barBaz;").unwrap();
+        std::fs::write(dir.join("b.ts"), "const useWidget = 1;").unwrap();
+        std::fs::write(dir.join("notes.md"), "ignored non-source").unwrap();
+
+        let mut seen = 0usize;
+        let mut last_term_count = 0usize;
+        let outcome = collect_source_files(
+            &dir,
+            |_, terms_so_far| {
+                seen += 1;
+                last_term_count = terms_so_far;
+            },
+            |_| {},
+        );
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(outcome.files_read, 2, "only the two source files");
+        assert_eq!(seen, 2, "progress callback fired once per file read");
+        // on_file receives the running distinct-term count (monotonically grows as
+        // files fold in); by the last file it equals the accumulator's total.
+        assert!(last_term_count > 0, "on_file receives a running term count");
+        assert_eq!(last_term_count, outcome.vocab.len(), "final tally matches accumulator");
+        assert!(!outcome.capped, "small tree should not be capped");
+        assert!(outcome.total_bytes > 0);
+        // The accumulator folded both files' identifiers (fooBar, barBaz, useWidget).
+        assert!(outcome.vocab.len() >= 3, "got {} terms", outcome.vocab.len());
+    }
+
+    #[test]
+    fn walk_skips_dependency_dirs_and_counts_them() {
+        let dir = scratch_dir("skip");
+        std::fs::create_dir_all(dir.join("node_modules")).unwrap();
+        std::fs::write(dir.join("node_modules").join("dep.js"), "var depThing = 1;").unwrap();
+        std::fs::create_dir_all(dir.join(".git")).unwrap();
+        std::fs::write(dir.join(".git").join("c.rs"), "let gitThing = 1;").unwrap();
+        std::fs::write(dir.join("main.rs"), "let realThing = 1;").unwrap();
+
+        let mut skipped: Vec<String> = Vec::new();
+        let outcome = collect_source_files(&dir, |_, _| {}, |p| {
+            skipped.push(p.file_name().unwrap().to_string_lossy().to_string());
+        });
+        std::fs::remove_dir_all(&dir).ok();
+
+        // Only the top-level real source file; the two skip-dirs are not descended.
+        assert_eq!(outcome.files_read, 1, "got {} files", outcome.files_read);
+        assert_eq!(outcome.dirs_skipped, 2, "node_modules + .git both skipped");
+        // on_skip fires once per declined dir, carrying its path.
+        assert_eq!(skipped.len(), 2, "on_skip fired per skipped dir, got {:?}", skipped);
+        assert!(skipped.contains(&"node_modules".to_string()), "got {:?}", skipped);
+        assert!(skipped.contains(&".git".to_string()), "got {:?}", skipped);
+    }
+
+    #[test]
+    fn walk_is_breadth_first_across_sibling_projects() {
+        // Two sibling project dirs, each with a source file two levels deep. A
+        // depth-first walk that exhausted a 1-file budget would only see one
+        // project; breadth-first must touch the shallow files of both first.
+        let dir = scratch_dir("bfs");
+        for proj in ["projA", "projB"] {
+            let src = dir.join(proj).join("src");
+            std::fs::create_dir_all(&src).unwrap();
+            std::fs::write(dir.join(proj).join(format!("{}Top.rs", proj)), "let topThing = 1;").unwrap();
+            std::fs::write(src.join("deepThing.rs"), "let deepThing = 1;").unwrap();
+        }
+
+        let mut order: Vec<String> = Vec::new();
+        let outcome = collect_source_files(&dir, |p, _| {
+            order.push(p.file_name().unwrap().to_string_lossy().to_string());
+        }, |_| {});
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(outcome.files_read, 4);
+        // Both shallow (top-level-of-project) files must come before either deep
+        // file — proof the walk is breadth-first, not depth-first.
+        let pos_a_top = order.iter().position(|n| n == "projATop.rs").unwrap();
+        let pos_b_top = order.iter().position(|n| n == "projBTop.rs").unwrap();
+        let pos_deep = order.iter().position(|n| n == "deepThing.rs").unwrap();
+        assert!(pos_a_top < pos_deep, "shallow projA file before deep, order={:?}", order);
+        assert!(pos_b_top < pos_deep, "shallow projB file before deep, order={:?}", order);
+    }
+
+    #[test]
+    fn walk_not_capped_when_tree_runs_dry() {
+        let dir = scratch_dir("dry");
+        std::fs::write(dir.join("only.rs"), "let oneThing = 1;").unwrap();
+        let outcome = collect_source_files(&dir, |_, _| {}, |_| {});
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(!outcome.capped, "exhausted tree under caps is not 'capped'");
     }
 
     #[test]

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
+import { VocabScanStrip } from './VocabScanStrip';
+import { useVocabScan } from '../../lib/hooks/useVocabScan';
 import { countVocabTokens } from '../../lib/dictation';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
@@ -440,15 +442,43 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     }
   };
 
+  // Code-vocab scan: live walker + ticking counts + done-state. Seeded from the
+  // persisted last-scan summary so reopening settings shows the prior result.
+  const vocabScan = useVocabScan(settings.codeVocabLastScan);
+  // useVocabScan returns a fresh object literal each render, but scan/cancel are
+  // stable useCallbacks — depend on the function, not the whole object, so
+  // runVocabScan (and the closures built from it) keep a stable identity.
+  const { scan: doScan } = vocabScan;
+
+  // Run a scan against a folder and persist its summary so the done-state
+  // survives a settings reopen. Persisting via onUpdateSettings keeps the hook
+  // and localStorage in sync (the hook also resolves to the summary).
+  const runVocabScan = useCallback(
+    async (folder: string) => {
+      if (!folder) return;
+      const summary = await doScan(folder);
+      if (summary) onUpdateSettings({ codeVocabLastScan: summary });
+    },
+    [doScan, onUpdateSettings],
+  );
+
   const handleChooseCodeVocabFolder = async () => {
     try {
       const selected = await open({ directory: true, multiple: false });
       if (typeof selected === 'string') {
         onUpdateSettings({ codeVocabFolder: selected });
+        // Auto-scan the freshly chosen folder.
+        void runVocabScan(selected);
       }
     } catch {
       // Dialog cancelled or unavailable — keep the current folder.
     }
+  };
+
+  // Clear the folder: also drop the persisted scan and reset the strip to idle.
+  const handleClearCodeVocabFolder = () => {
+    vocabScan.cancel();
+    onUpdateSettings({ codeVocabFolder: '', codeVocabLastScan: null });
   };
 
   const saveToFile = settings.saveTranscript || settings.saveAudio;
@@ -1180,13 +1210,24 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 </button>
                 {settings.codeVocabFolder && (
                   <button
-                    onClick={() => onUpdateSettings({ codeVocabFolder: '' })}
+                    onClick={handleClearCodeVocabFolder}
                     className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-500 dark:hover:text-stone-300 underline hover:no-underline transition-colors"
                   >
                     Clear
                   </button>
                 )}
               </div>
+
+              {/* Live scan feedback strip: idle / scanning / done+empty. */}
+              <VocabScanStrip
+                status={vocabScan.status}
+                walker={vocabScan.walker}
+                stats={vocabScan.stats}
+                folder={settings.codeVocabFolder}
+                onScan={() => void runVocabScan(settings.codeVocabFolder)}
+                onCancel={vocabScan.cancel}
+              />
+
               <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
                 Optional. When set, the folder is scanned once for your identifiers (dependency and build directories are skipped) and layered on top of the built-in terms. Re-select to rescan after big code changes.
               </p>

--- a/app/src/components/settings/VocabScanStrip.tsx
+++ b/app/src/components/settings/VocabScanStrip.tsx
@@ -184,11 +184,21 @@ export function VocabScanStrip({
               Point at a single project (e.g. <b>/code/murmur-app</b>) for full coverage.
             </WarnBox>
           )}
-          {/* empty result warning */}
+          {/* empty result warning — distinguish "no files scanned" from
+              "scanned files but no identifiers" (status==='empty' is terms===0). */}
           {!summary.capped && status === 'empty' && (
             <WarnBox>
-              Found <b>0 source files</b>. Wrong folder, or everything was in skipped dirs
-              (node_modules, target, .git).
+              {summary.files > 0 ? (
+                <>
+                  Scanned <b>{summary.files} files</b> but found <b>0 identifiers</b> —
+                  built-in dev terms still apply.
+                </>
+              ) : (
+                <>
+                  Found <b>0 source files</b>. Wrong folder, or everything was in skipped dirs
+                  (node_modules, target, .git).
+                </>
+              )}
             </WarnBox>
           )}
 

--- a/app/src/components/settings/VocabScanStrip.tsx
+++ b/app/src/components/settings/VocabScanStrip.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react';
+import type { VocabScanSummary } from '../../lib/settings';
+import type {
+  VocabScanStatus,
+  VocabScanStats,
+  WalkerRow,
+} from '../../lib/hooks/useVocabScan';
+import { VocabTermsModal } from './VocabTermsModal';
+
+interface VocabScanStripProps {
+  status: VocabScanStatus;
+  walker: WalkerRow[];
+  stats: VocabScanStats;
+  /** Absolute path of the folder being / to be scanned. Empty = none chosen. */
+  folder: string;
+  onScan: () => void;
+  onCancel: () => void;
+}
+
+/** Bytes -> compact "2.3 MB" / "812 KB" string. */
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 MB';
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `${mb.toFixed(1)} MB`;
+  const kb = bytes / 1024;
+  return `${Math.round(kb)} KB`;
+}
+
+function formatMs(ms: number): string {
+  if (ms <= 0) return '0.0s';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// The backend streams file reads and skipped dirs only (no dir-descent callback),
+// so the walker has just two row kinds.
+const ROW_ICON: Record<WalkerRow['kind'], string> = {
+  file: '›',
+  skip: '⊘',
+};
+
+const ROW_CLASS: Record<WalkerRow['kind'], string> = {
+  file: 'text-stone-500 dark:text-stone-500',
+  skip: 'text-stone-400 dark:text-stone-600 line-through opacity-60',
+};
+
+/**
+ * Three-state scan feedback strip (idle / scanning / done|empty) shown under the
+ * Project Folder field. Idle copy stays honest about the built-in dev terms;
+ * scanning streams the live walker + ticking counts; done surfaces the result
+ * stats, the amber 1000-file cap warning, and sample-term chips.
+ */
+export function VocabScanStrip({
+  status,
+  walker,
+  stats,
+  folder,
+  onScan,
+  onCancel,
+}: VocabScanStripProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const scanning = status === 'scanning';
+  const summary: VocabScanSummary | null = stats.summary;
+  // Result card needs the full Summary; only render it once invoke() has resolved.
+  const showResult = (status === 'done' || status === 'empty') && summary !== null;
+  // The walk has settled (terminal status) even if the Summary hasn't landed yet.
+  // Keep the progress bar full across that gap so it doesn't collapse to 0% for a
+  // few ms between the done tick and the invoke() resolution.
+  const settled = status === 'done' || status === 'empty';
+
+  // Status dot color.
+  const dotClass =
+    status === 'scanning'
+      ? 'bg-amber-500 animate-pulse'
+      : status === 'done'
+        ? 'bg-green-500'
+        : status === 'empty'
+          ? 'bg-amber-500'
+          : 'bg-stone-400 dark:bg-stone-500';
+
+  // Header label + sub copy per state. The terminal 'done'/'empty' status lands a
+  // few ms before invoke() resolves (the backend's final progress tick sets it),
+  // so `summary` can be briefly null while status is already terminal. Fall back
+  // to the live stats counters for the sub copy in that window so the header never
+  // flickers to the idle "Not scanned yet" text between the done tick and resolve.
+  let label: string;
+  let sub: string;
+  if (scanning) {
+    label = 'Scanning…';
+    sub = `${stats.filesRead} files · ${stats.dirsSkipped} dirs skipped · ${stats.termsSoFar} terms`;
+  } else if (status === 'done') {
+    label = 'Scan complete';
+    sub = summary
+      ? `${summary.terms} terms layered on top of built-ins · just now`
+      : `${stats.termsSoFar} terms layered on top of built-ins · just now`;
+  } else if (status === 'empty') {
+    label = 'No identifiers found';
+    sub = 'Folder had no source files — built-in dev terms still active.';
+  } else {
+    label = 'Not scanned yet';
+    sub = 'Built-in dev terms active. Scan this folder to add your own identifiers.';
+  }
+
+  // Primary action button.
+  const actionLabel = scanning
+    ? 'Cancel'
+    : status === 'done' || status === 'empty'
+      ? 'Rescan'
+      : 'Scan now';
+  const actionDisabled = !scanning && !folder;
+
+  return (
+    <div className="mt-3.5 overflow-hidden rounded-xl border border-stone-200 bg-stone-50 dark:border-stone-800 dark:bg-stone-950">
+      {/* status row */}
+      <div className="flex items-center gap-2.5 px-3 py-3">
+        <span className={`h-2 w-2 shrink-0 rounded-full ${dotClass}`} />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-stone-700 dark:text-stone-300">{label}</div>
+          <div className="mt-0.5 truncate text-[11px] tabular-nums text-stone-500 dark:text-stone-500">
+            {sub}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={scanning ? onCancel : onScan}
+          disabled={actionDisabled}
+          className={`shrink-0 whitespace-nowrap rounded-md border px-3 py-1.5 text-[11px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+            scanning
+              ? 'border-stone-300 text-stone-500 hover:border-stone-400 dark:border-stone-700 dark:text-stone-400'
+              : 'border-stone-300 bg-white text-stone-700 hover:border-stone-400 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-200 dark:hover:border-stone-400'
+          }`}
+        >
+          {actionLabel}
+        </button>
+      </div>
+
+      {/* progress bar */}
+      <div className="h-[3px] w-full overflow-hidden bg-stone-200 dark:bg-stone-800">
+        <div
+          className="h-full bg-amber-500 transition-[width] duration-300 ease-out"
+          style={{ width: scanning ? '66%' : settled ? '100%' : '0%' }}
+        />
+      </div>
+
+      {/* live walker (scanning only) */}
+      {scanning && (
+        <div className="relative max-h-[172px] overflow-hidden border-t border-stone-200 px-3 pb-3 pt-1 dark:border-stone-800">
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-[2] h-4 bg-gradient-to-b from-stone-50 to-transparent dark:from-stone-950" />
+          {walker.length === 0 ? (
+            <div className="py-2 font-mono text-[11px] text-stone-400 dark:text-stone-600">
+              Walking…
+            </div>
+          ) : (
+            walker.map((row) => (
+              <div
+                key={row.id}
+                className={`flex items-center gap-1.5 whitespace-nowrap font-mono text-[11px] leading-[1.85] ${ROW_CLASS[row.kind]}`}
+              >
+                <span className="w-3.5 shrink-0 text-center">{ROW_ICON[row.kind]}</span>
+                <span className="truncate">
+                  {row.path}
+                  {row.kind === 'skip' ? '  (skipped)' : ''}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* result card (done / empty) */}
+      {showResult && summary && (
+        <div className="border-t border-stone-200 px-3 py-3 dark:border-stone-800">
+          <div className="flex flex-wrap gap-4">
+            <Stat num={summary.terms.toLocaleString()} cap="terms" />
+            <Stat num={summary.files.toLocaleString()} cap="files read" />
+            <Stat num={summary.skipped.toLocaleString()} cap="dirs skipped" />
+            <Stat num={formatBytes(summary.bytes)} cap="scanned" />
+            <Stat num={formatMs(summary.ms)} cap="duration" />
+          </div>
+
+          {/* cap warning steers toward a single project */}
+          {summary.capped && (
+            <WarnBox>
+              Hit the <b>1,000-file cap</b> before finishing — some folders weren't indexed.
+              Point at a single project (e.g. <b>/code/murmur-app</b>) for full coverage.
+            </WarnBox>
+          )}
+          {/* empty result warning */}
+          {!summary.capped && status === 'empty' && (
+            <WarnBox>
+              Found <b>0 source files</b>. Wrong folder, or everything was in skipped dirs
+              (node_modules, target, .git).
+            </WarnBox>
+          )}
+
+          {/* sample-term chips */}
+          {summary.sampleTerms.length > 0 && (
+            <div className="mt-3">
+              <div className="mb-1.5 text-[10px] uppercase tracking-wide text-stone-500 dark:text-stone-500">
+                Top terms found
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {summary.sampleTerms.map((term) => (
+                  <span
+                    key={term}
+                    className="rounded-md border border-stone-200 bg-stone-100 px-2 py-0.5 font-mono text-[11px] text-stone-700 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                  >
+                    {term}
+                  </span>
+                ))}
+                {summary.terms > summary.sampleTerms.length && (
+                  <span className="rounded-md px-2 py-0.5 font-mono text-[11px] text-stone-400 dark:text-stone-500">
+                    +{summary.terms - summary.sampleTerms.length} more
+                  </span>
+                )}
+                {/* View-all link: only when the backend returned a ranked list. */}
+                {summary.rankedTerms.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setModalOpen(true)}
+                    className="ml-0.5 cursor-pointer text-[11px] font-semibold text-blue-500 underline hover:no-underline dark:text-blue-400"
+                  >
+                    View all {summary.rankedTerms.length} →
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* View-all pop-out (over the panel). Only mountable once a ranked scan exists. */}
+      {modalOpen && summary && summary.rankedTerms.length > 0 && (
+        <VocabTermsModal
+          summary={summary}
+          folder={folder}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function Stat({ num, cap }: { num: string; cap: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-lg font-semibold tabular-nums text-stone-800 dark:text-stone-200">
+        {num}
+      </span>
+      <span className="mt-px text-[10px] uppercase tracking-wide text-stone-500 dark:text-stone-500">
+        {cap}
+      </span>
+    </div>
+  );
+}
+
+function WarnBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-3 flex gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-600 dark:bg-amber-500/[0.08] dark:text-amber-500">
+      <svg
+        className="mt-px shrink-0"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/app/src/components/settings/VocabTermsModal.tsx
+++ b/app/src/components/settings/VocabTermsModal.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { RankedTerm, VocabScanSummary } from '../../lib/settings';
+
+interface VocabTermsModalProps {
+  /** The completed scan whose ranked terms are shown. */
+  summary: VocabScanSummary;
+  /** Absolute path of the scanned folder, shown in the subheader. */
+  folder: string;
+  onClose: () => void;
+}
+
+type SortMode = 'freq' | 'alpha';
+
+/**
+ * View-all pop-out for a code-vocab scan. Shows the full ranked term list
+ * (<=500) with a search filter and a frequency<->A-Z sort toggle. The top
+ * `whisperCount` terms feed Whisper's token-bound prompt (blue); the rest are
+ * Smart-Correction-only (green). When sorted by frequency without a search
+ * query, a sticky divider splits the two sections.
+ *
+ * Closes on Escape, the close button, and a click on the backdrop.
+ */
+export function VocabTermsModal({ summary, folder, onClose }: VocabTermsModalProps) {
+  const [query, setQuery] = useState('');
+  const [sortMode, setSortMode] = useState<SortMode>('freq');
+  const [copied, setCopied] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const ranked = summary.rankedTerms;
+  const whisperCount = summary.whisperCount;
+
+  // VocabScanStrip passes a fresh onClose closure each render. Stash it in a ref
+  // so the keydown/focus effect can attach exactly once for the modal's lifetime
+  // (empty deps) without tearing down the listener / rescheduling the focus timer
+  // on every parent re-render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Esc closes; focus the search box on open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCloseRef.current();
+    };
+    document.addEventListener('keydown', onKey);
+    const t = setTimeout(() => searchRef.current?.focus(), 60);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      clearTimeout(t);
+    };
+  }, []);
+
+  // Clean up the "Copied" reset timer on unmount.
+  useEffect(
+    () => () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+    },
+    [],
+  );
+
+  // Each ranked term carries its 1-based rank from the *original* frequency
+  // order (array index + 1) — that's what the feed-color and divider depend on,
+  // so it must survive re-sorting and filtering.
+  const withRank = useMemo(
+    () => ranked.map((t, i) => ({ ...t, rank: i + 1 })),
+    [ranked],
+  );
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    let list = q ? withRank.filter((t) => t.term.toLowerCase().includes(q)) : withRank;
+    if (sortMode === 'alpha') {
+      list = [...list].sort((a, b) => a.term.localeCompare(b.term));
+    }
+    return list;
+  }, [withRank, query, sortMode]);
+
+  // The sticky section dividers only make sense in frequency order with no
+  // active filter (otherwise rows aren't contiguous by section).
+  const showDividers = sortMode === 'freq' && query.trim() === '';
+
+  const handleCopyAll = () => {
+    const text = withRank.map((t) => t.term).join('\n');
+    void navigator.clipboard?.writeText(text);
+    setCopied(true);
+    if (copyResetRef.current) clearTimeout(copyResetRef.current);
+    copyResetRef.current = setTimeout(() => setCopied(false), 1200);
+  };
+
+  const countLabel = `${rows.length} ${rows.length === 1 ? 'term' : 'terms'}${
+    query.trim() ? ` matching "${query.trim()}"` : ''
+  }`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-6 backdrop-blur-[2px]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex max-h-[82vh] w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-2xl dark:border-stone-700 dark:bg-stone-900">
+        {/* header */}
+        <div className="border-b border-stone-200 px-[18px] pb-3 pt-4 dark:border-stone-800">
+          <div className="flex items-center justify-between">
+            <div className="text-[15px] font-semibold text-stone-800 dark:text-stone-200">
+              Scanned vocabulary
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="flex h-[26px] w-[26px] items-center justify-center rounded-md border border-stone-300 text-sm leading-none text-stone-500 transition-colors hover:border-stone-400 hover:text-stone-700 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-500 dark:hover:text-stone-200"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="mt-1 truncate text-[11px] text-stone-500 dark:text-stone-500">
+            {folder ? `${folder} · ` : ''}
+            {ranked.length} identifiers ranked by frequency
+          </div>
+          <div className="mt-2.5 flex flex-wrap gap-2">
+            <span className="flex items-center gap-1.5 rounded-md border border-blue-400/40 px-2 py-[3px] text-[10px] text-blue-500 dark:text-blue-400">
+              <span className="h-2 w-2 rounded-sm bg-blue-500 dark:bg-blue-400" />
+              top {whisperCount} → Whisper prompt
+            </span>
+            <span className="flex items-center gap-1.5 rounded-md border border-green-500/35 px-2 py-[3px] text-[10px] text-green-600 dark:text-green-500">
+              <span className="h-2 w-2 rounded-sm bg-green-500" />
+              all {ranked.length} → Smart Correction
+            </span>
+          </div>
+        </div>
+
+        {/* tools: search + sort */}
+        <div className="flex items-center gap-2.5 border-b border-stone-200 px-[18px] py-[11px] dark:border-stone-800">
+          <div className="flex flex-1 items-center gap-2 rounded-lg border border-stone-300 bg-stone-50 px-[11px] py-[7px] dark:border-stone-700 dark:bg-stone-950">
+            <svg
+              className="shrink-0 text-stone-500"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+            <input
+              ref={searchRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter terms…"
+              autoComplete="off"
+              spellCheck={false}
+              className="min-w-0 flex-1 border-none bg-transparent text-xs text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-200 dark:placeholder:text-stone-600"
+            />
+          </div>
+          <select
+            value={sortMode}
+            onChange={(e) => setSortMode(e.target.value as SortMode)}
+            className="cursor-pointer rounded-lg border border-stone-300 bg-stone-50 px-2.5 py-[7px] text-[11px] text-stone-600 dark:border-stone-700 dark:bg-stone-950 dark:text-stone-300"
+          >
+            <option value="freq">Sort: frequency</option>
+            <option value="alpha">Sort: A–Z</option>
+          </select>
+        </div>
+
+        {/* list */}
+        <div className="flex-1 overflow-y-auto py-1.5">
+          {rows.length === 0 ? (
+            <div className="px-[18px] py-8 text-center text-xs text-stone-400 dark:text-stone-600">
+              No terms match.
+            </div>
+          ) : (
+            <TermRows rows={rows} whisperCount={whisperCount} showDividers={showDividers} />
+          )}
+        </div>
+
+        {/* footer */}
+        <div className="flex items-center justify-between border-t border-stone-200 px-[18px] py-2.5 text-[11px] text-stone-500 dark:border-stone-800 dark:text-stone-500">
+          <span>{countLabel}</span>
+          <button
+            type="button"
+            onClick={handleCopyAll}
+            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-[11px] font-semibold text-stone-600 transition-colors hover:border-stone-400 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300 dark:hover:border-stone-500"
+          >
+            {copied ? 'Copied ✓' : 'Copy all'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type RankedRow = RankedTerm & { rank: number };
+
+/**
+ * Renders the term rows, inserting a sticky section divider before the first
+ * Whisper row and before the first correction-only row (only when
+ * `showDividers` — i.e. frequency-sorted and unfiltered).
+ */
+function TermRows({
+  rows,
+  whisperCount,
+  showDividers,
+}: {
+  rows: RankedRow[];
+  whisperCount: number;
+  showDividers: boolean;
+}) {
+  const total = rows.length;
+  let whisperHdrDone = false;
+  let belowHdrDone = false;
+  const out: React.ReactNode[] = [];
+
+  for (const t of rows) {
+    const inWhisper = t.rank <= whisperCount;
+    if (showDividers) {
+      if (inWhisper && !whisperHdrDone) {
+        whisperHdrDone = true;
+        out.push(
+          <Divider
+            key="hdr-whisper"
+            label={`Feeds Whisper prompt · top ${whisperCount}`}
+            tone="whisper"
+          />,
+        );
+      }
+      if (!inWhisper && !belowHdrDone) {
+        belowHdrDone = true;
+        out.push(
+          <Divider
+            key="hdr-below"
+            label={`Smart Correction only · ${whisperCount + 1}–${total}`}
+            tone="below"
+          />,
+        );
+      }
+    }
+    out.push(<TermRow key={`${t.rank}-${t.term}`} row={t} inWhisper={inWhisper} />);
+  }
+
+  return <>{out}</>;
+}
+
+function Divider({ label, tone }: { label: string; tone: 'whisper' | 'below' }) {
+  return (
+    <div
+      className={`sticky top-0 z-[1] flex items-center gap-2 bg-white px-[18px] pb-1.5 pt-2 text-[10px] uppercase tracking-wider dark:bg-stone-900 ${
+        tone === 'whisper'
+          ? 'text-blue-500 dark:text-blue-400'
+          : 'text-stone-500 dark:text-stone-500'
+      }`}
+    >
+      <span>{label}</span>
+      <span className="h-px flex-1 bg-stone-200 dark:bg-stone-800" />
+    </div>
+  );
+}
+
+function TermRow({ row, inWhisper }: { row: RankedRow; inWhisper: boolean }) {
+  return (
+    <div className="flex items-center gap-2.5 px-[18px] py-[5px] text-xs hover:bg-stone-50 dark:hover:bg-stone-800/40">
+      <span className="w-[30px] shrink-0 text-right text-[10px] tabular-nums text-stone-400 dark:text-stone-600">
+        {row.rank}
+      </span>
+      <span
+        className={`h-2 w-2 shrink-0 rounded-sm ${
+          inWhisper ? 'bg-blue-500 dark:bg-blue-400' : 'bg-green-500 opacity-60'
+        }`}
+      />
+      <span
+        className={`flex-1 truncate font-mono ${
+          inWhisper ? 'text-stone-800 dark:text-stone-200' : 'text-stone-500 dark:text-stone-400'
+        }`}
+      >
+        {row.term}
+      </span>
+      <span className="shrink-0 text-[10px] tabular-nums text-stone-400 dark:text-stone-500">
+        {row.freq}×
+      </span>
+    </div>
+  );
+}

--- a/app/src/lib/hooks/useVocabScan.ts
+++ b/app/src/lib/hooks/useVocabScan.ts
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { VocabScanSummary } from '../settings';
+
+/**
+ * Live progress payload streamed during the walk. Shape matches the Rust
+ * `vocab-scan-progress` event exactly (serde camelCase).
+ */
+export interface VocabScanProgress {
+  currentPath: string;
+  filesRead: number;
+  dirsSkipped: number;
+  termsSoFar: number;
+  done: boolean;
+}
+
+export type VocabScanStatus = 'idle' | 'scanning' | 'done' | 'empty';
+
+/** One streamed row in the live walker tree. */
+export interface WalkerRow {
+  /** Stable key for React lists (monotonic counter). */
+  id: number;
+  /**
+   * file = read for terms, skip = dependency/build dir skipped. The backend only
+   * fires on_file and on_skip — there is no "descended into a dir" callback — so
+   * every progress tick is one or the other; there is no 'dir' kind.
+   */
+  kind: 'file' | 'skip';
+  /** Display path (basename-ish — whatever the backend reports as currentPath). */
+  path: string;
+}
+
+/** Running counts surfaced while scanning + the final summary when done. */
+export interface VocabScanStats {
+  filesRead: number;
+  dirsSkipped: number;
+  termsSoFar: number;
+  /** Final command result; null until a scan completes. */
+  summary: VocabScanSummary | null;
+}
+
+const EVENT = 'vocab-scan-progress';
+const COMMAND = 'scan_code_vocab';
+/** Cap the in-memory walker so a huge repo can't grow the list unbounded. */
+const MAX_WALKER_ROWS = 200;
+
+const EMPTY_STATS: VocabScanStats = {
+  filesRead: 0,
+  dirsSkipped: 0,
+  termsSoFar: 0,
+  summary: null,
+};
+
+export interface UseVocabScan {
+  status: VocabScanStatus;
+  walker: WalkerRow[];
+  stats: VocabScanStats;
+  /** Start scanning `folder`. Resolves to the Summary (also surfaced via stats). */
+  scan: (folder: string) => Promise<VocabScanSummary | null>;
+  /** Stop listening and reset to idle (the backend walk runs to completion regardless). */
+  cancel: () => void;
+}
+
+/**
+ * Drives a code-vocabulary scan: invokes `scan_code_vocab`, subscribes to the
+ * throttled `vocab-scan-progress` stream, accumulates walker rows (capped in
+ * memory), and resolves to the Summary — `'done'` normally, `'empty'` when no
+ * terms were found.
+ *
+ * Cleanup is the load-bearing part. The active listener is torn down (a) on
+ * unmount, (b) at the start of every new scan (no double-subscribe), and
+ * (c) when the scan settles or `cancel()` is called (no leak). A run id guards
+ * against a stale scan's listener or promise mutating state after a newer scan
+ * has started.
+ *
+ * `initial` seeds the done-state from a persisted summary so the panel shows the
+ * last scan immediately on reopen, without re-walking.
+ */
+export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
+  const [status, setStatus] = useState<VocabScanStatus>(() =>
+    initial ? (initial.terms > 0 ? 'done' : 'empty') : 'idle',
+  );
+  const [walker, setWalker] = useState<WalkerRow[]>([]);
+  const [stats, setStats] = useState<VocabScanStats>(() =>
+    initial
+      ? {
+          filesRead: initial.files,
+          dirsSkipped: initial.skipped,
+          termsSoFar: initial.terms,
+          summary: initial,
+        }
+      : EMPTY_STATS,
+  );
+
+  // Active event unlisten fn + the run id it belongs to. Refs (not state) so the
+  // async scan() closure always sees the current listener without re-running.
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+  const runIdRef = useRef(0);
+  const rowIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  // Previous tick's CUMULATIVE backend counts, used to classify each new row as
+  // file vs. skip by delta. Tracked in refs (not re-derived from the rendered
+  // rows) so classification is O(1) and correct even after rows scroll past the
+  // MAX_WALKER_ROWS window — re-deriving from the truncated list misreported
+  // skips on large repos and misclassified file reads as skips.
+  const prevFilesRef = useRef(0);
+  const prevSkipsRef = useRef(0);
+
+  // Detach the active progress listener (idempotent). The pending listen()
+  // promise (if any) is handled by run-id guards in scan().
+  const detach = useCallback(() => {
+    if (unlistenRef.current) {
+      unlistenRef.current();
+      unlistenRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      detach();
+    };
+  }, [detach]);
+
+  const cancel = useCallback(() => {
+    // Bump the run id so any in-flight listen()/invoke from the cancelled scan
+    // is ignored, then detach and reset visible state.
+    runIdRef.current += 1;
+    detach();
+    prevFilesRef.current = 0;
+    prevSkipsRef.current = 0;
+    if (!mountedRef.current) return;
+    setStatus('idle');
+    setWalker([]);
+    setStats(EMPTY_STATS);
+  }, [detach]);
+
+  const scan = useCallback(
+    async (folder: string): Promise<VocabScanSummary | null> => {
+      // New run: invalidate any prior scan and tear down its listener so we
+      // never double-subscribe to the progress stream.
+      const runId = runIdRef.current + 1;
+      runIdRef.current = runId;
+      detach();
+      prevFilesRef.current = 0;
+      prevSkipsRef.current = 0;
+
+      if (mountedRef.current) {
+        setStatus('scanning');
+        setWalker([]);
+        setStats(EMPTY_STATS);
+      }
+
+      // Subscribe before invoking so we don't miss early progress events.
+      const unlisten = await listen<VocabScanProgress>(EVENT, (event) => {
+        // Stale listener from a superseded scan — ignore.
+        if (runId !== runIdRef.current || !mountedRef.current) return;
+        const p = event.payload;
+
+        // Terminal event: the backend's final tick carries the real cumulative
+        // counts and an empty path. Settle the running counters + terminal status
+        // deterministically from it, rather than racing the invoke() resolution.
+        // invoke's Summary remains the authoritative stats source (bytes, ms,
+        // sampleTerms, capped) and overwrites these counts when it lands.
+        if (p.done) {
+          setStats((prev) => ({
+            ...prev,
+            filesRead: p.filesRead,
+            dirsSkipped: p.dirsSkipped,
+            termsSoFar: p.termsSoFar,
+          }));
+          setStatus(p.termsSoFar > 0 ? 'done' : 'empty');
+          return;
+        }
+
+        setStats((prev) => ({
+          ...prev,
+          filesRead: p.filesRead,
+          dirsSkipped: p.dirsSkipped,
+          termsSoFar: p.termsSoFar,
+        }));
+
+        // The backend reports the most-recent path + cumulative counts. Classify
+        // the row by the delta of those cumulative counts against the previous
+        // tick (tracked in refs) so it's O(1) and independent of the truncated
+        // row window. A skip event bumps dirsSkipped; otherwise it's a file read.
+        const kind: WalkerRow['kind'] =
+          p.dirsSkipped > prevSkipsRef.current ? 'skip' : 'file';
+        prevFilesRef.current = p.filesRead;
+        prevSkipsRef.current = p.dirsSkipped;
+        setWalker((prev) => {
+          const row: WalkerRow = { id: rowIdRef.current++, kind, path: p.currentPath };
+          const next = [...prev, row];
+          return next.length > MAX_WALKER_ROWS ? next.slice(-MAX_WALKER_ROWS) : next;
+        });
+      });
+
+      // If a newer scan started (or we unmounted) while awaiting listen(), drop
+      // this listener immediately rather than leaking it.
+      if (runId !== runIdRef.current || !mountedRef.current) {
+        unlisten();
+        return null;
+      }
+      unlistenRef.current = unlisten;
+
+      try {
+        const summary = await invoke<VocabScanSummary>(COMMAND, { folder });
+        // Superseded or unmounted mid-walk — discard the result. Only tear down a
+        // listener that still belongs to THIS run: a newer scan has already
+        // installed its own listener into unlistenRef, and the shared detach()
+        // would unsubscribe that active newer walk (freezing its live feedback).
+        if (runId !== runIdRef.current || !mountedRef.current) {
+          if (runId === runIdRef.current) detach();
+          return null;
+        }
+        detach();
+        setStats({
+          filesRead: summary.files,
+          dirsSkipped: summary.skipped,
+          termsSoFar: summary.terms,
+          summary,
+        });
+        setStatus(summary.terms > 0 ? 'done' : 'empty');
+        return summary;
+      } catch (err) {
+        if (runId !== runIdRef.current || !mountedRef.current) {
+          if (runId === runIdRef.current) detach();
+          return null;
+        }
+        detach();
+        if (import.meta.env.DEV) console.debug('[useVocabScan]', err);
+        // Treat a failed scan as an empty result so the UI leaves the spinner.
+        setStatus('empty');
+        return null;
+      }
+    },
+    [detach],
+  );
+
+  return { status, walker, stats, scan, cancel };
+}

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -240,4 +240,111 @@ describe('loadSettings', () => {
     expect(settings.correctionEnabled).toBe(false);
     expect(settings.correctionFuzzy).toBe(false);
   });
+
+  it('defaults codeVocabLastScan to null when absent', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      model: 'base.en',
+      doubleTapKey: 'shift_l',
+      language: 'en',
+      recordingMode: 'hold_down',
+    }));
+    const settings = loadSettings();
+    expect(settings.codeVocabLastScan).toBeNull();
+  });
+
+  it('sanitizes a valid codeVocabLastScan with ranked terms', () => {
+    const scan = {
+      files: 87,
+      skipped: 6,
+      terms: 268,
+      bytes: 2_400_000,
+      capped: false,
+      ms: 610,
+      sampleTerms: ['useRecordingState', 'TranscriptionBackend'],
+      rankedTerms: [
+        { term: 'useRecordingState', freq: 42 },
+        { term: 'TranscriptionBackend', freq: 31 },
+      ],
+      whisperCount: 2,
+    };
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      codeVocabLastScan: scan,
+    }));
+    const settings = loadSettings();
+    expect(settings.codeVocabLastScan).toEqual(scan);
+  });
+
+  it('defaults rankedTerms/whisperCount on a pre-feature scan blob', () => {
+    // A scan summary persisted before this feature lacks rankedTerms/whisperCount.
+    const legacyScan = {
+      files: 10,
+      skipped: 1,
+      terms: 5,
+      bytes: 1000,
+      capped: false,
+      ms: 100,
+      sampleTerms: ['foo', 'bar'],
+    };
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      codeVocabLastScan: legacyScan,
+    }));
+    const settings = loadSettings();
+    expect(settings.codeVocabLastScan).not.toBeNull();
+    expect(settings.codeVocabLastScan!.rankedTerms).toEqual([]);
+    expect(settings.codeVocabLastScan!.whisperCount).toBe(0);
+    expect(settings.codeVocabLastScan!.sampleTerms).toEqual(['foo', 'bar']);
+  });
+
+  it('drops malformed ranked-term entries and clamps the list to 500', () => {
+    const ranked = [
+      { term: 'good', freq: 9 },
+      { term: 'noFreq' }, // missing freq -> dropped
+      { freq: 3 }, // missing term -> dropped
+      { term: '', freq: 1 }, // empty term -> dropped
+      { term: 'nanFreq', freq: Number.NaN }, // non-finite -> dropped
+      ...Array.from({ length: 600 }, (_, i) => ({ term: `t${i}`, freq: 1 })),
+    ];
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      codeVocabLastScan: {
+        ...DEFAULT_SETTINGS,
+        files: 1,
+        skipped: 0,
+        terms: 601,
+        bytes: 1,
+        capped: true,
+        ms: 1,
+        sampleTerms: ['good'],
+        rankedTerms: ranked,
+        whisperCount: 96,
+      },
+    }));
+    const settings = loadSettings();
+    const kept = settings.codeVocabLastScan!.rankedTerms;
+    expect(kept.length).toBe(500);
+    expect(kept[0]).toEqual({ term: 'good', freq: 9 });
+    // whisperCount stays valid since 96 <= 500 kept entries.
+    expect(settings.codeVocabLastScan!.whisperCount).toBe(96);
+  });
+
+  it('clamps whisperCount to the number of ranked terms kept', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      codeVocabLastScan: {
+        files: 1,
+        skipped: 0,
+        terms: 2,
+        bytes: 1,
+        capped: false,
+        ms: 1,
+        sampleTerms: ['a'],
+        rankedTerms: [{ term: 'a', freq: 2 }],
+        whisperCount: 96, // more than the single kept term
+      },
+    }));
+    const settings = loadSettings();
+    expect(settings.codeVocabLastScan!.whisperCount).toBe(1);
+  });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -58,6 +58,9 @@ export interface VocabScanSummary {
 /** Hard ceiling on the persisted ranked list, mirroring the backend cap. */
 const MAX_RANKED_TERMS = 500;
 
+/** Hard ceiling on the persisted sample-chip list (backend sends ~12). */
+const MAX_SAMPLE_TERMS = 50;
+
 export interface Settings {
   model: ModelOption;
   doubleTapKey: DoubleTapKey;
@@ -234,7 +237,7 @@ function sanitizeVocabScan(raw: unknown): VocabScanSummary | null {
           );
         })
         .slice(0, MAX_RANKED_TERMS)
-        .map((t) => ({ term: t.term, freq: t.freq }))
+        .map((t) => ({ term: t.term, freq: Math.max(0, Math.trunc(t.freq)) }))
     : [];
 
   // whisperCount is additive too; coerce anything non-finite to 0 and never let
@@ -245,14 +248,20 @@ function sanitizeVocabScan(raw: unknown): VocabScanSummary | null {
       ? Math.max(0, Math.min(Math.trunc(rawWhisper), rankedTerms.length))
       : 0;
 
+  // Counts passed the finite check above; coerce to non-negative integers so a
+  // tampered blob can't surface negative/fractional stats (NaN already rejected).
+  const count = (v: unknown) => Math.max(0, Math.trunc(v as number));
   return {
-    files: r.files as number,
-    skipped: r.skipped as number,
-    terms: r.terms as number,
-    bytes: r.bytes as number,
-    ms: r.ms as number,
+    files: count(r.files),
+    skipped: count(r.skipped),
+    terms: count(r.terms),
+    bytes: count(r.bytes),
+    ms: count(r.ms),
     capped: r.capped as boolean,
-    sampleTerms: (r.sampleTerms as unknown[]).filter((t): t is string => typeof t === 'string'),
+    // Bound the persisted sample list so a tampered blob can't bloat the chip row.
+    sampleTerms: (r.sampleTerms as unknown[])
+      .filter((t): t is string => typeof t === 'string')
+      .slice(0, MAX_SAMPLE_TERMS),
     rankedTerms,
     whisperCount,
   };

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -24,6 +24,40 @@ export interface VoiceCommand {
   replacement: string;
 }
 
+/**
+ * Result of a code-vocabulary scan. Shape matches the Rust `scan_code_vocab`
+ * command return value exactly (serde camelCase). Persisted so the settings
+ * panel can show the last completed scan when reopened.
+ */
+/** One ranked term actually kept by the scan. `rank` is the array index + 1. */
+export interface RankedTerm {
+  term: string;
+  freq: number;
+}
+
+export interface VocabScanSummary {
+  files: number;
+  skipped: number;
+  terms: number;
+  bytes: number;
+  capped: boolean;
+  ms: number;
+  /** Top ~12 written forms surfaced as sample chips. */
+  sampleTerms: string[];
+  /**
+   * Full ranked list of terms actually kept (<=500), ordered by frequency.
+   * rank = array index + 1. Powers the View-all pop-out. The top
+   * `whisperCount` of these also feed Whisper's token-bound prompt; the rest
+   * are Smart-Correction-only.
+   */
+  rankedTerms: RankedTerm[];
+  /** How many of `rankedTerms` feed the Whisper prompt (= min(96, len)). */
+  whisperCount: number;
+}
+
+/** Hard ceiling on the persisted ranked list, mirroring the backend cap. */
+const MAX_RANKED_TERMS = 500;
+
 export interface Settings {
   model: ModelOption;
   doubleTapKey: DoubleTapKey;
@@ -58,6 +92,11 @@ export interface Settings {
   codeVocabEnabled: boolean;
   /** Optional absolute path to a project folder scanned for code identifiers. */
   codeVocabFolder: string;
+  /**
+   * Last completed code-vocab scan summary, persisted so the settings panel
+   * shows the done-state on reopen. `null` until the folder has been scanned.
+   */
+  codeVocabLastScan: VocabScanSummary | null;
   /**
    * Post-model correction: apply the vocabulary to the transcript *output* of every
    * backend (Tier 1 exact map + Tier 2 sounds-like). On by default — it's what makes
@@ -154,6 +193,7 @@ export const DEFAULT_SETTINGS: Settings = {
   cleanupCapitalize: true,
   codeVocabEnabled: false,
   codeVocabFolder: '',
+  codeVocabLastScan: null,
   // Correction on by default: it's the fix that makes vocab actually apply on the
   // default Parakeet engine. A no-op when there's no vocabulary configured.
   correctionEnabled: true,
@@ -161,6 +201,62 @@ export const DEFAULT_SETTINGS: Settings = {
 };
 
 export const STORAGE_KEY = 'dictation-settings';
+
+/**
+ * Validate a persisted code-vocab scan summary. Returns a clean
+ * `VocabScanSummary` only when every field has the expected type; otherwise
+ * `null` (treated as "never scanned"). Keeps a malformed/partial blob from
+ * rendering NaN counts or a non-array chip list in the done-state.
+ */
+function sanitizeVocabScan(raw: unknown): VocabScanSummary | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const nums = ['files', 'skipped', 'terms', 'bytes', 'ms'] as const;
+  for (const k of nums) {
+    if (typeof r[k] !== 'number' || !Number.isFinite(r[k] as number)) return null;
+  }
+  if (typeof r.capped !== 'boolean') return null;
+  if (!Array.isArray(r.sampleTerms)) return null;
+
+  // rankedTerms is additive (absent on pre-feature blobs). Drop malformed
+  // entries, keep only well-formed { term:string, freq:finite-number } rows,
+  // and clamp the length to the backend cap so a bad blob can't bloat the modal.
+  const rankedTerms: RankedTerm[] = Array.isArray(r.rankedTerms)
+    ? (r.rankedTerms as unknown[])
+        .filter((t): t is RankedTerm => {
+          if (!t || typeof t !== 'object') return false;
+          const e = t as Record<string, unknown>;
+          return (
+            typeof e.term === 'string' &&
+            e.term.length > 0 &&
+            typeof e.freq === 'number' &&
+            Number.isFinite(e.freq)
+          );
+        })
+        .slice(0, MAX_RANKED_TERMS)
+        .map((t) => ({ term: t.term, freq: t.freq }))
+    : [];
+
+  // whisperCount is additive too; coerce anything non-finite to 0 and never let
+  // it exceed how many ranked terms we actually have.
+  const rawWhisper = r.whisperCount;
+  const whisperCount =
+    typeof rawWhisper === 'number' && Number.isFinite(rawWhisper)
+      ? Math.max(0, Math.min(Math.trunc(rawWhisper), rankedTerms.length))
+      : 0;
+
+  return {
+    files: r.files as number,
+    skipped: r.skipped as number,
+    terms: r.terms as number,
+    bytes: r.bytes as number,
+    ms: r.ms as number,
+    capped: r.capped as boolean,
+    sampleTerms: (r.sampleTerms as unknown[]).filter((t): t is string => typeof t === 'string'),
+    rankedTerms,
+    whisperCount,
+  };
+}
 
 export function loadSettings(): Settings {
   try {
@@ -259,6 +355,11 @@ export function loadSettings(): Settings {
       if (typeof parsed.codeVocabFolder !== 'string') {
         parsed.codeVocabFolder = DEFAULT_SETTINGS.codeVocabFolder;
       }
+
+      // codeVocabLastScan is a persisted scan summary (or null). Validate the
+      // whole shape — a partial/malformed blob would render bad numbers in the
+      // done-state, so coerce anything that doesn't match back to null.
+      parsed.codeVocabLastScan = sanitizeVocabScan(parsed.codeVocabLastScan);
 
       // Correction toggles — coerce non-booleans (or absent on pre-feature blobs)
       // back to defaults. correctionEnabled defaults ON, so an older settings blob


### PR DESCRIPTION
Delivers and extends #43 (code-aware vocabulary folder scan).

## What

**Live scan feedback** — choosing a project folder now shows a live scan strip: a breadth-first walk streams files and skipped dirs as it indexes, with running counts, a cap warning when the walk truncates, and the top terms found. Replaces the previous silent scan.

**View-all pop-out** — searchable, sortable modal of every kept identifier with frequency, split into the top-96 that feed Whisper's prompt vs the rest that feed Smart Correction.

**Decoupled budgets** — Whisper's prompt stays token-bound at the top 96; Smart Correction now consumes the top 500 (no token limit) — a recall win on every engine.

**Fairer + leaner scan** — breadth-first (FIFO, name-sorted) so a parent folder like `~/code` samples across sibling projects instead of depth-diving one. Memory bounded by extracting identifiers per file and dropping contents. Caps raised to 1000 files / 32 MB.

## Fixes (surfaced by live dictation)

- **Tier-2 no longer re-fragments Tier-1 output** — `_` is now a word char in Tier-2 tokenization, so `error_message` isn't split and a sub-token fuzzy-rewritten (`error` → `Errorf`).
- **Tier-2 over-correction** — only structured identifiers (camelCase/snake_case/digit) are fuzzy-eligible; plain words (`Errorf`, `kubectl`) are exact-only, so ordinary English isn't flipped to a scanned identifier.
- Smart Correction rebuilds with folder terms on the lazy/restart path (was built-in-only until an unrelated settings change).

## Verification

- `cargo test --lib` — 231 passed / 0 failed
- `npx tsc --noEmit` — clean
- `npx vitest run` — 67 passed
- Live dictation: folder-scan → correction confirmed 10/10 on a `~/code` scan, including the `error_message` fix.

## Not yet verified

- **View-all modal** not eyeballed against real data live (built + type-checked only).
- Built/tested in **debug** only — the release/Metal profile is first compiled by the release workflow.
- ggml `transcription_integration` test aborts locally (pre-existing, env-only, "not CI") — excluded; all lib tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live feedback while scanning a project’s vocabulary, including progress, scan stats, and a “view all terms” modal.
  * Added support for saving the most recent scan so results can be revisited later.
  * Improved vocabulary handling so more relevant terms are used for correction and suggestions.

* **Bug Fixes**
  * Reduced incorrect corrections for plain words.
  * Improved handling of snake_case terms so they are not broken apart during correction.
  * Fixed scan results refreshing after restart so saved folder vocabulary is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->