### PR TITLE
Add Sonic Canvas design tokens and surface hierarchy

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -178,7 +178,7 @@ function App() {
   const error = initError || recordingError;
 
   if (onboardingState === 'unknown' || modelReady === null) {
-    return <div className="h-screen bg-stone-50 dark:bg-stone-900" />;
+    return <div className="h-screen bg-background" />;
   }
   if (onboardingState === 'needed') {
     return (
@@ -200,7 +200,7 @@ function App() {
   }
 
   return (
-    <div className="h-screen bg-stone-50 dark:bg-stone-900 flex flex-col font-[-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,sans-serif]">
+    <div className="h-screen bg-background text-on-surface flex flex-col font-[-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,sans-serif]">
       {import.meta.env.DEV && (
         <div className="bg-amber-400 text-amber-900 text-xs font-semibold text-center py-0.5 tracking-widest uppercase select-none">
           Dev

--- a/app/src/components/PermissionsBanner.tsx
+++ b/app/src/components/PermissionsBanner.tsx
@@ -122,7 +122,7 @@ export function PermissionsBanner() {
   }
 
   return (
-    <div className="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-800 px-4 py-3">
+    <div className="bg-amber-50 dark:bg-amber-900/30 px-4 py-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1">
           <h3 className="text-sm font-medium text-amber-800 dark:text-amber-200">

--- a/app/src/components/RecordingControls.tsx
+++ b/app/src/components/RecordingControls.tsx
@@ -25,7 +25,7 @@ export function RecordingControls({ status, initialized, onStart, onStop }: Reco
         <button
           onClick={onStart}
           disabled={!initialized || status === 'processing'}
-          className="flex items-center gap-2 px-6 py-3 bg-stone-800 hover:bg-stone-900 active:bg-stone-950 dark:bg-stone-100 dark:hover:bg-white dark:text-stone-900 text-white font-medium rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-dim active:bg-primary-dim text-on-primary font-medium rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <circle cx="10" cy="10" r="6" />

--- a/app/src/components/StatsBar.tsx
+++ b/app/src/components/StatsBar.tsx
@@ -24,9 +24,9 @@ export function StatsBar({ statsVersion }: StatsBarProps) {
 
 function Chip({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex-1 flex flex-col items-center px-3 py-2 rounded-lg bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700">
-      <span className="text-xs font-semibold text-stone-800 dark:text-stone-100 tabular-nums">{value}</span>
-      <span className="text-[10px] text-stone-500 dark:text-stone-400 mt-0.5 leading-none">{label}</span>
+    <div className="flex-1 flex flex-col items-center px-3 py-2 rounded-lg bg-surface-container-low">
+      <span className="text-xs font-semibold text-on-surface tabular-nums">{value}</span>
+      <span className="text-[10px] text-on-surface-variant mt-0.5 leading-none">{label}</span>
     </div>
   );
 }

--- a/app/src/components/StatusHeader.tsx
+++ b/app/src/components/StatusHeader.tsx
@@ -29,9 +29,9 @@ export function StatusHeader({ status, initialized, recordingDuration, onSetting
   return (
     <header
       data-tauri-drag-region
-      className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-stone-200 dark:border-stone-700 bg-white/80 dark:bg-stone-800/80 backdrop-blur-sm"
+      className="shrink-0 flex items-center justify-between px-4 py-3 bg-surface-container-low/90 backdrop-blur-sm"
     >
-      <span className="text-sm font-semibold text-stone-800 dark:text-stone-100">Murmur</span>
+      <span className="text-sm font-semibold text-on-surface">Murmur</span>
 
       <div className="flex items-center gap-3">
         <div className={`flex items-center gap-1.5 text-sm font-medium ${statusColor}`}>
@@ -53,8 +53,8 @@ export function StatusHeader({ status, initialized, recordingDuration, onSetting
           onClick={onSettingsToggle}
           className={`p-1.5 rounded-md transition-colors ${
             isSettingsOpen
-              ? 'text-stone-900 dark:text-stone-100 bg-stone-100 dark:bg-stone-700'
-              : 'text-stone-500 dark:text-stone-400 hover:text-stone-800 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-700'
+              ? 'text-on-surface bg-surface-container-high'
+              : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container'
           }`}
           aria-label="Toggle settings"
           aria-expanded={isSettingsOpen}

--- a/app/src/components/log-viewer/EventRow.tsx
+++ b/app/src/components/log-viewer/EventRow.tsx
@@ -17,9 +17,9 @@ export function EventRow({ event }: EventRowProps) {
   const timeStr = event.timestamp.replace(/.*T/, '').replace('Z', '');
 
   return (
-    <div className="border-b border-stone-100 dark:border-stone-800 last:border-0">
+    <div>
       <div
-        className={`flex items-baseline gap-2 py-1 px-1 ${hasData ? 'cursor-pointer hover:bg-stone-50 dark:hover:bg-stone-800/50' : ''}`}
+        className={`flex items-baseline gap-2 py-1 px-1 ${hasData ? 'cursor-pointer hover:bg-surface-container-low' : ''}`}
         onClick={() => hasData && setExpanded(!expanded)}
         {...(hasData && {
           role: 'button',
@@ -33,7 +33,7 @@ export function EventRow({ event }: EventRowProps) {
           },
         })}
       >
-        <span className="text-stone-400 dark:text-stone-500 shrink-0 tabular-nums text-[11px]">
+        <span className="text-on-surface-variant shrink-0 tabular-nums text-[11px]">
           {timeStr}
         </span>
         <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold shrink-0 ${streamColors.bg} ${streamColors.text}`}>
@@ -42,17 +42,17 @@ export function EventRow({ event }: EventRowProps) {
         <span className={`text-[10px] font-medium shrink-0 uppercase ${levelColor}`}>
           {event.level}
         </span>
-        <span className="text-stone-700 dark:text-stone-300 text-xs break-all flex-1">
+        <span className="text-on-surface text-xs break-all flex-1">
           {event.summary}
         </span>
         {hasData && (
-          <span className={`text-stone-400 dark:text-stone-500 text-xs shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}>
+          <span className={`text-on-surface-variant text-xs shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}>
             &#9656;
           </span>
         )}
       </div>
       {expanded && hasData && (
-        <pre className="mx-1 mb-1 px-3 py-2 bg-stone-100 dark:bg-stone-900 rounded text-[11px] text-stone-600 dark:text-stone-400 overflow-x-auto">
+        <pre className="mx-1 mb-1 px-3 py-2 bg-surface-container-low rounded text-[11px] text-on-surface-variant overflow-x-auto">
           {JSON.stringify(event.data, null, 2)}
         </pre>
       )}

--- a/app/src/components/log-viewer/LogViewerApp.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.tsx
@@ -65,9 +65,9 @@ export function LogViewerApp() {
   }, [filteredEvents]);
 
   return (
-    <div className="h-screen flex flex-col bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-100">
+    <div className="h-screen flex flex-col bg-background text-on-surface">
       {/* Header */}
-      <div className="shrink-0 border-b border-stone-200 dark:border-stone-700 px-4 py-3">
+      <div className="shrink-0 bg-surface-container-low px-4 py-3">
         <div className="flex items-center justify-between mb-3">
           {/* Tabs */}
           <div className="flex gap-1">
@@ -77,8 +77,8 @@ export function LogViewerApp() {
                 onClick={() => setTab(t)}
                 className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
                   tab === t
-                    ? 'bg-stone-800 dark:bg-stone-200 text-white dark:text-stone-900'
-                    : 'text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800'
+                    ? 'bg-primary text-on-primary'
+                    : 'text-on-surface-variant hover:bg-surface-container hover:text-on-surface'
                 }`}
               >
                 {t.charAt(0).toUpperCase() + t.slice(1)}
@@ -89,13 +89,13 @@ export function LogViewerApp() {
           <div className="flex gap-2">
             <button
               onClick={handleCopyAll}
-              className="px-3 py-1 rounded-md text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+              className="px-3 py-1 rounded-md text-xs font-medium border border-outline-variant/10 bg-surface-container-lowest text-on-surface hover:bg-surface-container transition-colors"
             >
               Copy All
             </button>
             <button
               onClick={clear}
-              className="px-3 py-1 rounded-md text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+              className="px-3 py-1 rounded-md text-xs font-medium border border-outline-variant/10 bg-surface-container-lowest text-on-surface hover:bg-surface-container transition-colors"
             >
               Clear
             </button>
@@ -118,7 +118,7 @@ export function LogViewerApp() {
           className="flex-1 overflow-y-auto font-mono text-xs"
         >
           {filteredEvents.length === 0 ? (
-            <div className="flex items-center justify-center h-32 text-stone-400 dark:text-stone-500 text-sm">
+            <div className="flex items-center justify-center h-32 text-on-surface-variant text-sm">
               No events to display
             </div>
           ) : (

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -44,7 +44,7 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
         value={draft}
         onChange={(e) => setDraft(Number(e.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-stone-200 dark:bg-stone-600 rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
+        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
       />
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
         Delay before paste. Increase if paste lands in the wrong window.
@@ -124,7 +124,7 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
         value={draft}
         onChange={(e) => setDraft(Number(e.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-stone-200 dark:bg-stone-600 rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
+        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
       />
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
         Higher = keeps more audio. Lower = trims silence more aggressively.
@@ -595,15 +595,15 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     : null;
 
   return (
-    <div className="flex-1 flex overflow-hidden bg-white dark:bg-stone-900">
+    <div className="flex-1 flex overflow-hidden bg-surface text-on-surface">
       {/* Left: category nav rail */}
-      <nav className="w-48 shrink-0 flex flex-col border-r border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800/40 overflow-y-auto">
+      <nav className="w-48 shrink-0 flex flex-col bg-surface-container-low overflow-y-auto">
         <div className="flex items-center justify-between h-12 shrink-0 px-3">
-          <h2 className="text-sm font-semibold text-stone-900 dark:text-stone-100">Settings</h2>
+          <h2 className="text-sm font-semibold text-on-surface">Settings</h2>
           <button
             onClick={onClose}
             aria-label="Close settings"
-            className="p-1 rounded-md text-stone-500 hover:bg-stone-200 dark:hover:bg-stone-700 transition-colors"
+            className="p-1 rounded-md text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface transition-colors"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -618,8 +618,8 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               onClick={() => setActiveCat(c.id)}
               className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
                 activeCat === c.id
-                  ? 'bg-stone-200 dark:bg-stone-700 text-stone-900 dark:text-stone-100 font-medium'
-                  : 'text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700/50'
+                  ? 'bg-surface-container-high text-on-surface font-medium'
+                  : 'text-on-surface-variant hover:bg-surface-container'
               }`}
             >
               {c.label}
@@ -713,7 +713,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                   <span>Working...</span>
                 )}
               </div>
-              <div className="w-full h-1.5 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
+              <div className="w-full h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
                 <div
                   role="progressbar"
                   aria-valuenow={downloadProgressPercent ?? undefined}
@@ -871,7 +871,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Cleanup sub-options — only meaningful while cleanup is enabled. */}
         {settings.cleanupEnabled && (
-          <div className="ml-3 pl-3 border-l border-stone-200 dark:border-stone-700 space-y-3">
+          <div className="ml-3 pl-3 space-y-3">
             <div className="flex items-center justify-between">
               <label className="text-xs text-stone-600 dark:text-stone-400">
                 Remove filler words (um, uh)

--- a/app/src/components/settings/SettingsSection.tsx
+++ b/app/src/components/settings/SettingsSection.tsx
@@ -35,9 +35,9 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
     if (activePage !== undefined && activePage !== pageId) return null;
     return (
       <div>
-        <h1 className="text-base font-semibold text-stone-900 dark:text-stone-100">{title}</h1>
+        <h1 className="text-base font-semibold text-on-surface">{title}</h1>
         {subtitle && (
-          <p className="mt-0.5 text-xs text-stone-400 dark:text-stone-500">{subtitle}</p>
+          <p className="mt-0.5 text-xs text-on-surface-variant">{subtitle}</p>
         )}
         <div className="pt-4 space-y-4">{children}</div>
       </div>
@@ -45,23 +45,23 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
   }
 
   return (
-    <div className="border-b border-stone-200 dark:border-stone-700">
+    <div className="mb-2 last:mb-0">
       <button
         type="button"
         id={headerId}
         aria-expanded={expanded}
         aria-controls={contentId}
         onClick={handleToggle}
-        className="flex w-full items-center justify-between py-3 text-sm font-semibold text-stone-900 dark:text-stone-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-1 rounded-sm"
+        className="flex w-full items-center justify-between py-3 text-sm font-semibold text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded-sm"
       >
         <span className="text-left">
           {title}
           {subtitle && !expanded && (
-            <span className="block text-xs font-normal text-stone-400 dark:text-stone-500">{subtitle}</span>
+            <span className="block text-xs font-normal text-on-surface-variant">{subtitle}</span>
           )}
         </span>
         <svg
-          className={`w-4 h-4 text-stone-400 shrink-0 transition-transform duration-200 ${
+          className={`w-4 h-4 text-on-surface-variant shrink-0 transition-transform duration-200 ${
             expanded ? 'rotate-180' : ''
           }`}
           fill="none"

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,8 +1,91 @@
 @import "tailwindcss";
 
+:root {
+  color-scheme: light;
+  --murmur-background: #f7fafc;
+  --murmur-surface: #f7fafc;
+  --murmur-surface-container-low: #eff4f8;
+  --murmur-surface-container: #e9eff3;
+  --murmur-surface-container-high: #e2e9ee;
+  --murmur-surface-container-lowest: #ffffff;
+  --murmur-surface-container-highest: #dbe4e9;
+  --murmur-primary: #036785;
+  --murmur-primary-dim: #005a75;
+  --murmur-on-primary: #f3faff;
+  --murmur-on-surface: #2b3438;
+  --murmur-on-surface-variant: #586065;
+  --murmur-outline-variant: #abb3b9;
+  --murmur-error: #a83836;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --murmur-background: #0b0f11;
+    --murmur-surface: #0b0f11;
+    --murmur-surface-container-low: #151a1e;
+    --murmur-surface-container: #1e2529;
+    --murmur-surface-container-high: #283035;
+    --murmur-surface-container-lowest: #0f1315;
+    --murmur-surface-container-highest: #323b41;
+    --murmur-primary: #92dbfe;
+    --murmur-primary-dim: #84cdef;
+    --murmur-on-primary: #00394b;
+    --murmur-on-surface: #dbe4e9;
+    --murmur-on-surface-variant: #abb3b9;
+    --murmur-outline-variant: #586065;
+    --murmur-error: #fa746f;
+  }
+}
+
+/* Tailwind v4 generates semantic utilities from the runtime theme variables. */
+@theme inline {
+  --color-background: var(--murmur-background);
+  --color-surface: var(--murmur-surface);
+  --color-surface-container-low: var(--murmur-surface-container-low);
+  --color-surface-container: var(--murmur-surface-container);
+  --color-surface-container-high: var(--murmur-surface-container-high);
+  --color-surface-container-lowest: var(--murmur-surface-container-lowest);
+  --color-surface-container-highest: var(--murmur-surface-container-highest);
+  --color-primary: var(--murmur-primary);
+  --color-primary-dim: var(--murmur-primary-dim);
+  --color-on-primary: var(--murmur-on-primary);
+  --color-on-surface: var(--murmur-on-surface);
+  --color-on-surface-variant: var(--murmur-on-surface-variant);
+  --color-outline-variant: var(--murmur-outline-variant);
+  --color-error: var(--murmur-error);
+}
+
 body {
+  background: var(--murmur-background);
+  color: var(--murmur-on-surface);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  scrollbar-color: color-mix(in srgb, var(--murmur-outline-variant) 24%, transparent) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--murmur-outline-variant) 24%, transparent);
+  background-clip: padding-box;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--murmur-outline-variant) 40%, transparent);
+  background-clip: padding-box;
 }
 
 @keyframes pulse {

--- a/app/src/styles.test.ts
+++ b/app/src/styles.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error Node types are intentionally absent from the browser app.
+import { readFileSync } from 'node:fs';
+
+const css = readFileSync('./src/styles.css', 'utf8');
+
+const lightTheme = {
+  background: '#f7fafc',
+  surface: '#f7fafc',
+  'surface-container-low': '#eff4f8',
+  'surface-container': '#e9eff3',
+  'surface-container-high': '#e2e9ee',
+  'surface-container-lowest': '#ffffff',
+  'surface-container-highest': '#dbe4e9',
+  primary: '#036785',
+  'primary-dim': '#005a75',
+  'on-primary': '#f3faff',
+  'on-surface': '#2b3438',
+  'on-surface-variant': '#586065',
+  'outline-variant': '#abb3b9',
+  error: '#a83836',
+} as const;
+
+const darkTheme = {
+  background: '#0b0f11',
+  surface: '#0b0f11',
+  'surface-container-low': '#151a1e',
+  'surface-container': '#1e2529',
+  'surface-container-high': '#283035',
+  'surface-container-lowest': '#0f1315',
+  'surface-container-highest': '#323b41',
+  primary: '#92dbfe',
+  'primary-dim': '#84cdef',
+  'on-primary': '#00394b',
+  'on-surface': '#dbe4e9',
+  'on-surface-variant': '#abb3b9',
+  'outline-variant': '#586065',
+  error: '#fa746f',
+} as const;
+
+function luminance(hex: string): number {
+  const channels = hex.slice(1).match(/.{2}/g)!.map((channel) => parseInt(channel, 16) / 255);
+  const [red, green, blue] = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrast(foreground: string, background: string): number {
+  const foregroundLuminance = luminance(foreground);
+  const backgroundLuminance = luminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+describe('Sonic Canvas semantic color tokens', () => {
+  it('defines the complete light and dark palettes in the Tailwind v4 stylesheet', () => {
+    expect(css).toContain('@theme inline');
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+
+    for (const [token, value] of Object.entries(lightTheme)) {
+      expect(css).toContain(`--murmur-${token}: ${value};`);
+      expect(css).toContain(`--color-${token}: var(--murmur-${token});`);
+    }
+
+    for (const [token, value] of Object.entries(darkTheme)) {
+      expect(css).toContain(`--murmur-${token}: ${value};`);
+    }
+  });
+
+  it.each([
+    ['light', lightTheme],
+    ['dark', darkTheme],
+  ] as const)('%s text pairs meet WCAG AA contrast', (_mode, theme) => {
+    expect(contrast(theme['on-surface'], theme.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(theme['on-surface-variant'], theme.background)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(theme['on-primary'], theme.primary)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(theme.error, theme.background)).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
## Summary
- define the Sonic Canvas light/dark semantic color system in the active Tailwind v4 CSS theme
- replace foundation-level layout dividers with tonal surfaces across the main window, settings, stats, permissions, recording action, and log viewer
- add semantic scrollbar styling plus token and WCAG contrast contract tests

## Test plan
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1` (274 unit tests + transcription integration)
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test` (90 tests)
- [x] `cd app && npm run build`
- [x] localhost:1420 dev server served the updated main component and generated semantic stylesheet
- [x] native debug bundle smoke: main window, settings open/closed, history preserved, and log viewer
- [x] native visual QA in light and dark mode for main window, settings, and log viewer

Closes #140
