### PR TITLE
Fix quick Both-mode Core ML dictations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- Quick Both-mode holds now stop and transcribe as soon as the 200 ms promotion threshold is reached instead of being discarded by an obsolete 300 ms grace window; empty Core ML results after VAD also retry once with the original audio and emit privacy-safe diagnostics (#221).
 - Fast hold-down dictations no longer disappear when key release races Core Audio startup; native start, stop, and cancel transitions are serialized and the frontend waits for startup before processing (#216).
 - Parakeet v2 downloads now survive an interrupted extraction: Murmur reuses the completed archive, validates a staged bundle, and publishes it atomically instead of leaving a partial model that appears undownloaded (#215).
 - Core ML model setup now shows an animated indeterminate Installing state across onboarding, Settings, and Performance Lab instead of a frozen 0% bar (#217).

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -418,6 +418,30 @@ pub(crate) struct PipelineTimings {
     pub rss_after_mb: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
+fn transcribe_with_coreml_vad_retry(
+    backend: &mut dyn transcriber::TranscriptionBackend,
+    model_name: &str,
+    samples_for_transcription: &[f32],
+    original_samples: &[f32],
+    vad_trimmed: bool,
+    language: &str,
+    prompt: Option<&str>,
+    smart_punctuation: bool,
+) -> Result<String, String> {
+    let text = backend.transcribe(samples_for_transcription, language, prompt, smart_punctuation)?;
+    if transcriber::is_coreml_model(model_name) && vad_trimmed && text.trim().is_empty() {
+        tracing::warn!(
+            target: "pipeline",
+            filtered_sample_count = samples_for_transcription.len(),
+            original_sample_count = original_samples.len(),
+            "coreml_empty_after_vad_retry_original"
+        );
+        return backend.transcribe(original_samples, language, prompt, smart_punctuation);
+    }
+    Ok(text)
+}
+
 /// Shared transcription pipeline: model init -> transcribe -> inject text -> set idle.
 /// `recording_id` is checked against `app_state.cancelled_id` at checkpoints;
 /// if cancelled, returns empty text without clipboard write or paste.
@@ -474,7 +498,7 @@ async fn run_transcription_pipeline(
     // Phase: VAD -- filter out silence to prevent Whisper hallucination loops
     let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
     let t_vad = std::time::Instant::now();
-    let samples_for_transcription = match vad::vad_model_path() {
+    let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
         Some(vad_path) if vad_path.exists() => {
             let vad_path_str = vad_path.to_string_lossy().to_string();
             let samples_owned = samples.to_vec();
@@ -497,11 +521,12 @@ async fn run_transcription_pipeline(
                         samples.len(), trimmed.len(),
                         trimmed.len() as f64 / samples.len() as f64 * 100.0,
                         t_vad.elapsed());
-                    trimmed
+                    let vad_trimmed = trimmed.len() != samples.len();
+                    (trimmed, vad_trimmed)
                 }
                 Err(e) => {
                     tracing::warn!(target: "pipeline", "VAD failed ({}), proceeding without filtering", e);
-                    samples.to_vec()
+                    (samples.to_vec(), false)
                 }
             }
         }
@@ -513,7 +538,7 @@ async fn run_transcription_pipeline(
                     tracing::warn!(target: "pipeline", "VAD model download failed ({}), skipping VAD", e);
                 }
             });
-            samples.to_vec()
+            (samples.to_vec(), false)
         }
     };
     let vad_ms = t_vad.elapsed().as_millis() as u64;
@@ -540,7 +565,10 @@ async fn run_transcription_pipeline(
         backend.load_model(&model_name)?;
         let model_load_ms = load_started.elapsed().as_millis() as u64;
         let decode_started = std::time::Instant::now();
-        let text = backend.transcribe(&samples_for_transcription, &language, prompt.as_deref(), smart_punctuation)?;
+        let text = transcribe_with_coreml_vad_retry(
+            backend.as_mut(), &model_name, &samples_for_transcription, samples,
+            vad_trimmed, &language, prompt.as_deref(), smart_punctuation,
+        )?;
         let decode_ms = decode_started.elapsed().as_millis() as u64;
         (text, model_load_ms, decode_ms)
     };
@@ -1653,7 +1681,7 @@ pub async fn transcribe_file(
 
     // Phase: VAD — skip silence, best-effort with fallback to full audio (mirrors live).
     let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
-    let samples_for_transcription = match vad::vad_model_path() {
+    let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
         Some(vad_path) if vad_path.exists() => {
             let vad_path_str = vad_path.to_string_lossy().to_string();
             let samples_owned = samples.clone();
@@ -1670,10 +1698,13 @@ pub async fn transcribe_file(
                         "type": "file_transcription", "text": "", "duration": duration_secs
                     }));
                 }
-                Ok(vad::VadResult::Speech(trimmed)) => trimmed,
+                Ok(vad::VadResult::Speech(trimmed)) => {
+                    let vad_trimmed = trimmed.len() != samples.len();
+                    (trimmed, vad_trimmed)
+                }
                 Err(e) => {
                     tracing::warn!(target: "pipeline", "transcribe_file: VAD failed ({}), proceeding without filtering", e);
-                    samples
+                    (samples.clone(), false)
                 }
             }
         }
