### PR TITLE
feat: first-launch setup assistant (guided permissions + model onboarding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **First-launch setup assistant** — new installs get a guided wizard (Welcome → Microphone → Accessibility → Model download → Done) instead of a dismissible permissions banner next to a lone model-download screen. The microphone step fires the native macOS permission dialog in-app (new `request_microphone_access` command via `AVCaptureDevice.requestAccess`) instead of waiting for the first recording attempt; both permission steps poll live so a grant made in System Settings flips the step when you come back, and denied/stale-TCC states get inline reset-and-retry paths. Existing installs with permissions and a model already in place are grandfathered silently. Re-run anytime via Settings → About → Run Setup Assistant (`OnboardingFlow.tsx`, `lib/onboarding.ts`).
+
 ## [0.14.1] - 2026-07-16
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ cd app && npx tsc --noEmit         # TypeScript check
 Read these before working on a feature:
 
 - **[docs/onboarding.md](docs/onboarding.md)** — Setup, permissions, model installation, logs
+- **[docs/features/onboarding-flow.md](docs/features/onboarding-flow.md)** — First-launch setup assistant (permissions wizard + model download)
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript
@@ -35,7 +36,7 @@ Read these before working on a feature:
 | `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/recording.rs` | `IdleGuard`, transcription pipeline with VAD, 7 recording/status commands |
-| `commands/permissions.rs` | 6 permission and audio device commands |
+| `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
 | `commands/keyboard.rs` | 4 keyboard listener commands |
 | `commands/logging.rs` | 4 logging commands, delegates to telemetry.rs |
 | `commands/models.rs` | Model download pipeline and existence checks |
@@ -56,6 +57,7 @@ Read these before working on a feature:
 |------|---------|
 | `App.tsx` | Main orchestrator, wires hooks together |
 | `lib/settings.ts` | Settings types, defaults, localStorage persistence |
+| `lib/onboarding.ts` | First-launch setup-assistant completion flag |
 | `lib/events.ts` | Event types, stream/level definitions, color constants |
 | `lib/history.ts` | History entry types and localStorage persistence |
 | `lib/stats.ts` | Usage metrics: words, WPM, recordings, tokens |
@@ -72,6 +74,7 @@ Read these before working on a feature:
 | `lib/hooks/useShowAboutListener.ts` | Listens for show-about tray event |
 | `lib/hooks/useEventStore.ts` | Structured event log buffer with live streaming |
 | `lib/hooks/useResourceMonitor.ts` | CPU/memory polling with rolling buffer |
+| `components/onboarding/OnboardingFlow.tsx` | First-launch setup assistant (permissions + model wizard) |
 | `components/settings/SettingsPanel.tsx` | Settings UI with mode switching |
 | `components/log-viewer/LogViewerApp.tsx` | Structured event viewer with Events + Metrics tabs |
 | `components/OverlayWidget.tsx` | Dynamic Island notch overlay |

--- a/app/src-tauri/src/commands/permissions.rs
+++ b/app/src-tauri/src/commands/permissions.rs
@@ -124,6 +124,53 @@ pub fn request_microphone_permission() -> Result<(), String> {
     { Ok(()) }
 }
 
+/// Trigger the native macOS microphone permission prompt (TCC) in-flow.
+///
+/// Calls `AVCaptureDevice.requestAccessForMediaType:completionHandler:`. When the
+/// status is `notDetermined` this shows the system dialog and registers the app in
+/// the Microphone pane — without opening the device, so it cannot duck other apps'
+/// audio (issue #177). When the status is already determined the completion fires
+/// immediately and no dialog appears. Fire-and-forget: callers observe the outcome
+/// by polling `check_microphone_permission_status`, so this never blocks on the
+/// user's answer.
+#[tauri::command]
+pub fn request_microphone_access() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2::msg_send;
+        use objc2::runtime::{AnyClass, Bool};
+        use objc2_foundation::NSString;
+
+        unsafe {
+            let Some(cls) = AnyClass::get(c"AVCaptureDevice") else {
+                return Err("AVCaptureDevice is unavailable".to_string());
+            };
+            // AVMediaTypeAudio == @"soun"
+            let media = NSString::from_str("soun");
+            // The completion handler runs on an arbitrary dispatch queue after the
+            // user answers; the block only logs, all state reads go through the
+            // polling commands.
+            let handler = block2::RcBlock::new(|granted: Bool| {
+                tracing::info!(
+                    target: "system",
+                    "microphone access request completed: granted={}",
+                    granted.as_bool()
+                );
+            });
+            let _: () = msg_send![
+                cls,
+                requestAccessForMediaType: &*media,
+                completionHandler: &*handler
+            ];
+        }
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(())
+    }
+}
+
 /// Reset this app's stale macOS Microphone TCC entry, then reopen the pane.
 ///
 /// Mirrors `reset_accessibility_permission` for the case where the running build

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -135,6 +135,7 @@ pub fn run() {
             commands::permissions::request_accessibility_permission,
             commands::permissions::reset_accessibility_permission,
             commands::permissions::request_microphone_permission,
+            commands::permissions::request_microphone_access,
             commands::permissions::check_microphone_permission,
             commands::permissions::check_microphone_permission_status,
             commands::permissions::reset_microphone_permission,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,9 @@ const ResourceMonitor = lazy(() => import('./components/ResourceMonitor').then(m
 const UsageDashboard = lazy(() => import('./components/UsageDashboard').then(m => ({ default: m.UsageDashboard })));
 import { resetStats } from './lib/stats';
 import { ModelDownloader } from './components/ModelDownloader';
+import { OnboardingFlow } from './components/onboarding/OnboardingFlow';
+import { isOnboardingComplete, markOnboardingComplete, resetOnboarding } from './lib/onboarding';
+import { checkMicrophonePermissionStatus } from './lib/dictation';
 
 function App() {
   // --- Diagnostic: track when main window becomes visible/focused ---
@@ -65,6 +68,39 @@ function App() {
       .catch(() => setModelReady(true)); // fail open so main UI still loads
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Setup-assistant gate. Runs when the completion flag is absent, but
+  // grandfathers existing installs: if both permissions and the model are
+  // already in place, set the flag silently so upgrades never see the wizard.
+  const [onboardingState, setOnboardingState] = useState<'unknown' | 'needed' | 'done'>('unknown');
+  useEffect(() => {
+    if (isOnboardingComplete()) {
+      setOnboardingState('done');
+      return;
+    }
+    (async () => {
+      const [micStatus, axGranted, modelExists] = await Promise.all([
+        checkMicrophonePermissionStatus().catch(() => 'unknown' as const),
+        invoke<boolean>('check_accessibility_permission').catch(() => false),
+        invoke<boolean>('check_specific_model_exists', { modelName: settings.model }).catch(() => false),
+      ]);
+      if (micStatus === 'granted' && axGranted && modelExists) {
+        flog.info('main', 'Onboarding grandfathered: permissions and model already present');
+        markOnboardingComplete();
+        setOnboardingState('done');
+      } else {
+        flog.info('main', 'Onboarding needed', { micStatus, axGranted, modelExists });
+        setOnboardingState('needed');
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const completeOnboarding = useCallback((model: typeof settings.model) => {
+    markOnboardingComplete();
+    markModelReady(model);
+    setOnboardingState('done');
+  }, [markModelReady]);
 
   // Keep settings in sync when the overlay's quick controls change them.
   useOverlaySettingsSync(applyExternalSettings);
@@ -137,7 +173,17 @@ function App() {
 
   const error = initError || recordingError;
 
-  if (modelReady === null) return <div className="h-screen bg-stone-50 dark:bg-stone-900" />;
+  if (onboardingState === 'unknown' || modelReady === null) {
+    return <div className="h-screen bg-stone-50 dark:bg-stone-900" />;
+  }
+  if (onboardingState === 'needed') {
+    return (
+      <OnboardingFlow
+        initialModel={settings.model}
+        onComplete={completeOnboarding}
+      />
+    );
+  }
   if (modelReady === false) {
     return (
       <ModelDownloader
@@ -217,6 +263,11 @@ function App() {
           status={status}
           onResetStats={handleResetStats}
           onViewLogs={() => invoke('open_log_viewer').catch((e: unknown) => flog.warn('main', 'Failed to open log viewer', { error: String(e) }))}
+          onRerunSetup={() => {
+            setIsSettingsOpen(false);
+            resetOnboarding();
+            setOnboardingState('needed');
+          }}
           accessibilityGranted={accessibilityGranted}
           onCheckForUpdate={checkForUpdate}
           updateStatus={updateStatus}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -127,10 +127,14 @@ function App() {
   const [statsResetVersion, setStatsResetVersion] = useState(0);
   const combinedStatsVersion = statsVersion + statsResetVersion;
   const handleResetStats = () => { resetStats(); setStatsResetVersion(v => v + 1); };
-  useHoldDownToggle({ enabled: settings.recordingMode === 'hold_down', initialized, accessibilityGranted, holdDownKey: settings.doubleTapKey, onStart: handleStart, onStop: handleStop });
-  useDoubleTapToggle({ enabled: settings.recordingMode === 'double_tap', initialized, accessibilityGranted, doubleTapKey: settings.doubleTapKey, status, onToggle: toggleRecording });
-  useCombinedToggle({ enabled: settings.recordingMode === 'both', initialized, accessibilityGranted, triggerKey: settings.doubleTapKey, status, onStart: handleStart, onStop: handleStop, onToggle: toggleRecording });
-  useEscapeCancel({ status, enabled: initialized && accessibilityGranted === true });
+  // Keep the global hotkeys disarmed until onboarding completes — accessibility
+  // can be granted mid-wizard, and a hold/double-tap must not start a recording
+  // behind the OnboardingFlow screen.
+  const hotkeysArmed = onboardingState === 'done';
+  useHoldDownToggle({ enabled: hotkeysArmed && settings.recordingMode === 'hold_down', initialized, accessibilityGranted, holdDownKey: settings.doubleTapKey, onStart: handleStart, onStop: handleStop });
+  useDoubleTapToggle({ enabled: hotkeysArmed && settings.recordingMode === 'double_tap', initialized, accessibilityGranted, doubleTapKey: settings.doubleTapKey, status, onToggle: toggleRecording });
+  useCombinedToggle({ enabled: hotkeysArmed && settings.recordingMode === 'both', initialized, accessibilityGranted, triggerKey: settings.doubleTapKey, status, onStart: handleStart, onStop: handleStop, onToggle: toggleRecording });
+  useEscapeCancel({ status, enabled: hotkeysArmed && initialized && accessibilityGranted === true });
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 
@@ -180,6 +184,8 @@ function App() {
     return (
       <OnboardingFlow
         initialModel={settings.model}
+        recordingMode={settings.recordingMode}
+        triggerKey={settings.doubleTapKey}
         onComplete={completeOnboarding}
       />
     );

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -29,7 +29,7 @@ import { resetStats } from './lib/stats';
 import { ModelDownloader } from './components/ModelDownloader';
 import { OnboardingFlow } from './components/onboarding/OnboardingFlow';
 import { isOnboardingComplete, markOnboardingComplete, resetOnboarding } from './lib/onboarding';
-import { checkMicrophonePermissionStatus } from './lib/dictation';
+import { checkAccessibilityPermission, checkMicrophonePermissionStatus, checkModelExists } from './lib/dictation';
 
 function App() {
   // --- Diagnostic: track when main window becomes visible/focused ---
@@ -63,7 +63,7 @@ function App() {
   // mount (not reactively) so changing models in Settings uses the inline
   // download flow there rather than re-showing this full-screen downloader.
   useEffect(() => {
-    invoke<boolean>('check_specific_model_exists', { modelName: settings.model })
+    checkModelExists(settings.model)
       .then(setModelReady)
       .catch(() => setModelReady(true)); // fail open so main UI still loads
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -81,8 +81,8 @@ function App() {
     (async () => {
       const [micStatus, axGranted, modelExists] = await Promise.all([
         checkMicrophonePermissionStatus().catch(() => 'unknown' as const),
-        invoke<boolean>('check_accessibility_permission').catch(() => false),
-        invoke<boolean>('check_specific_model_exists', { modelName: settings.model }).catch(() => false),
+        checkAccessibilityPermission().catch(() => false),
+        checkModelExists(settings.model).catch(() => false),
       ]);
       if (micStatus === 'granted' && axGranted && modelExists) {
         flog.info('main', 'Onboarding grandfathered: permissions and model already present');

--- a/app/src/components/ModelDownloader.tsx
+++ b/app/src/components/ModelDownloader.tsx
@@ -26,6 +26,8 @@ const MODELS = DOWNLOAD_MODEL_KEYS.map((key) => {
 interface Props {
   initialModel: ModelOption;
   onComplete: (model: ModelOption) => void;
+  /** Notifies embedders when a download starts/stops (e.g. to lock navigation). */
+  onDownloadingChange?: (downloading: boolean) => void;
 }
 
 type DownloadState =
@@ -33,7 +35,12 @@ type DownloadState =
   | { phase: 'downloading'; received: number; total: number }
   | { phase: 'error'; message: string };
 
-export function ModelDownloader({ initialModel, onComplete }: Props) {
+/**
+ * Model picker + download progress card, without the full-screen chrome.
+ * Used by the standalone first-launch gate (ModelDownloader) and embedded in
+ * the onboarding wizard's model step (OnboardingFlow).
+ */
+export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChange }: Props) {
   const [selected, setSelected] = useState<ModelOption>(
     MODELS.some((model) => model.name === initialModel) ? initialModel : MODELS[0].name
   );
@@ -48,6 +55,7 @@ export function ModelDownloader({ initialModel, onComplete }: Props) {
   }, []);
 
   const handleDownload = async () => {
+    onDownloadingChange?.(true);
     setDownloadState({ phase: 'downloading', received: 0, total: 0 });
 
     const unlisten = await listen<{ received: number; total: number }>(
@@ -66,10 +74,12 @@ export function ModelDownloader({ initialModel, onComplete }: Props) {
       await invoke('download_model', { modelName: selected });
       unlisten();
       downloadUnlistenRef.current = null;
+      onDownloadingChange?.(false);
       onComplete(selected);
     } catch (err) {
       unlisten();
       downloadUnlistenRef.current = null;
+      onDownloadingChange?.(false);
       setDownloadState({
         phase: 'error',
         message: String(err),
@@ -85,16 +95,8 @@ export function ModelDownloader({ initialModel, onComplete }: Props) {
   const isDownloading = downloadState.phase === 'downloading';
 
   return (
-    <div className="h-screen bg-stone-50 dark:bg-stone-900 flex flex-col items-center justify-center p-8">
-      <div className="w-full max-w-md">
-        <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100 mb-1">
-          Download a Model
-        </h1>
-        <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
-          A model file is required for transcription. Choose one to download.
-        </p>
-
-        <div className="space-y-2 mb-6">
+    <div>
+      <div className="space-y-2 mb-6">
           {MODELS.map((model) => (
             <button
               key={model.name}
@@ -163,6 +165,25 @@ export function ModelDownloader({ initialModel, onComplete }: Props) {
             ? 'Retry Download'
             : 'Download'}
         </button>
+    </div>
+  );
+}
+
+/**
+ * Full-screen first-launch gate shown when the selected model is missing but
+ * onboarding has already completed (e.g. the model file was deleted).
+ */
+export function ModelDownloader({ initialModel, onComplete }: Props) {
+  return (
+    <div className="h-screen bg-stone-50 dark:bg-stone-900 flex flex-col items-center justify-center p-8">
+      <div className="w-full max-w-md">
+        <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100 mb-1">
+          Download a Model
+        </h1>
+        <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
+          A model file is required for transcription. Choose one to download.
+        </p>
+        <ModelDownloadPanel initialModel={initialModel} onComplete={onComplete} />
       </div>
     </div>
   );

--- a/app/src/components/ModelDownloader.tsx
+++ b/app/src/components/ModelDownloader.tsx
@@ -58,26 +58,29 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
     onDownloadingChange?.(true);
     setDownloadState({ phase: 'downloading', received: 0, total: 0 });
 
-    const unlisten = await listen<{ received: number; total: number }>(
-      'download-progress',
-      (event) => {
-        setDownloadState({
-          phase: 'downloading',
-          received: event.payload.received,
-          total: event.payload.total,
-        });
-      }
-    );
-    downloadUnlistenRef.current = unlisten;
-
+    // Single try/catch covering listen() as well as the download itself, so a
+    // listen failure can't strand the downloading state (or an embedder's
+    // navigation lock) forever.
     try {
+      const unlisten = await listen<{ received: number; total: number }>(
+        'download-progress',
+        (event) => {
+          setDownloadState({
+            phase: 'downloading',
+            received: event.payload.received,
+            total: event.payload.total,
+          });
+        }
+      );
+      downloadUnlistenRef.current = unlisten;
+
       await invoke('download_model', { modelName: selected });
       unlisten();
       downloadUnlistenRef.current = null;
       onDownloadingChange?.(false);
       onComplete(selected);
     } catch (err) {
-      unlisten();
+      downloadUnlistenRef.current?.();
       downloadUnlistenRef.current = null;
       onDownloadingChange?.(false);
       setDownloadState({

--- a/app/src/components/onboarding/OnboardingFlow.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import {
   checkMicrophonePermissionStatus,
@@ -7,14 +7,23 @@ import {
   type MicPermissionStatus,
 } from '../../lib/dictation';
 import { ModelDownloadPanel } from '../ModelDownloader';
-import type { ModelOption } from '../../lib/settings';
+import type { DoubleTapKey, ModelOption, RecordingMode } from '../../lib/settings';
 
 type Step = 'welcome' | 'microphone' | 'accessibility' | 'model' | 'done';
 
 const STEP_ORDER: Step[] = ['welcome', 'microphone', 'accessibility', 'model', 'done'];
 
+const KEY_LABELS: Record<DoubleTapKey, string> = {
+  shift_l: 'Left Shift',
+  alt_l: 'Left Option',
+  ctrl_r: 'Right Control',
+};
+
 interface Props {
   initialModel: ModelOption;
+  /** Configured recording trigger, so the final tip shows the real binding. */
+  recordingMode: RecordingMode;
+  triggerKey: DoubleTapKey;
   /** Called when the user finishes the wizard; receives the installed model. */
   onComplete: (model: ModelOption) => void;
 }
@@ -35,7 +44,7 @@ interface Props {
  *   returns the status to `notDetermined` so the in-app prompt works again
  * - accessibility listed-but-stale → reset entry + re-grant manually
  */
-export function OnboardingFlow({ initialModel, onComplete }: Props) {
+export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComplete }: Props) {
   const [step, setStep] = useState<Step>('welcome');
   const [micStatus, setMicStatus] = useState<MicPermissionStatus>('unknown');
   const [micRequested, setMicRequested] = useState(false);
@@ -51,17 +60,26 @@ export function OnboardingFlow({ initialModel, onComplete }: Props) {
   // second concurrent download of the same file.
   const [modelDownloading, setModelDownloading] = useState(false);
 
+  // Monotonic sequence so an interval probe overlapping a focus probe can't
+  // apply an older TCC result over a newer one.
+  const pollSeq = useRef(0);
   const refreshPermissions = useCallback(async () => {
+    const seq = ++pollSeq.current;
+    let mic: MicPermissionStatus = 'unknown';
+    let ax: boolean | null = null;
     try {
-      setMicStatus(await checkMicrophonePermissionStatus());
+      mic = await checkMicrophonePermissionStatus();
     } catch {
-      setMicStatus('unknown');
+      mic = 'unknown';
     }
     try {
-      setAxGranted(await invoke<boolean>('check_accessibility_permission'));
+      ax = await invoke<boolean>('check_accessibility_permission');
     } catch {
       // keep previous value; a probe glitch must not flip the UI
     }
+    if (seq !== pollSeq.current) return; // superseded by a newer probe
+    setMicStatus(mic);
+    if (ax !== null) setAxGranted(ax);
   }, []);
 
   useEffect(() => {
@@ -377,7 +395,7 @@ export function OnboardingFlow({ initialModel, onComplete }: Props) {
             <div className="space-y-2 mb-6">
               <SummaryRow ok={micGranted} label="Microphone" okText="Granted" missingText="Not granted — grant later from the in-app banner or Settings" />
               <SummaryRow ok={axGranted === true} label="Accessibility" okText="Granted" missingText="Not granted — the recording key won't work outside the app" />
-              <SummaryRow ok label="Model" okText="Installed" missingText="" />
+              <SummaryRow ok={modelInstalled === true} label="Model" okText="Installed" missingText="Not verified — the app will ask again if it's missing" />
             </div>
 
             <div className="mb-6 px-4 py-3 bg-stone-100 dark:bg-stone-800 rounded-lg">
@@ -385,10 +403,16 @@ export function OnboardingFlow({ initialModel, onComplete }: Props) {
                 Try it out
               </p>
               <p className="text-xs text-stone-500 dark:text-stone-400">
-                Hold <kbd className="px-1 py-0.5 rounded bg-white dark:bg-stone-700 border border-stone-300 dark:border-stone-600 font-mono text-[10px]">Left Shift</kbd> and
-                speak, then release — your words are transcribed and copied to the
-                clipboard. The recording key, auto-paste, and everything else can be
-                changed in Settings.
+                {recordingMode === 'double_tap' ? 'Double-tap ' : 'Hold '}
+                <kbd className="px-1 py-0.5 rounded bg-white dark:bg-stone-700 border border-stone-300 dark:border-stone-600 font-mono text-[10px]">{KEY_LABELS[triggerKey]}</kbd>
+                {recordingMode === 'double_tap'
+                  ? ' to start recording and tap it once to stop'
+                  : recordingMode === 'both'
+                  ? ' and speak, then release (or double-tap to toggle)'
+                  : ' and speak, then release'}
+                {' '}— your words are transcribed and copied to the clipboard. The
+                recording key, auto-paste, and everything else can be changed in
+                Settings.
               </p>
             </div>
 

--- a/app/src/components/onboarding/OnboardingFlow.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,491 @@
+import { useCallback, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  checkMicrophonePermissionStatus,
+  resetAccessibilityPermission,
+  resetMicrophonePermission,
+  type MicPermissionStatus,
+} from '../../lib/dictation';
+import { ModelDownloadPanel } from '../ModelDownloader';
+import type { ModelOption } from '../../lib/settings';
+
+type Step = 'welcome' | 'microphone' | 'accessibility' | 'model' | 'done';
+
+const STEP_ORDER: Step[] = ['welcome', 'microphone', 'accessibility', 'model', 'done'];
+
+interface Props {
+  initialModel: ModelOption;
+  /** Called when the user finishes the wizard; receives the installed model. */
+  onComplete: (model: ModelOption) => void;
+}
+
+/**
+ * First-launch setup assistant.
+ *
+ * Walks a new install through the two macOS permissions and the model
+ * download, replacing the old flow where the mic TCC prompt only fired on the
+ * first recording attempt and permissions were a dismissible banner.
+ *
+ * Permission state is polled every second (plus on window focus) for the whole
+ * wizard lifetime, so a grant made in System Settings flips the step live when
+ * the user comes back. Both permission steps handle the "wishy-washy" TCC
+ * states explicitly:
+ * - mic `notDetermined`/`unknown` → in-app native prompt (request_microphone_access)
+ * - mic `denied` → open System Settings, or reset the stale TCC entry, which
+ *   returns the status to `notDetermined` so the in-app prompt works again
+ * - accessibility listed-but-stale → reset entry + re-grant manually
+ */
+export function OnboardingFlow({ initialModel, onComplete }: Props) {
+  const [step, setStep] = useState<Step>('welcome');
+  const [micStatus, setMicStatus] = useState<MicPermissionStatus>('unknown');
+  const [micRequested, setMicRequested] = useState(false);
+  const [micError, setMicError] = useState<string | null>(null);
+  const [axGranted, setAxGranted] = useState<boolean | null>(null);
+  const [axRequested, setAxRequested] = useState(false);
+  const [axError, setAxError] = useState<string | null>(null);
+  // null = not checked yet; the model step shows a spinner-less blank until known.
+  const [modelInstalled, setModelInstalled] = useState<boolean | null>(null);
+  const [installedModel, setInstalledModel] = useState<ModelOption>(initialModel);
+  // Lock Back while a download is in flight: unmounting the panel wouldn't stop
+  // the Rust download_model command, and re-entering the step could start a
+  // second concurrent download of the same file.
+  const [modelDownloading, setModelDownloading] = useState(false);
+
+  const refreshPermissions = useCallback(async () => {
+    try {
+      setMicStatus(await checkMicrophonePermissionStatus());
+    } catch {
+      setMicStatus('unknown');
+    }
+    try {
+      setAxGranted(await invoke<boolean>('check_accessibility_permission'));
+    } catch {
+      // keep previous value; a probe glitch must not flip the UI
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshPermissions();
+    const id = setInterval(refreshPermissions, 1000);
+    window.addEventListener('focus', refreshPermissions);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('focus', refreshPermissions);
+    };
+  }, [refreshPermissions]);
+
+  // Check whether the selected model is already on disk when entering the
+  // model step (re-run of the wizard, or a partially completed first launch).
+  useEffect(() => {
+    if (step !== 'model') return;
+    invoke<boolean>('check_specific_model_exists', { modelName: initialModel })
+      .then(setModelInstalled)
+      // Fail open (skip the download) — matches the standalone gate's behavior;
+      // a genuine fresh install resolves to `false` rather than throwing.
+      .catch(() => setModelInstalled(true));
+  }, [step, initialModel]);
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+  const goNext = () => setStep(STEP_ORDER[Math.min(stepIndex + 1, STEP_ORDER.length - 1)]);
+  const goBack = () => setStep(STEP_ORDER[Math.max(stepIndex - 1, 0)]);
+
+  const micGranted = micStatus === 'granted';
+  const micDenied = micStatus === 'denied';
+
+  const handleAllowMic = async () => {
+    setMicError(null);
+    setMicRequested(true);
+    try {
+      // Fires the native TCC dialog when the status is notDetermined; the
+      // 1s poll picks up the answer.
+      await invoke('request_microphone_access');
+    } catch (error) {
+      setMicError(typeof error === 'string' ? error : 'Could not request microphone access.');
+    }
+  };
+
+  const handleOpenMicSettings = async () => {
+    setMicError(null);
+    try {
+      await invoke('request_microphone_permission');
+    } catch (error) {
+      setMicError(typeof error === 'string' ? error : 'Could not open System Settings.');
+    }
+  };
+
+  const handleResetMic = async () => {
+    setMicError(null);
+    try {
+      await resetMicrophonePermission();
+      // After a reset the status returns to notDetermined, so the in-app
+      // prompt button works again.
+      setMicRequested(false);
+    } catch (error) {
+      setMicError(
+        typeof error === 'string'
+          ? error
+          : "Couldn't reset the Microphone entry. Check the logs for details.",
+      );
+    } finally {
+      refreshPermissions();
+    }
+  };
+
+  const handleGrantAx = async () => {
+    setAxError(null);
+    setAxRequested(true);
+    try {
+      // Registers Murmur in the Accessibility list, shows the system dialog,
+      // and opens the Accessibility pane.
+      await invoke('request_accessibility_permission');
+    } catch (error) {
+      setAxError(typeof error === 'string' ? error : 'Could not open System Settings.');
+    }
+  };
+
+  const handleResetAx = async () => {
+    setAxError(null);
+    try {
+      await resetAccessibilityPermission();
+      setAxRequested(false);
+    } catch (error) {
+      setAxError(
+        typeof error === 'string'
+          ? error
+          : "Couldn't reset the Accessibility entry. Check the logs for details.",
+      );
+    } finally {
+      refreshPermissions();
+    }
+  };
+
+  return (
+    <div className="h-screen bg-stone-50 dark:bg-stone-900 flex flex-col items-center justify-center p-8 font-[-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,sans-serif]">
+      <div className="w-full max-w-md">
+        {/* Progress dots */}
+        <div className="flex items-center justify-center gap-2 mb-8" aria-label={`Step ${stepIndex + 1} of ${STEP_ORDER.length}`}>
+          {STEP_ORDER.map((s, i) => (
+            <span
+              key={s}
+              className={`h-1.5 rounded-full transition-all duration-300 ${
+                i === stepIndex
+                  ? 'w-6 bg-blue-500'
+                  : i < stepIndex
+                  ? 'w-1.5 bg-blue-400/60'
+                  : 'w-1.5 bg-stone-300 dark:bg-stone-600'
+              }`}
+            />
+          ))}
+        </div>
+
+        {step === 'welcome' && (
+          <div className="text-center">
+            <h1 className="text-2xl font-semibold text-stone-800 dark:text-stone-100 mb-2">
+              Welcome to Murmur
+            </h1>
+            <p className="text-sm text-stone-500 dark:text-stone-400 mb-2">
+              Voice-to-text that runs entirely on your Mac. No cloud, no accounts —
+              your audio never leaves this machine.
+            </p>
+            <p className="text-sm text-stone-500 dark:text-stone-400 mb-8">
+              Setup takes about a minute: two macOS permissions and a one-time
+              model download.
+            </p>
+            <button
+              onClick={goNext}
+              className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              Get Started
+            </button>
+          </div>
+        )}
+
+        {step === 'microphone' && (
+          <div>
+            <StepHeading
+              title="Microphone Access"
+              granted={micGranted}
+              subtitle="Murmur records from your microphone to transcribe your speech. Audio is processed locally and discarded after transcription."
+            />
+
+            {micGranted ? (
+              <GrantedCard label="Microphone access granted" />
+            ) : micDenied ? (
+              <div className="mb-6 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg space-y-3">
+                <p className="text-sm text-red-700 dark:text-red-300">
+                  Microphone access is denied. Enable Murmur under Privacy &amp;
+                  Security → Microphone, then come back — this screen updates
+                  automatically.
+                </p>
+                <button
+                  onClick={handleOpenMicSettings}
+                  className="w-full py-2 px-4 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  Open System Settings
+                </button>
+                <div>
+                  <button
+                    onClick={handleResetMic}
+                    className="text-xs text-red-600/80 dark:text-red-400/80 underline hover:no-underline"
+                  >
+                    Still not working? Reset the permission
+                  </button>
+                  <p className="mt-1 text-xs text-red-600/70 dark:text-red-400/70">
+                    Clears Murmur's stale Microphone entry so macOS can ask fresh —
+                    useful when the toggle is on but recording still fails.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="mb-6">
+                <button
+                  onClick={handleAllowMic}
+                  className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  Allow Microphone Access
+                </button>
+                {micRequested && (
+                  <p className="mt-2 text-xs text-stone-500 dark:text-stone-400 text-center">
+                    Waiting for your answer in the macOS dialog…
+                  </p>
+                )}
+              </div>
+            )}
+
+            {micError && (
+              <p className="mb-4 text-xs text-red-600 dark:text-red-400">{micError}</p>
+            )}
+
+            <WizardFooter
+              onBack={goBack}
+              onNext={goNext}
+              nextEnabled={micGranted}
+              nextLabel="Continue"
+              skippable={!micGranted}
+              skipLabel="Skip for now"
+            />
+          </div>
+        )}
+
+        {step === 'accessibility' && (
+          <div>
+            <StepHeading
+              title="Accessibility Access"
+              granted={axGranted === true}
+              subtitle="Needed for the global recording key (so it works while Murmur is in the background) and for auto-paste. Without it, recording only works from buttons inside the app."
+            />
+
+            {axGranted ? (
+              <GrantedCard label="Accessibility access granted" />
+            ) : (
+              <div className="mb-6 space-y-3">
+                <button
+                  onClick={handleGrantAx}
+                  className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  Grant Accessibility Access
+                </button>
+                <p className="text-xs text-stone-500 dark:text-stone-400 text-center">
+                  macOS opens System Settings — turn on <strong>Murmur</strong> in the
+                  list, then come back. This screen updates automatically.
+                </p>
+                {axRequested && (
+                  <div className="pt-1">
+                    <button
+                      onClick={handleResetAx}
+                      className="text-xs text-stone-500/90 dark:text-stone-400/90 underline hover:no-underline"
+                    >
+                      Murmur is listed and enabled, but still not detected? Reset the permission
+                    </button>
+                    <p className="mt-1 text-xs text-stone-400 dark:text-stone-500">
+                      Clears a stale Accessibility entry (common after reinstalling).
+                      You'll need to re-enable Murmur in the list afterward.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {axError && (
+              <p className="mb-4 text-xs text-red-600 dark:text-red-400">{axError}</p>
+            )}
+
+            <WizardFooter
+              onBack={goBack}
+              onNext={goNext}
+              nextEnabled={axGranted === true}
+              nextLabel="Continue"
+              skippable={axGranted !== true}
+              skipLabel="Skip for now"
+            />
+          </div>
+        )}
+
+        {step === 'model' && (
+          <div>
+            <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100 mb-1">
+              Transcription Model
+            </h1>
+            <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
+              Murmur transcribes with a local model — downloaded once, then everything
+              runs offline.
+            </p>
+
+            {modelInstalled === null ? (
+              <div className="h-24" />
+            ) : modelInstalled ? (
+              <div>
+                <GrantedCard label="Model already installed" />
+                <WizardFooter onBack={goBack} onNext={goNext} nextEnabled nextLabel="Continue" />
+              </div>
+            ) : (
+              <div>
+                <ModelDownloadPanel
+                  initialModel={initialModel}
+                  onDownloadingChange={setModelDownloading}
+                  onComplete={(model) => {
+                    setInstalledModel(model);
+                    setModelInstalled(true);
+                    setModelDownloading(false);
+                    goNext();
+                  }}
+                />
+                {!modelDownloading && (
+                  <div className="mt-3 text-center">
+                    <button
+                      onClick={goBack}
+                      className="text-xs text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 transition-colors"
+                    >
+                      Back
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {step === 'done' && (
+          <div>
+            <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100 mb-1 text-center">
+              You're all set
+            </h1>
+            <p className="text-sm text-stone-500 dark:text-stone-400 mb-6 text-center">
+              Here's how everything looks:
+            </p>
+
+            <div className="space-y-2 mb-6">
+              <SummaryRow ok={micGranted} label="Microphone" okText="Granted" missingText="Not granted — grant later from the in-app banner or Settings" />
+              <SummaryRow ok={axGranted === true} label="Accessibility" okText="Granted" missingText="Not granted — the recording key won't work outside the app" />
+              <SummaryRow ok label="Model" okText="Installed" missingText="" />
+            </div>
+
+            <div className="mb-6 px-4 py-3 bg-stone-100 dark:bg-stone-800 rounded-lg">
+              <p className="text-sm text-stone-700 dark:text-stone-300 font-medium mb-1">
+                Try it out
+              </p>
+              <p className="text-xs text-stone-500 dark:text-stone-400">
+                Hold <kbd className="px-1 py-0.5 rounded bg-white dark:bg-stone-700 border border-stone-300 dark:border-stone-600 font-mono text-[10px]">Left Shift</kbd> and
+                speak, then release — your words are transcribed and copied to the
+                clipboard. The recording key, auto-paste, and everything else can be
+                changed in Settings.
+              </p>
+            </div>
+
+            <button
+              onClick={() => onComplete(installedModel)}
+              className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              Start Using Murmur
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepHeading({ title, subtitle, granted }: { title: string; subtitle: string; granted: boolean }) {
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-2 mb-1">
+        <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100">{title}</h1>
+        {granted && <CheckIcon />}
+      </div>
+      <p className="text-sm text-stone-500 dark:text-stone-400">{subtitle}</p>
+    </div>
+  );
+}
+
+function GrantedCard({ label }: { label: string }) {
+  return (
+    <div className="mb-6 px-4 py-3 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg flex items-center gap-2">
+      <CheckIcon />
+      <span className="text-sm text-emerald-700 dark:text-emerald-300">{label}</span>
+    </div>
+  );
+}
+
+function SummaryRow({ ok, label, okText, missingText }: { ok: boolean; label: string; okText: string; missingText: string }) {
+  return (
+    <div className="flex items-start gap-2 px-4 py-2.5 bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-lg">
+      <span className={`mt-1 w-2 h-2 shrink-0 rounded-full ${ok ? 'bg-emerald-500' : 'bg-amber-500'}`} />
+      <div className="min-w-0">
+        <span className="text-sm font-medium text-stone-700 dark:text-stone-200">{label}</span>
+        <span className="text-sm text-stone-500 dark:text-stone-400"> — {ok ? okText : missingText}</span>
+      </div>
+    </div>
+  );
+}
+
+function WizardFooter({
+  onBack,
+  onNext,
+  nextEnabled,
+  nextLabel,
+  skippable = false,
+  skipLabel = 'Skip',
+}: {
+  onBack: () => void;
+  onNext: () => void;
+  nextEnabled: boolean;
+  nextLabel: string;
+  skippable?: boolean;
+  skipLabel?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <button
+        onClick={onBack}
+        className="text-xs text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 transition-colors"
+      >
+        Back
+      </button>
+      <div className="flex items-center gap-3">
+        {skippable && (
+          <button
+            onClick={onNext}
+            className="text-xs text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 transition-colors"
+          >
+            {skipLabel}
+          </button>
+        )}
+        <button
+          onClick={onNext}
+          disabled={!nextEnabled}
+          className="py-2 px-5 bg-blue-600 hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          {nextLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg className="w-4 h-4 text-emerald-500 shrink-0" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}

--- a/app/src/components/onboarding/OnboardingFlow.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import {
+  checkAccessibilityPermission,
   checkMicrophonePermissionStatus,
+  checkModelExists,
+  openMicrophoneSettings,
+  requestAccessibilityPermission,
+  requestMicrophoneAccess,
   resetAccessibilityPermission,
   resetMicrophonePermission,
   type MicPermissionStatus,
@@ -73,7 +77,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
       mic = 'unknown';
     }
     try {
-      ax = await invoke<boolean>('check_accessibility_permission');
+      ax = await checkAccessibilityPermission();
     } catch {
       // keep previous value; a probe glitch must not flip the UI
     }
@@ -96,7 +100,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
   // model step (re-run of the wizard, or a partially completed first launch).
   useEffect(() => {
     if (step !== 'model') return;
-    invoke<boolean>('check_specific_model_exists', { modelName: initialModel })
+    checkModelExists(initialModel)
       .then(setModelInstalled)
       // Fail open (skip the download) — matches the standalone gate's behavior;
       // a genuine fresh install resolves to `false` rather than throwing.
@@ -116,7 +120,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
     try {
       // Fires the native TCC dialog when the status is notDetermined; the
       // 1s poll picks up the answer.
-      await invoke('request_microphone_access');
+      await requestMicrophoneAccess();
     } catch (error) {
       setMicError(typeof error === 'string' ? error : 'Could not request microphone access.');
     }
@@ -125,7 +129,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
   const handleOpenMicSettings = async () => {
     setMicError(null);
     try {
-      await invoke('request_microphone_permission');
+      await openMicrophoneSettings();
     } catch (error) {
       setMicError(typeof error === 'string' ? error : 'Could not open System Settings.');
     }
@@ -155,7 +159,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
     try {
       // Registers Murmur in the Accessibility list, shows the system dialog,
       // and opens the Accessibility pane.
-      await invoke('request_accessibility_permission');
+      await requestAccessibilityPermission();
     } catch (error) {
       setAxError(typeof error === 'string' ? error : 'Could not open System Settings.');
     }

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -392,6 +392,8 @@ interface SettingsPanelProps {
   status: DictationStatus;
   onResetStats: () => void;
   onViewLogs: () => void;
+  /** Relaunch the first-run setup assistant (permission troubleshooting). */
+  onRerunSetup: () => void;
   accessibilityGranted: boolean | null;
   onCheckForUpdate: () => Promise<void>;
   updateStatus: UpdateStatus;
@@ -406,7 +408,7 @@ const SETTINGS_CATEGORIES = [
   { id: 'about', label: 'About' },
 ] as const;
 
-export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, accessibilityGranted, onCheckForUpdate, updateStatus }: SettingsPanelProps) {
+export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, onRerunSetup, accessibilityGranted, onCheckForUpdate, updateStatus }: SettingsPanelProps) {
   const [confirmReset, setConfirmReset] = useState(false);
   const [activeCat, setActiveCat] = useState<string>('transcription');
   const [version, setVersion] = useState('');
@@ -1366,6 +1368,20 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           >
             View Logs
           </button>
+        </div>
+
+        {/* Setup assistant */}
+        <div>
+          <button
+            onClick={onRerunSetup}
+            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"
+          >
+            Run Setup Assistant
+          </button>
+          <p className="mt-1.5 text-xs text-stone-400 dark:text-stone-500">
+            Re-check permissions and the model step by step — useful if a
+            permission was revoked or stopped working.
+          </p>
         </div>
 
         {/* Updates */}

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -145,6 +145,38 @@ export async function resetAccessibilityPermission(): Promise<void> {
   return await invoke('reset_accessibility_permission');
 }
 
+/** Check whether accessibility permission is currently granted (macOS). */
+export async function checkAccessibilityPermission(): Promise<boolean> {
+  return await invoke('check_accessibility_permission');
+}
+
+/**
+ * Trigger the accessibility permission flow: registers the app in the
+ * Accessibility list, shows the system dialog, and opens the settings pane.
+ */
+export async function requestAccessibilityPermission(): Promise<void> {
+  return await invoke('request_accessibility_permission');
+}
+
+/**
+ * Fire the native microphone TCC prompt in-app (no device open, no audio
+ * ducking). Fire-and-forget: poll `checkMicrophonePermissionStatus` to observe
+ * the user's answer.
+ */
+export async function requestMicrophoneAccess(): Promise<void> {
+  return await invoke('request_microphone_access');
+}
+
+/** Open System Settings at the Microphone privacy pane. */
+export async function openMicrophoneSettings(): Promise<void> {
+  return await invoke('request_microphone_permission');
+}
+
+/** Check whether a specific model's files already exist on disk. */
+export async function checkModelExists(modelName: string): Promise<boolean> {
+  return await invoke('check_specific_model_exists', { modelName });
+}
+
 /** Live microphone authorization state, mirroring the Rust banner-state mapping. */
 export type MicPermissionStatus = 'granted' | 'denied' | 'notDetermined' | 'unknown';
 

--- a/app/src/lib/onboarding.ts
+++ b/app/src/lib/onboarding.ts
@@ -1,0 +1,38 @@
+/**
+ * First-launch onboarding completion flag.
+ *
+ * The setup assistant (OnboardingFlow) runs when this flag is absent. Existing
+ * installs are grandfathered at mount: if the mic + accessibility permissions
+ * and the selected model are already in place, App sets the flag silently so
+ * upgrades never see the wizard. Stored in localStorage alongside settings,
+ * stats, and history.
+ */
+
+const ONBOARDING_KEY = 'murmur_onboarding_complete';
+
+export function isOnboardingComplete(): boolean {
+  try {
+    return localStorage.getItem(ONBOARDING_KEY) === 'true';
+  } catch {
+    // Storage unavailable: treat as complete so the app never hard-blocks on
+    // the wizard; the permissions banner still catches missing grants.
+    return true;
+  }
+}
+
+export function markOnboardingComplete(): void {
+  try {
+    localStorage.setItem(ONBOARDING_KEY, 'true');
+  } catch {
+    // Non-fatal: the wizard will show again next launch.
+  }
+}
+
+/** Clear the flag so the setup assistant runs again (Settings → Setup Assistant). */
+export function resetOnboarding(): void {
+  try {
+    localStorage.removeItem(ONBOARDING_KEY);
+  } catch {
+    // Non-fatal.
+  }
+}

--- a/docs/features/onboarding-flow.md
+++ b/docs/features/onboarding-flow.md
@@ -1,0 +1,60 @@
+# First-Launch Setup Assistant
+
+Guided onboarding wizard shown on first launch, replacing the old flow where
+the mic TCC prompt only fired on the first recording attempt and missing
+permissions were a dismissible banner.
+
+## Flow
+
+Five steps, forward-only with Back links and per-step Skip where the app can
+partially function without the grant:
+
+1. **Welcome** — privacy pitch (local-only processing), what setup covers.
+2. **Microphone** — fires the *native* macOS permission dialog in-app via the
+   `request_microphone_access` command (`AVCaptureDevice.requestAccessForMediaType`,
+   fire-and-forget; never opens the device, so it can't duck other apps' audio —
+   see issue #177). Skippable, but Continue stays disabled until granted.
+3. **Accessibility** — explains the global recording key + auto-paste need,
+   triggers `request_accessibility_permission` (system dialog + opens the pane).
+   Skippable.
+4. **Model** — embeds `ModelDownloadPanel` (shared with the standalone
+   `ModelDownloader` gate); shows "already installed" on re-runs.
+5. **Done** — live summary of the three checks plus a "hold Left Shift and
+   speak" quick-start card.
+
+## Permission-state handling
+
+Both permission steps poll every second (plus on window focus) for the whole
+wizard lifetime, so a grant made during the System Settings roundtrip flips the
+step live. The wishy-washy TCC states are handled explicitly:
+
+| State | UI |
+|-------|-----|
+| mic `notDetermined` / `unknown` | "Allow Microphone Access" → native in-app dialog |
+| mic `denied` | Open System Settings + "Reset the permission" (`tccutil reset` via `reset_microphone_permission`) — the reset returns the status to `notDetermined`, so the in-app dialog works again |
+| accessibility not granted | Grant button (dialog + pane); after an attempt, a reset path for the listed-but-stale entry (common after reinstall/rebuild — see DEVELOPMENT.md) |
+
+## Gating and grandfathering
+
+`App.tsx` checks a localStorage flag (`murmur_onboarding_complete`,
+`lib/onboarding.ts`) at mount:
+
+- Flag present → straight to the main UI (the existing `PermissionsBanner`
+  still catches later permission drift, and the standalone `ModelDownloader`
+  gate still catches a deleted model file).
+- Flag absent → probe mic + accessibility + model. **All three already in
+  place → set the flag silently** so existing installs never see the wizard on
+  upgrade. Anything missing → show `OnboardingFlow`.
+
+Settings → About → **Run Setup Assistant** clears the flag and relaunches the
+wizard — the recovery path when a user revokes a permission and wants a guided
+re-grant instead of spelunking through System Settings.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `app/src/components/onboarding/OnboardingFlow.tsx` | The wizard |
+| `app/src/lib/onboarding.ts` | Completion-flag persistence |
+| `app/src/components/ModelDownloader.tsx` | `ModelDownloadPanel` extracted for reuse |
+| `app/src-tauri/src/commands/permissions.rs` | `request_microphone_access` (block2 completion handler) |


### PR DESCRIPTION
## Summary

Replaces the first-launch experience — previously a lone model-download screen with permissions relegated to a dismissible banner — with a guided setup assistant: **Welcome → Microphone → Accessibility → Model download → Done**.

### Highlights
- **In-app mic prompt**: new `request_microphone_access` command calls `AVCaptureDevice.requestAccess` (block2 completion handler) so the native TCC dialog fires when the user clicks Allow — not on their first recording attempt. Never opens the device, so no audio ducking (#177).
- **Live permission polling**: both permission steps poll every 1s + on focus, so a grant made during the System Settings roundtrip flips the step when the user returns.
- **Stale-TCC recovery in-flow**: denied mic gets Open Settings + a reset path; since `tccutil reset` returns the status to `notDetermined`, the in-app dialog re-arms after reset. Accessibility gets the listed-but-stale reset path (#190-family drift states).
- **Grandfathering**: existing installs with mic + accessibility + model already in place get the completion flag set silently — upgrades never see the wizard.
- **Recovery entry point**: Settings → About → **Run Setup Assistant** re-launches the wizard when a permission was revoked or drifted.
- `ModelDownloadPanel` extracted from `ModelDownloader` and embedded as the wizard's model step (Back locked during an active download to prevent concurrent `download_model` runs).

### Not changed
- `PermissionsBanner` remains as the post-onboarding drift catcher.
- Standalone `ModelDownloader` gate remains for a deleted model file after onboarding.

## Test plan
- [x] `npx tsc --noEmit` clean (Linux)
- [x] `npm test` 70/70 (Linux)
- [x] `cargo check` clean on macOS (Mac Mini)
- [x] `cargo test --lib -- --test-threads=1` 249/249 on macOS (Mac Mini)
- [ ] Manual: fresh-TCC run on a real Mac (`tccutil reset Microphone/Accessibility` + `build`) to see the dialogs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-launch setup assistant guiding users through microphone access, accessibility permissions, and model selection or download.
  * Added inline recovery options for denied or outdated permission states.
  * Existing installations that are already configured continue without interruption.
  * Added **Run Setup Assistant** under Settings → About to restart setup at any time.

* **Bug Fixes**
  * Recording controls remain unavailable until required setup steps are complete.
  * Permission status updates automatically when returning from System Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->