### PR TITLE
fix: recover interrupted model installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Parakeet v2 downloads now survive an interrupted extraction: Murmur reuses the completed archive, validates a staged bundle, and publishes it atomically instead of leaving a partial model that appears undownloaded (#215).
+- Core ML model setup now shows an animated indeterminate Installing state across onboarding, Settings, and Performance Lab instead of a frozen 0% bar (#217).
+
 ## [0.16.0] - 2026-07-17
 
 ### Added

--- a/app/src-tauri/src/commands/models.rs
+++ b/app/src-tauri/src/commands/models.rs
@@ -1,7 +1,22 @@
 use crate::{MutexExt, State};
 use crate::transcriber::{self, TranscriptionBackend};
 use crate::vad;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
 use tauri::Emitter;
+
+type ModelInstallLock = Arc<tokio::sync::Mutex<()>>;
+
+static MODEL_INSTALL_LOCKS: LazyLock<Mutex<HashMap<String, ModelInstallLock>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn model_install_lock(model_name: &str) -> ModelInstallLock {
+    let mut locks = MODEL_INSTALL_LOCKS.lock_or_recover();
+    locks
+        .entry(model_name.to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
 
 #[tauri::command]
 pub fn check_model_exists(state: tauri::State<'_, State>) -> bool {
@@ -54,6 +69,11 @@ pub async fn download_model(app_handle: tauri::AppHandle, model_name: String) ->
         return Err(format!("Unknown model '{}'. Allowed: {}", model_name, ALLOWED_MODELS.join(", ")));
     }
 
+    // The entire existence-check/download/install transaction is single-flight
+    // per model. Different models may still download concurrently.
+    let install_lock = model_install_lock(&model_name);
+    let _install_guard = install_lock.lock().await;
+
     // Whisper and sherpa share Murmur's models directory. FluidAudio owns a
     // separate Application Support cache, but VAD must still land here.
     let models_dir = transcriber::WhisperBackend::new().models_dir()?;
@@ -85,23 +105,10 @@ pub async fn download_model(app_handle: tauri::AppHandle, model_name: String) ->
         download_whisper_model(&app_handle, &model_name, &models_dir).await?;
     }
 
-    // Co-download VAD model alongside the transcription model (~1.8MB)
-    if !vad::vad_model_exists() {
-        let vad_dest = models_dir.join(vad::VAD_MODEL_FILENAME);
-        let vad_tmp = models_dir.join(format!("{}.tmp", vad::VAD_MODEL_FILENAME));
-        match stream_download(&app_handle, vad::VAD_MODEL_URL, &vad_tmp).await {
-            Ok(bytes) => {
-                if let Err(e) = tokio::fs::rename(&vad_tmp, &vad_dest).await {
-                    let _ = tokio::fs::remove_file(&vad_tmp).await;
-                    tracing::warn!(target: "system", "Failed to finalize VAD model download: {}", e);
-                } else {
-                    tracing::info!(target: "system", "VAD model co-downloaded: {} ({} bytes)", vad::VAD_MODEL_FILENAME, bytes);
-                }
-            }
-            Err(e) => {
-                tracing::warn!(target: "system", "VAD model co-download failed (non-fatal): {}", e);
-            }
-        }
+    // Co-download VAD model alongside the transcription model (~1.8MB).
+    // Its own lock prevents different model installs from sharing a temp file.
+    if let Err(error) = ensure_vad_model(&app_handle).await {
+        tracing::warn!(target: "system", "VAD model co-download failed (non-fatal): {}", error);
     }
 
     Ok(())
@@ -201,10 +208,65 @@ mod tests {
         let error = extract_parakeet_archive(&archive_path, &models_dir, model_name, &dir_name)
             .unwrap_err();
 
-        assert!(error.contains("incomplete"));
+        assert!(
+            matches!(error, ParakeetInstallError::InvalidArchive(_)),
+            "unexpected classification: {error:?}"
+        );
+        assert!(should_discard_archive(&error));
         assert!(!models_dir.join(&dir_name).exists());
         assert!(!models_dir.join(format!(".{dir_name}.extracting")).exists());
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn corrupt_parakeet_archive_is_marked_for_redownload() {
+        let root = test_dir("parakeet-corrupt-archive");
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let model_name = "parakeet-tdt-0.6b-v2-fp16";
+        let (_, dir_name) = transcriber::parakeet::download_spec(model_name).unwrap();
+        let archive_path = root.join("model.tar.bz2");
+        fs::write(&archive_path, b"not a bzip2 archive").unwrap();
+
+        let error = extract_parakeet_archive(&archive_path, &models_dir, model_name, &dir_name)
+            .unwrap_err();
+
+        assert!(
+            matches!(error, ParakeetInstallError::InvalidArchive(_)),
+            "unexpected classification: {error:?}"
+        );
+        assert!(should_discard_archive(&error));
+        assert!(!models_dir.join(&dir_name).exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn transient_publish_failure_preserves_a_retryable_archive() {
+        let root = test_dir("parakeet-transient-install");
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let model_name = "parakeet-tdt-0.6b-v2-fp16";
+        let (_, dir_name) = transcriber::parakeet::download_spec(model_name).unwrap();
+        let archive_path = root.join("model.tar.bz2");
+        write_parakeet_archive(&archive_path, &dir_name, true);
+        fs::write(models_dir.join(&dir_name), b"blocks directory publication").unwrap();
+
+        let error = extract_parakeet_archive(&archive_path, &models_dir, model_name, &dir_name)
+            .unwrap_err();
+
+        assert!(matches!(error, ParakeetInstallError::Installation(_)));
+        assert!(!should_discard_archive(&error));
+        assert!(archive_path.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn model_install_locks_are_keyed_and_reused() {
+        let first = model_install_lock("test-model-a");
+        let same = model_install_lock("test-model-a");
+        let different = model_install_lock("test-model-b");
+        assert!(Arc::ptr_eq(&first, &same));
+        assert!(!Arc::ptr_eq(&first, &different));
     }
 }
 
@@ -259,53 +321,99 @@ async fn download_parakeet_model(
         let root = models_dir.to_path_buf();
         let model = model_name.to_string();
         let bundle = dir_name.clone();
-        match tokio::task::spawn_blocking(move || {
-            extract_parakeet_archive(&archive, &root, &model, &bundle)
-        })
-        .await
-        .map_err(|e| format!("Extraction task failed: {}", e))?
-        {
+        match extract_parakeet_archive_on_worker(archive, root, model, bundle).await {
             Ok(()) => {
                 let _ = tokio::fs::remove_file(&legacy_temp_path).await;
+                let _ = tokio::fs::remove_file(&archive_path).await;
                 tracing::info!(target: "system", "Recovered Parakeet installation from retained archive: {}", dir_name);
                 return Ok(());
             }
-            Err(error) => {
+            Err(error) if should_discard_archive(&error) => {
                 tracing::warn!(target: "system", "Retained Parakeet archive was unusable; downloading again: {}", error);
                 let _ = tokio::fs::remove_file(&legacy_temp_path).await;
             }
+            Err(error) => return Err(error.to_string()),
         }
     }
 
-    // A finalized archive is retained when extraction fails (for example due
-    // to low disk space), so Retry performs only the local install work.
-    if !archive_path.is_file() {
-        let download_path = models_dir.join(format!("{}.tar.bz2.download", dir_name));
-        let received = stream_download(app_handle, &url, &download_path).await?;
-        tokio::fs::rename(&download_path, &archive_path)
-            .await
-            .map_err(|e| {
-                let _ = std::fs::remove_file(&download_path);
-                format!("Failed to finalize Parakeet archive: {}", e)
-            })?;
-        tracing::info!(target: "system", "Parakeet archive downloaded: {} ({} bytes)", dir_name, received);
-    }
+    let mut downloaded_this_attempt = false;
+    loop {
+        // A finalized archive is retained after transient installation failures
+        // so Retry performs only local work. Invalid contents are discarded and
+        // downloaded once more in the same attempt.
+        if !archive_path.is_file() {
+            let download_path = models_dir.join(format!("{}.tar.bz2.download", dir_name));
+            let received = stream_download(app_handle, &url, &download_path).await?;
+            tokio::fs::rename(&download_path, &archive_path)
+                .await
+                .map_err(|e| {
+                    let _ = std::fs::remove_file(&download_path);
+                    format!("Failed to finalize Parakeet archive: {}", e)
+                })?;
+            downloaded_this_attempt = true;
+            tracing::info!(target: "system", "Parakeet archive downloaded: {} ({} bytes)", dir_name, received);
+        }
 
-    emit_installing(app_handle);
-    let archive = archive_path.clone();
-    let root = models_dir.to_path_buf();
-    let model = model_name.to_string();
-    let bundle = dir_name.clone();
+        emit_installing(app_handle);
+        let result = extract_parakeet_archive_on_worker(
+            archive_path.clone(),
+            models_dir.to_path_buf(),
+            model_name.to_string(),
+            dir_name.clone(),
+        )
+        .await;
+
+        match result {
+            Ok(()) => {
+                let _ = tokio::fs::remove_file(&archive_path).await;
+                tracing::info!(target: "system", "Parakeet model installed: {}", dir_name);
+                return Ok(());
+            }
+            Err(error) if should_discard_archive(&error) => {
+                let _ = tokio::fs::remove_file(&archive_path).await;
+                if downloaded_this_attempt {
+                    return Err(error.to_string());
+                }
+                tracing::warn!(target: "system", "Retained Parakeet archive was invalid; downloading again: {}", error);
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ParakeetInstallError {
+    InvalidArchive(String),
+    Installation(String),
+}
+
+impl std::fmt::Display for ParakeetInstallError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArchive(message) | Self::Installation(message) => {
+                formatter.write_str(message)
+            }
+        }
+    }
+}
+
+fn should_discard_archive(error: &ParakeetInstallError) -> bool {
+    matches!(error, ParakeetInstallError::InvalidArchive(_))
+}
+
+async fn extract_parakeet_archive_on_worker(
+    archive_path: std::path::PathBuf,
+    models_dir: std::path::PathBuf,
+    model_name: String,
+    dir_name: String,
+) -> Result<(), ParakeetInstallError> {
     tokio::task::spawn_blocking(move || {
-        extract_parakeet_archive(&archive, &root, &model, &bundle)
+        extract_parakeet_archive(&archive_path, &models_dir, &model_name, &dir_name)
     })
     .await
-    .map_err(|e| format!("Extraction task failed: {}", e))??;
-
-    let _ = tokio::fs::remove_file(&archive_path).await;
-
-    tracing::info!(target: "system", "Parakeet model installed: {}", dir_name);
-    Ok(())
+    .map_err(|error| {
+        ParakeetInstallError::Installation(format!("Extraction task failed: {error}"))
+    })?
 }
 
 fn emit_installing(app_handle: &tauri::AppHandle) {
@@ -321,7 +429,7 @@ fn extract_parakeet_archive(
     models_dir: &std::path::Path,
     model_name: &str,
     dir_name: &str,
-) -> Result<(), String> {
+) -> Result<(), ParakeetInstallError> {
     let final_dir = models_dir.join(dir_name);
     let staging_root = models_dir.join(format!(".{}.extracting", dir_name));
     let staged_dir = staging_root.join(dir_name);
@@ -331,24 +439,43 @@ fn extract_parakeet_archive(
         && !transcriber::parakeet::specific_model_exists_in(model_name, models_dir)
     {
         std::fs::remove_dir_all(&final_dir)
-            .map_err(|e| format!("Failed to remove incomplete model bundle: {}", e))?;
+            .map_err(|e| {
+                ParakeetInstallError::Installation(format!(
+                    "Failed to remove incomplete model bundle: {}",
+                    e
+                ))
+            })?;
     }
     std::fs::create_dir_all(&staging_root)
-        .map_err(|e| format!("Failed to create extraction staging directory: {}", e))?;
+        .map_err(|e| {
+            ParakeetInstallError::Installation(format!(
+                "Failed to create extraction staging directory: {}",
+                e
+            ))
+        })?;
 
     let extraction = (|| {
         let file = std::fs::File::open(archive_path)
-            .map_err(|e| format!("Failed to open archive: {}", e))?;
+            .map_err(|e| {
+                ParakeetInstallError::Installation(format!("Failed to open archive: {}", e))
+            })?;
         let decompressor = bzip2::read::BzDecoder::new(file);
         let mut archive = tar::Archive::new(decompressor);
         archive
             .unpack(&staging_root)
-            .map_err(|e| format!("Failed to extract archive: {}", e))?;
+            .map_err(classify_archive_unpack_error)?;
         if !transcriber::parakeet::specific_model_exists_in(model_name, &staging_root) {
-            return Err("Extracted Parakeet bundle is incomplete".to_string());
+            return Err(ParakeetInstallError::InvalidArchive(
+                "Extracted Parakeet bundle is incomplete".to_string(),
+            ));
         }
         std::fs::rename(&staged_dir, &final_dir)
-            .map_err(|e| format!("Failed to publish Parakeet model bundle: {}", e))?;
+            .map_err(|e| {
+                ParakeetInstallError::Installation(format!(
+                    "Failed to publish Parakeet model bundle: {}",
+                    e
+                ))
+            })?;
         Ok(())
     })();
 
@@ -356,10 +483,29 @@ fn extract_parakeet_archive(
     extraction
 }
 
+fn classify_archive_unpack_error(error: std::io::Error) -> ParakeetInstallError {
+    let message = error.to_string();
+    let normalized = message.to_ascii_lowercase();
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::InvalidData | std::io::ErrorKind::UnexpectedEof
+    )
+        || normalized.contains("data integrity")
+        || normalized.contains("corrupt")
+        || normalized.contains("failed to iterate over archive")
+    {
+        ParakeetInstallError::InvalidArchive(format!("Invalid Parakeet archive: {message}"))
+    } else {
+        ParakeetInstallError::Installation(format!("Failed to extract archive: {message}"))
+    }
+}
+
 /// Ensure the VAD model is present, downloading it if necessary.
 /// This is the fallback for users who have a transcription model but not the
 /// VAD model (e.g. upgrade from a pre-VAD version or manual model install).
 pub(crate) async fn ensure_vad_model(app_handle: &tauri::AppHandle) -> Result<(), String> {
+    let install_lock = model_install_lock(vad::VAD_MODEL_FILENAME);
+    let _install_guard = install_lock.lock().await;
     if vad::vad_model_exists() {
         return Ok(());
     }

--- a/app/src-tauri/src/commands/models.rs
+++ b/app/src-tauri/src/commands/models.rs
@@ -64,7 +64,8 @@ pub async fn download_model(app_handle: tauri::AppHandle, model_name: String) ->
     if is_coreml {
         let _ = app_handle.emit("download-progress", serde_json::json!({
             "received": 0,
-            "total": 0
+            "total": 0,
+            "phase": "installing"
         }));
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
@@ -75,7 +76,8 @@ pub async fn download_model(app_handle: tauri::AppHandle, model_name: String) ->
         }
         let _ = app_handle.emit("download-progress", serde_json::json!({
             "received": 1,
-            "total": 1
+            "total": 1,
+            "phase": "installing"
         }));
     } else if is_parakeet {
         download_parakeet_model(&app_handle, &model_name, &models_dir).await?;
@@ -108,6 +110,43 @@ pub async fn download_model(app_handle: tauri::AppHandle, model_name: String) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_dir(label: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "murmur-{label}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    fn write_parakeet_archive(
+        archive_path: &std::path::Path,
+        dir_name: &str,
+        complete: bool,
+    ) {
+        let source_root = archive_path.with_extension("source");
+        let bundle = source_root.join(dir_name);
+        fs::create_dir_all(&bundle).unwrap();
+        fs::write(bundle.join("encoder.fp16.onnx"), b"encoder").unwrap();
+        fs::write(bundle.join("decoder.fp16.onnx"), b"decoder").unwrap();
+        if complete {
+            fs::write(bundle.join("joiner.fp16.onnx"), b"joiner").unwrap();
+        }
+        fs::write(bundle.join("tokens.txt"), b"tokens").unwrap();
+
+        let file = fs::File::create(archive_path).unwrap();
+        let encoder = bzip2::write::BzEncoder::new(file, bzip2::Compression::best());
+        let mut archive = tar::Builder::new(encoder);
+        archive.append_dir_all(dir_name, &bundle).unwrap();
+        let encoder = archive.into_inner().unwrap();
+        encoder.finish().unwrap();
+        fs::remove_dir_all(source_root).unwrap();
+    }
 
     #[test]
     fn specific_model_check_rejects_paths() {
@@ -122,6 +161,50 @@ mod tests {
         assert!(transcriber::parakeet::is_parakeet_model(
             transcriber::COREML_MODEL_NAME
         ));
+    }
+
+    #[test]
+    fn parakeet_extraction_replaces_partial_bundle_only_after_validation() {
+        let root = test_dir("parakeet-atomic-install");
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let model_name = "parakeet-tdt-0.6b-v2-fp16";
+        let (_, dir_name) = transcriber::parakeet::download_spec(model_name).unwrap();
+        let partial = models_dir.join(&dir_name);
+        fs::create_dir_all(&partial).unwrap();
+        fs::write(partial.join("encoder.fp16.onnx"), b"partial").unwrap();
+        let archive_path = root.join("model.tar.bz2");
+        write_parakeet_archive(&archive_path, &dir_name, true);
+
+        extract_parakeet_archive(&archive_path, &models_dir, model_name, &dir_name).unwrap();
+
+        assert!(transcriber::parakeet::specific_model_exists_in(
+            model_name,
+            &models_dir
+        ));
+        assert_eq!(fs::read(partial.join("encoder.fp16.onnx")).unwrap(), b"encoder");
+        assert!(!models_dir.join(format!(".{dir_name}.extracting")).exists());
+        assert!(archive_path.exists(), "caller owns archive cleanup after success");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn incomplete_parakeet_archive_never_publishes_a_model() {
+        let root = test_dir("parakeet-incomplete-install");
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let model_name = "parakeet-tdt-0.6b-v2-fp16";
+        let (_, dir_name) = transcriber::parakeet::download_spec(model_name).unwrap();
+        let archive_path = root.join("model.tar.bz2");
+        write_parakeet_archive(&archive_path, &dir_name, false);
+
+        let error = extract_parakeet_archive(&archive_path, &models_dir, model_name, &dir_name)
+            .unwrap_err();
+
+        assert!(error.contains("incomplete"));
+        assert!(!models_dir.join(&dir_name).exists());
+        assert!(!models_dir.join(format!(".{dir_name}.extracting")).exists());
+        fs::remove_dir_all(root).unwrap();
     }
 }
 
@@ -161,36 +244,116 @@ async fn download_parakeet_model(
 ) -> Result<(), String> {
     let (url, dir_name) = transcriber::parakeet::download_spec(model_name)
         .ok_or_else(|| format!("Unknown Parakeet model '{}'", model_name))?;
-    let temp_path = models_dir.join(format!("{}.tar.bz2.tmp", dir_name));
+    if transcriber::parakeet::specific_model_exists_in(model_name, models_dir) {
+        return Ok(());
+    }
 
-    let received = stream_download(app_handle, &url, &temp_path).await?;
+    let archive_path = models_dir.join(format!("{}.tar.bz2", dir_name));
+    let legacy_temp_path = models_dir.join(format!("{}.tar.bz2.tmp", dir_name));
 
-    // Decompress + untar on a blocking thread; archive unpacks to `<dir_name>/`.
-    let temp_clone = temp_path.clone();
-    let models_dir_owned = models_dir.to_path_buf();
-    let extracted_dir = models_dir.join(&dir_name);
-    let extraction_result = tokio::task::spawn_blocking(move || {
-        // Remove any stale/partial bundle before extracting.
-        let _ = std::fs::remove_dir_all(&extracted_dir);
-        let file = std::fs::File::open(&temp_clone)
+    // v0.16.0 could leave a complete `.tmp` archive when Murmur exited during
+    // extraction. Try that expensive local data before downloading it again.
+    if legacy_temp_path.is_file() {
+        emit_installing(app_handle);
+        let archive = legacy_temp_path.clone();
+        let root = models_dir.to_path_buf();
+        let model = model_name.to_string();
+        let bundle = dir_name.clone();
+        match tokio::task::spawn_blocking(move || {
+            extract_parakeet_archive(&archive, &root, &model, &bundle)
+        })
+        .await
+        .map_err(|e| format!("Extraction task failed: {}", e))?
+        {
+            Ok(()) => {
+                let _ = tokio::fs::remove_file(&legacy_temp_path).await;
+                tracing::info!(target: "system", "Recovered Parakeet installation from retained archive: {}", dir_name);
+                return Ok(());
+            }
+            Err(error) => {
+                tracing::warn!(target: "system", "Retained Parakeet archive was unusable; downloading again: {}", error);
+                let _ = tokio::fs::remove_file(&legacy_temp_path).await;
+            }
+        }
+    }
+
+    // A finalized archive is retained when extraction fails (for example due
+    // to low disk space), so Retry performs only the local install work.
+    if !archive_path.is_file() {
+        let download_path = models_dir.join(format!("{}.tar.bz2.download", dir_name));
+        let received = stream_download(app_handle, &url, &download_path).await?;
+        tokio::fs::rename(&download_path, &archive_path)
+            .await
+            .map_err(|e| {
+                let _ = std::fs::remove_file(&download_path);
+                format!("Failed to finalize Parakeet archive: {}", e)
+            })?;
+        tracing::info!(target: "system", "Parakeet archive downloaded: {} ({} bytes)", dir_name, received);
+    }
+
+    emit_installing(app_handle);
+    let archive = archive_path.clone();
+    let root = models_dir.to_path_buf();
+    let model = model_name.to_string();
+    let bundle = dir_name.clone();
+    tokio::task::spawn_blocking(move || {
+        extract_parakeet_archive(&archive, &root, &model, &bundle)
+    })
+    .await
+    .map_err(|e| format!("Extraction task failed: {}", e))??;
+
+    let _ = tokio::fs::remove_file(&archive_path).await;
+
+    tracing::info!(target: "system", "Parakeet model installed: {}", dir_name);
+    Ok(())
+}
+
+fn emit_installing(app_handle: &tauri::AppHandle) {
+    let _ = app_handle.emit("download-progress", serde_json::json!({
+        "received": 0,
+        "total": 0,
+        "phase": "installing"
+    }));
+}
+
+fn extract_parakeet_archive(
+    archive_path: &std::path::Path,
+    models_dir: &std::path::Path,
+    model_name: &str,
+    dir_name: &str,
+) -> Result<(), String> {
+    let final_dir = models_dir.join(dir_name);
+    let staging_root = models_dir.join(format!(".{}.extracting", dir_name));
+    let staged_dir = staging_root.join(dir_name);
+
+    let _ = std::fs::remove_dir_all(&staging_root);
+    if final_dir.exists()
+        && !transcriber::parakeet::specific_model_exists_in(model_name, models_dir)
+    {
+        std::fs::remove_dir_all(&final_dir)
+            .map_err(|e| format!("Failed to remove incomplete model bundle: {}", e))?;
+    }
+    std::fs::create_dir_all(&staging_root)
+        .map_err(|e| format!("Failed to create extraction staging directory: {}", e))?;
+
+    let extraction = (|| {
+        let file = std::fs::File::open(archive_path)
             .map_err(|e| format!("Failed to open archive: {}", e))?;
         let decompressor = bzip2::read::BzDecoder::new(file);
         let mut archive = tar::Archive::new(decompressor);
-        archive.unpack(&models_dir_owned).map_err(|e| {
-            let _ = std::fs::remove_dir_all(&extracted_dir);
-            format!("Failed to extract archive: {}", e)
-        })?;
-        Ok::<(), String>(())
-    })
-    .await
-    .map_err(|e| format!("Extraction task failed: {}", e))?;
+        archive
+            .unpack(&staging_root)
+            .map_err(|e| format!("Failed to extract archive: {}", e))?;
+        if !transcriber::parakeet::specific_model_exists_in(model_name, &staging_root) {
+            return Err("Extracted Parakeet bundle is incomplete".to_string());
+        }
+        std::fs::rename(&staged_dir, &final_dir)
+            .map_err(|e| format!("Failed to publish Parakeet model bundle: {}", e))?;
+        Ok(())
+    })();
 
-    // Remove the temp archive regardless of extraction outcome.
-    let _ = tokio::fs::remove_file(&temp_path).await;
-    extraction_result?;
-
-    tracing::info!(target: "system", "Parakeet model downloaded and extracted: {} ({} bytes)", dir_name, received);
-    Ok(())
+    let _ = std::fs::remove_dir_all(&staging_root);
+    extraction
 }
 
 /// Ensure the VAD model is present, downloading it if necessary.
@@ -267,7 +430,8 @@ pub(crate) async fn stream_download(
             received += chunk.len() as u64;
             let _ = app_handle.emit("download-progress", serde_json::json!({
                 "received": received,
-                "total": total
+                "total": total,
+                "phase": "downloading"
             }));
         }
         file.flush()
@@ -279,6 +443,14 @@ pub(crate) async fn stream_download(
     if let Err(e) = stream_result {
         let _ = tokio::fs::remove_file(dest).await;
         return Err(e);
+    }
+
+    if total > 0 && received != total {
+        let _ = tokio::fs::remove_file(dest).await;
+        return Err(format!(
+            "Download ended early: received {} of {} bytes",
+            received, total
+        ));
     }
 
     Ok(received)

--- a/app/src-tauri/src/transcriber/parakeet.rs
+++ b/app/src-tauri/src/transcriber/parakeet.rs
@@ -104,6 +104,12 @@ pub fn specific_model_exists(model_name: &str) -> bool {
     }
 }
 
+/// Check a model bundle under an explicit models root. Download installation
+/// uses this to validate a staging directory before publishing it atomically.
+pub(crate) fn specific_model_exists_in(model_name: &str, models_dir: &Path) -> bool {
+    variant_for(model_name).is_some_and(|variant| variant.is_complete(models_dir))
+}
+
 /// Download info for a Parakeet model: `(tarball_url, extracted_dir_name)`.
 /// The sherpa-onnx release ships each bundle as `<dir>.tar.bz2` which unpacks
 /// to a top-level `<dir>/` folder. Returns None for unknown models.

--- a/app/src/components/ModelDownloader.tsx
+++ b/app/src/components/ModelDownloader.tsx
@@ -2,6 +2,11 @@ import { useState, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { AVAILABLE_MODEL_OPTIONS, type ModelOption } from '../lib/settings';
+import {
+  modelDownloadLabel,
+  modelDownloadPercent,
+  type ModelDownloadProgress,
+} from '../lib/modelDownload';
 
 const MODEL_DESCRIPTIONS: Record<string, string> = {
   'parakeet-tdt-0.6b-v3-coreml': 'Fastest on Apple Silicon — multilingual, Apple Neural Engine (recommended)',
@@ -32,7 +37,7 @@ interface Props {
 
 type DownloadState =
   | { phase: 'idle' }
-  | { phase: 'downloading'; received: number; total: number }
+  | { phase: 'downloading'; progress: ModelDownloadProgress }
   | { phase: 'error'; message: string };
 
 /**
@@ -56,19 +61,21 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
 
   const handleDownload = async () => {
     onDownloadingChange?.(true);
-    setDownloadState({ phase: 'downloading', received: 0, total: 0 });
+    setDownloadState({
+      phase: 'downloading',
+      progress: { received: 0, total: 0, phase: 'downloading' },
+    });
 
     // Single try/catch covering listen() as well as the download itself, so a
     // listen failure can't strand the downloading state (or an embedder's
     // navigation lock) forever.
     try {
-      const unlisten = await listen<{ received: number; total: number }>(
+      const unlisten = await listen<ModelDownloadProgress>(
         'download-progress',
         (event) => {
           setDownloadState({
             phase: 'downloading',
-            received: event.payload.received,
-            total: event.payload.total,
+            progress: event.payload,
           });
         }
       );
@@ -90,10 +97,8 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
     }
   };
 
-  const progressPercent =
-    downloadState.phase === 'downloading' && downloadState.total > 0
-      ? Math.round((downloadState.received / downloadState.total) * 100)
-      : null;
+  const progress = downloadState.phase === 'downloading' ? downloadState.progress : null;
+  const progressPercent = progress ? modelDownloadPercent(progress) : null;
 
   const isDownloading = downloadState.phase === 'downloading';
 
@@ -129,23 +134,32 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
         {isDownloading && (
           <div className="mb-4">
             <div className="flex justify-between text-xs text-stone-500 dark:text-stone-400 mb-1">
-              <span>Downloading…</span>
+              <span>{progress ? modelDownloadLabel(progress) : 'Starting...'}</span>
               {progressPercent !== null ? (
                 <span>{progressPercent}%</span>
               ) : (
-                <span>Starting…</span>
+                <span>Working...</span>
               )}
             </div>
             <div className="w-full h-2 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
               <div
-                className="h-full bg-blue-500 rounded-full transition-all duration-200"
-                style={{ width: `${progressPercent ?? 0}%` }}
+                role="progressbar"
+                aria-valuenow={progressPercent ?? undefined}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuetext={progressPercent === null ? 'Model installation in progress' : undefined}
+                className={`h-full bg-blue-500 rounded-full ${
+                  progressPercent === null
+                    ? 'model-download-indeterminate'
+                    : 'transition-all duration-200'
+                }`}
+                style={progressPercent === null ? undefined : { width: `${progressPercent}%` }}
               />
             </div>
-            {downloadState.total > 0 && (
+            {progress && progress.total > 0 && progress.phase !== 'installing' && (
               <p className="text-xs text-stone-400 dark:text-stone-500 mt-1 text-right">
-                {(downloadState.received / 1024 / 1024).toFixed(1)} /{' '}
-                {(downloadState.total / 1024 / 1024).toFixed(1)} MB
+                {(progress.received / 1024 / 1024).toFixed(1)} /{' '}
+                {(progress.total / 1024 / 1024).toFixed(1)} MB
               </p>
             )}
           </div>
@@ -163,7 +177,7 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
           className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
         >
           {isDownloading
-            ? 'Downloading…'
+            ? progress ? modelDownloadLabel(progress) : 'Starting...'
             : downloadState.phase === 'error'
             ? 'Retry Download'
             : 'Download'}

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -16,6 +16,11 @@ import {
   saveBenchmarkReports,
 } from '../../lib/benchmark';
 import { downloadModel } from '../../lib/dictation';
+import {
+  modelDownloadLabel,
+  modelDownloadPercent,
+  type ModelDownloadProgress,
+} from '../../lib/modelDownload';
 import type { DictationStatus } from '../../lib/types';
 
 const PRESETS: { id: BenchmarkPreset; label: string; detail: string }[] = [
@@ -136,7 +141,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [downloading, setDownloading] = useState<string | null>(null);
-  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
+  const [downloadProgress, setDownloadProgress] = useState<ModelDownloadProgress | null>(null);
   const [fileTranscribing, setFileTranscribing] = useState(false);
   const mounted = useRef(true);
   const runningRef = useRef(false);
@@ -250,9 +255,8 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
     setDownloadProgress(null);
     let unlisten: (() => void) | undefined;
     try {
-      unlisten = await listen<{ received: number; total: number }>('download-progress', (event) => {
-        const { received, total } = event.payload;
-        setDownloadProgress(total > 0 ? Math.round((received / total) * 100) : null);
+      unlisten = await listen<ModelDownloadProgress>('download-progress', (event) => {
+        setDownloadProgress(event.payload);
       });
       await downloadModel(modelName);
       await refreshModels();
@@ -327,7 +331,11 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-stone-300 dark:border-stone-600 rounded-md text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700 disabled:opacity-50"
                 >
                   {downloading === model.modelName
-                    ? downloadProgress === null ? 'Preparing...' : `${downloadProgress}%`
+                    ? downloadProgress === null
+                      ? 'Starting...'
+                      : modelDownloadPercent(downloadProgress) === null
+                        ? modelDownloadLabel(downloadProgress)
+                        : `${modelDownloadPercent(downloadProgress)}%`
                     : 'Download'}
                 </button>
               )}

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -14,6 +14,11 @@ import { VocabScanStrip } from './VocabScanStrip';
 import { PerformanceLab } from './PerformanceLab';
 import { useVocabScan } from '../../lib/hooks/useVocabScan';
 import { countVocabTokens } from '../../lib/dictation';
+import {
+  modelDownloadLabel,
+  modelDownloadPercent,
+  type ModelDownloadProgress,
+} from '../../lib/modelDownload';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
 
@@ -491,7 +496,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
   const [modelAvailable, setModelAvailable] = useState<boolean | null>(null);
   const [modelDownload, setModelDownload] = useState<
     | { phase: 'idle' }
-    | { phase: 'downloading'; received: number; total: number }
+    | { phase: 'downloading'; progress: ModelDownloadProgress }
     | { phase: 'error'; message: string }
   >({ phase: 'idle' });
   const downloadUnlistenRef = useRef<(() => void) | null>(null);
@@ -518,17 +523,19 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
   const handleModelDownload = useCallback(async () => {
     const modelName = settings.model;
     downloadModelRef.current = modelName;
-    setModelDownload({ phase: 'downloading', received: 0, total: 0 });
+    setModelDownload({
+      phase: 'downloading',
+      progress: { received: 0, total: 0, phase: 'downloading' },
+    });
     let unlisten: (() => void) | null = null;
     try {
-      unlisten = await listen<{ received: number; total: number }>(
+      unlisten = await listen<ModelDownloadProgress>(
         'download-progress',
         (event) => {
           if (downloadModelRef.current !== modelName) return;
           setModelDownload({
             phase: 'downloading',
-            received: event.payload.received,
-            total: event.payload.total,
+            progress: event.payload,
           });
         }
       );
@@ -579,10 +586,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
   const useNeuralEngine = selectedModel?.backend === 'coreml';
   // The sherpa Parakeet bundle is English-only; FluidAudio Parakeet v3 is multilingual.
   const isEnglishOnlyModel = settings.model.endsWith('.en') || selectedModel?.backend === 'parakeet';
-  const downloadProgressPercent =
-    modelDownload.phase === 'downloading' && modelDownload.total > 0
-      ? Math.round((modelDownload.received / modelDownload.total) * 100)
-      : null;
+  const activeModelDownload = modelDownload.phase === 'downloading'
+    ? modelDownload.progress
+    : null;
+  const downloadProgressPercent = activeModelDownload
+    ? modelDownloadPercent(activeModelDownload)
+    : null;
 
   return (
     <div className="flex-1 flex overflow-hidden bg-white dark:bg-stone-900">
@@ -696,22 +705,30 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           {modelDownload.phase === 'downloading' && (
             <div className="mt-2">
               <div className="flex justify-between text-xs text-stone-500 dark:text-stone-400 mb-1">
-                <span>Downloading…</span>
+                <span>{activeModelDownload ? modelDownloadLabel(activeModelDownload) : 'Starting...'}</span>
                 {downloadProgressPercent !== null ? (
                   <span>{downloadProgressPercent}%</span>
                 ) : (
-                  <span>Starting…</span>
+                  <span>Working...</span>
                 )}
               </div>
               <div className="w-full h-1.5 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
                 <div
                   role="progressbar"
-                  aria-valuenow={downloadProgressPercent ?? 0}
+                  aria-valuenow={downloadProgressPercent ?? undefined}
                   aria-valuemin={0}
                   aria-valuemax={100}
-                  aria-valuetext={`Download progress: ${downloadProgressPercent ?? 0} percent`}
-                  className="h-full bg-blue-500 rounded-full transition-all duration-200"
-                  style={{ width: `${downloadProgressPercent ?? 0}%` }}
+                  aria-valuetext={downloadProgressPercent === null
+                    ? 'Model installation in progress'
+                    : `Download progress: ${downloadProgressPercent} percent`}
+                  className={`h-full bg-blue-500 rounded-full ${
+                    downloadProgressPercent === null
+                      ? 'model-download-indeterminate'
+                      : 'transition-all duration-200'
+                  }`}
+                  style={downloadProgressPercent === null
+                    ? undefined
+                    : { width: `${downloadProgressPercent}%` }}
                 />
               </div>
             </div>

--- a/app/src/lib/modelDownload.test.ts
+++ b/app/src/lib/modelDownload.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { modelDownloadLabel, modelDownloadPercent } from './modelDownload';
+
+describe('model download progress', () => {
+  it('reports determinate byte progress for streamed models', () => {
+    const progress = { received: 50, total: 200, phase: 'downloading' as const };
+    expect(modelDownloadPercent(progress)).toBe(25);
+    expect(modelDownloadLabel(progress)).toBe('Downloading...');
+  });
+
+  it('keeps Core ML setup indeterminate instead of showing a frozen zero', () => {
+    const progress = { received: 0, total: 0, phase: 'installing' as const };
+    expect(modelDownloadPercent(progress)).toBeNull();
+    expect(modelDownloadLabel(progress)).toBe('Installing...');
+  });
+
+  it('treats old unknown-total events as indeterminate', () => {
+    expect(modelDownloadPercent({ received: 0, total: 0 })).toBeNull();
+  });
+
+  it('clamps malformed byte progress to the completed state', () => {
+    expect(modelDownloadPercent({ received: 250, total: 200 })).toBe(100);
+  });
+});

--- a/app/src/lib/modelDownload.ts
+++ b/app/src/lib/modelDownload.ts
@@ -1,0 +1,16 @@
+export type ModelDownloadPhase = 'downloading' | 'installing';
+
+export interface ModelDownloadProgress {
+  received: number;
+  total: number;
+  phase?: ModelDownloadPhase;
+}
+
+export function modelDownloadPercent(progress: ModelDownloadProgress): number | null {
+  if (progress.phase === 'installing' || progress.total <= 0) return null;
+  return Math.min(100, Math.round((progress.received / progress.total) * 100));
+}
+
+export function modelDownloadLabel(progress: ModelDownloadProgress): string {
+  return progress.phase === 'installing' ? 'Installing...' : 'Downloading...';
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -9,3 +9,20 @@ body {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(0.85); }
 }
+
+@keyframes model-download-indeterminate {
+  from { transform: translateX(-120%); }
+  to { transform: translateX(280%); }
+}
+
+.model-download-indeterminate {
+  width: 40%;
+  animation: model-download-indeterminate 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .model-download-indeterminate {
+    width: 100%;
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -23,6 +23,6 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .model-download-indeterminate {
     width: 100%;
-    animation: pulse 1.5s ease-in-out infinite;
+    animation: none;
   }
 }

--- a/docs/features/models.md
+++ b/docs/features/models.md
@@ -144,6 +144,17 @@ The settings panel supports downloading models without leaving the settings view
 4. On error: red error banner with message and "Retry" link
 5. Stale-request protection prevents progress updates from a previously selected model
 
+Core ML setup has no byte-progress callback in FluidAudio, so onboarding,
+Settings, and Performance Lab show an animated indeterminate **Installing**
+state instead of a misleading frozen 0%. Whisper and sherpa downloads continue
+to show measured byte percentages.
+
+Parakeet archives are retained until installation succeeds. Extraction happens
+under a staging directory, the four required files are validated there, and the
+bundle is renamed into its final location only after validation. If Murmur exits
+during extraction, Retry reuses the completed local archive rather than
+downloading 1.2 GB again; partial bundles are never reported as installed.
+
 Model selection is disabled while recording is active.
 
 ## Settings

--- a/docs/features/models.md
+++ b/docs/features/models.md
@@ -98,7 +98,7 @@ The main app controls are gated on `initialized` (which requires a model to exis
 
 - Uses `reqwest` with 30s connect timeout and 15-minute overall timeout
 - Writes chunks to a temp file (`.tmp` suffix)
-- Emits `download-progress` events with `{ received, total }` payload
+- Emits `download-progress` events with `{ received, total, phase }` payload
 - On success: atomic rename from `.tmp` to final path
 - On failure: temp file cleaned up
 
@@ -108,7 +108,7 @@ Single `.bin` file downloaded directly from HuggingFace. Atomic rename on comple
 
 ### Parakeet Downloads
 
-The model bundle ships as a `.tar.bz2` from the sherpa-onnx `asr-models` GitHub release. `download_parakeet_model` streams it (same progress events), then decompresses (`bzip2`) and untars (`tar`) on a blocking thread into the models dir, replacing any stale bundle. The temp archive is removed afterward.
+The model bundle ships as a `.tar.bz2` from the sherpa-onnx `asr-models` GitHub release. `download_parakeet_model` streams it with the same progress events, retains the completed archive, and extracts it on a blocking thread under a staging directory. Murmur validates all required files before atomically renaming the bundle into the models directory. The archive is deleted only after a successful install or when its contents are invalid; transient extraction or publication failures preserve it for Retry. Partial bundles are never published.
 
 ### FluidAudio Core ML Setup
 


### PR DESCRIPTION
## Summary
- recover complete Parakeet v2 archives left by v0.16.0 instead of downloading them again
- extract and validate model bundles in staging before atomically publishing them
- serialize same-model installs and the shared VAD transaction
- distinguish invalid archives from transient install failures so retries reuse good local data
- show indeterminate Installing progress for Core ML setup across onboarding, Settings, and Performance Lab
- reject truncated streamed downloads

## Verification
- cargo test -- --test-threads=1 (261 passed; Core ML hardware test ignored)
- npm test -- --run (78 passed)
- npm run build
- npx tsc --noEmit
- bzip2 -tv on the retained 1.12 GB v2 archive

Closes #215
Closes #217