@@ -1685,7 +1716,7 @@ pub async fn transcribe_file(
                     tracing::warn!(target: "pipeline", "transcribe_file: VAD model download failed ({})", e);
                 }
             });
-            samples
+            (samples.clone(), false)
         }
     };
 
@@ -1700,7 +1731,10 @@ pub async fn transcribe_file(
         backend.load_model(&model_name)?;
         let model_load_ms = load_started.elapsed().as_millis() as u64;
         let decode_started = std::time::Instant::now();
-        let text = backend.transcribe(&samples_for_transcription, &language, prompt.as_deref(), smart_punctuation)?;
+        let text = transcribe_with_coreml_vad_retry(
+            backend.as_mut(), &model_name, &samples_for_transcription, &samples,
+            vad_trimmed, &language, prompt.as_deref(), smart_punctuation,
+        )?;
         let decode_ms = decode_started.elapsed().as_millis() as u64;
         (text, model_load_ms, decode_ms)
     };
@@ -1728,6 +1762,82 @@ pub async fn transcribe_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+
+    struct RetryTestBackend {
+        responses: VecDeque<String>,
+        sample_counts: Vec<usize>,
+    }
+
+    impl RetryTestBackend {
+        fn new(responses: &[&str]) -> Self {
+            Self {
+                responses: responses.iter().map(|response| response.to_string()).collect(),
+                sample_counts: Vec::new(),
+            }
+        }
+    }
+
+    impl transcriber::TranscriptionBackend for RetryTestBackend {
+        fn name(&self) -> &str { "retry-test" }
+        fn load_model(&mut self, _model_name: &str) -> Result<(), String> { Ok(()) }
+        fn is_model_loaded(&self, _model_name: &str) -> bool { true }
+        fn transcribe(&mut self, samples: &[f32], _language: &str, _initial_prompt: Option<&str>, _smart_punctuation: bool) -> Result<String, String> {
+            self.sample_counts.push(samples.len());
+            self.responses.pop_front().ok_or_else(|| "unexpected extra transcription attempt".to_string())
+        }
+        fn token_count(&self, _text: &str) -> Option<usize> { None }
+        fn model_exists(&self) -> bool { true }
+        fn models_dir(&self) -> Result<PathBuf, String> { Ok(std::env::temp_dir()) }
+        fn reset(&mut self) {}
+    }
+
+    #[test]
+    fn empty_coreml_result_after_vad_retries_original_audio_once() {
+        let filtered = vec![0.0; 8_000];
+        let original = vec![0.0; 16_000];
+        let mut backend = RetryTestBackend::new(&["", "recovered words"]);
+        let text = transcribe_with_coreml_vad_retry(
+            &mut backend, transcriber::COREML_MODEL_NAME, &filtered, &original,
+            true, "auto", None, true,
+        ).unwrap();
+        assert_eq!(text, "recovered words");
+        assert_eq!(backend.sample_counts, vec![8_000, 16_000]);
+    }
+
+    #[test]
+    fn still_empty_coreml_retry_is_bounded_to_two_attempts() {
+        let filtered = vec![0.0; 8_000];
+        let original = vec![0.0; 16_000];
+        let mut backend = RetryTestBackend::new(&["", ""]);
+        let text = transcribe_with_coreml_vad_retry(
+            &mut backend, transcriber::COREML_MODEL_NAME, &filtered, &original,
+            true, "auto", None, true,
+        ).unwrap();
+        assert!(text.is_empty());
+        assert_eq!(backend.sample_counts, vec![8_000, 16_000]);
+    }
+
+    #[test]
+    fn empty_result_without_coreml_vad_trim_is_not_retried() {
+        let samples = vec![0.0; 8_000];
+        let mut non_coreml = RetryTestBackend::new(&[""]);
+        let text = transcribe_with_coreml_vad_retry(
+            &mut non_coreml, "base.en", &samples, &samples,
+            true, "en", None, true,
+        ).unwrap();
+        assert!(text.is_empty());
+        assert_eq!(non_coreml.sample_counts, vec![8_000]);
+
+        let mut untrimmed_coreml = RetryTestBackend::new(&[""]);
+        let text = transcribe_with_coreml_vad_retry(
+            &mut untrimmed_coreml, transcriber::COREML_MODEL_NAME, &samples, &samples,
+            false, "auto", None, true,
+        ).unwrap();
+        assert!(text.is_empty());
+        assert_eq!(untrimmed_coreml.sample_counts, vec![8_000]);
+    }
 
     #[test]
     fn dedupe_prompt_drops_case_insensitive_repeats() {

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -23,14 +23,6 @@ use tauri::Emitter;
 /// Max duration a single tap can be held before it's rejected
 const MAX_HOLD_DURATION_MS: u128 = 200;
 
-/// Grace window after the hold-promotion timer fires during which a key release
-/// cancels (instead of stops) the speculative recording. Audio thread init has
-/// been observed to take up to ~233 ms, so 300 ms leaves headroom while keeping
-/// the total minimum intentional hold at ~500 ms (200 ms timer + 300 ms grace).
-/// This is a workaround for the RECORDING_STATE mutex race in audio::start_recording
-/// — not a true fix of the underlying audio-init contention.
-const MIN_POST_PROMOTION_MS: u128 = 300;
-
 /// Max gap between first key-up and second key-down
 const DOUBLE_TAP_WINDOW_MS: u128 = 400;
 
@@ -479,11 +471,6 @@ fn log_rejection(reason: RejectionReason, mode: DetectorMode, event_type: &Event
 static HOLD_PRESS_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// Set to true by the timer thread when it promotes a press to a real hold.
 static HOLD_PROMOTED: AtomicBool = AtomicBool::new(false);
-/// Unix-epoch millis at the moment the promotion timer emitted `hold-down-start`.
-/// Zero means no active promotion. Used to detect releases that arrive inside the
-/// audio-init grace window so they can be converted into `hold-down-cancel` instead
-/// of `hold-down-stop`.
-static HOLD_PROMOTED_AT_MS: AtomicU64 = AtomicU64::new(0);
 /// When true, the Both-mode callback ignores all key events.
 /// Set by lib.rs when the transcription pipeline is running.
 static IS_PROCESSING: AtomicBool = AtomicBool::new(false);
@@ -514,7 +501,6 @@ pub fn set_processing(processing: bool) {
         // Entering processing: invalidate any pending hold-promotion timer
         // so it can't fire hold-down-start during active processing.
         HOLD_PROMOTED.store(false, Ordering::SeqCst);
-        HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
         HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
         if let Ok(mut det) = HOLD_DOWN_DETECTOR.lock() {
             if let Some(d) = det.as_mut() {
@@ -542,7 +528,6 @@ pub fn set_processing(processing: bool) {
             }
         }
         HOLD_PROMOTED.store(false, Ordering::SeqCst);
-        HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
         HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
     }
 }
@@ -561,7 +546,6 @@ pub fn set_app_disabled(disabled: bool) {
     if !was_disabled && disabled {
         // Transitioning false → true: clean up any partial detector state
         HOLD_PROMOTED.store(false, Ordering::SeqCst);
-        HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
         HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
         if let Ok(mut det) = HOLD_DOWN_DETECTOR.lock() {
             if let Some(d) = det.as_mut() {
@@ -731,7 +715,6 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
                     }
                     // Invalidate pending hold-promotion timers
                     HOLD_PROMOTED.store(false, Ordering::SeqCst);
-                    HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
                     HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
 
                     tracing::info!(target: "keyboard", "Escape pressed — emitting escape-cancel");
@@ -858,8 +841,6 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
                                                 .unwrap_or(false)
                                         };
                                         if still_held {
-                                            HOLD_PROMOTED_AT_MS
-                                                .store(now_unix_ms(), Ordering::SeqCst);
                                             HOLD_PROMOTED.store(true, Ordering::SeqCst);
                                             tracing::info!(target: "keyboard", "BOTH -> timer promoted to hold-down-start");
                                             let _ = timer_handle.emit("hold-down-start", ());
@@ -869,24 +850,15 @@ pub fn start_listener(app_handle: tauri::AppHandle, hotkey: &str, mode: &str) {
                             }
                             HoldDownEvent::Stop => {
                                 let promoted = HOLD_PROMOTED.load(Ordering::SeqCst);
-                                let promoted_at = HOLD_PROMOTED_AT_MS.load(Ordering::SeqCst);
                                 HOLD_PROMOTED.store(false, Ordering::SeqCst);
-                                HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
                                 // Invalidate any pending timer
                                 HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst);
 
                                 if promoted {
-                                    let elapsed = now_unix_ms().saturating_sub(promoted_at) as u128;
-                                    if promoted_at != 0 && elapsed < MIN_POST_PROMOTION_MS {
-                                        // Release arrived inside the audio-init grace window —
-                                        // cancel the speculative recording instead of stopping.
-                                        tracing::info!(target: "keyboard", "BOTH -> emit hold-down-cancel (grace window; elapsed={}ms, threshold={}ms)", elapsed, MIN_POST_PROMOTION_MS);
-                                        let _ = handle.emit("hold-down-cancel", ());
-                                    } else {
-                                        // Real hold ended — stop + transcribe
-                                        tracing::info!(target: "keyboard", "BOTH -> emit hold-down-stop (promoted hold; elapsed={}ms)", elapsed);
-                                        let _ = handle.emit("hold-down-stop", ());
-                                    }
+                                    // Recorder transitions are serialized, so a stop safely
+                                    // waits for an in-flight start even on an immediate release.
+                                    tracing::info!(target: "keyboard", "BOTH -> emit hold-down-stop (promoted hold)");
+                                    let _ = handle.emit("hold-down-stop", ());
                                 } else if dtap_fired {
                                     // Double-tap completed
                                     tracing::info!(target: "keyboard", "BOTH -> emit double-tap-toggle");
@@ -967,7 +939,6 @@ pub fn stop_listener() {
         }
     }
     HOLD_PROMOTED.store(false, Ordering::SeqCst);
-    HOLD_PROMOTED_AT_MS.store(0, Ordering::SeqCst);
     HOLD_PRESS_COUNTER.fetch_add(1, Ordering::SeqCst); // invalidate pending timers
 }
 
@@ -1593,21 +1564,17 @@ mod tests {
     #[derive(Debug, PartialEq)]
     enum BothEmit {
         HoldStop,
-        HoldCancel,
         DoubleTapToggle,
     }
 
     /// Simulate the Both-mode deferred-hold arbitration logic.
     /// `promoted` simulates whether the timer thread promoted the press
     /// to a real hold (i.e. HOLD_PROMOTED was true).
-    /// `elapsed_since_promotion_ms` simulates how many ms have passed since
-    /// promotion — used to exercise the MIN_POST_PROMOTION_MS grace window.
     fn both_handle_event(
         hold: &mut HoldDownDetector,
         dtap: &mut DoubleTapDetector,
         event_type: &EventType,
         promoted: bool,
-        elapsed_since_promotion_ms: u128,
     ) -> Vec<BothEmit> {
         // Check dtap phase BEFORE feeding — also verify the window hasn't expired
         let dtap_second_phase = matches!(
@@ -1632,11 +1599,7 @@ mod tests {
             }
             HoldDownEvent::Stop => {
                 if promoted {
-                    if elapsed_since_promotion_ms < MIN_POST_PROMOTION_MS {
-                        emitted.push(BothEmit::HoldCancel);
-                    } else {
-                        emitted.push(BothEmit::HoldStop);
-                    }
+                    emitted.push(BothEmit::HoldStop);
                 } else if dtap_fired {
                     emitted.push(BothEmit::DoubleTapToggle);
                 }
@@ -1657,14 +1620,14 @@ mod tests {
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // Press — no synchronous emission (timer deferred)
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
 
         // Wait past the tap threshold (timer would have promoted)
         sleep(Duration::from_millis(250));
 
-        // Release — promoted hold past grace window → stop
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true, 500);
+        // Release after promotion → stop
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true);
         assert_eq!(e, vec![BothEmit::HoldStop]);
     }
 
@@ -1674,10 +1637,10 @@ mod tests {
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // Quick press + release — no promotion, no emission
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
 
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
         assert_eq!(dtap.state, DetectorState::WaitingSecondDown);
     }
@@ -1688,16 +1651,16 @@ mod tests {
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // First tap
-        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
-        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false, 0);
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
         assert_eq!(dtap.state, DetectorState::WaitingSecondDown);
 
         // Second tap — hold suppressed (second phase), dtap completes
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]); // hold suppressed
         assert_eq!(dtap.state, DetectorState::WaitingSecondUp);
 
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
         assert_eq!(e, vec![BothEmit::DoubleTapToggle]);
     }
 
@@ -1708,11 +1671,11 @@ mod tests {
         dtap.recording = true;
 
         // Press — no sync emission
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
 
         // Quick release — dtap fires (single tap to stop)
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
         assert_eq!(e, vec![BothEmit::DoubleTapToggle]);
     }
 
@@ -1722,42 +1685,42 @@ mod tests {
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // First tap
-        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
-        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false, 0);
+        both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
+        both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), false);
 
         // Wait for double-tap window + hold cooldown to expire
         sleep(Duration::from_millis(550));
 
         // Next press — fresh sequence, timer would start (no sync emission)
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
     }
 
     #[test]
