### PR TITLE
fix: bridge clients to the next updater channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,7 @@ jobs:
               --repo "${{ github.repository }}"
           done
 
-      - name: Generate and upload latest.json
+      - name: Generate and upload updater channel manifests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -352,8 +352,13 @@ jobs:
               notes: $notes
             }' > latest.json
 
-          cat latest.json
-          gh release upload "${TAG}" latest.json \
+          # v0.14.1 is the macOS 13-compatible bridge. Publishing identical
+          # manifests under both names moves installed clients from the legacy
+          # endpoint to latest-v2 without interrupting this release.
+          cp latest.json latest-v2.json
+          cmp latest.json latest-v2.json
+          cat latest-v2.json
+          gh release upload "${TAG}" latest.json latest-v2.json \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-16
+
+### Changed
+- Migrated installed clients to the `latest-v2.json` updater channel while retaining macOS 13 compatibility. This bridge release keeps automatic updates working before Murmur's macOS 14 transition.
+
 ## [0.14.0] - 2026-06-24
 
 ### Added

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.14.0"
+version = "0.14.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -73,7 +73,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/georgenijo/murmur-app/releases/latest/download/latest.json"
+        "https://github.com/georgenijo/murmur-app/releases/latest/download/latest-v2.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE1NUQ4ODNFNUE2MjQ4RDcKUldUWFNHSmFQb2hkcFRWNUpGSXRCZ3pITjFrc3Qvd01aczJSdDVvTEJROWw5bCt0bnRTY3d3SDIK"
     }

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -3,7 +3,7 @@ const LAST_CHECK_KEY = 'updater-last-check';
 export const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const LATEST_JSON_URL =
-  'https://github.com/georgenijo/murmur-app/releases/latest/download/latest.json';
+  'https://github.com/georgenijo/murmur-app/releases/latest/download/latest-v2.json';
 
 // --- Semver comparison ---
 
@@ -87,7 +87,7 @@ export function isDueForCheck(): boolean {
 // --- min_version fetch ---
 
 /**
- * Fetch the custom min_version field from latest.json.
+ * Fetch the custom min_version field from the current update channel.
  * Returns null if absent, fetch fails, or JSON is invalid.
  */
 export async function fetchMinVersion(): Promise<string | null> {

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -14,10 +14,18 @@ The app checks for updates on launch and every 24 hours. Updates are downloaded 
 The update manifest is fetched from:
 
 ```
-https://github.com/georgenijo/murmur-app/releases/latest/download/latest.json
+https://github.com/georgenijo/murmur-app/releases/latest/download/latest-v2.json
 ```
 
 This URL is configured in `tauri.conf.json` as the updater plugin endpoint. The fetch uses `cache: 'no-store'` to bypass browser caching.
+
+### macOS 14 Transition Bridge
+
+Version 0.14.1 remains compatible with macOS 13 and changes the installed
+updater endpoint from `latest.json` to `latest-v2.json`. Its release publishes
+the same signed macOS 13 artifact through both names. This lets a later release
+raise its deployment target without leaving existing installations behind or
+offering macOS 13 an application that cannot launch.
 
 The manifest contains version information, download URLs, signatures, and an optional `min_version` field for forced updates.
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -30,7 +30,7 @@ interface UseAutoUpdaterReturn {
 - Sends a macOS notification when an update is discovered during a background check.
 
 **Key interactions:**
-- Fetches `min_version` from GitHub releases `latest.json` via HTTP.
+- Fetches `min_version` from the current GitHub releases `latest-v2.json` channel via HTTP.
 - Stores skipped version in localStorage under `skipped-update-version`.
 - Stores last check timestamp in localStorage under `updater-last-check`.
 


### PR DESCRIPTION
## Summary
- ship a macOS 13-compatible v0.14.1 bridge that switches installed clients to `latest-v2.json`
- publish identical legacy and v2 manifests for the bridge release
- document the two-stage macOS 14 updater migration

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1`
- [x] `npx tsc --noEmit`
- [x] frontend tests (67 passed)
- [x] debug bundle inspection: one executable, macOS 13 minimum, v0.14.1, `latest-v2.json` endpoint
- [x] release workflow parses as YAML

## Release note
This PR does not create the v0.14.1 tag. The bridge must be released before the macOS 14 performance branch can ship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the automatic updater to use the `latest-v2.json` release channel.
  * Published updater metadata under both the existing and new channel names to support seamless updates.

* **Bug Fixes**
  * Preserved macOS 13 compatibility during the transition to the macOS 14 update path.

* **Documentation**
  * Updated updater documentation and changelog details for version 0.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->