### PR TITLE
fix: harden macOS modifier hotkey reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- Global modifier hotkeys now recover when macOS disables the underlying event tap, avoid stale modifier-state dead zones after system context changes, and no longer process mouse movement or perform main-thread key-name translation on the modifier hot path (#194, fixes #137).
 - Quick Both-mode holds now stop and transcribe as soon as the 200 ms promotion threshold is reached instead of being discarded by an obsolete 300 ms grace window; empty Core ML results after VAD also retry once with the original audio and emit privacy-safe diagnostics (#221).
 - Fast hold-down dictations no longer disappear when key release races Core Audio startup; native start, stop, and cancel transitions are serialized and the frontend waits for startup before processing (#216).
 - Parakeet v2 downloads now survive an interrupted extraction: Murmur reuses the completed archive, validates a staged bundle, and publishes it atomically instead of leaving a partial model that appears undownloaded (#215).

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3800,7 +3800,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 [[package]]
 name = "rdev"
 version = "0.6.0"
-source = "git+https://github.com/Narsil/rdev?branch=main#b7e201bf80be7b9632207366f277d29fe732b9c1"
+source = "git+https://github.com/georgenijo/rdev?rev=9f510e406327b797eaf2acdc30adcda3dc1e1bb3#9f510e406327b797eaf2acdc30adcda3dc1e1bb3"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ hound = "3.5"
 symphonia = { version = "0.5", default-features = false, features = ["wav", "pcm", "mp3", "isomp4", "aac", "alac"] }
 dirs = "5"
 cpal = "0.15"
-rdev = { git = "https://github.com/Narsil/rdev", branch = "main" }
+rdev = { git = "https://github.com/georgenijo/rdev", rev = "9f510e406327b797eaf2acdc30adcda3dc1e1bb3", features = ["macos_keyboard_only", "macos_no_modifier_event_name", "macos_test_force_tap_timeout"] }
 memory-stats = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -57,7 +57,7 @@ core-graphics = "0.25"
 fluidaudio-rs = { version = "=0.14.1", default-features = false, features = ["asr"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rdev = { git = "https://github.com/Narsil/rdev", branch = "main", features = ["x11"] }
+rdev = { git = "https://github.com/georgenijo/rdev", rev = "9f510e406327b797eaf2acdc30adcda3dc1e1bb3", features = ["x11"] }
 whisper-rs = { version = "0.15", features = ["cuda"] }
 
 [profile.release]

--- a/docs/features/recording-modes.md
+++ b/docs/features/recording-modes.md
@@ -96,6 +96,7 @@ WaitingFirstUp → KeyUp(target) within 300ms → FIRE
 
 - Both modes share a single `rdev::listen()` background thread (spawned once, lives for app lifetime)
 - `set_is_main_thread(false)` is called before `listen()` — this is **critical** on macOS because rdev's keyboard translation calls TIS/TSM APIs that Apple requires on the main thread. Without this flag, the app segfaults on key press.
+- rdev is pinned to Murmur's fork by commit revision. Its macOS listener derives modifier press/release directly from the physical keycode and device-specific flag (no cached global modifier state), automatically re-enables a disabled event tap, listens only for key events, and skips key-name translation for modifier events.
 - `AtomicBool` (`LISTENER_ACTIVE`) gates event processing without killing the thread
 - `DetectorMode` enum (`DoubleTap` | `HoldDown`) determines which detector processes events
 - Separate `Mutex`-wrapped detectors: `DOUBLE_TAP_DETECTOR` and `HOLD_DOWN_DETECTOR`


### PR DESCRIPTION
## Summary
- pin rdev to the Murmur fork at an immutable revision
- recover disabled macOS event taps and eliminate cached modifier-flag desync
- limit the tap to keyboard events and skip modifier name translation on the hot path
- document the fork behavior and open general-purpose fixes upstream

## Upstream rdev PRs
- Narsil/rdev#195 — event-tap recovery
- Narsil/rdev#196 — keycode/device-mask modifier classification
- Narsil/rdev#197 — keyboard-only event mask

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` (266 unit tests + Whisper integration; optional Core ML test ignored)
- [x] `npx tsc --noEmit`
- [x] `npm test` (79 tests)
- [x] rdev fork tests with all Murmur features (9 tests)
- [x] native debug `.app` smoke with Computer Use: TextEdit full screen and focused, Murmur hidden/unfocused; forced tap disable logged recovery and subsequent ShiftLeft holds reached Both-mode start/stop

Closes #194
Closes #137