-    fn both_promoted_release_within_grace_window_cancels() {
+    fn both_promoted_release_immediately_stops() {
         let mut hold = make_hold_detector(Key::ShiftLeft);
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // Press — timer would start (no sync emission)
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
 
-        // Release 40ms after promotion — within the 300ms grace window → cancel
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true, 40);
-        assert_eq!(e, vec![BothEmit::HoldCancel]);
+        // Release 40ms after promotion — the promoted hold must stop and transcribe.
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true);
+        assert_eq!(e, vec![BothEmit::HoldStop]);
     }
 
     #[test]
-    fn both_promoted_release_after_grace_window_stops() {
+    fn both_promoted_later_release_stops() {
         let mut hold = make_hold_detector(Key::ShiftLeft);
         let mut dtap = make_detector(Key::ShiftLeft);
 
         // Press — timer would start (no sync emission)
-        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false, 0);
+        let e = both_handle_event(&mut hold, &mut dtap, &press(Key::ShiftLeft), false);
         assert_eq!(e, vec![]);
 
-        // Release 400ms after promotion — past the 300ms grace window → stop
-        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true, 400);
+        // A later release remains a normal stop.
+        let e = both_handle_event(&mut hold, &mut dtap, &release(Key::ShiftLeft), true);
         assert_eq!(e, vec![BothEmit::HoldStop]);
     }
 

