### PR TITLE
Build once and promote immutable release artifacts

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -1,5 +1,5 @@
 name: Setup Linux build environment
-description: Installs apt deps, CUDA toolkit (cached), and sets up Rust cache for whisper-rs-sys.
+description: Installs apt deps, restores the minimal CUDA toolchain, and configures Rust caching.
 
 inputs:
   cuda-version:
@@ -14,7 +14,10 @@ inputs:
     default: 'linux-cuda-debug'
   rust-cache-save-if:
     description: Expression controlling whether the Rust cache is saved; defaults to main-branch pushes only
-    default: "${{ github.ref == 'refs/heads/main' }}"
+    default: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
+  cuda-cache-save-if:
+    description: Expression controlling whether the CUDA cache is saved; defaults to trusted main-branch pushes only
+    default: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
 
 runs:
   using: composite
@@ -44,14 +47,8 @@ runs:
       id: cuda-cache
       uses: actions/cache/restore@v4
       with:
-        path: |
-          /usr/local/cuda-${{ env.CUDA_MM }}
-          /usr/local/cuda
-          /usr/lib/x86_64-linux-gnu/libcuda*
-          /usr/lib/x86_64-linux-gnu/libnvidia-*
-          /etc/ld.so.conf.d/cuda-*.conf
-          /etc/ld.so.conf.d/nvidia-*.conf
-        key: cuda-toolkit-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-jimver-v0.2.21
+        path: /usr/local/cuda-${{ env.CUDA_MM }}
+        key: cuda-minimal-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-v1
 
     - name: Install CUDA toolkit
       if: steps.cuda-cache.outputs.cache-hit != 'true'
@@ -59,38 +56,67 @@ runs:
       with:
         cuda: ${{ inputs.cuda-version }}
         method: network
+        sub-packages: '["nvcc", "cudart-dev"]'
+        non-cuda-sub-packages: '["libcublas-dev"]'
 
-    # On cache hit Jimver does not run, so we must restore the env vars it normally sets.
-    # These mirror what Jimver exports; any missing var surfaces as a hard linker error in
-    # the next cargo step (not a silent wrong binary).
-    - name: Restore CUDA env vars on cache hit
-      if: steps.cuda-cache.outputs.cache-hit == 'true'
+    # Cache only the physical versioned tree. Recreate transient aliases and loader
+    # configuration on every runner so archives cannot contain duplicate/unstable paths.
+    - name: Configure CUDA environment
       shell: bash
       run: |
+        if [ ! -d "/usr/local/cuda-${CUDA_MM}" ]; then
+          echo "ERROR: CUDA tree is missing: /usr/local/cuda-${CUDA_MM}"
+          exit 1
+        fi
+        if [ -e /usr/local/cuda ] && [ ! -L /usr/local/cuda ]; then
+          sudo rm -rf /usr/local/cuda
+        fi
+        sudo ln -sfn "/usr/local/cuda-${CUDA_MM}" /usr/local/cuda
+        echo '/usr/local/cuda/lib64' | sudo tee /etc/ld.so.conf.d/cuda-murmur.conf >/dev/null
+        echo '/usr/local/cuda/targets/x86_64-linux/lib' | sudo tee -a /etc/ld.so.conf.d/cuda-murmur.conf >/dev/null
         echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
         echo "CUDA_PATH=/usr/local/cuda" >> "$GITHUB_ENV"
         echo "CUDA_PATH_V${CUDA_MM//./_}=/usr/local/cuda" >> "$GITHUB_ENV"
-        echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
         sudo ldconfig
 
-    # Runs on both hit and miss paths; fails immediately if the install or cache restore
-    # produced a broken layout rather than waiting for cmake to die midway through.
+    # A claimed hit with a damaged tree fails closed. It must not silently reinstall and
+    # overwrite a trusted cache with another ambiguous archive.
     - name: Verify CUDA install
       shell: bash
-      run: nvcc --version || { echo "CUDA toolkit not available after install/restore"; exit 1; }
+      run: |
+        NVCC="/usr/local/cuda-${CUDA_MM}/bin/nvcc"
+        if [ ! -x "$NVCC" ]; then
+          echo "ERROR: CUDA cache-hit=${{ steps.cuda-cache.outputs.cache-hit }} but nvcc is missing: $NVCC"
+          exit 1
+        fi
+        "$NVCC" --version | tee /tmp/murmur-nvcc-version.txt
+        if ! grep -q "release ${CUDA_MM}" /tmp/murmur-nvcc-version.txt; then
+          echo "ERROR: nvcc version does not match requested CUDA ${CUDA_MM}"
+          exit 1
+        fi
+        if ! find "/usr/local/cuda-${CUDA_MM}" -name 'libcublas.so*' -print -quit | grep -q .; then
+          echo "ERROR: minimal CUDA tree is missing cuBLAS runtime/development libraries"
+          exit 1
+        fi
 
     - name: Save CUDA toolkit cache
-      if: steps.cuda-cache.outputs.cache-hit != 'true'
+      if: steps.cuda-cache.outputs.cache-hit != 'true' && inputs.cuda-cache-save-if == 'true'
       uses: actions/cache/save@v4
       with:
-        path: |
-          /usr/local/cuda-${{ env.CUDA_MM }}
-          /usr/local/cuda
-          /usr/lib/x86_64-linux-gnu/libcuda*
-          /usr/lib/x86_64-linux-gnu/libnvidia-*
-          /etc/ld.so.conf.d/cuda-*.conf
-          /etc/ld.so.conf.d/nvidia-*.conf
-        key: cuda-toolkit-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-jimver-v0.2.21
+        path: /usr/local/cuda-${{ env.CUDA_MM }}
+        key: cuda-minimal-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-v1
+
+    - name: Summarize CUDA cache policy
+      shell: bash
+      run: |
+        {
+          echo "### CUDA cache"
+          echo "- key: \`cuda-minimal-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-v1\`"
+          echo "- restore hit: \`${{ steps.cuda-cache.outputs.cache-hit || 'false' }}\`"
+          echo "- write authorized: \`${{ inputs.cuda-cache-save-if }}\`"
+          echo "- physical tree: \`/usr/local/cuda-${CUDA_MM}\` ($(du -sh "/usr/local/cuda-${CUDA_MM}" | cut -f1))"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     # cuda-${{ inputs.cuda-version }} is appended to the key so a CUDA upgrade invalidates
     # stale whisper-rs-sys kernels compiled against older headers.

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -80,6 +80,19 @@ runs:
         echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
         sudo ldconfig
 
+        # GitHub-hosted runners have no NVIDIA driver. cuda-driver-dev supplies
+        # a link-time libcuda.so stub but no libcuda.so.1 runtime soname. Keep a
+        # runner-local alias for tests/smoke only; never cache or package it.
+        DRIVER_STUB=$(find "/usr/local/cuda-${CUDA_MM}" -path '*/stubs/libcuda.so' -print -quit)
+        if [ -z "$DRIVER_STUB" ]; then
+          echo "ERROR: minimal CUDA tree is missing the driver development stub"
+          exit 1
+        fi
+        STUB_DIR="$RUNNER_TEMP/murmur-cuda-driver-stub"
+        mkdir -p "$STUB_DIR"
+        ln -sfn "$DRIVER_STUB" "$STUB_DIR/libcuda.so.1"
+        echo "CUDA_DRIVER_STUB_DIR=$STUB_DIR" >> "$GITHUB_ENV"
+
     # A claimed hit with a damaged tree fails closed. It must not silently reinstall and
     # overwrite a trusted cache with another ambiguous archive.
     - name: Verify CUDA install
@@ -99,6 +112,10 @@ runs:
           echo "ERROR: minimal CUDA tree is missing cuBLAS runtime/development libraries"
           exit 1
         fi
+        test -L "$CUDA_DRIVER_STUB_DIR/libcuda.so.1" || {
+          echo "ERROR: runner-local libcuda.so.1 test stub was not configured"
+          exit 1
+        }
 
     - name: Save CUDA toolkit cache
       if: steps.cuda-cache.outputs.cache-hit != 'true' && inputs.cuda-cache-save-if == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
           rust-cache-shared-key: linux-cuda-debug
 
       - name: Run tests
-        run: cd app/src-tauri && cargo test --lib -- --test-threads=1
+        run: |
+          cd app/src-tauri
+          LD_LIBRARY_PATH="$CUDA_DRIVER_STUB_DIR:${LD_LIBRARY_PATH:-}" \
+            cargo test --lib -- --test-threads=1
 
   ci-pass:
     needs: [changes, typecheck, rust-macos, linux]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,14 @@ jobs:
             github:
               - '.github/**'
               - 'scripts/validate_workflow_policy.py'
+              - 'scripts/release_artifacts.py'
+              - 'tests/test_release_artifacts.py'
+              - 'tests/test_workflow_policy.py'
 
       - name: Validate workflow policy
-        run: python3 scripts/validate_workflow_policy.py
+        run: |
+          python3 scripts/validate_workflow_policy.py
+          python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py
 
   typecheck:
     needs: changes

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -269,7 +269,8 @@ jobs:
             exit 1
           fi
           rm -f "$LOG"
-          xvfb-run -a dbus-run-session -- "$DEB_BINARY" >/tmp/murmur-deb-smoke.log 2>&1 &
+          LD_LIBRARY_PATH="$CUDA_DRIVER_STUB_DIR:${LD_LIBRARY_PATH:-}" \
+            xvfb-run -a dbus-run-session -- "$DEB_BINARY" >/tmp/murmur-deb-smoke.log 2>&1 &
           PID=$!
           for i in $(seq 1 20); do
             sleep 1
@@ -286,7 +287,8 @@ jobs:
 
           chmod +x "$APPIMAGE"
           rm -f "$LOG"
-          xvfb-run -a dbus-run-session -- "$APPIMAGE" --appimage-extract-and-run \
+          LD_LIBRARY_PATH="$CUDA_DRIVER_STUB_DIR:${LD_LIBRARY_PATH:-}" \
+            xvfb-run -a dbus-run-session -- "$APPIMAGE" --appimage-extract-and-run \
             >/tmp/murmur-appimage-smoke.log 2>&1 &
           PID=$!
           for i in $(seq 1 30); do

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,344 @@
+name: Release Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      prime_caches:
+        description: Save trusted main release caches after this non-publishing rehearsal
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  context:
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: bump version') }}"
+    runs-on: ubuntu-latest
+    outputs:
+      source-sha: ${{ steps.context.outputs.source_sha }}
+      cache-write: ${{ steps.context.outputs.cache_write }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate trusted main source
+        id: context
+        env:
+          PRIME_CACHES: ${{ inputs.prime_caches || false }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "ERROR: release builds may only execute from the trusted main branch"
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "ERROR: release source $GITHUB_SHA is not on origin/main"
+            exit 1
+          fi
+
+          CACHE_WRITE=false
+          if [ "$GITHUB_EVENT_NAME" = "push" ] || [ "$PRIME_CACHES" = "true" ]; then
+            CACHE_WRITE=true
+          fi
+          echo "source_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          echo "cache_write=$CACHE_WRITE" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Trusted release build"
+            echo "- source: \`$GITHUB_SHA\`"
+            echo "- event: \`$GITHUB_EVENT_NAME\`"
+            echo "- cache write authorized: \`$CACHE_WRITE\`"
+            echo "- publication: disabled (artifacts only)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  typecheck:
+    needs: context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.context.outputs.source-sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        run: cd app && npm ci
+
+      - name: TypeScript check
+        run: cd app && npx tsc --noEmit
+
+      - name: Unit tests
+        run: cd app && npm test
+
+      - name: Workflow and artifact policy tests
+        run: |
+          python3 scripts/validate_workflow_policy.py
+          python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py
+
+  release-macos:
+    needs: context
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.context.outputs.source-sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore release-profile Rust cache
+        id: rust-cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+          shared-key: macos-release-v1
+          key: profile-release
+          add-job-id-key: false
+          save-if: ${{ needs.context.outputs.cache-write == 'true' }}
+
+      - name: Install frontend dependencies
+        run: cd app && npm ci
+
+      - name: Locate clang runtime for ggml-metal symbol resolution
+        run: |
+          CLANG_RT=$(find /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang \
+            -name "libclang_rt.osx.a" 2>/dev/null | sort -V | tail -1)
+          if [ -z "$CLANG_RT" ]; then
+            echo "ERROR: libclang_rt.osx.a not found"
+            exit 1
+          fi
+          echo "RUSTFLAGS=-C link-arg=$CLANG_RT -C link-arg=-mmacosx-version-min=14.0 -C link-arg=-Wl,-rpath,/usr/lib/swift" >> "$GITHUB_ENV"
+
+      - name: Build, sign, and notarize
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: app
+
+      - name: Smoke test signed application
+        run: |
+          APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
+          BINARY="$APP/Contents/MacOS/$(ls "$APP/Contents/MacOS/" | head -1)"
+          if [ -z "$APP" ] || [ ! -x "$BINARY" ]; then
+            echo "ERROR: signed application bundle or binary is missing"
+            exit 1
+          fi
+          "$BINARY" &
+          PID=$!
+          for i in 1 2 3 4 5; do
+            sleep 1
+            if ! kill -0 "$PID" 2>/dev/null; then
+              echo "ERROR: signed application exited after ${i}s"
+              exit 1
+            fi
+          done
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+
+      - name: Stage immutable macOS artifacts
+        env:
+          SOURCE_SHA: ${{ needs.context.outputs.source-sha }}
+        run: |
+          mkdir -p release-artifacts
+          find app/src-tauri/target/release/bundle/dmg -maxdepth 1 -type f -name '*.dmg' \
+            -exec cp {} release-artifacts/ \;
+          find app/src-tauri/target/release/bundle/macos -maxdepth 1 -type f \
+            \( -name '*.app.tar.gz' -o -name '*.app.tar.gz.sig' \) \
+            -exec cp {} release-artifacts/ \;
+          ARCH=$(uname -m)
+          [ "$ARCH" = "arm64" ] && ARCH=aarch64
+          python3 scripts/release_artifacts.py record \
+            --platform macos \
+            --platform-key "darwin-${ARCH}" \
+            --artifacts release-artifacts \
+            --commit-sha "$SOURCE_SHA" \
+            --run-id "$GITHUB_RUN_ID"
+
+      - name: Upload immutable macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-${{ needs.context.outputs.source-sha }}
+          path: release-artifacts
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: true
+
+      - name: Summarize macOS cache
+        run: |
+          {
+            echo "### macOS release cache"
+            echo "- restore hit: \`${{ steps.rust-cache.outputs.cache-hit || 'false' }}\`"
+            echo "- write authorized: \`${{ needs.context.outputs.cache-write }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-linux:
+    needs: context
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.context.outputs.source-sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Free disk space for CUDA release build
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker system prune --all --force || true
+
+      - name: Setup minimal Linux release environment
+        uses: ./.github/actions/setup-linux-build
+        with:
+          cuda-version: '12.8.0'
+          rust-cache-shared-key: linux-cuda-release-v1
+          rust-cache-save-if: ${{ needs.context.outputs.cache-write == 'true' }}
+          cuda-cache-save-if: ${{ needs.context.outputs.cache-write == 'true' }}
+
+      - name: Install frontend dependencies
+        run: cd app && npm ci
+
+      - name: Build signed packages
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: app
+
+      - name: Install package smoke-test dependencies
+        run: sudo apt-get install -y xvfb dbus-x11 at-spi2-core
+
+      - name: Smoke test deb and AppImage packages
+        run: |
+          LOG="$HOME/.local/share/local-dictation/logs/app.log"
+          DEB=$(find app/src-tauri/target/release/bundle/deb -maxdepth 1 -type f -name '*.deb' -print -quit)
+          APPIMAGE=$(find app/src-tauri/target/release/bundle/appimage -maxdepth 1 -type f -name '*.AppImage' -print -quit)
+          if [ -z "$DEB" ] || [ -z "$APPIMAGE" ]; then
+            echo "ERROR: deb or AppImage package is missing"
+            exit 1
+          fi
+
+          rm -rf /tmp/murmur-deb-root
+          mkdir -p /tmp/murmur-deb-root
+          dpkg-deb -x "$DEB" /tmp/murmur-deb-root
+          DEB_BINARY=$(find /tmp/murmur-deb-root/usr/bin -maxdepth 1 -type f -perm -111 -print -quit)
+          if [ -z "$DEB_BINARY" ]; then
+            echo "ERROR: deb package has no executable in /usr/bin"
+            exit 1
+          fi
+          rm -f "$LOG"
+          xvfb-run -a dbus-run-session -- "$DEB_BINARY" >/tmp/murmur-deb-smoke.log 2>&1 &
+          PID=$!
+          for i in $(seq 1 20); do
+            sleep 1
+            if ! kill -0 "$PID" 2>/dev/null; then
+              tail -80 /tmp/murmur-deb-smoke.log || true
+              echo "ERROR: deb executable exited during smoke test"
+              exit 1
+            fi
+            grep -q '\[main\] App mounted' "$LOG" 2>/dev/null && break
+          done
+          grep -q '\[main\] App mounted' "$LOG" || { echo "ERROR: deb frontend did not mount"; exit 1; }
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+
+          chmod +x "$APPIMAGE"
+          rm -f "$LOG"
+          xvfb-run -a dbus-run-session -- "$APPIMAGE" --appimage-extract-and-run \
+            >/tmp/murmur-appimage-smoke.log 2>&1 &
+          PID=$!
+          for i in $(seq 1 30); do
+            sleep 1
+            if ! kill -0 "$PID" 2>/dev/null; then
+              tail -80 /tmp/murmur-appimage-smoke.log || true
+              echo "ERROR: AppImage exited during smoke test"
+              exit 1
+            fi
+            grep -q '\[main\] App mounted' "$LOG" 2>/dev/null && break
+          done
+          grep -q '\[main\] App mounted' "$LOG" || { echo "ERROR: AppImage frontend did not mount"; exit 1; }
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+
+      - name: Audit packaged CUDA libraries
+        run: |
+          APPIMAGE=$(find app/src-tauri/target/release/bundle/appimage -maxdepth 1 -type f -name '*.AppImage' -print -quit)
+          rm -rf squashfs-root
+          "$APPIMAGE" --appimage-extract >/dev/null
+          find squashfs-root -type f \( -name 'libcuda*' -o -name 'libcublas*' -o -name 'libnv*' \) \
+            -print | sort | tee /tmp/murmur-packaged-cuda-libraries.txt
+          {
+            echo "### Packaged CUDA libraries"
+            echo '```'
+            cat /tmp/murmur-packaged-cuda-libraries.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stage immutable Linux artifacts
+        env:
+          SOURCE_SHA: ${{ needs.context.outputs.source-sha }}
+        run: |
+          mkdir -p release-artifacts
+          find app/src-tauri/target/release/bundle/deb -maxdepth 1 -type f -name '*.deb' \
+            -exec cp {} release-artifacts/ \;
+          find app/src-tauri/target/release/bundle/appimage -maxdepth 1 -type f \
+            \( -name '*.AppImage' -o -name '*.AppImage.sig' \) \
+            -exec cp {} release-artifacts/ \;
+          python3 scripts/release_artifacts.py record \
+            --platform linux \
+            --platform-key "linux-$(uname -m)" \
+            --artifacts release-artifacts \
+            --commit-sha "$SOURCE_SHA" \
+            --run-id "$GITHUB_RUN_ID"
+
+      - name: Upload immutable Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release-${{ needs.context.outputs.source-sha }}
+          path: release-artifacts
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,434 +4,274 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full trusted-main commit SHA to rehearse (never publishes)
+        required: true
+      artifact_run_id:
+        description: Successful Release Build workflow run ID for that SHA
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
-  typecheck:
+  resolve:
     runs-on: ubuntu-latest
+    outputs:
+      source-sha: ${{ steps.resolve.outputs.source_sha }}
+      artifact-run-id: ${{ steps.resolve.outputs.artifact_run_id }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      publish: ${{ steps.resolve.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: app/package-lock.json
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: cd app && npm ci
-
-      - name: TypeScript check
-        run: cd app && npx tsc --noEmit
-
-      - name: Unit tests
-        run: cd app && npm test
-
-  release-macos:
-    needs: [typecheck]
-    runs-on: macos-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: app/package-lock.json
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: app/src-tauri
-
-      - name: Install frontend dependencies
-        run: cd app && npm ci
-
-      - name: Locate clang runtime for ggml-metal symbol resolution
-        run: |
-          CLANG_RT=$(find /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang \
-            -name "libclang_rt.osx.a" 2>/dev/null | sort -V | tail -1)
-          if [ -z "$CLANG_RT" ]; then
-            echo "ERROR: libclang_rt.osx.a not found"
-            find /Applications/Xcode.app/Contents/Developer/Toolchains -name "libclang_rt*.a" 2>/dev/null | head -10
-            exit 1
-          fi
-          echo "Found: $CLANG_RT"
-          echo "RUSTFLAGS=-C link-arg=$CLANG_RT -C link-arg=-mmacosx-version-min=14.0 -C link-arg=-Wl,-rpath,/usr/lib/swift" >> $GITHUB_ENV
-
-      - name: Build, sign, and notarize
-        id: tauri-build
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MACOSX_DEPLOYMENT_TARGET: "14.0"
-          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
-          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
-          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          projectPath: app
-
-      - name: Smoke test — verify .app launches
-        run: |
-          APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name "*.app" | head -1)
-          BINARY="$APP/Contents/MacOS/$(ls "$APP/Contents/MacOS/" | head -1)"
-
-          echo "=== Verifying bundle exists ==="
-          ls -la "$APP/Contents/MacOS/"
-
-          echo "=== Launching binary ==="
-          "$BINARY" &
-          PID=$!
-          echo "Started with PID $PID"
-
-          echo "=== Waiting 5 seconds ==="
-          for i in 1 2 3 4 5; do
-            sleep 1
-            if ! kill -0 "$PID" 2>/dev/null; then
-              echo "FAIL: Process died after ${i}s"
-              echo "=== Crash logs ==="
-              find ~/Library/Logs/DiagnosticReports -name "ui-*" -newer "$BINARY" 2>/dev/null \
-                | head -5 | while read -r f; do
-                  echo "--- $f ---"
-                  cat "$f"
-                done
-              exit 1
-            fi
-            echo "  Alive at ${i}s"
-          done
-
-          echo "=== Smoke test passed — killing process ==="
-          kill "$PID" 2>/dev/null || true
-          wait "$PID" 2>/dev/null || true
-
-      - name: Collect updater artifact info
-        run: |
-          ARTIFACTS='${{ steps.tauri-build.outputs.artifactPaths }}'
-          TAR_GZ_FILE=$(echo "$ARTIFACTS" | jq -r '.[]' | grep '\.app\.tar\.gz$' | head -1)
-          TAR_GZ_BASENAME=$(basename "$TAR_GZ_FILE")
-          RUNNER_ARCH=$(uname -m)
-          [ "$RUNNER_ARCH" = "arm64" ] && RUNNER_ARCH="aarch64"
-
-          SIG_FILE="${TAR_GZ_FILE}.sig"
-          SIGNATURE=""
-          if [ -f "$SIG_FILE" ]; then
-            SIGNATURE=$(cat "$SIG_FILE")
-          fi
-
-          mkdir -p updater-info
-          cat > updater-info/macos.json <<ENDJSON
-          {
-            "platform": "darwin-${RUNNER_ARCH}",
-            "url_basename": "${TAR_GZ_BASENAME}",
-            "signature": "${SIGNATURE}"
-          }
-          ENDJSON
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-artifacts
-          path: |
-            app/src-tauri/target/release/bundle/dmg/*.dmg
-            app/src-tauri/target/release/bundle/macos/*.app.tar.gz
-            app/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
-
-      - name: Upload updater info
-        uses: actions/upload-artifact@v4
-        with:
-          name: updater-macos
-          path: updater-info/macos.json
-
-  release-linux:
-    needs: [typecheck]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: app/package-lock.json
-
-      - name: Free disk space for CUDA release build
-        run: |
-          echo "=== Disk before cleanup ==="
-          df -h /
-          sudo rm -rf \
-            /usr/local/lib/android \
-            /usr/share/dotnet \
-            /opt/ghc \
-            /usr/local/.ghcup \
-            /opt/hostedtoolcache/CodeQL
-          sudo apt-get clean
-          docker system prune --all --force || true
-          echo "=== Disk after cleanup ==="
-          df -h /
-
-      # actions/checkout above must run first so the local composite action is on disk.
-      - name: Setup Linux build environment
-        uses: ./.github/actions/setup-linux-build
-        with:
-          cuda-version: '12.8.0'
-          rust-cache-shared-key: linux-cuda-release
-          rust-cache-save-if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
-
-      - name: Install frontend dependencies
-        run: cd app && npm ci
-
-      - name: Build
-        id: tauri-build
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          projectPath: app
-
-      - name: Install smoke test dependencies
-        run: sudo apt-get install -y xvfb dbus-x11 at-spi2-core
-
-      - name: Smoke test — verify binary launches and frontend mounts
-        run: |
-          BINARY="app/src-tauri/target/release/ui"
-          LOG="$HOME/.local/share/local-dictation/logs/app.log"
-
-          echo "=== Verifying binary exists ==="
-          ls -la "$BINARY"
-
-          echo "=== Clearing any prior log ==="
-          rm -f "$LOG"
-
-          echo "=== Launching under xvfb + dbus ==="
-          xvfb-run -a --server-args="-screen 0 1280x800x24" \
-            dbus-run-session -- "$BINARY" > /tmp/murmur-smoke.log 2>&1 &
-          PID=$!
-          echo "Started with PID $PID"
-
-          echo "=== Waiting up to 20s for [main] App mounted ==="
-          MOUNTED=0
-          for i in $(seq 1 20); do
-            sleep 1
-            if ! kill -0 "$PID" 2>/dev/null; then
-              echo "FAIL: Process died after ${i}s"
-              echo "--- stderr ---"; tail -50 /tmp/murmur-smoke.log || true
-              echo "--- app.log ---"; tail -50 "$LOG" 2>/dev/null || echo "(no log)"
-              exit 1
-            fi
-            if grep -q "\[main\] App mounted" "$LOG" 2>/dev/null; then
-              echo "  Mounted at ${i}s"
-              MOUNTED=1
-              break
-            fi
-            echo "  Alive at ${i}s (not mounted yet)"
-          done
-
-          if [ "$MOUNTED" != "1" ]; then
-            echo "FAIL: Frontend never mounted within 20s"
-            echo "--- stderr ---"; tail -50 /tmp/murmur-smoke.log || true
-            echo "--- app.log ---"; tail -80 "$LOG" 2>/dev/null || echo "(no log)"
-            kill "$PID" 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "=== Smoke test passed — killing process ==="
-          kill "$PID" 2>/dev/null || true
-          wait "$PID" 2>/dev/null || true
-
-      - name: Collect updater artifact info
-        run: |
-          # Tauri v2 reuses the AppImage itself as the Linux updater bundle.
-          # Do not rely on tauri-action's artifactPaths output here: it can omit
-          # updater-only paths even when the signed files exist on disk.
-          APPIMAGE_FILE=$(find app/src-tauri/target/release/bundle/appimage \
-            -maxdepth 1 -type f -name '*.AppImage' -print -quit)
-          if [ -z "$APPIMAGE_FILE" ]; then
-            echo "ERROR: Linux updater AppImage was not generated"
-            exit 1
-          fi
-          APPIMAGE_BASENAME=$(basename "$APPIMAGE_FILE")
-          RUNNER_ARCH=$(uname -m)
-
-          SIG_FILE="${APPIMAGE_FILE}.sig"
-          if [ ! -s "$SIG_FILE" ]; then
-            echo "ERROR: Linux updater signature was not generated: $SIG_FILE"
-            exit 1
-          fi
-          SIGNATURE=$(cat "$SIG_FILE")
-
-          mkdir -p updater-info
-          cat > updater-info/linux.json <<ENDJSON
-          {
-            "platform": "linux-${RUNNER_ARCH}",
-            "url_basename": "${APPIMAGE_BASENAME}",
-            "signature": "${SIGNATURE}"
-          }
-          ENDJSON
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-artifacts
-          path: |
-            app/src-tauri/target/release/bundle/deb/*.deb
-            app/src-tauri/target/release/bundle/appimage/*.AppImage
-            app/src-tauri/target/release/bundle/appimage/*.AppImage.sig
-
-      - name: Upload updater info
-        uses: actions/upload-artifact@v4
-        with:
-          name: updater-linux
-          path: updater-info/linux.json
-
-  publish:
-    needs: [release-macos, release-linux]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Create draft release
+      - name: Resolve exact trusted build
+        id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}" \
-            --title "${{ github.ref_name }}" \
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            TAG="$GITHUB_REF_NAME"
+            if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$'; then
+              echo "ERROR: invalid release tag: $TAG"
+              exit 1
+            fi
+            SOURCE_SHA=$(git rev-list -n 1 "$TAG")
+            VERSION=$(jq -r '.version' app/src-tauri/tauri.conf.json)
+            CARGO_VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' app/src-tauri/Cargo.toml | head -1)
+            if [ "v$VERSION" != "$TAG" ] || [ "$CARGO_VERSION" != "$VERSION" ]; then
+              echo "ERROR: tag/config versions differ: tag=$TAG tauri=$VERSION cargo=$CARGO_VERSION"
+              exit 1
+            fi
+
+            RUNS=$(gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/release-build.yml/runs" \
+              -f head_sha="$SOURCE_SHA" -f status=success -f per_page=100)
+            ARTIFACT_RUN_ID=$(echo "$RUNS" | jq -r --arg sha "$SOURCE_SHA" '
+              [.workflow_runs[]
+                | select(.head_sha == $sha)
+                | select(.head_branch == "main")
+                | select(.event == "push")
+                | select(.conclusion == "success")]
+              | sort_by(.run_number) | last | .id // empty
+            ')
+            if [ -z "$ARTIFACT_RUN_ID" ]; then
+              echo "ERROR: no successful trusted-main Release Build exists for tag SHA $SOURCE_SHA"
+              exit 1
+            fi
+            PUBLISH=true
+          else
+            TAG=""
+            SOURCE_SHA="$INPUT_SOURCE_SHA"
+            ARTIFACT_RUN_ID="$INPUT_ARTIFACT_RUN_ID"
+            PUBLISH=false
+          fi
+
+          if ! echo "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "ERROR: source SHA must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if ! echo "$ARTIFACT_RUN_ID" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "ERROR: artifact run ID must be a positive integer"
+            exit 1
+          fi
+
+          RUN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}")
+          echo "$RUN" | jq -e --arg sha "$SOURCE_SHA" '
+            .name == "Release Build"
+            and .head_sha == $sha
+            and .head_branch == "main"
+            and (.event == "push" or .event == "workflow_dispatch")
+            and .status == "completed"
+            and .conclusion == "success"
+            and (.path | startswith(".github/workflows/release-build.yml"))
+          ' >/dev/null || {
+            echo "ERROR: workflow run $ARTIFACT_RUN_ID is not a successful trusted-main Release Build for $SOURCE_SHA"
+            exit 1
+          }
+          if [ "$PUBLISH" = "true" ] && [ "$(echo "$RUN" | jq -r .event)" != "push" ]; then
+            echo "ERROR: automatic tag publication requires the trusted main push build"
+            exit 1
+          fi
+
+          ARTIFACTS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/artifacts")
+          for NAME in "macos-release-${SOURCE_SHA}" "linux-release-${SOURCE_SHA}"; do
+            COUNT=$(echo "$ARTIFACTS" | jq --arg name "$NAME" \
+              '[.artifacts[] | select(.name == $name and .expired == false)] | length')
+            if [ "$COUNT" != "1" ]; then
+              echo "ERROR: expected one unexpired $NAME artifact on run $ARTIFACT_RUN_ID, found $COUNT"
+              exit 1
+            fi
+          done
+
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Immutable promotion source"
+            echo "- commit: \`$SOURCE_SHA\`"
+            echo "- Release Build run: \`$ARTIFACT_RUN_ID\`"
+            echo "- tag: \`${TAG:-rehearsal-only}\`"
+            echo "- publish authorized: \`$PUBLISH\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  promote:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.source-sha }}
+
+      - name: Download immutable macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-release-${{ needs.resolve.outputs.source-sha }}
+          path: artifacts/macos
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve.outputs.artifact-run-id }}
+
+      - name: Download immutable Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-${{ needs.resolve.outputs.source-sha }}
+          path: artifacts/linux
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve.outputs.artifact-run-id }}
+
+      - name: Validate SHA, provenance, artifact hashes, and updater signatures
+        run: |
+          python3 scripts/release_artifacts.py validate \
+            --artifacts artifacts \
+            --expected-sha '${{ needs.resolve.outputs.source-sha }}' \
+            --expected-run-id '${{ needs.resolve.outputs.artifact-run-id }}' \
+            --output validated-release.json
+
+      - name: Report non-publishing promotion rehearsal
+        if: needs.resolve.outputs.publish != 'true'
+        run: |
+          {
+            echo "### Promotion rehearsal passed"
+            echo "All commit-SHA, workflow-run, artifact-hash, and updater-signature gates passed."
+            echo "No tag, draft release, release asset, updater manifest, or published release was created."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create draft release
+        if: needs.resolve.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
             --generate-notes \
             --draft
 
-      - name: Upload release assets
+      - name: Upload signed release assets
+        if: needs.resolve.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
         run: |
-          find artifacts/macos-artifacts artifacts/linux-artifacts -type f | while read -r file; do
-            echo "Uploading: $file"
-            gh release upload "${{ github.ref_name }}" "$file" \
-              --repo "${{ github.repository }}"
+          find artifacts/macos artifacts/linux -maxdepth 1 -type f ! -name provenance.json \
+            -print0 | while IFS= read -r -d '' FILE; do
+              echo "Uploading: $FILE"
+              gh release upload "$TAG" "$FILE" --repo "$GITHUB_REPOSITORY"
+            done
+
+      - name: Verify uploaded updater signatures
+        if: needs.resolve.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          mkdir -p remote-signatures
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern '*.sig' --dir remote-signatures
+          for LOCAL in artifacts/macos/*.sig artifacts/linux/*.sig; do
+            REMOTE="remote-signatures/$(basename "$LOCAL")"
+            if [ ! -f "$REMOTE" ] || ! cmp -s "$LOCAL" "$REMOTE"; then
+              echo "ERROR: uploaded signature differs from trusted build artifact: $(basename "$LOCAL")"
+              exit 1
+            fi
           done
 
-      - name: Generate and upload updater channel manifests
+      - name: Generate updater channel manifests from verified signatures
+        if: needs.resolve.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
         run: |
-          TAG="${{ github.ref_name }}"
-          VERSION="${TAG#v}"
-          REPO="${{ github.repository }}"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-
-          # Read platform info from both builds
-          MACOS=$(cat artifacts/updater-macos/macos.json)
-          LINUX=$(cat artifacts/updater-linux/linux.json)
-
-          MACOS_PLATFORM=$(echo "$MACOS" | jq -r '.platform')
-          MACOS_URL="${BASE_URL}/$(echo "$MACOS" | jq -r '.url_basename')"
-          MACOS_SIG=$(echo "$MACOS" | jq -r '.signature')
-
-          LINUX_PLATFORM=$(echo "$LINUX" | jq -r '.platform')
-          LINUX_URL="${BASE_URL}/$(echo "$LINUX" | jq -r '.url_basename')"
-          LINUX_SIG=$(echo "$LINUX" | jq -r '.signature')
-
-          if [ -z "$MACOS_PLATFORM" ] || [ -z "$MACOS_SIG" ] \
-            || [ -z "$LINUX_PLATFORM" ] || [ -z "$LINUX_SIG" ]; then
-            echo "ERROR: current updater artifact metadata or signature is missing"
-            exit 1
-          fi
-
-          # New builds use this channel. It includes macOS 14+ and Linux so the
-          # shared Tauri config works on both platforms.
-          jq -n \
-            --arg version "$VERSION" \
-            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg macos_platform "$MACOS_PLATFORM" \
-            --arg macos_url "$MACOS_URL" \
-            --arg macos_sig "$MACOS_SIG" \
-            --arg linux_platform "$LINUX_PLATFORM" \
-            --arg linux_url "$LINUX_URL" \
-            --arg linux_sig "$LINUX_SIG" \
-            --arg notes "See release notes at https://github.com/${REPO}/releases/tag/${TAG}" \
-            '{
-              version: $version,
-              pub_date: $pub_date,
-              platforms: {
-                ($macos_platform): { url: $macos_url, signature: $macos_sig },
-                ($linux_platform): { url: $linux_url, signature: $linux_sig }
-              },
-              notes: $notes
-            }' > latest-v2.json
-
-          # Clients older than v0.14.1 still request latest.json. Route those
-          # Macs through the signed macOS 13-compatible bridge, whose embedded
-          # updater endpoint is latest-v2. Linux updates directly.
-          BRIDGE_TAG="v0.14.1"
-          BRIDGE_RELEASE=$(gh api "repos/${REPO}/releases/tags/${BRIDGE_TAG}")
-          BRIDGE_URL=$(echo "$BRIDGE_RELEASE" | jq -r '
-            [.assets[] | select(.name | endswith(".app.tar.gz")) | .browser_download_url][0] // empty
-          ')
-          BRIDGE_SIG_URL=$(echo "$BRIDGE_RELEASE" | jq -r '
-            [.assets[] | select(.name | endswith(".app.tar.gz.sig")) | .browser_download_url][0] // empty
-          ')
+          BRIDGE_TAG=v0.14.1
+          BRIDGE_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${BRIDGE_TAG}")
+          BRIDGE_URL=$(echo "$BRIDGE_RELEASE" | jq -r \
+            '[.assets[] | select(.name | endswith(".app.tar.gz")) | .browser_download_url][0] // empty')
+          BRIDGE_SIG_URL=$(echo "$BRIDGE_RELEASE" | jq -r \
+            '[.assets[] | select(.name | endswith(".app.tar.gz.sig")) | .browser_download_url][0] // empty')
           if [ -z "$BRIDGE_URL" ] || [ -z "$BRIDGE_SIG_URL" ]; then
-            echo "ERROR: ${BRIDGE_TAG} is missing its signed macOS updater artifact"
+            echo "ERROR: $BRIDGE_TAG is missing its signed macOS updater artifact"
             exit 1
           fi
           BRIDGE_SIG=$(curl --fail --silent --show-error --location "$BRIDGE_SIG_URL")
-          if [ -z "$BRIDGE_SIG" ]; then
-            echo "ERROR: ${BRIDGE_TAG} updater signature is empty"
-            exit 1
-          fi
+          python3 scripts/release_artifacts.py manifests \
+            --validated validated-release.json \
+            --tag "$TAG" \
+            --repository "$GITHUB_REPOSITORY" \
+            --bridge-url "$BRIDGE_URL" \
+            --bridge-signature "$BRIDGE_SIG" \
+            --output-dir manifests
 
-          jq -n \
-            --arg version "$VERSION" \
-            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg macos_platform "$MACOS_PLATFORM" \
-            --arg macos_url "$BRIDGE_URL" \
-            --arg macos_sig "$BRIDGE_SIG" \
-            --arg linux_platform "$LINUX_PLATFORM" \
-            --arg linux_url "$LINUX_URL" \
-            --arg linux_sig "$LINUX_SIG" \
-            --arg notes "Compatibility bridge for existing macOS installs. Murmur will offer the current release after relaunch." \
-            '{
-              version: $version,
-              pub_date: $pub_date,
-              platforms: {
-                ($macos_platform): { url: $macos_url, signature: $macos_sig },
-                ($linux_platform): { url: $linux_url, signature: $linux_sig }
-              },
-              notes: $notes
-            }' > latest.json
+          PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          for MANIFEST in manifests/latest-v2.json manifests/latest.json; do
+            jq --arg pub_date "$PUB_DATE" '.pub_date = $pub_date' "$MANIFEST" > "$MANIFEST.tmp"
+            mv "$MANIFEST.tmp" "$MANIFEST"
+          done
 
-          echo "=== Modern v2 channel ==="
-          cat latest-v2.json
-          echo "=== legacy channel (macOS 13 bridge + current Linux) ==="
-          cat latest.json
-          gh release upload "${TAG}" latest-v2.json latest.json \
-            --repo "${{ github.repository }}" \
-            --clobber
-
-      - name: Publish release
+      - name: Upload and verify updater manifests
+        if: needs.resolve.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          gh release upload "$TAG" manifests/latest-v2.json manifests/latest.json \
+            --repo "$GITHUB_REPOSITORY" --clobber
+          mkdir -p remote-manifests
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'latest*.json' --dir remote-manifests
+          cmp manifests/latest-v2.json remote-manifests/latest-v2.json
+          cmp manifests/latest.json remote-manifests/latest.json
+
+          MACOS_SIG=$(cat artifacts/macos/*.app.tar.gz.sig)
+          LINUX_SIG=$(cat artifacts/linux/*.AppImage.sig)
+          jq -e --arg mac "$MACOS_SIG" --arg linux "$LINUX_SIG" '
+            ([.platforms[] | .signature] | index($mac)) != null
+            and ([.platforms[] | .signature] | index($linux)) != null
+          ' remote-manifests/latest-v2.json >/dev/null || {
+            echo "ERROR: published modern manifest signatures do not match uploaded .sig assets"
+            exit 1
+          }
+
+      - name: Publish release
+        if: needs.resolve.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false --repo "$GITHUB_REPOSITORY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Optional **Hotkey Timing Feedback** flashes the overlay amber when a bare-modifier tap times out before its second tap in Double-Tap or Both mode. The setting is off by default, and intentional holds, modifier shortcuts, processing skips, and valid double-taps remain silent (#154).
 
+### Changed
+- Release automation now builds signed macOS and Linux artifacts once on trusted `main`, keeps Cargo/CUDA cache ownership off tags and pull requests, and promotes only commit-SHA-matched artifacts with fail-closed updater-signature checks (#220).
+
 ### Fixed
 - Code-vocabulary scans now keep the View-all dialog keyboard focus contained and restore the opener on close, correlate live progress by scan ID, and report superseded results when settings change during a walk instead of presenting non-adopted terms as complete (#209).
 - Global modifier hotkeys now recover when macOS disables the underlying event tap, avoid stale modifier-state dead zones after system context changes, and no longer process mouse movement or perform main-thread key-name translation on the modifier hot path (#194, fixes #137).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -521,11 +521,19 @@ cd app && npx tsc --noEmit         # TypeScript check
 
 ### Release Pipeline
 
-1. `git tag vX.Y.Z && git push --tags`
-2. GitHub Actions: TypeScript check + `cargo test`
-3. macOS: `tauri-action` -> Developer ID signing -> Apple notarization
-4. Smoke test: launch built `.app`, verify alive for 5 seconds
-5. Publish: `.dmg`, `.app.tar.gz`, `.sig`, `latest-v2.json`, legacy-safe `latest.json` -> GitHub Release
+1. Push the `chore: bump version ...` commit to trusted `main`.
+2. `Release Build` runs frontend verification, macOS signing/notarization, and
+   Linux CUDA packaging concurrently, including package launch smoke tests.
+3. The successful build stores macOS and Linux artifacts plus SHA-256
+   provenance under names keyed by the exact commit SHA.
+4. After a separate final confirmation, push `vX.Y.Z` at that same commit.
+5. The tag workflow validates the tag/build/artifact/signature chain, promotes
+   the already-built assets, verifies the remote `.sig` files, generates
+   `latest-v2.json` and the legacy-safe `latest.json`, then publishes.
+
+Tag workflows never build or save Cargo/CUDA caches. See
+[`docs/release.md`](release.md) for trust boundaries, rehearsals, cache policy,
+and the supported cold fallback.
 
 **Auto-updater**: New builds check the dual-platform `latest-v2.json`; legacy `latest.json` routes old Macs through the signed, macOS 13-compatible v0.14.1 bridge before they receive the macOS 14 build. Updates are signed (ed25519). Min-version enforcement removes "Skip"/"Later" for required updates.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,91 @@
+# Release build and promotion
+
+Murmur builds signed release artifacts once on trusted `main`, then promotes
+those exact artifacts when a version tag is pushed. A tag does not compile the
+application and cannot save Cargo or CUDA caches.
+
+## Trust and cache policy
+
+- `Release Build` runs automatically only for a `main` push whose commit starts
+  with `chore: bump version`, or by an explicit `workflow_dispatch` on `main`.
+- Frontend validation, macOS build/sign/notarization, and Linux CUDA packaging
+  run concurrently. A workflow run is successful only when all three pass.
+- Cargo and CUDA cache writes are authorized only for trusted `main` pushes or
+  a manually dispatched cache-prime rehearsal. Pull requests restore default-
+  branch caches but never save CUDA or release-profile Cargo caches.
+- No release workflow uses a self-hosted runner. In particular, pull-request
+  code is never sent to a Mac Mini or other signing/release host.
+- CUDA caching contains only `/usr/local/cuda-12.8`. The transient
+  `/usr/local/cuda` symlink and loader configuration are recreated after every
+  restore. A claimed hit with a missing or wrong-version `nvcc` fails instead
+  of silently reinstalling.
+
+## Immutable artifacts
+
+Each successful build uploads these 30-day artifacts:
+
+- `macos-release-<40-character-commit-sha>`
+- `linux-release-<40-character-commit-sha>`
+
+Each artifact contains `provenance.json` with the exact commit SHA, workflow
+run ID, platform/updater names, sizes, and SHA-256 hashes. Promotion accepts one
+unexpired macOS artifact and one unexpired Linux artifact from a successful
+`Release Build` on `main` for the exact tag commit. Any tag, run, filename,
+hash, or updater-signature mismatch fails before a draft release is created.
+
+The modern updater manifest is generated from the downloaded `.sig` files.
+After release-asset upload, the workflow downloads the remote `.sig` assets and
+compares them byte-for-byte, uploads the manifests, downloads them again, and
+checks that `latest-v2.json` contains those exact signatures before publishing.
+
+## Non-publishing rehearsal
+
+This is the supported way to measure a cold or warm build without creating a
+tag or GitHub Release:
+
+```bash
+gh workflow run release-build.yml \
+  --repo georgenijo/murmur-app \
+  --ref main \
+  -f prime_caches=true
+
+# After the Release Build succeeds, use its exact head SHA and run ID.
+gh workflow run release.yml \
+  --repo georgenijo/murmur-app \
+  --ref main \
+  -f source_sha=<40-character-main-sha> \
+  -f artifact_run_id=<release-build-run-id>
+```
+
+The second workflow downloads and validates the immutable artifacts but has no
+manual input that can authorize publication. Its summary explicitly confirms
+that no tag, draft, release asset, updater manifest, or published release was
+created.
+
+Run the build rehearsal once to prime caches and a second time to measure the
+warm path. Record the `release-macos`, `release-linux`, and overall workflow
+durations, the CUDA/Rust cache summaries, and repository cache usage. The
+release targets are macOS <= 5 minutes, Linux <= 9 minutes, and total wall time
+<= 9 minutes.
+
+## Cold fallback
+
+If the automatic build for a version-bump commit fails, do not push a tag.
+Correct the infrastructure problem and rerun the original workflow at the same
+commit (`gh run rerun <run-id> --failed`). A rerun preserves the trusted push
+event and exact source SHA. If `main` still points to the version-bump commit, a
+manual `Release Build` dispatch is also supported; leave `prime_caches=false`
+for a restore-only recovery build unless the cache itself is intentionally
+being repaired.
+
+If artifacts expired or `main` has advanced, rerun the original version-bump
+workflow rather than building arbitrary PR or tag code with signing secrets.
+Promotion remains blocked until a successful build and both SHA-named artifacts
+exist for the tag commit.
+
+## Final release gate
+
+`prompts/PROMPT_RELEASE.md` requires a separate explicit confirmation after the
+trusted build succeeds and before creating or pushing `vX.Y.Z`. Pushing that
+tag is the real release action: it validates the tag SHA, promotes the stored
+artifacts, creates a draft, verifies remote updater integrity, and publishes.

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -1,6 +1,6 @@
 # Agent Startup — Release Mode
 
-You are starting a release session for the Murmur project. Work autonomously through every step. Only stop to confirm the final release action before pushing the tag.
+You are starting a release session for the Murmur project. Work autonomously through preparation and the trusted release build. Stop for a separate explicit final confirmation before creating or pushing the tag, because the tag promotes and publishes the release.
 
 ## 1. Load Context
 
@@ -42,26 +42,51 @@ If any of the above apply, ask: **"Is this a critical update? Should min_version
 
 Include the min_version decision in the release summary.
 
-## 4. Summarise and Confirm
+## 4. Summarise the Build Plan
 
 Present a concise release summary:
 - Current version → New version (and why: major/minor/patch)
 - Bullet list of what's included (one line per meaningful commit, skip chores/docs)
-- Ask: **"Ready to release v{new_version}? Confirm to proceed."**
+- Explain that pushing the version-bump commit starts a signed, non-publishing
+  `Release Build`; the tag/publish confirmation comes only after that build is green.
+- Ask: **"Ready to prepare the signed v{new_version} build on main? This will not create a tag or publish a release."**
 
-Stop and wait for confirmation.
+Stop and wait for confirmation. This confirmation authorizes only the version
+bump, main push, and non-publishing build. Do not create or push a tag yet.
 
-## 5. Execute Release
+## 5. Build Trusted Artifacts
 
-On confirmation, run these steps in order:
+Run these steps in order:
 
 1. Bump `"version"` in `app/src-tauri/tauri.conf.json`
 2. Bump `version` (package field only) in `app/src-tauri/Cargo.toml`
 3. Commit: `git add app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml && git commit -m "chore: bump version to {new_version}"`
 4. Push: `git push origin main`
-5. Tag: `git tag v{new_version}`
-6. Push tag: `git push origin v{new_version}`
-7. Wait for the GitHub release to be created by CI (~1–2 min), then update its notes:
+5. Wait for the `Release Build` workflow on that exact commit to succeed.
+6. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
+   artifacts named with the exact 40-character commit SHA, package smoke tests,
+   and cache summaries. Do not continue if any job or artifact is missing.
+
+If the build fails, use the cold fallback in `docs/release.md`; do not tag.
+
+## 6. Final Tag and Publish Confirmation
+
+Present the exact commit SHA, successful Release Build run URL/timings, artifact
+names, and proposed tag. Ask:
+
+**"The signed artifacts are ready. Confirm pushing v{new_version}; this will promote and publish the GitHub Release."**
+
+Stop and wait for explicit confirmation. A prior confirmation to prepare or
+build the release does not authorize the tag.
+
+## 7. Promote Release
+
+Only after the final confirmation:
+
+1. Tag the already-built commit: `git tag v{new_version}`
+2. Push the tag: `git push origin v{new_version}`
+3. Wait for the tag-triggered `Release` workflow to validate and publish the
+   immutable artifacts (normally under two minutes), then update its notes:
    ```
    gh release edit v{new_version} --repo georgenijo/murmur-app --notes "$(cat <<'EOF'
    ## What's New
@@ -80,9 +105,9 @@ On confirmation, run these steps in order:
    ```
    Write the notes yourself from the commit list in Step 3 — use clear, user-facing language (not raw commit messages). Omit any section that has no entries. Skip `chore:`, `docs:`, `test:` commits.
 
-## 6. Hand Off
+## 8. Hand Off
 
 Tell the user:
-- Tag pushed — GitHub Actions is now building the signed DMG (~15–20 min)
+- Tag pushed — GitHub Actions is promoting the already-built signed artifacts
 - Where to watch: `https://github.com/georgenijo/murmur-app/actions`
 - Release will publish automatically at: `https://github.com/georgenijo/murmur-app/releases`

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Create and verify immutable Murmur release artifact provenance."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+PLATFORM_SUFFIXES = {
+    "macos": (".dmg", ".app.tar.gz", ".app.tar.gz.sig"),
+    "linux": (".deb", ".AppImage", ".AppImage.sig"),
+}
+UPDATER_SUFFIX = {
+    "macos": ".app.tar.gz",
+    "linux": ".AppImage",
+}
+
+
+class ArtifactError(ValueError):
+    """Raised when release artifacts fail closed validation."""
+
+
+def _require_sha(value: str, label: str = "commit SHA") -> str:
+    if not SHA_RE.fullmatch(value):
+        raise ArtifactError(f"{label} must be a full lowercase 40-character SHA")
+    return value
+
+
+def _require_run_id(value: str | int) -> int:
+    try:
+        run_id = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ArtifactError("workflow run ID must be an integer") from exc
+    if run_id <= 0:
+        raise ArtifactError("workflow run ID must be positive")
+    return run_id
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        raise ArtifactError(f"artifact directory does not exist: {root}")
+    return sorted(
+        path for path in root.iterdir() if path.is_file() and path.name != "provenance.json"
+    )
+
+
+def _one_with_suffix(files: list[Path], suffix: str) -> Path:
+    matches = [path for path in files if path.name.endswith(suffix)]
+    if len(matches) != 1:
+        raise ArtifactError(
+            f"expected exactly one *{suffix} artifact, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _signature_text(path: Path) -> str:
+    value = path.read_text(encoding="utf-8").strip()
+    if not value:
+        raise ArtifactError(f"updater signature is empty: {path.name}")
+    if "\n" in value or "\r" in value:
+        raise ArtifactError(f"updater signature must be a single line: {path.name}")
+    return value
+
+
+def create_provenance(
+    platform: str,
+    platform_key: str,
+    root: Path,
+    commit_sha: str,
+    run_id: str | int,
+) -> dict[str, Any]:
+    if platform not in PLATFORM_SUFFIXES:
+        raise ArtifactError(f"unsupported platform: {platform}")
+    if not platform_key:
+        raise ArtifactError("updater platform key must not be empty")
+    commit_sha = _require_sha(commit_sha)
+    run_id = _require_run_id(run_id)
+    files = _files(root)
+
+    expected = {
+        _one_with_suffix(files, suffix).name for suffix in PLATFORM_SUFFIXES[platform]
+    }
+    actual = {path.name for path in files}
+    if actual != expected:
+        extras = sorted(actual - expected)
+        raise ArtifactError(f"unexpected files in {platform} artifact set: {extras}")
+
+    updater = _one_with_suffix(files, UPDATER_SUFFIX[platform])
+    signature = root / f"{updater.name}.sig"
+    if signature not in files:
+        raise ArtifactError(f"missing updater signature: {signature.name}")
+    _signature_text(signature)
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "commit_sha": commit_sha,
+        "workflow_run_id": run_id,
+        "platform": platform,
+        "platform_key": platform_key,
+        "updater_bundle": updater.name,
+        "updater_signature": signature.name,
+        "assets": [
+            {
+                "name": path.name,
+                "size": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+            for path in files
+        ],
+    }
+    (root / "provenance.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def validate_platform(
+    platform: str,
+    root: Path,
+    expected_sha: str,
+    expected_run_id: str | int,
+) -> dict[str, Any]:
+    expected_sha = _require_sha(expected_sha, "expected commit SHA")
+    expected_run_id = _require_run_id(expected_run_id)
+    provenance_path = root / "provenance.json"
+    if not provenance_path.is_file():
+        raise ArtifactError(f"missing provenance: {provenance_path}")
+    try:
+        payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ArtifactError(f"invalid provenance JSON: {provenance_path}") from exc
+
+    expected_fields = {
+        "schema_version": SCHEMA_VERSION,
+        "commit_sha": expected_sha,
+        "workflow_run_id": expected_run_id,
+        "platform": platform,
+    }
+    for field, expected in expected_fields.items():
+        if payload.get(field) != expected:
+            raise ArtifactError(
+                f"{platform} provenance {field} mismatch: "
+                f"expected {expected!r}, got {payload.get(field)!r}"
+            )
+    if not payload.get("platform_key"):
+        raise ArtifactError(f"{platform} provenance has an empty platform key")
+
+    files = _files(root)
+    declared_assets = payload.get("assets")
+    if not isinstance(declared_assets, list):
+        raise ArtifactError(f"{platform} provenance assets must be a list")
+    declared_names = [entry.get("name") for entry in declared_assets]
+    actual_names = [path.name for path in files]
+    if declared_names != actual_names:
+        raise ArtifactError(
+            f"{platform} artifact names differ from signed provenance: "
+            f"declared={declared_names!r}, actual={actual_names!r}"
+        )
+
+    for entry, path in zip(declared_assets, files):
+        if entry.get("size") != path.stat().st_size:
+            raise ArtifactError(f"artifact size mismatch: {path.name}")
+        if entry.get("sha256") != sha256_file(path):
+            raise ArtifactError(f"artifact SHA-256 mismatch: {path.name}")
+
+    updater_name = payload.get("updater_bundle")
+    signature_name = payload.get("updater_signature")
+    if signature_name != f"{updater_name}.sig":
+        raise ArtifactError(f"{platform} updater/signature filenames do not match")
+    updater = root / str(updater_name)
+    signature = root / str(signature_name)
+    if updater not in files or signature not in files:
+        raise ArtifactError(f"{platform} updater files are absent from the artifact set")
+
+    payload["signature"] = _signature_text(signature)
+    return payload
+
+
+def validate_release(
+    artifacts_root: Path,
+    expected_sha: str,
+    expected_run_id: str | int,
+    output: Path | None = None,
+) -> dict[str, Any]:
+    platforms = {
+        platform: validate_platform(
+            platform, artifacts_root / platform, expected_sha, expected_run_id
+        )
+        for platform in ("macos", "linux")
+    }
+    names: list[str] = []
+    for payload in platforms.values():
+        names.extend(entry["name"] for entry in payload["assets"])
+    if len(names) != len(set(names)):
+        raise ArtifactError("release artifacts contain duplicate asset basenames")
+
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "commit_sha": _require_sha(expected_sha),
+        "workflow_run_id": _require_run_id(expected_run_id),
+        "platforms": platforms,
+    }
+    if output is not None:
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    return result
+
+
+def write_updater_manifests(
+    validated_path: Path,
+    tag: str,
+    repository: str,
+    bridge_url: str,
+    bridge_signature: str,
+    output_dir: Path,
+) -> tuple[Path, Path]:
+    if not re.fullmatch(r"v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", tag):
+        raise ArtifactError(f"invalid release tag: {tag}")
+    if not re.fullmatch(r"[^/\s]+/[^/\s]+", repository):
+        raise ArtifactError(f"invalid repository: {repository}")
+    bridge_signature = bridge_signature.strip()
+    if not bridge_url.startswith("https://") or not bridge_signature:
+        raise ArtifactError("bridge updater URL and signature are required")
+
+    validated = json.loads(validated_path.read_text(encoding="utf-8"))
+    macos = validated["platforms"]["macos"]
+    linux = validated["platforms"]["linux"]
+    version = tag[1:]
+    base_url = f"https://github.com/{repository}/releases/download/{tag}"
+    pub_date = "${PUB_DATE}"
+
+    modern = {
+        "version": version,
+        "pub_date": pub_date,
+        "platforms": {
+            macos["platform_key"]: {
+                "url": f"{base_url}/{macos['updater_bundle']}",
+                "signature": macos["signature"],
+            },
+            linux["platform_key"]: {
+                "url": f"{base_url}/{linux['updater_bundle']}",
+                "signature": linux["signature"],
+            },
+        },
+        "notes": f"See release notes at https://github.com/{repository}/releases/tag/{tag}",
+    }
+    legacy = {
+        "version": version,
+        "pub_date": pub_date,
+        "platforms": {
+            macos["platform_key"]: {
+                "url": bridge_url,
+                "signature": bridge_signature,
+            },
+            linux["platform_key"]: {
+                "url": f"{base_url}/{linux['updater_bundle']}",
+                "signature": linux["signature"],
+            },
+        },
+        "notes": (
+            "Compatibility bridge for existing macOS installs. "
+            "Murmur will offer the current release after relaunch."
+        ),
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    modern_path = output_dir / "latest-v2.json"
+    legacy_path = output_dir / "latest.json"
+    modern_path.write_text(json.dumps(modern, indent=2) + "\n", encoding="utf-8")
+    legacy_path.write_text(json.dumps(legacy, indent=2) + "\n", encoding="utf-8")
+    return modern_path, legacy_path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    record = subparsers.add_parser("record")
+    record.add_argument("--platform", choices=sorted(PLATFORM_SUFFIXES), required=True)
+    record.add_argument("--platform-key", required=True)
+    record.add_argument("--artifacts", type=Path, required=True)
+    record.add_argument("--commit-sha", required=True)
+    record.add_argument("--run-id", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--artifacts", type=Path, required=True)
+    validate.add_argument("--expected-sha", required=True)
+    validate.add_argument("--expected-run-id", required=True)
+    validate.add_argument("--output", type=Path, required=True)
+
+    manifests = subparsers.add_parser("manifests")
+    manifests.add_argument("--validated", type=Path, required=True)
+    manifests.add_argument("--tag", required=True)
+    manifests.add_argument("--repository", required=True)
+    manifests.add_argument("--bridge-url", required=True)
+    manifests.add_argument("--bridge-signature", required=True)
+    manifests.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        if args.command == "record":
+            payload = create_provenance(
+                args.platform,
+                args.platform_key,
+                args.artifacts,
+                args.commit_sha,
+                args.run_id,
+            )
+            print(
+                f"recorded {args.platform} provenance for {payload['commit_sha']} "
+                f"(run {payload['workflow_run_id']})"
+            )
+        elif args.command == "validate":
+            payload = validate_release(
+                args.artifacts, args.expected_sha, args.expected_run_id, args.output
+            )
+            print(
+                f"validated immutable release artifacts for {payload['commit_sha']} "
+                f"(run {payload['workflow_run_id']})"
+            )
+        else:
+            modern, legacy = write_updater_manifests(
+                args.validated,
+                args.tag,
+                args.repository,
+                args.bridge_url,
+                args.bridge_signature,
+                args.output_dir,
+            )
+            print(f"wrote updater manifests: {modern}, {legacy}")
+    except ArtifactError as exc:
+        raise SystemExit(f"ERROR: {exc}") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -135,6 +135,8 @@ def validate_linux_cache_policy(action: str) -> None:
     assert "cuda-minimal-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-v1" in action
     assert 'sub-packages: \'["nvcc", "cudart-dev"]\'' in action
     assert 'non-cuda-sub-packages: \'["libcublas-dev"]\'' in action
+    assert 'STUB_DIR="$RUNNER_TEMP/murmur-cuda-driver-stub"' in action
+    assert "CUDA_DRIVER_STUB_DIR=$STUB_DIR" in action
 
     restore = named_step_block(action, "Restore CUDA toolkit cache", 4)
     save = named_step_block(action, "Save CUDA toolkit cache", 4)
@@ -148,6 +150,8 @@ def validate_linux_cache_policy(action: str) -> None:
     ):
         assert forbidden not in restore
         assert forbidden not in save
+    assert "$RUNNER_TEMP" not in restore
+    assert "$RUNNER_TEMP" not in save
     assert (
         "if: steps.cuda-cache.outputs.cache-hit != 'true' && "
         "inputs.cuda-cache-save-if == 'true'"

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the CI release-bump guard and release publication dependencies."""
+"""Validate Murmur's CI, trusted release-build, cache, and promotion policy."""
 
 from pathlib import Path
 import re
@@ -8,7 +8,9 @@ from typing import Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+RELEASE_BUILD_WORKFLOW = ROOT / ".github/workflows/release-build.yml"
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+LINUX_SETUP_ACTION = ROOT / ".github/actions/setup-linux-build/action.yml"
 
 CI_GUARD = (
     '"${{ github.event_name != \'push\' || '
@@ -17,6 +19,13 @@ CI_GUARD = (
 CI_PASS_GUARD = (
     '"${{ always() && (github.event_name != \'push\' || '
     "!startsWith(github.event.head_commit.message, 'chore: bump version')) }}\""
+)
+RELEASE_BUILD_GUARD = (
+    '"${{ github.event_name == \'workflow_dispatch\' || '
+    "startsWith(github.event.head_commit.message, 'chore: bump version') }}\""
+)
+TRUSTED_MAIN_CACHE_DEFAULT = (
+    '"${{ github.event_name == \'push\' && github.ref == \'refs/heads/main\' }}\"'
 )
 
 
@@ -38,16 +47,33 @@ def scalar(block: str, key: str) -> str:
     return match.group(1).strip()
 
 
+def named_step_block(text: str, name: str, indent: int) -> str:
+    marker = " " * indent + f"- name: {name}\n"
+    start = text.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing step: {name}")
+    next_step = text.find("\n" + " " * indent + "- name:", start + len(marker))
+    if next_step < 0:
+        next_step = len(text)
+    return text[start:next_step]
+
+
 def should_run_ci(event_name: str, head_commit_message: Optional[str]) -> bool:
     return event_name != "push" or not (head_commit_message or "").startswith(
         "chore: bump version"
     )
 
 
-def main() -> None:
-    ci = CI_WORKFLOW.read_text()
-    release = RELEASE_WORKFLOW.read_text()
+def should_run_release_build(
+    event_name: str, head_commit_message: Optional[str]
+) -> bool:
+    return event_name == "workflow_dispatch" or (
+        event_name == "push"
+        and (head_commit_message or "").startswith("chore: bump version")
+    )
 
+
+def validate_ci(ci: str) -> int:
     assert "push:\n    branches: [main]" in ci
     assert "\n  pull_request:" in ci
     assert scalar(job_block(ci, "changes"), "if") == CI_GUARD
@@ -57,32 +83,130 @@ def main() -> None:
         "[changes, typecheck, rust-macos, linux]"
     )
     assert scalar(job_block(ci, "ci-pass"), "if") == CI_PASS_GUARD
+    assert "scripts/validate_workflow_policy.py" in ci
+    assert "scripts/release_artifacts.py" in ci
+    assert "tests/test_release_artifacts.py" in ci
+    assert "tests/test_workflow_policy.py" in ci
 
     cases = (
         ("push", "chore: bump version to 0.17.0", False),
         ("push", "chore: bump version", False),
         ("push", "feat: add a normal feature", True),
-        ("push", "fix: chore: bump version text elsewhere", True),
         ("pull_request", "chore: bump version to 0.17.0", True),
         ("pull_request", None, True),
     )
     for event_name, message, expected in cases:
-        actual = should_run_ci(event_name, message)
-        assert actual is expected, (
-            f"unexpected CI decision for event={event_name!r}, message={message!r}: "
-            f"expected {expected}, got {actual}"
-        )
+        assert should_run_ci(event_name, message) is expected
+    return len(cases)
 
-    assert "tags:\n      - 'v*'" in release
-    assert scalar(job_block(release, "release-macos"), "needs") == "[typecheck]"
-    assert scalar(job_block(release, "release-linux"), "needs") == "[typecheck]"
-    assert scalar(job_block(release, "publish"), "needs") == (
-        "[release-macos, release-linux]"
+
+def validate_release_build(workflow: str) -> int:
+    assert "push:\n    branches: [main]" in workflow
+    assert "\n  workflow_dispatch:" in workflow
+    assert "pull_request" not in workflow
+    assert "self-hosted" not in workflow
+    assert "contents: write" not in workflow
+    assert scalar(job_block(workflow, "context"), "if") == RELEASE_BUILD_GUARD
+    for job in ("typecheck", "release-macos", "release-linux"):
+        assert scalar(job_block(workflow, job), "needs") == "context"
+
+    # Native builds and frontend verification share only `context`, so all three
+    # enter the queue concurrently instead of serializing behind typecheck.
+    assert "needs: [typecheck]" not in workflow
+    assert "macos-release-${{ needs.context.outputs.source-sha }}" in workflow
+    assert "linux-release-${{ needs.context.outputs.source-sha }}" in workflow
+    assert "shared-key: macos-release-v1" in workflow
+    assert "shared-key: linux-cuda-release-v1" in workflow
+    assert workflow.count("${{ needs.context.outputs.cache-write == 'true' }}") >= 3
+
+    cases = (
+        ("push", "chore: bump version to 0.17.0", True),
+        ("push", "feat: normal merge", False),
+        ("pull_request", "chore: bump version to 0.17.0", False),
+        ("workflow_dispatch", None, True),
     )
+    for event_name, message, expected in cases:
+        assert should_run_release_build(event_name, message) is expected
+    return len(cases)
+
+
+def validate_linux_cache_policy(action: str) -> None:
+    assert action.count(TRUSTED_MAIN_CACHE_DEFAULT) == 2
+    assert "cuda-minimal-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cuda-version }}-v1" in action
+    assert 'sub-packages: \'["nvcc", "cudart-dev"]\'' in action
+    assert 'non-cuda-sub-packages: \'["libcublas-dev"]\'' in action
+
+    restore = named_step_block(action, "Restore CUDA toolkit cache", 4)
+    save = named_step_block(action, "Save CUDA toolkit cache", 4)
+    assert "path: /usr/local/cuda-${{ env.CUDA_MM }}" in restore
+    assert "path: /usr/local/cuda-${{ env.CUDA_MM }}" in save
+    for forbidden in (
+        "/usr/local/cuda\n",
+        "/usr/lib/x86_64-linux-gnu/libcuda",
+        "/usr/lib/x86_64-linux-gnu/libnvidia",
+        "/etc/ld.so.conf.d",
+    ):
+        assert forbidden not in restore
+        assert forbidden not in save
+    assert (
+        "if: steps.cuda-cache.outputs.cache-hit != 'true' && "
+        "inputs.cuda-cache-save-if == 'true'"
+    ) in save
+
+    verify = named_step_block(action, "Verify CUDA install", 4)
+    assert "nvcc --version" not in verify  # absolute versioned nvcc path is required
+    assert '"$NVCC" --version' in verify
+    assert "cache-hit=${{ steps.cuda-cache.outputs.cache-hit }}" in verify
+    assert "release ${CUDA_MM}" in verify
+
+
+def validate_promotion_policy(workflow: str) -> int:
+    assert "tags:\n      - 'v*'" in workflow
+    assert "\n  workflow_dispatch:" in workflow
+    assert "self-hosted" not in workflow
+    assert "actions/cache" not in workflow
+    assert "swatinem/rust-cache" not in workflow
+    assert scalar(job_block(workflow, "promote"), "needs") == "resolve"
+    assert "head_branch == \"main\"" in workflow
+    assert ".head_sha == $sha" in workflow
+    assert ".event == \"push\"" in workflow
+    assert "release-build.yml" in workflow
+    assert "expired == false" in workflow
+    assert "scripts/release_artifacts.py validate" in workflow
+
+    publish_steps = (
+        "Create draft release",
+        "Upload signed release assets",
+        "Verify uploaded updater signatures",
+        "Generate updater channel manifests from verified signatures",
+        "Upload and verify updater manifests",
+        "Publish release",
+    )
+    for name in publish_steps:
+        block = named_step_block(workflow, name, 6)
+        assert "if: needs.resolve.outputs.publish == 'true'" in block
+    rehearsal = named_step_block(
+        workflow, "Report non-publishing promotion rehearsal", 6
+    )
+    assert "if: needs.resolve.outputs.publish != 'true'" in rehearsal
+    return len(publish_steps)
+
+
+def main() -> None:
+    ci = CI_WORKFLOW.read_text()
+    release_build = RELEASE_BUILD_WORKFLOW.read_text()
+    release = RELEASE_WORKFLOW.read_text()
+    linux_action = LINUX_SETUP_ACTION.read_text()
+
+    ci_cases = validate_ci(ci)
+    release_build_cases = validate_release_build(release_build)
+    validate_linux_cache_policy(linux_action)
+    publication_steps = validate_promotion_policy(release)
 
     print(
-        f"workflow policy validation passed ({len(cases)} CI cases; "
-        "release publication gating intact)"
+        "workflow policy validation passed "
+        f"({ci_cases} CI cases; {release_build_cases} release-build cases; "
+        f"{publication_steps} publication gates; trusted cache ownership intact)"
     )
 
 

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.release_artifacts import (
+    ArtifactError,
+    create_provenance,
+    validate_release,
+    write_updater_manifests,
+)
+
+
+SHA = "1" * 40
+OTHER_SHA = "2" * 40
+RUN_ID = 123456
+
+
+class ReleaseArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.artifacts = self.root / "artifacts"
+        macos = self.artifacts / "macos"
+        linux = self.artifacts / "linux"
+        macos.mkdir(parents=True)
+        linux.mkdir(parents=True)
+
+        (macos / "Murmur.dmg").write_bytes(b"dmg")
+        (macos / "Murmur.app.tar.gz").write_bytes(b"mac updater")
+        (macos / "Murmur.app.tar.gz.sig").write_text("mac-signature\n")
+        (linux / "Murmur.deb").write_bytes(b"deb")
+        (linux / "Murmur.AppImage").write_bytes(b"linux updater")
+        (linux / "Murmur.AppImage.sig").write_text("linux-signature\n")
+
+        create_provenance("macos", "darwin-aarch64", macos, SHA, RUN_ID)
+        create_provenance("linux", "linux-x86_64", linux, SHA, RUN_ID)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_valid_artifacts_and_manifest_signatures_match_sig_assets(self) -> None:
+        validated_path = self.root / "validated.json"
+        validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        modern_path, legacy_path = write_updater_manifests(
+            validated_path,
+            "v1.2.3",
+            "owner/repo",
+            "https://example.invalid/bridge.app.tar.gz",
+            "bridge-signature",
+            self.root / "manifests",
+        )
+
+        modern = json.loads(modern_path.read_text())
+        legacy = json.loads(legacy_path.read_text())
+        self.assertEqual(
+            modern["platforms"]["darwin-aarch64"]["signature"], "mac-signature"
+        )
+        self.assertEqual(
+            modern["platforms"]["linux-x86_64"]["signature"], "linux-signature"
+        )
+        self.assertEqual(
+            legacy["platforms"]["darwin-aarch64"]["signature"],
+            "bridge-signature",
+        )
+        self.assertEqual(
+            legacy["platforms"]["linux-x86_64"]["signature"], "linux-signature"
+        )
+
+    def test_commit_sha_mismatch_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "commit_sha mismatch"):
+            validate_release(self.artifacts, OTHER_SHA, RUN_ID)
+
+    def test_workflow_run_mismatch_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "workflow_run_id mismatch"):
+            validate_release(self.artifacts, SHA, RUN_ID + 1)
+
+    def test_signature_tampering_fails_closed(self) -> None:
+        signature = self.artifacts / "linux" / "Murmur.AppImage.sig"
+        signature.write_text("xxxxx-signature\n")
+        with self.assertRaisesRegex(ArtifactError, "SHA-256 mismatch"):
+            validate_release(self.artifacts, SHA, RUN_ID)
+
+    def test_missing_updater_signature_fails_closed(self) -> None:
+        (self.artifacts / "macos" / "Murmur.app.tar.gz.sig").unlink()
+        with self.assertRaisesRegex(ArtifactError, "artifact names differ"):
+            validate_release(self.artifacts, SHA, RUN_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import unittest
+
+from scripts.validate_workflow_policy import (
+    validate_linux_cache_policy,
+    validate_promotion_policy,
+    validate_release_build,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_tag_workflow_rejects_cuda_cache_save_action(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        mutated = workflow.replace(
+            "jobs:\n", "jobs:\n  # uses: actions/cache/save@v4\n", 1
+        )
+        with self.assertRaises(AssertionError):
+            validate_promotion_policy(mutated)
+
+    def test_tag_workflow_rejects_rust_cache_action(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        mutated = workflow.replace(
+            "jobs:\n", "jobs:\n  # uses: swatinem/rust-cache@v2\n", 1
+        )
+        with self.assertRaises(AssertionError):
+            validate_promotion_policy(mutated)
+
+    def test_cuda_cache_save_requires_explicit_trusted_condition(self) -> None:
+        action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
+        mutated = action.replace(
+            "if: steps.cuda-cache.outputs.cache-hit != 'true' && "
+            "inputs.cuda-cache-save-if == 'true'",
+            "if: steps.cuda-cache.outputs.cache-hit != 'true'",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            validate_linux_cache_policy(mutated)
+
+    def test_release_build_rejects_pull_request_trigger(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-build.yml").read_text()
+        mutated = workflow.replace(
+            "  workflow_dispatch:\n", "  pull_request:\n  workflow_dispatch:\n", 1
+        )
+        with self.assertRaises(AssertionError):
+            validate_release_build(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build, sign, notarize, and smoke-test macOS/Linux release artifacts once on trusted version-bump commits to `main`, with frontend verification running concurrently
- promote only SHA-named artifacts from the exact successful trusted-main workflow run; fail closed on tag, run, artifact hash, or updater signature mismatches
- make Cargo/CUDA cache writes trusted-main-only, shrink CUDA to the physical minimal 12.8 compiler/CUDART/cuBLAS tree, and validate `nvcc` after every restore
- add deterministic workflow mutation tests and artifact provenance/signature tests, plus a documented restore-only rehearsal and cold fallback

## Evidence and critical path
- v0.16.1 run 29601508595: typecheck 24s, macOS 12m46s, Linux 20m15s, publish 35s; builders waited for typecheck and both Rust caches missed
- current cache inventory at implementation time: 9,839,280,831 bytes across eight entries, including a 3,615,710,865-byte PR-scoped CUDA cache created by the old unconditional save step
- recent warm main CI run 29656703762: macOS Rust restore/check/test completed in 1m21s; Linux setup took 4m02s while restoring the old 3.45GB CUDA archive
- predicted warm critical path is Linux: smaller CUDA restore + cached release compile + ~3m36 packaging/smoke/upload; macOS removes the 9m40 cold compile from the cited release; tag promotion should stay near the observed 35s plus cross-run provenance validation

## Test plan
- [x] `python3 scripts/validate_workflow_policy.py`
- [x] `python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py` (9 tests, including negative SHA/run/signature/cache-policy cases)
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml .github/workflows/release-build.yml .github/workflows/release.yml`
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1` (274 unit + integration tests pass; one opt-in Core ML test ignored)
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test -- --run` (87 tests)
- [x] Native app smoke: N/A — workflow/script/docs-only diff; release-build workflow retains signed macOS launch smoke and adds deb + AppImage launch smoke

## Acceptance boundary
This PR intentionally **does not close #220**. The implementation can merge safely, but the <=5 minute macOS, <=9 minute Linux/wall-time, <=2 minute real promotion, remote published updater integrity, and post-two-release cache footprint require merged-workflow rehearsal and one separately authorized real tag release. No tag or release was created by this work.

Refs #220
