### PR TITLE
Harden code-vocab scan races and modal focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- Code-vocabulary scans now keep the View-all dialog keyboard focus contained and restore the opener on close, correlate live progress by scan ID, and report superseded results when settings change during a walk instead of presenting non-adopted terms as complete (#209).
 - Global modifier hotkeys now recover when macOS disables the underlying event tap, avoid stale modifier-state dead zones after system context changes, and no longer process mouse movement or perform main-thread key-name translation on the modifier hot path (#194, fixes #137).
 - Quick Both-mode holds now stop and transcribe as soon as the 200 ms promotion threshold is reached instead of being discarded by an obsolete 300 ms grace window; empty Core ML results after VAD also retry once with the original audio and emit privacy-safe diagnostics (#221).
 - Fast hold-down dictations no longer disappear when key release races Core Audio startup; native start, stop, and cancel transitions are serialized and the frontend waits for startup before processing (#216).

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1158,6 +1158,21 @@ fn complete_code_vocab_scan(
     adopted
 }
 
+/// Invalidate one explicit scan without disturbing a newer overlapping scan.
+fn cancel_code_vocab_scan_id(app_state: &AppState, scan_id: &str) -> bool {
+    let mut dictation = app_state.dictation.lock_or_recover();
+    if dictation.code_vocab_scan_id.as_deref() != Some(scan_id) {
+        return false;
+    }
+    dictation.code_vocab_scan_id = None;
+    true
+}
+
+#[tauri::command]
+pub fn cancel_code_vocab_scan(state: tauri::State<'_, State>, scan_id: String) -> bool {
+    cancel_code_vocab_scan_id(&state.app_state, &scan_id)
+}
+
 /// Emit a throttled `vocab-scan-progress` tick carrying the live running counts
 /// and the path being read/skipped. `force` bypasses the throttle (used for skip
 /// rows so struck-through dependency/build dirs always render live). Updates
@@ -2029,6 +2044,26 @@ mod tests {
         let dictation = app_state.dictation.lock_or_recover();
         assert_eq!(dictation.code_vocab_prompt.as_deref(), Some("currentTerm"));
         assert!(dictation.code_vocab_scan_id.is_none());
+    }
+
+    #[test]
+    fn cancellation_only_invalidates_the_matching_scan() {
+        let app_state = AppState::default();
+        begin_code_vocab_scan(&app_state, "scan-a", "/project");
+
+        assert!(!cancel_code_vocab_scan_id(&app_state, "scan-b"));
+        assert_eq!(
+            app_state.dictation.lock_or_recover().code_vocab_scan_id.as_deref(),
+            Some("scan-a"),
+        );
+        assert!(cancel_code_vocab_scan_id(&app_state, "scan-a"));
+        assert!(!complete_code_vocab_scan(
+            &app_state,
+            "scan-a",
+            "/project",
+            "canceledTerm".into(),
+        ));
+        assert!(app_state.dictation.lock_or_recover().code_vocab_prompt.is_none());
     }
 
     #[test]

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -980,6 +980,7 @@ pub async fn configure_dictation(
         // programmatically), `resolve_code_vocab_prompt` lazily builds + caches the
         // prompt on the first transcription. Net: exactly one walk per folder.
         dictation.code_vocab_prompt = None;
+        dictation.code_vocab_scan_id = None;
     }
 
     // Post-model correction toggles.
@@ -1071,11 +1072,13 @@ pub async fn configure_dictation(
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VocabScanProgress {
+    scan_id: String,
     current_path: String,
     files_read: usize,
     dirs_skipped: usize,
     terms_so_far: usize,
     done: bool,
+    adopted: bool,
 }
 
 /// One ranked vocabulary term surfaced to the frontend pop-out: the written form
@@ -1109,6 +1112,50 @@ pub struct VocabScanSummary {
     /// min([`WHISPER_PROMPT_TERMS`], ranked_terms.len()). The first `whisper_count`
     /// entries are the Whisper budget; the rest are correction-only.
     whisper_count: usize,
+    /// Whether this result was adopted into the live dictation settings. False
+    /// means a newer scan or settings change superseded it while it was walking.
+    adopted: bool,
+}
+
+/// Register an explicit scan as the latest settings intent before walking. This
+/// makes the command own the folder transition even when the frontend's
+/// configure call is still in flight, while the scan id lets later changes
+/// supersede it deterministically.
+fn begin_code_vocab_scan(app_state: &AppState, scan_id: &str, folder: &str) {
+    let mut dictation = app_state.dictation.lock_or_recover();
+    let folder_changed = dictation.code_vocab_folder != folder;
+    let was_disabled = !dictation.code_vocab_enabled;
+    dictation.code_vocab_enabled = true;
+    dictation.code_vocab_folder = folder.to_string();
+    dictation.code_vocab_scan_id = Some(scan_id.to_string());
+    if folder_changed || was_disabled {
+        dictation.code_vocab_prompt = None;
+        rebuild_correction_matcher(app_state, &dictation);
+    }
+}
+
+/// Adopt a completed scan only when it is still the latest run and the settings
+/// still target the folder it walked. Returns false for overlapping scans and
+/// for enable/folder changes made during the walk.
+fn complete_code_vocab_scan(
+    app_state: &AppState,
+    scan_id: &str,
+    folder: &str,
+    prompt: String,
+) -> bool {
+    let mut dictation = app_state.dictation.lock_or_recover();
+    let is_active = dictation.code_vocab_scan_id.as_deref() == Some(scan_id);
+    let adopted = is_active
+        && dictation.code_vocab_enabled
+        && dictation.code_vocab_folder == folder;
+    if adopted {
+        dictation.code_vocab_prompt = Some(prompt);
+        dictation.code_vocab_scan_id = None;
+        rebuild_correction_matcher(app_state, &dictation);
+    } else if is_active {
+        dictation.code_vocab_scan_id = None;
+    }
+    adopted
 }
 
 /// Emit a throttled `vocab-scan-progress` tick carrying the live running counts
@@ -1119,6 +1166,7 @@ pub struct VocabScanSummary {
 #[allow(clippy::too_many_arguments)]
 fn emit_scan_progress(
     handle: &tauri::AppHandle,
+    scan_id: &str,
     last_emit: &mut std::time::Instant,
     current_path: String,
     files_read: usize,
@@ -1134,11 +1182,13 @@ fn emit_scan_progress(
         let _ = handle.emit(
             "vocab-scan-progress",
             VocabScanProgress {
+                scan_id: scan_id.to_string(),
                 current_path,
                 files_read,
                 dirs_skipped,
                 terms_so_far,
                 done: false,
+                adopted: false,
             },
         );
     }
@@ -1166,17 +1216,24 @@ pub async fn scan_code_vocab(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
     folder: String,
+    scan_id: String,
 ) -> Result<VocabScanSummary, String> {
     let folder_trimmed = folder.trim().to_string();
     if folder_trimmed.is_empty() {
         return Err("No folder selected to scan.".to_string());
     }
+    if scan_id.trim().is_empty() {
+        return Err("Missing scan id.".to_string());
+    }
+
+    begin_code_vocab_scan(&state.app_state, &scan_id, &folder_trimmed);
 
     tracing::info!(target: "pipeline", "scan_code_vocab: start");
 
     // Walk + prompt build are blocking (filesystem + CPU). Run them off the async
     // runtime; the closure emits throttled progress as files are read.
     let emit_handle = app_handle.clone();
+    let emit_scan_id = scan_id.clone();
     let scan_folder = folder_trimmed.clone();
     let t_start = std::time::Instant::now();
     let (prompt, summary) = tokio::task::spawn_blocking(move || {
@@ -1202,6 +1259,7 @@ pub async fn scan_code_vocab(
             let mut le = last_emit.get();
             emit_scan_progress(
                 &emit_handle,
+                &emit_scan_id,
                 &mut le,
                 current_path,
                 files_read.get(),
@@ -1269,42 +1327,35 @@ pub async fn scan_code_vocab(
             sample_terms,
             ranked_terms,
             whisper_count,
+            adopted: false,
         };
         (prompt, summary)
     })
     .await
     .map_err(|e| format!("Vocab scan task panicked: {}", e))?;
 
-    // Final progress tick so the UI lands on a settled "done" state.
+    let mut summary = summary;
+    summary.adopted = complete_code_vocab_scan(
+        &state.app_state,
+        &scan_id,
+        &folder_trimmed,
+        prompt,
+    );
+
+    // Final progress tick so the UI lands on the accurate adopted/superseded
+    // state before the command result resolves.
     let _ = app_handle.emit(
         "vocab-scan-progress",
         VocabScanProgress {
+            scan_id: scan_id.clone(),
             current_path: String::new(),
             files_read: summary.files,
             dirs_skipped: summary.skipped,
             terms_so_far: summary.terms,
             done: true,
+            adopted: summary.adopted,
         },
     );
-
-    // Adopt the scan: cache the built prompt and rebuild the correction matcher
-    // under the lock — but ONLY if the current settings still point at the folder
-    // we just walked with code-vocab enabled. The walk runs concurrently with
-    // configure_dictation (both fire on the same folder pick), and a large repo
-    // can take long enough for the user to toggle code-vocab OFF or clear/change
-    // the folder mid-walk. configure_dictation owns code_vocab_enabled +
-    // code_vocab_folder; if it has since cleared them, dropping this stale result
-    // is correct — re-enabling here would silently re-inject the code prompt while
-    // the frontend toggle reads OFF (last-writer-wins divergence). Mirrors the
-    // lazy path's guard in resolve_code_vocab_prompt. The lock is taken AFTER all
-    // awaits, scoped, and released before returning — never held across an `.await`.
-    {
-        let mut dictation = state.app_state.dictation.lock_or_recover();
-        if dictation.code_vocab_enabled && dictation.code_vocab_folder == folder_trimmed {
-            dictation.code_vocab_prompt = Some(prompt);
-            rebuild_correction_matcher(&state.app_state, &dictation);
-        }
-    }
 
     tracing::info!(
         target: "pipeline",
@@ -1313,6 +1364,7 @@ pub async fn scan_code_vocab(
         terms = summary.terms,
         bytes = summary.bytes,
         capped = summary.capped,
+        adopted = summary.adopted,
         ms = t_start.elapsed().as_millis() as u64,
         "scan_code_vocab: complete"
     );
@@ -1921,6 +1973,7 @@ mod tests {
                 RankedTermJson { term: "barBaz".into(), freq: 2 },
             ],
             whisper_count: 2,
+            adopted: true,
         };
         let v = serde_json::to_value(&summary).unwrap();
         // New camelCase keys present; snake_case absent.
@@ -1929,12 +1982,83 @@ mod tests {
         assert!(v.get("ranked_terms").is_none(), "snake_case leaked: {v}");
         assert!(v.get("whisper_count").is_none(), "snake_case leaked: {v}");
         assert_eq!(v["whisperCount"], 2);
+        assert_eq!(v["adopted"], true);
         // sampleTerms (existing field) stays camelCase too.
         assert!(v.get("sampleTerms").is_some(), "sampleTerms missing: {v}");
         // Each ranked entry carries term + freq.
         let first = &v["rankedTerms"][0];
         assert_eq!(first["term"], "fooBar");
         assert_eq!(first["freq"], 5);
+    }
+
+    #[test]
+    fn progress_serializes_scan_id_camel_case() {
+        let progress = VocabScanProgress {
+            scan_id: "scan-42".into(),
+            current_path: "/project/src/main.rs".into(),
+            files_read: 1,
+            dirs_skipped: 0,
+            terms_so_far: 3,
+            done: false,
+            adopted: false,
+        };
+        let value = serde_json::to_value(progress).unwrap();
+        assert_eq!(value["scanId"], "scan-42");
+        assert!(value.get("scan_id").is_none());
+    }
+
+    #[test]
+    fn newer_scan_prevents_older_result_adoption() {
+        let app_state = AppState::default();
+        begin_code_vocab_scan(&app_state, "scan-a", "/project");
+        begin_code_vocab_scan(&app_state, "scan-b", "/project");
+
+        assert!(!complete_code_vocab_scan(
+            &app_state,
+            "scan-a",
+            "/project",
+            "staleTerm".into(),
+        ));
+        assert!(complete_code_vocab_scan(
+            &app_state,
+            "scan-b",
+            "/project",
+            "currentTerm".into(),
+        ));
+
+        let dictation = app_state.dictation.lock_or_recover();
+        assert_eq!(dictation.code_vocab_prompt.as_deref(), Some("currentTerm"));
+        assert!(dictation.code_vocab_scan_id.is_none());
+    }
+
+    #[test]
+    fn settings_changes_during_scan_report_non_adoption() {
+        for change in ["disable", "folder"] {
+            let app_state = AppState::default();
+            begin_code_vocab_scan(&app_state, "scan-a", "/project-a");
+            {
+                let mut dictation = app_state.dictation.lock_or_recover();
+                if change == "disable" {
+                    dictation.code_vocab_enabled = false;
+                } else {
+                    dictation.code_vocab_folder = "/project-b".into();
+                }
+                dictation.code_vocab_prompt = None;
+                dictation.code_vocab_scan_id = None;
+            }
+
+            assert!(
+                !complete_code_vocab_scan(
+                    &app_state,
+                    "scan-a",
+                    "/project-a",
+                    "staleTerm".into(),
+                ),
+                "{change} must supersede the in-flight scan",
+            );
+            let dictation = app_state.dictation.lock_or_recover();
+            assert!(dictation.code_vocab_prompt.is_none());
+        }
     }
 
     #[test]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run() {
             commands::recording::count_vocab_tokens,
             commands::recording::transcribe_file,
             commands::recording::scan_code_vocab,
+            commands::recording::cancel_code_vocab_scan,
             commands::permissions::open_system_preferences,
             commands::permissions::check_accessibility_permission,
             commands::permissions::request_accessibility_permission,

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -81,6 +81,10 @@ pub struct DictationState {
     /// when the folder/enabled flag changes so we don't rescan every utterance.
     /// `None` means "not yet scanned" (build lazily on first use).
     pub code_vocab_prompt: Option<String>,
+    /// Correlates the currently running explicit folder scan. A newer scan or a
+    /// settings change supersedes the previous id so its result cannot be
+    /// adopted after the user's intent has moved on.
+    pub code_vocab_scan_id: Option<String>,
     /// Post-model correction (Tier 1 exact map + Tier 2 sounds-like). Applies the
     /// vocabulary to the text *output* of every backend (not just Whisper's
     /// prompt), so the default Parakeet engine benefits too.
@@ -116,6 +120,7 @@ impl Default for DictationState {
             code_vocab_enabled: false,
             code_vocab_folder: String::new(),
             code_vocab_prompt: None,
+            code_vocab_scan_id: None,
             // Post-model correction on by default: it's the fix that makes vocab
             // actually work on the default Parakeet engine. No-op without vocab.
             correction_enabled: true,

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -466,7 +466,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     async (folder: string) => {
       if (!folder) return;
       const summary = await doScan(folder);
-      if (summary) onUpdateSettings({ codeVocabLastScan: summary });
+      if (summary?.adopted) onUpdateSettings({ codeVocabLastScan: summary });
     },
     [doScan, onUpdateSettings],
   );

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -467,6 +467,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
       if (!folder) return;
       const summary = await doScan(folder);
       if (summary?.adopted) onUpdateSettings({ codeVocabLastScan: summary });
+      else if (summary) onUpdateSettings({ codeVocabLastScan: null });
     },
     [doScan, onUpdateSettings],
   );
@@ -475,7 +476,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     try {
       const selected = await open({ directory: true, multiple: false });
       if (typeof selected === 'string') {
-        onUpdateSettings({ codeVocabFolder: selected });
+        onUpdateSettings({ codeVocabFolder: selected, codeVocabLastScan: null });
         // Auto-scan the freshly chosen folder.
         void runVocabScan(selected);
       }

--- a/app/src/components/settings/VocabScanStrip.tsx
+++ b/app/src/components/settings/VocabScanStrip.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { VocabScanSummary } from '../../lib/settings';
 import type {
   VocabScanStatus,
@@ -58,14 +58,16 @@ export function VocabScanStrip({
   onCancel,
 }: VocabScanStripProps) {
   const [modalOpen, setModalOpen] = useState(false);
+  const viewAllRef = useRef<HTMLButtonElement>(null);
   const scanning = status === 'scanning';
   const summary: VocabScanSummary | null = stats.summary;
   // Result card needs the full Summary; only render it once invoke() has resolved.
-  const showResult = (status === 'done' || status === 'empty') && summary !== null;
+  const showResult =
+    (status === 'done' || status === 'empty' || status === 'superseded') && summary !== null;
   // The walk has settled (terminal status) even if the Summary hasn't landed yet.
   // Keep the progress bar full across that gap so it doesn't collapse to 0% for a
   // few ms between the done tick and the invoke() resolution.
-  const settled = status === 'done' || status === 'empty';
+  const settled = status === 'done' || status === 'empty' || status === 'superseded';
 
   // Status dot color.
   const dotClass =
@@ -75,6 +77,8 @@ export function VocabScanStrip({
         ? 'bg-green-500'
         : status === 'empty'
           ? 'bg-amber-500'
+          : status === 'superseded'
+            ? 'bg-stone-400 dark:bg-stone-500'
           : 'bg-stone-400 dark:bg-stone-500';
 
   // Header label + sub copy per state. The terminal 'done'/'empty' status lands a
@@ -95,6 +99,9 @@ export function VocabScanStrip({
   } else if (status === 'empty') {
     label = 'No identifiers found';
     sub = 'Folder had no source files — built-in dev terms still active.';
+  } else if (status === 'superseded') {
+    label = 'Scan superseded';
+    sub = 'Settings changed before this scan finished, so its terms were not applied.';
   } else {
     label = 'Not scanned yet';
     sub = 'Built-in dev terms active. Scan this folder to add your own identifiers.';
@@ -103,7 +110,7 @@ export function VocabScanStrip({
   // Primary action button.
   const actionLabel = scanning
     ? 'Cancel'
-    : status === 'done' || status === 'empty'
+    : status === 'done' || status === 'empty' || status === 'superseded'
       ? 'Rescan'
       : 'Scan now';
   const actionDisabled = !scanning && !folder;
@@ -177,6 +184,13 @@ export function VocabScanStrip({
             <Stat num={formatMs(summary.ms)} cap="duration" />
           </div>
 
+          {status === 'superseded' && (
+            <WarnBox>
+              This result was <b>not applied</b> because the selected folder, toggle, or active
+              scan changed while it was running. Rescan the current folder to use its terms.
+            </WarnBox>
+          )}
+
           {/* cap warning steers toward a single project */}
           {summary.capped && (
             <WarnBox>
@@ -203,7 +217,7 @@ export function VocabScanStrip({
           )}
 
           {/* sample-term chips */}
-          {summary.sampleTerms.length > 0 && (
+          {summary.adopted && summary.sampleTerms.length > 0 && (
             <div className="mt-3">
               <div className="mb-1.5 text-[10px] uppercase tracking-wide text-stone-500 dark:text-stone-500">
                 Top terms found
@@ -225,6 +239,7 @@ export function VocabScanStrip({
                 {/* View-all link: only when the backend returned a ranked list. */}
                 {summary.rankedTerms.length > 0 && (
                   <button
+                    ref={viewAllRef}
                     type="button"
                     onClick={() => setModalOpen(true)}
                     className="ml-0.5 cursor-pointer text-[11px] font-semibold text-blue-500 underline hover:no-underline dark:text-blue-400"
@@ -244,6 +259,7 @@ export function VocabScanStrip({
           summary={summary}
           folder={folder}
           onClose={() => setModalOpen(false)}
+          returnFocusRef={viewAllRef}
         />
       )}
     </div>

--- a/app/src/components/settings/VocabTermsModal.test.tsx
+++ b/app/src/components/settings/VocabTermsModal.test.tsx
@@ -1,0 +1,113 @@
+import { act, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VocabScanSummary } from '../../lib/settings';
+import { VocabTermsModal } from './VocabTermsModal';
+
+const SUMMARY: VocabScanSummary = {
+  files: 2,
+  skipped: 0,
+  terms: 2,
+  bytes: 24,
+  capped: false,
+  ms: 4,
+  sampleTerms: ['useEffect', 'scanId'],
+  rankedTerms: [
+    { term: 'useEffect', freq: 4 },
+    { term: 'scanId', freq: 2 },
+  ],
+  whisperCount: 2,
+  adopted: true,
+};
+
+describe('VocabTermsModal accessibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      const openerRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={openerRef} type="button" onClick={() => setOpen(true)}>
+            View all terms
+          </button>
+          {open && (
+            <VocabTermsModal
+              summary={SUMMARY}
+              folder="/project"
+              onClose={() => setOpen(false)}
+              returnFocusRef={openerRef}
+            />
+          )}
+        </>
+      );
+    }
+
+    await act(async () => root.render(<Harness />));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('labels the dialog, traps Tab at both edges, and restores opener focus', async () => {
+    const opener = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => opener.click());
+    await act(async () => vi.advanceTimersByTime(60));
+
+    const dialog = container.querySelector('[role="dialog"]') as HTMLDivElement;
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    const titleId = dialog.getAttribute('aria-labelledby');
+    expect(titleId).toBeTruthy();
+    expect(document.getElementById(titleId!)?.textContent).toContain('Scanned vocabulary');
+
+    const search = dialog.querySelector('[aria-label="Filter scanned terms"]');
+    expect(document.activeElement).toBe(search);
+
+    const close = dialog.querySelector('[aria-label="Close"]') as HTMLButtonElement;
+    const copy = Array.from(dialog.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Copy all'),
+    ) as HTMLButtonElement;
+
+    opener.focus();
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }),
+      );
+    });
+    expect(document.activeElement).toBe(close);
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true }),
+      );
+    });
+    expect(document.activeElement).toBe(copy);
+
+    copy.focus();
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }),
+      );
+    });
+    expect(document.activeElement).toBe(close);
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(opener);
+  });
+});

--- a/app/src/components/settings/VocabTermsModal.tsx
+++ b/app/src/components/settings/VocabTermsModal.tsx
@@ -7,6 +7,8 @@ interface VocabTermsModalProps {
   /** Absolute path of the scanned folder, shown in the subheader. */
   folder: string;
   onClose: () => void;
+  /** Explicit opener for reliable focus restoration after AX-initiated clicks. */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 }
 
 type SortMode = 'freq' | 'alpha';
@@ -20,10 +22,16 @@ type SortMode = 'freq' | 'alpha';
  *
  * Closes on Escape, the close button, and a click on the backdrop.
  */
-export function VocabTermsModal({ summary, folder, onClose }: VocabTermsModalProps) {
+export function VocabTermsModal({
+  summary,
+  folder,
+  onClose,
+  returnFocusRef,
+}: VocabTermsModalProps) {
   const [query, setQuery] = useState('');
   const [sortMode, setSortMode] = useState<SortMode>('freq');
   const [copied, setCopied] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -37,18 +45,54 @@ export function VocabTermsModal({ summary, folder, onClose }: VocabTermsModalPro
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
-  // Esc closes; focus the search box on open.
+  // Keep keyboard focus inside the dialog, close on Escape, and restore the
+  // element that opened it after unmount.
   useEffect(() => {
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCloseRef.current();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((element) => !element.hasAttribute('hidden'));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (!dialog.contains(active)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      } else if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKey);
     const t = setTimeout(() => searchRef.current?.focus(), 60);
     return () => {
       document.removeEventListener('keydown', onKey);
       clearTimeout(t);
+      (returnFocusRef?.current ?? previouslyFocused)?.focus();
     };
-  }, []);
+  }, [returnFocusRef]);
 
   // Clean up the "Copied" reset timer on unmount.
   useEffect(
@@ -98,11 +142,21 @@ export function VocabTermsModal({ summary, folder, onClose }: VocabTermsModalPro
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="flex max-h-[82vh] w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-2xl dark:border-stone-700 dark:bg-stone-900">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="vocab-terms-title"
+        tabIndex={-1}
+        className="flex max-h-[82vh] w-full max-w-[560px] flex-col overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-2xl dark:border-stone-700 dark:bg-stone-900"
+      >
         {/* header */}
         <div className="border-b border-stone-200 px-[18px] pb-3 pt-4 dark:border-stone-800">
           <div className="flex items-center justify-between">
-            <div className="text-[15px] font-semibold text-stone-800 dark:text-stone-200">
+            <div
+              id="vocab-terms-title"
+              className="text-[15px] font-semibold text-stone-800 dark:text-stone-200"
+            >
               Scanned vocabulary
             </div>
             <button
@@ -150,6 +204,7 @@ export function VocabTermsModal({ summary, folder, onClose }: VocabTermsModalPro
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Filter terms…"
+              aria-label="Filter scanned terms"
               autoComplete="off"
               spellCheck={false}
               className="min-w-0 flex-1 border-none bg-transparent text-xs text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-200 dark:placeholder:text-stone-600"

--- a/app/src/lib/hooks/useVocabScan.test.tsx
+++ b/app/src/lib/hooks/useVocabScan.test.tsx
@@ -153,4 +153,28 @@ describe('useVocabScan correlation and adoption', () => {
     expect(current.status).toBe('superseded');
     expect(current.stats.summary?.adopted).toBe(false);
   });
+
+  it('invalidates the matching backend scan when canceled', async () => {
+    const pending = deferred<VocabScanSummary>();
+    mocks.invoke.mockImplementation((command: string) =>
+      command === 'scan_code_vocab' ? pending.promise : Promise.resolve(true),
+    );
+
+    let scanRun!: Promise<VocabScanSummary | null>;
+    await act(async () => {
+      scanRun = current.scan('/cancel-me');
+      await Promise.resolve();
+    });
+    const scanId = mocks.invoke.mock.calls[0][1].scanId as string;
+
+    await act(async () => current.cancel());
+    expect(mocks.invoke).toHaveBeenCalledWith('cancel_code_vocab_scan', { scanId });
+    expect(current.status).toBe('idle');
+
+    pending.resolve(summary(false));
+    await act(async () => {
+      expect(await scanRun).toBeNull();
+    });
+    expect(current.status).toBe('idle');
+  });
 });

--- a/app/src/lib/hooks/useVocabScan.test.tsx
+++ b/app/src/lib/hooks/useVocabScan.test.tsx
@@ -1,0 +1,156 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VocabScanSummary } from '../settings';
+
+type ProgressListener = (event: { payload: Record<string, unknown> }) => void;
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listeners: [] as ProgressListener[],
+  unlisteners: [] as ReturnType<typeof vi.fn>[],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (_event: string, listener: ProgressListener) => {
+    const unlisten = vi.fn();
+    mocks.listeners.push(listener);
+    mocks.unlisteners.push(unlisten);
+    return unlisten;
+  }),
+}));
+
+import { useVocabScan } from './useVocabScan';
+
+type ScanState = ReturnType<typeof useVocabScan>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function summary(adopted: boolean, terms = 2): VocabScanSummary {
+  return {
+    files: 3,
+    skipped: 1,
+    terms,
+    bytes: 42,
+    capped: false,
+    ms: 7,
+    sampleTerms: terms > 0 ? ['fooBar'] : [],
+    rankedTerms: terms > 0 ? [{ term: 'fooBar', freq: 2 }] : [],
+    whisperCount: terms > 0 ? 1 : 0,
+    adopted,
+  };
+}
+
+describe('useVocabScan correlation and adoption', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: ScanState;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.listeners.length = 0;
+    mocks.unlisteners.length = 0;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    function Harness() {
+      current = useVocabScan();
+      return null;
+    }
+
+    await act(async () => root.render(<Harness />));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('ignores orphaned progress from an overlapping older scan', async () => {
+    const first = deferred<VocabScanSummary>();
+    const second = deferred<VocabScanSummary>();
+    mocks.invoke.mockImplementation((_command: string, args: { folder: string }) =>
+      args.folder === '/first' ? first.promise : second.promise,
+    );
+
+    let firstRun!: Promise<VocabScanSummary | null>;
+    await act(async () => {
+      firstRun = current.scan('/first');
+      await Promise.resolve();
+    });
+    const firstScanId = mocks.invoke.mock.calls[0][1].scanId as string;
+
+    let secondRun!: Promise<VocabScanSummary | null>;
+    await act(async () => {
+      secondRun = current.scan('/second');
+      await Promise.resolve();
+    });
+    const secondScanId = mocks.invoke.mock.calls[1][1].scanId as string;
+    expect(secondScanId).not.toBe(firstScanId);
+
+    await act(async () => {
+      mocks.listeners[1]({
+        payload: {
+          scanId: firstScanId,
+          currentPath: '/first/stale.ts',
+          filesRead: 99,
+          dirsSkipped: 8,
+          termsSoFar: 77,
+          done: false,
+          adopted: false,
+        },
+      });
+    });
+    expect(current.stats.filesRead).toBe(0);
+    expect(current.walker).toHaveLength(0);
+
+    await act(async () => {
+      mocks.listeners[1]({
+        payload: {
+          scanId: secondScanId,
+          currentPath: '/second/current.ts',
+          filesRead: 1,
+          dirsSkipped: 0,
+          termsSoFar: 4,
+          done: false,
+          adopted: false,
+        },
+      });
+    });
+    expect(current.stats.filesRead).toBe(1);
+    expect(current.walker[0].path).toBe('/second/current.ts');
+
+    second.resolve(summary(true));
+    await act(async () => {
+      await secondRun;
+    });
+    expect(current.status).toBe('done');
+
+    first.resolve(summary(false));
+    await act(async () => {
+      expect(await firstRun).toBeNull();
+    });
+    expect(current.status).toBe('done');
+  });
+
+  it('surfaces a completed but non-adopted scan as superseded', async () => {
+    mocks.invoke.mockResolvedValueOnce(summary(false));
+
+    let result!: VocabScanSummary | null;
+    await act(async () => {
+      result = await current.scan('/changed-during-walk');
+    });
+
+    expect(result?.adopted).toBe(false);
+    expect(current.status).toBe('superseded');
+    expect(current.stats.summary?.adopted).toBe(false);
+  });
+});

--- a/app/src/lib/hooks/useVocabScan.ts
+++ b/app/src/lib/hooks/useVocabScan.ts
@@ -8,14 +8,16 @@ import type { VocabScanSummary } from '../settings';
  * `vocab-scan-progress` event exactly (serde camelCase).
  */
 export interface VocabScanProgress {
+  scanId: string;
   currentPath: string;
   filesRead: number;
   dirsSkipped: number;
   termsSoFar: number;
   done: boolean;
+  adopted: boolean;
 }
 
-export type VocabScanStatus = 'idle' | 'scanning' | 'done' | 'empty';
+export type VocabScanStatus = 'idle' | 'scanning' | 'done' | 'empty' | 'superseded';
 
 /** One streamed row in the live walker tree. */
 export interface WalkerRow {
@@ -44,6 +46,12 @@ const EVENT = 'vocab-scan-progress';
 const COMMAND = 'scan_code_vocab';
 /** Cap the in-memory walker so a huge repo can't grow the list unbounded. */
 const MAX_WALKER_ROWS = 200;
+let scanSequence = 0;
+
+function createScanId(): string {
+  scanSequence += 1;
+  return `${Date.now().toString(36)}-${scanSequence.toString(36)}`;
+}
 
 const EMPTY_STATS: VocabScanStats = {
   filesRead: 0,
@@ -79,7 +87,13 @@ export interface UseVocabScan {
  */
 export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
   const [status, setStatus] = useState<VocabScanStatus>(() =>
-    initial ? (initial.terms > 0 ? 'done' : 'empty') : 'idle',
+    initial
+      ? initial.adopted
+        ? initial.terms > 0
+          ? 'done'
+          : 'empty'
+        : 'superseded'
+      : 'idle',
   );
   const [walker, setWalker] = useState<WalkerRow[]>([]);
   const [stats, setStats] = useState<VocabScanStats>(() =>
@@ -142,6 +156,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
       // New run: invalidate any prior scan and tear down its listener so we
       // never double-subscribe to the progress stream.
       const runId = runIdRef.current + 1;
+      const scanId = createScanId();
       runIdRef.current = runId;
       detach();
       prevFilesRef.current = 0;
@@ -158,6 +173,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
         // Stale listener from a superseded scan — ignore.
         if (runId !== runIdRef.current || !mountedRef.current) return;
         const p = event.payload;
+        if (p.scanId !== scanId) return;
 
         // Terminal event: the backend's final tick carries the real cumulative
         // counts and an empty path. Settle the running counters + terminal status
@@ -171,7 +187,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
             dirsSkipped: p.dirsSkipped,
             termsSoFar: p.termsSoFar,
           }));
-          setStatus(p.termsSoFar > 0 ? 'done' : 'empty');
+          setStatus(p.adopted ? (p.termsSoFar > 0 ? 'done' : 'empty') : 'superseded');
           return;
         }
 
@@ -206,7 +222,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
       unlistenRef.current = unlisten;
 
       try {
-        const summary = await invoke<VocabScanSummary>(COMMAND, { folder });
+        const summary = await invoke<VocabScanSummary>(COMMAND, { folder, scanId });
         // Superseded or unmounted mid-walk — discard the result. Only tear down a
         // listener that still belongs to THIS run: a newer scan has already
         // installed its own listener into unlistenRef, and the shared detach()
@@ -222,7 +238,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
           termsSoFar: summary.terms,
           summary,
         });
-        setStatus(summary.terms > 0 ? 'done' : 'empty');
+        setStatus(summary.adopted ? (summary.terms > 0 ? 'done' : 'empty') : 'superseded');
         return summary;
       } catch (err) {
         if (runId !== runIdRef.current || !mountedRef.current) {

--- a/app/src/lib/hooks/useVocabScan.ts
+++ b/app/src/lib/hooks/useVocabScan.ts
@@ -44,6 +44,7 @@ export interface VocabScanStats {
 
 const EVENT = 'vocab-scan-progress';
 const COMMAND = 'scan_code_vocab';
+const CANCEL_COMMAND = 'cancel_code_vocab_scan';
 /** Cap the in-memory walker so a huge repo can't grow the list unbounded. */
 const MAX_WALKER_ROWS = 200;
 let scanSequence = 0;
@@ -111,6 +112,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
   // async scan() closure always sees the current listener without re-running.
   const unlistenRef = useRef<UnlistenFn | null>(null);
   const runIdRef = useRef(0);
+  const activeScanIdRef = useRef<string | null>(null);
   const rowIdRef = useRef(0);
   const mountedRef = useRef(true);
   // Previous tick's CUMULATIVE backend counts, used to classify each new row as
@@ -142,6 +144,13 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
     // Bump the run id so any in-flight listen()/invoke from the cancelled scan
     // is ignored, then detach and reset visible state.
     runIdRef.current += 1;
+    const scanId = activeScanIdRef.current;
+    activeScanIdRef.current = null;
+    if (scanId) {
+      void invoke<boolean>(CANCEL_COMMAND, { scanId }).catch((err) => {
+        if (import.meta.env.DEV) console.debug('[useVocabScan cancel]', err);
+      });
+    }
     detach();
     prevFilesRef.current = 0;
     prevSkipsRef.current = 0;
@@ -157,6 +166,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
       // never double-subscribe to the progress stream.
       const runId = runIdRef.current + 1;
       const scanId = createScanId();
+      activeScanIdRef.current = scanId;
       runIdRef.current = runId;
       detach();
       prevFilesRef.current = 0;
@@ -232,6 +242,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
           return null;
         }
         detach();
+        if (activeScanIdRef.current === scanId) activeScanIdRef.current = null;
         setStats({
           filesRead: summary.files,
           dirsSkipped: summary.skipped,
@@ -246,6 +257,7 @@ export function useVocabScan(initial?: VocabScanSummary | null): UseVocabScan {
           return null;
         }
         detach();
+        if (activeScanIdRef.current === scanId) activeScanIdRef.current = null;
         if (import.meta.env.DEV) console.debug('[useVocabScan]', err);
         // Treat a failed scan as an empty result so the UI leaves the spinner.
         setStatus('empty');

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -290,6 +290,7 @@ describe('loadSettings', () => {
         { term: 'TranscriptionBackend', freq: 31 },
       ],
       whisperCount: 2,
+      adopted: true,
     };
     localStorage.setItem('dictation-settings', JSON.stringify({
       ...DEFAULT_SETTINGS,
@@ -319,6 +320,7 @@ describe('loadSettings', () => {
     expect(settings.codeVocabLastScan!.rankedTerms).toEqual([]);
     expect(settings.codeVocabLastScan!.whisperCount).toBe(0);
     expect(settings.codeVocabLastScan!.sampleTerms).toEqual(['foo', 'bar']);
+    expect(settings.codeVocabLastScan!.adopted).toBe(true);
   });
 
   it('drops malformed ranked-term entries and clamps the list to 500', () => {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -53,6 +53,8 @@ export interface VocabScanSummary {
   rankedTerms: RankedTerm[];
   /** How many of `rankedTerms` feed the Whisper prompt (= min(96, len)). */
   whisperCount: number;
+  /** False when a newer scan or settings change superseded this walk. */
+  adopted: boolean;
 }
 
 /** Hard ceiling on the persisted ranked list, mirroring the backend cap. */
@@ -286,6 +288,9 @@ function sanitizeVocabScan(raw: unknown): VocabScanSummary | null {
       .slice(0, MAX_SAMPLE_TERMS),
     rankedTerms,
     whisperCount,
+    // Added after persisted summaries first shipped; old successful summaries
+    // predate the field and are therefore treated as adopted.
+    adopted: typeof r.adopted === 'boolean' ? r.adopted : true,
   };
 }
 


### PR DESCRIPTION
## Summary
- make the scanned-terms pop-out an accessible focus-trapped dialog with deterministic opener focus restoration
- correlate every Rust/frontend progress event with a unique scan ID so orphaned overlapping walks cannot update the active UI
- mark scan summaries as adopted or superseded and prevent settings-raced results from being cached or persisted as complete

## Test plan
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1` (269 unit + integration tests)
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test` (82 tests)
- [x] `cd app && npm run build`
- [x] native debug `.app` smoke: real code-vocab scan; initial search focus; Shift-Tab/Tab focus wrap; Escape close; opener focus restoration

Closes #209


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code-vocabulary scans now prevent outdated or superseded results from being applied when scans overlap or settings change.
  * Scan progress is accurately associated with the active scan, and superseded results are clearly identified.
  * Scan completion data is saved only when the results are applied successfully.

* **Accessibility**
  * The View-all terms dialog now traps keyboard focus, focuses the search field when opened, and restores focus to the opening control when closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->