--- a/app/src-tauri/src/transcriber/coreml.rs
+++ b/app/src-tauri/src/transcriber/coreml.rs
@@ -182,6 +182,7 @@ impl TranscriptionBackend for CoreMlBackend {
             .transcribe_samples(samples)
             .map_err(|error| format!("Core ML transcription failed: {error}"))?;
         let text = normalize_result_text(&result.text);
+        let output = if smart_punctuation { text.clone() } else { strip_punctuation(&text) };
 
         tracing::info!(
             target: "pipeline",
@@ -190,11 +191,19 @@ impl TranscriptionBackend for CoreMlBackend {
             "coreml_transcription_complete"
         );
 
-        if smart_punctuation {
-            Ok(text)
-        } else {
-            Ok(strip_punctuation(&text))
+        if output.trim().is_empty() {
+            let diagnostics = empty_output_diagnostics(samples.len(), &result.text, &text);
+            tracing::warn!(
+                target: "pipeline",
+                input_sample_count = diagnostics.input_sample_count,
+                raw_output_length = diagnostics.raw_output_length,
+                normalized_length = diagnostics.normalized_length,
+                period_only = diagnostics.period_only,
+                "coreml_empty_output"
+            );
         }
+
+        Ok(output)
     }
 
     fn token_count(&self, _text: &str) -> Option<usize> {
@@ -230,6 +239,29 @@ fn strip_punctuation(input: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[derive(Debug, PartialEq)]
+struct EmptyOutputDiagnostics {
+    input_sample_count: usize,
+    raw_output_length: usize,
+    normalized_length: usize,
+    period_only: bool,
+}
+
+fn empty_output_diagnostics(
+    input_sample_count: usize,
+    raw_output: &str,
+    normalized_output: &str,
+) -> EmptyOutputDiagnostics {
+    let raw_trimmed = raw_output.trim();
+    EmptyOutputDiagnostics {
+        input_sample_count,
+        raw_output_length: raw_output.chars().count(),
+        normalized_length: normalized_output.chars().count(),
+        period_only: !raw_trimmed.is_empty()
+            && raw_trimmed.chars().all(|character| character == '.'),
+    }
 }
 
 /// FluidAudio can occasionally emit a standalone sentence-boundary token at
@@ -301,6 +333,24 @@ mod tests {
         assert_eq!(normalize_result_text(".NET is fast."), ".NET is fast.");
         assert_eq!(normalize_result_text("...and then."), "...and then.");
         assert_eq!(normalize_result_text("Hello there."), "Hello there.");
+    }
+
+    #[test]
+    fn empty_output_diagnostics_are_privacy_safe_and_complete() {
+        let diagnostics = empty_output_diagnostics(12_345, " ... ", "");
+        assert_eq!(
+            diagnostics,
+            EmptyOutputDiagnostics {
+                input_sample_count: 12_345,
+                raw_output_length: 5,
+                normalized_length: 0,
+                period_only: true,
+            }
+        );
+
+        let diagnostics = empty_output_diagnostics(80, "", "");
+        assert_eq!(diagnostics.raw_output_length, 0);
+        assert!(!diagnostics.period_only);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop cancelling Both-mode holds after they have already promoted to recording
- retry Core ML transcription once with original audio when VAD-trimmed audio returns empty
- add privacy-safe empty-output diagnostics and regression coverage

## Validation
- reproduced the production v0.16.1 bug with a precise 330 ms Shift hold: promotion followed by `hold-down-cancel` 137 ms later
- `cargo check`
- `cargo test -- --test-threads=1` (266 passed)
- `npx tsc --noEmit`
- `npm test -- --run` (79 passed)
- installed Core ML integration test with `bench/audio/short.wav`
- native debug smoke: file transcription returned `Please commit these changes to the main branch.`; recording hardware error correctly surfaced on this Mac mini with no input device

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quick Both-mode holds now begin and stop transcription reliably once the hold threshold is reached.
  * Improved transcription reliability when voice activity detection trims audio and Core ML initially returns no text.
  * Added a limited retry using the original audio to recover valid transcription results.
  * Improved handling of empty Core ML transcription results with privacy-safe diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->