### PR TITLE
fix: prevent recording startup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Fast hold-down dictations no longer disappear when key release races Core Audio startup; native start, stop, and cancel transitions are serialized and the frontend waits for startup before processing (#216).
+
 ## [0.16.0] - 2026-07-17
 
 ### Added

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1298,6 +1298,10 @@ pub async fn start_native_recording(
     state: tauri::State<'_, State>,
     device_name: Option<String>,
 ) -> Result<serde_json::Value, String> {
+    // Hold through cpal readiness and the recording event. A quick release can
+    // invoke stop while start_recording is waiting for its capture thread; the
+    // stop command must observe the fully-started recorder, never a midpoint.
+    let _transition = state.app_state.recording_transition.lock().await;
     if keyboard::is_app_disabled() {
         tracing::info!(target: "pipeline", "start_native_recording: app disabled — ignoring");
         return Ok(serde_json::json!({ "type": "app_disabled", "state": "idle" }));
@@ -1368,6 +1372,7 @@ pub async fn stop_native_recording(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
+    let transition = state.app_state.recording_transition.lock().await;
     // Atomic check-and-set + rid capture in a single lock to avoid TOCTOU gap
     let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
@@ -1406,6 +1411,9 @@ pub async fn stop_native_recording(
         }
         e
     })?;
+    // Audio is now detached from the recorder state. Let cancel or another
+    // rejected start inspect Processing while inference continues.
+    drop(transition);
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
 
     if samples.is_empty() {
@@ -1519,6 +1527,7 @@ pub async fn cancel_native_recording(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<(), String> {
+    let _transition = state.app_state.recording_transition.lock().await;
     let (prev_status, rid) = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         let prev = dictation.status;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -126,6 +126,10 @@ impl Default for DictationState {
 
 pub struct AppState {
     pub dictation: Mutex<DictationState>,
+    /// Serializes recorder start/stop/cancel transitions. Audio startup waits
+    /// for the cpal stream to become ready, so a fast key release must not tear
+    /// the recorder down until that startup has fully completed.
+    pub recording_transition: tokio::sync::Mutex<()>,
     pub backend: Mutex<Box<dyn TranscriptionBackend>>,
     pub last_transcription_at: Mutex<Option<Instant>>,
     pub idle_timeout_minutes: Mutex<u32>,
@@ -165,6 +169,7 @@ impl Default for AppState {
     fn default() -> Self {
         Self {
             dictation: Mutex::new(DictationState::default()),
+            recording_transition: tokio::sync::Mutex::new(()),
             backend: Mutex::new(Box::new(WhisperBackend::new())),
             last_transcription_at: Mutex::new(None),
             idle_timeout_minutes: Mutex::new(5),
@@ -173,5 +178,19 @@ impl Default for AppState {
             file_transcribing: AtomicBool::new(false),
             correction_matcher: Mutex::new(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recording_transition_allows_only_one_audio_operation() {
+        let state = AppState::default();
+        let first = state.recording_transition.try_lock().unwrap();
+        assert!(state.recording_transition.try_lock().is_err());
+        drop(first);
+        assert!(state.recording_transition.try_lock().is_ok());
     }
 }

--- a/app/src/lib/hooks/useRecordingState.test.tsx
+++ b/app/src/lib/hooks/useRecordingState.test.tsx
@@ -1,0 +1,99 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  startRecording: vi.fn(),
+  stopRecording: vi.fn(),
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock('../dictation', () => ({
+  startRecording: mocks.startRecording,
+  stopRecording: mocks.stopRecording,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock('../stats', () => ({
+  updateStats: vi.fn(),
+}));
+
+vi.mock('../log', () => ({
+  flog: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { useRecordingState } from './useRecordingState';
+
+type RecordingState = ReturnType<typeof useRecordingState>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe('useRecordingState transition ordering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: RecordingState;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    function Harness() {
+      current = useRecordingState({
+        addEntry: vi.fn(),
+        microphone: 'system_default',
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('waits for in-flight recorder startup before invoking stop', async () => {
+    const startup = deferred<{ type: string; state: string }>();
+    mocks.startRecording.mockReturnValueOnce(startup.promise);
+    mocks.stopRecording.mockResolvedValueOnce({
+      type: 'transcription',
+      state: 'idle',
+      text: '',
+    });
+
+    let startPromise!: Promise<void>;
+    await act(async () => {
+      startPromise = current.handleStart();
+      await Promise.resolve();
+    });
+
+    let stopPromise!: Promise<void>;
+    await act(async () => {
+      stopPromise = current.handleStop();
+      await Promise.resolve();
+    });
+
+    expect(mocks.startRecording).toHaveBeenCalledOnce();
+    expect(mocks.stopRecording).not.toHaveBeenCalled();
+
+    startup.resolve({ type: 'recording_started', state: 'recording' });
+    await act(async () => {
+      await Promise.all([startPromise, stopPromise]);
+    });
+
+    expect(mocks.stopRecording).toHaveBeenCalledOnce();
+    expect(current.status).toBe('idle');
+  });
+});

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -28,6 +28,7 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { microphoneRef.current = microphone; }, [microphone]);
   const isStartingRef = useRef(false);
+  const startOperationRef = useRef<Promise<void> | null>(null);
   const isStoppingRef = useRef(false);
 
   // Recording duration timer
@@ -54,6 +55,9 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
           recordingStartTime: recordingStartTimeRef.current,
           isStopping: isStoppingRef.current,
         });
+        // Update the ref synchronously. Hotkey events can arrive before React
+        // commits the state update, and transition decisions read this ref.
+        statusRef.current = event.payload;
         setStatus(event.payload);
         // When recording starts from the overlay, handleStart doesn't run in this window.
         // Seed recordingStartTime so the duration timer ticks.
@@ -155,30 +159,48 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
     flog.info('recording', 'handleStart called', {
       isStarting: isStartingRef.current, status: statusRef.current,
     });
-    if (isStartingRef.current) return;
+    if (startOperationRef.current) {
+      await startOperationRef.current;
+      return;
+    }
     isStartingRef.current = true;
-    try {
-      setError('');
-      const res = await startRecording(microphoneRef.current);
-      if (isDictationStatus(res.state)) setStatus(res.state);
-      if (res.type === 'recording_started') {
-        if (!recordingStartTimeRef.current) {
-          const now = Date.now();
-          flog.info('recording', 'setting recordingStartTime', { value: now });
-          recordingStartTimeRef.current = now;
-          setRecordingStartTime(now);
+    const operation = (async () => {
+      try {
+        setError('');
+        const res = await startRecording(microphoneRef.current);
+        if (isDictationStatus(res.state)) {
+          statusRef.current = res.state;
+          setStatus(res.state);
         }
-      } else {
-        if (res.type === 'error') setError(res.error || 'Unknown error');
-        else if (res.type === 'busy_benchmarking') setError('Wait for the benchmark to finish.');
-        else if (res.type === 'busy_transcribing_file') setError('Wait for the file transcription to finish.');
+        if (res.type === 'recording_started') {
+          if (!recordingStartTimeRef.current) {
+            const now = Date.now();
+            flog.info('recording', 'setting recordingStartTime', { value: now });
+            recordingStartTimeRef.current = now;
+            setRecordingStartTime(now);
+          }
+        } else {
+          if (res.type === 'error') setError(res.error || 'Unknown error');
+          else if (res.type === 'busy_benchmarking') setError('Wait for the benchmark to finish.');
+          else if (res.type === 'busy_transcribing_file') setError('Wait for the file transcription to finish.');
+        }
+      } catch (err) {
+        statusRef.current = 'idle';
+        setStatus('idle');
+        setError(String(err));
+        setRecordingStartTime(null);
+        recordingStartTimeRef.current = null;
+      } finally {
+        isStartingRef.current = false;
       }
-    } catch (err) {
-      setError(String(err));
-      setRecordingStartTime(null);
-      recordingStartTimeRef.current = null;
+    })();
+    startOperationRef.current = operation;
+    try {
+      await operation;
     } finally {
-      isStartingRef.current = false;
+      if (startOperationRef.current === operation) {
+        startOperationRef.current = null;
+      }
     }
   }, []);
 
@@ -189,11 +211,24 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
     });
     if (isStoppingRef.current) return;
     isStoppingRef.current = true;
-    const duration = recordingStartTimeRef.current
-      ? Math.floor((Date.now() - recordingStartTimeRef.current) / 1000)
-      : 0;
-    flog.info('recording', 'computed duration', { duration });
     try {
+      // Hold-down release can arrive while native audio startup is still in
+      // flight. Wait for its result so Processing cannot precede Recording.
+      if (startOperationRef.current) {
+        flog.info('recording', 'handleStop waiting for recording startup');
+        await startOperationRef.current;
+      }
+      if (statusRef.current !== 'recording') {
+        flog.info('recording', 'handleStop ignored after startup', {
+          status: statusRef.current,
+        });
+        return;
+      }
+      const duration = recordingStartTimeRef.current
+        ? Math.floor((Date.now() - recordingStartTimeRef.current) / 1000)
+        : 0;
+      flog.info('recording', 'computed duration', { duration });
+      statusRef.current = 'processing';
       setStatus('processing');
       const res = await stopRecording();
       if (res.text) {
@@ -205,17 +240,21 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
       // Only update status from the return value if we're still in
       // processing. If cancel already set us to idle (or a new recording
       // started), don't clobber the current state with a stale result.
-      // Functional update ensures atomic check-and-set even if statusRef
-      // hasn't synced yet.
+      // Event handlers update statusRef synchronously, so this check cannot
+      // lag behind React rendering.
       const newStatus = isDictationStatus(res.state) ? res.state : 'idle';
-      setStatus(prev => prev === 'processing' ? newStatus : prev);
+      if (statusRef.current === 'processing') {
+        statusRef.current = newStatus;
+        setStatus(newStatus);
+      }
     } catch (err) {
       setError(String(err));
+      statusRef.current = 'idle';
       setStatus('idle');
     } finally {
       isStoppingRef.current = false;
     }
-  }, [addEntry]);
+  }, []);
 
   // Stable toggle for hotkey use — reads status from ref
   const toggleRecording = useCallback(async () => {

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -29,3 +29,5 @@ Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable
 if (typeof window !== 'undefined') {
   Object.defineProperty(window, 'localStorage', { value: storage, configurable: true });
 }
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -86,6 +86,9 @@ Idle → Recording (on start) → Processing (on stop) → Idle (after transcrip
 ```
 
 Status is managed in `DictationState` behind a `Mutex` with poison recovery (`MutexExt` trait).
+Recorder start, stop, and cancel also share an async transition mutex. The lock
+is held until cpal confirms startup or audio teardown completes, preventing a
+fast hotkey release from stopping a recorder that is still starting.
 
 ## Frontend Integration
 


### PR DESCRIPTION
## Summary
- serialize native start, stop, and cancel operations through audio readiness/teardown
- make the frontend await an in-flight start before entering Processing
- update status refs synchronously so rapid hotkey events never read stale React state
- add a regression test that fires stop while startup is unresolved

## Verification
- cargo check
- cargo test -- --test-threads=1 (257 passed; Whisper integration passed)
- npm test -- --run (75 passed)
- npx tsc --noEmit
- npm run build

Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where fast hold-down dictations could disappear when the key was released during audio startup.
  * Improved recording start, stop, and cancel handling to prevent conflicting transitions and ensure dictations complete reliably.

* **Documentation**
  * Clarified recording status transitions during startup, stopping, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->