### PR TITLE
feat: process Whisper audio during recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **True incremental Whisper transcription** — long Whisper dictations now process one bounded overlapping audio window at a time during recording and transcribe only the remaining tail after stop. The existing cached model is reused (no duplicate context), overlap reconciliation is deterministic, and any worker/VAD/session reliability failure falls back to the original authoritative full-buffer path (#129).
 - Optional **Hotkey Timing Feedback** flashes the overlay amber when a bare-modifier tap times out before its second tap in Double-Tap or Both mode. The setting is off by default, and intentional holds, modifier shortcuts, processing skips, and valid double-taps remain silent (#154).
 
 ### Fixed

--- a/app/src-tauri/examples/streaming_bench.rs
+++ b/app/src-tauri/examples/streaming_bench.rs
@@ -1,0 +1,154 @@
+//! Reproducible stop-latency comparison for Whisper's batch and incremental
+//! paths. The fixture is already 16 kHz mono; this isolates Whisper inference
+//! and deterministic overlap reconciliation from capture/VAD overhead.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use std::time::Instant;
+use ui_lib::transcriber::chunking::{
+    merge_overlapping_text, OVERLAP_SAMPLES, STEP_SAMPLES, WINDOW_SAMPLES,
+};
+use ui_lib::transcriber::{
+    parse_wav_to_samples, TranscriptionBackend, WhisperBackend, WHISPER_SAMPLE_RATE,
+};
+
+#[derive(Serialize)]
+struct Report {
+    fixture: String,
+    audio_seconds: f64,
+    model: String,
+    during_recording_chunks: usize,
+    during_recording_inference_ms: f64,
+    batch_post_stop_ms: f64,
+    incremental_post_stop_ms: f64,
+    post_stop_speedup: f64,
+    batch_wer: Option<f64>,
+    incremental_wer: Option<f64>,
+    incremental_vs_batch_wer: Option<f64>,
+    batch_text: String,
+    incremental_text: String,
+}
+
+fn words(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|character: char| !character.is_alphanumeric() && character != '\'')
+        .filter(|word| !word.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn word_error_rate(reference: &str, hypothesis: &str) -> Option<f64> {
+    let reference = words(reference);
+    if reference.is_empty() {
+        return None;
+    }
+    let hypothesis = words(hypothesis);
+    let mut previous: Vec<usize> = (0..=hypothesis.len()).collect();
+    for (row, reference_word) in reference.iter().enumerate() {
+        let mut current = vec![row + 1; hypothesis.len() + 1];
+        for (column, hypothesis_word) in hypothesis.iter().enumerate() {
+            current[column + 1] = (previous[column + 1] + 1)
+                .min(current[column] + 1)
+                .min(previous[column] + usize::from(reference_word != hypothesis_word));
+        }
+        previous = current;
+    }
+    Some(previous[hypothesis.len()] as f64 / reference.len() as f64)
+}
+
+fn main() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let fixture = args
+        .next()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("../../bench/audio/xlong.wav"));
+    let model = args.next().unwrap_or_else(|| "base.en".to_string());
+    let samples = parse_wav_to_samples(
+        &std::fs::read(&fixture)
+            .map_err(|error| format!("could not read {}: {error}", fixture.display()))?,
+    )?;
+    if samples.len() < WINDOW_SAMPLES {
+        return Err("fixture must be at least 10 seconds".to_string());
+    }
+    let reference = std::fs::read_to_string(fixture.with_extension("txt")).ok();
+
+    let mut backend = WhisperBackend::new();
+    backend.load_model(&model)?;
+    // Warm Metal allocations before either measured path.
+    backend.transcribe(&samples[..WINDOW_SAMPLES], "en", None, true)?;
+
+    let batch_started = Instant::now();
+    let batch_text = backend.transcribe(&samples, "en", None, true)?;
+    let batch_post_stop_ms = batch_started.elapsed().as_secs_f64() * 1000.0;
+
+    let mut incremental_text = String::new();
+    let mut during_recording_inference_ms = 0.0;
+    let mut processed_end = 0;
+    let mut chunk_count = 0;
+    let mut next_end = WINDOW_SAMPLES;
+    while next_end <= samples.len() {
+        let window = &samples[next_end - WINDOW_SAMPLES..next_end];
+        let started = Instant::now();
+        let chunk = backend.transcribe(window, "en", None, true)?;
+        println!("during-recording chunk {}: {}", chunk_count + 1, chunk);
+        during_recording_inference_ms += started.elapsed().as_secs_f64() * 1000.0;
+        incremental_text = merge_overlapping_text(&incremental_text, &chunk);
+        processed_end = next_end;
+        chunk_count += 1;
+        next_end = next_end.saturating_add(STEP_SAMPLES);
+    }
+
+    let tail_start = processed_end.saturating_sub(OVERLAP_SAMPLES);
+    let final_started = Instant::now();
+    let final_text = backend.transcribe(&samples[tail_start..], "en", None, true)?;
+    println!("post-stop final tail: {final_text}");
+    let incremental_post_stop_ms = final_started.elapsed().as_secs_f64() * 1000.0;
+    incremental_text = merge_overlapping_text(&incremental_text, &final_text);
+
+    let report = Report {
+        fixture: fixture.display().to_string(),
+        audio_seconds: samples.len() as f64 / WHISPER_SAMPLE_RATE as f64,
+        model,
+        during_recording_chunks: chunk_count,
+        during_recording_inference_ms,
+        batch_post_stop_ms,
+        incremental_post_stop_ms,
+        post_stop_speedup: batch_post_stop_ms / incremental_post_stop_ms,
+        batch_wer: reference
+            .as_deref()
+            .and_then(|text| word_error_rate(text, &batch_text)),
+        incremental_wer: reference
+            .as_deref()
+            .and_then(|text| word_error_rate(text, &incremental_text)),
+        incremental_vs_batch_wer: word_error_rate(&batch_text, &incremental_text),
+        batch_text,
+        incremental_text,
+    };
+    println!(
+        "batch post-stop={:.1}ms; incremental final-tail={:.1}ms; speedup={:.2}x; chunks during recording={}",
+        report.batch_post_stop_ms,
+        report.incremental_post_stop_ms,
+        report.post_stop_speedup,
+        report.during_recording_chunks,
+    );
+    println!(
+        "batch WER={}; incremental WER={}; incremental-vs-batch WER={}",
+        report
+            .batch_wer
+            .map(|value| format!("{:.1}%", value * 100.0))
+            .unwrap_or_else(|| "n/a".to_string()),
+        report
+            .incremental_wer
+            .map(|value| format!("{:.1}%", value * 100.0))
+            .unwrap_or_else(|| "n/a".to_string()),
+        report
+            .incremental_vs_batch_wer
+            .map(|value| format!("{:.1}%", value * 100.0))
+            .unwrap_or_else(|| "n/a".to_string()),
+    );
+    println!(
+        "STREAMING_BENCH_JSON:{}",
+        serde_json::to_string(&report).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -324,6 +324,73 @@ pub fn stop_recording() -> Result<Vec<f32>, String> {
     }
 }
 
+/// Number of 16 kHz-equivalent samples currently captured. This reads only the
+/// buffer length, so the incremental scheduler can decide whether a complete
+/// fixed-size window exists without cloning the recording.
+pub(crate) fn recording_sample_count_16k() -> Option<usize> {
+    let state = RECORDING_STATE.get()?;
+    let guard = state.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(target: "audio", "recording_sample_count_16k: recording state mutex was poisoned, recovering");
+        poisoned.into_inner()
+    });
+    if !guard.active.load(Ordering::Relaxed) || guard.sample_rate == 0 {
+        return None;
+    }
+    let sample_rate = guard.sample_rate as usize;
+    let buffer = Arc::clone(guard.shared.as_ref()?);
+    drop(guard);
+    let raw_len = buffer.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(target: "audio", "recording_sample_count_16k: samples mutex was poisoned, recovering");
+        poisoned.into_inner()
+    }).len();
+    Some(raw_len.saturating_mul(WHISPER_SAMPLE_RATE as usize) / sample_rate)
+}
+
+/// Copy one bounded range from the live recording and convert it to 16 kHz.
+/// Indices use the final pipeline's 16 kHz sample coordinate system. The full
+/// recording buffer remains owned by `stop_recording`; this function never
+/// clears it and never creates an audio queue.
+pub(crate) fn snapshot_recording_window_16k(start: usize, end: usize) -> Option<Vec<f32>> {
+    if start >= end {
+        return Some(Vec::new());
+    }
+    let state = RECORDING_STATE.get()?;
+    let guard = state.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(target: "audio", "snapshot_recording_window_16k: recording state mutex was poisoned, recovering");
+        poisoned.into_inner()
+    });
+    if !guard.active.load(Ordering::Relaxed) || guard.sample_rate == 0 {
+        return None;
+    }
+    let sample_rate = guard.sample_rate as usize;
+    let buffer = Arc::clone(guard.shared.as_ref()?);
+    drop(guard);
+
+    let raw_start = start.saturating_mul(sample_rate) / WHISPER_SAMPLE_RATE as usize;
+    let raw_end = end
+        .saturating_mul(sample_rate)
+        .saturating_add(WHISPER_SAMPLE_RATE as usize - 1)
+        / WHISPER_SAMPLE_RATE as usize;
+    let raw = {
+        let samples = buffer.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(target: "audio", "snapshot_recording_window_16k: samples mutex was poisoned, recovering");
+            poisoned.into_inner()
+        });
+        if raw_end > samples.len() {
+            return None;
+        }
+        samples[raw_start.min(raw_end)..raw_end].to_vec()
+    };
+
+    let mut converted = if sample_rate as u32 == WHISPER_SAMPLE_RATE {
+        raw
+    } else {
+        resample(&raw, sample_rate as u32, WHISPER_SAMPLE_RATE)
+    };
+    converted.truncate(end - start);
+    Some(converted)
+}
+
 #[allow(dead_code)]
 pub fn is_recording() -> bool {
     if let Some(state) = RECORDING_STATE.get() {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1,7 +1,7 @@
 use crate::{MutexExt, State};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
-use crate::{audio, audio_decode, injector, keyboard, vad};
+use crate::{audio, audio_decode, injector, keyboard, streaming, vad};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
@@ -407,6 +407,7 @@ fn spawn_idle_model_preparation(
     });
 }
 
+#[derive(Default)]
 pub(crate) struct PipelineTimings {
     pub vad_ms: u64,
     pub model_load_ms: u64,
@@ -416,6 +417,9 @@ pub(crate) struct PipelineTimings {
     pub paste_ms: u64,
     pub rss_before_mb: u64,
     pub rss_after_mb: u64,
+    pub incremental_chunks: u32,
+    pub streaming_inference_ms: u64,
+    pub final_chunk_ms: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -450,6 +454,7 @@ async fn run_transcription_pipeline(
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
     recording_id: u64,
+    incremental: Option<streaming::IncrementalTranscript>,
 ) -> Result<(String, PipelineTimings), String> {
     // Guard resets status to Idle on any return path (error or success),
     // but only if this recording is still the active one
@@ -492,89 +497,124 @@ async fn run_transcription_pipeline(
     // Checkpoint 1: cancelled before VAD?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before VAD (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms: 0, model_load_ms: 0, decode_ms: 0, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
+        return Ok((String::new(), PipelineTimings::default()));
     }
 
-    // Phase: VAD -- filter out silence to prevent Whisper hallucination loops
-    let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
-    let t_vad = std::time::Instant::now();
-    let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
-        Some(vad_path) if vad_path.exists() => {
-            let vad_path_str = vad_path.to_string_lossy().to_string();
-            let samples_owned = samples.to_vec();
-            let vad_result = tokio::task::spawn_blocking(move || {
-                vad::filter_speech(&vad_path_str, &samples_owned, vad_threshold)
-            })
-            .await
-            .unwrap_or_else(|e| {
-                Err(format!("VAD task panicked: {}", e))
-            });
+    let (text, mut timings) = if let Some(incremental) = incremental {
+        tracing::info!(
+            target: "pipeline",
+            recording_id,
+            chunks = incremental.chunk_count,
+            streaming_inference_ms = incremental.streaming_inference_ms,
+            final_chunk_ms = incremental.final_chunk_ms,
+            "using authoritative incremental transcript"
+        );
+        (
+            incremental.text,
+            PipelineTimings {
+                vad_ms: incremental.vad_ms,
+                inference_ms: incremental.final_chunk_ms,
+                decode_ms: incremental.final_chunk_ms,
+                rss_before_mb: incremental.rss_before_mb,
+                rss_after_mb: incremental.rss_after_mb,
+                incremental_chunks: incremental.chunk_count,
+                streaming_inference_ms: incremental.streaming_inference_ms,
+                final_chunk_ms: incremental.final_chunk_ms,
+                ..PipelineTimings::default()
+            },
+        )
+    } else {
+        // Batch fallback and all non-Whisper backends retain the pre-existing
+        // full-buffer VAD + inference behavior.
+        let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
+        let t_vad = std::time::Instant::now();
+        let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
+            Some(vad_path) if vad_path.exists() => {
+                let vad_path_str = vad_path.to_string_lossy().to_string();
+                let samples_owned = samples.to_vec();
+                let vad_result = tokio::task::spawn_blocking(move || {
+                    vad::filter_speech(&vad_path_str, &samples_owned, vad_threshold)
+                })
+                .await
+                .unwrap_or_else(|e| Err(format!("VAD task panicked: {}", e)));
 
-            match vad_result {
-                Ok(vad::VadResult::NoSpeech) => {
-                    tracing::info!(target: "pipeline", "VAD detected no speech ({} samples, {:?}), skipping transcription",
-                        samples.len(), t_vad.elapsed());
-                    return Ok((String::new(), PipelineTimings { vad_ms: t_vad.elapsed().as_millis() as u64, model_load_ms: 0, decode_ms: 0, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
-                }
-                Ok(vad::VadResult::Speech(trimmed)) => {
-                    tracing::info!(target: "pipeline", "VAD trimmed {} -> {} samples ({:.0}% speech, {:?})",
-                        samples.len(), trimmed.len(),
-                        trimmed.len() as f64 / samples.len() as f64 * 100.0,
-                        t_vad.elapsed());
-                    let vad_trimmed = trimmed.len() != samples.len();
-                    (trimmed, vad_trimmed)
-                }
-                Err(e) => {
-                    tracing::warn!(target: "pipeline", "VAD failed ({}), proceeding without filtering", e);
-                    (samples.to_vec(), false)
+                match vad_result {
+                    Ok(vad::VadResult::NoSpeech) => {
+                        tracing::info!(target: "pipeline", "VAD detected no speech ({} samples, {:?}), skipping transcription",
+                            samples.len(), t_vad.elapsed());
+                        return Ok((String::new(), PipelineTimings {
+                            vad_ms: t_vad.elapsed().as_millis() as u64,
+                            ..PipelineTimings::default()
+                        }));
+                    }
+                    Ok(vad::VadResult::Speech(trimmed)) => {
+                        tracing::info!(target: "pipeline", "VAD trimmed {} -> {} samples ({:.0}% speech, {:?})",
+                            samples.len(), trimmed.len(),
+                            trimmed.len() as f64 / samples.len() as f64 * 100.0,
+                            t_vad.elapsed());
+                        let vad_trimmed = trimmed.len() != samples.len();
+                        (trimmed, vad_trimmed)
+                    }
+                    Err(e) => {
+                        tracing::warn!(target: "pipeline", "VAD failed ({}), proceeding without filtering", e);
+                        (samples.to_vec(), false)
+                    }
                 }
             }
-        }
-        _ => {
-            // VAD model not available -- kick off background download for next time
-            let handle = app_handle.clone();
-            tokio::spawn(async move {
-                if let Err(e) = super::models::ensure_vad_model(&handle).await {
-                    tracing::warn!(target: "pipeline", "VAD model download failed ({}), skipping VAD", e);
-                }
-            });
-            (samples.to_vec(), false)
-        }
-    };
-    let vad_ms = t_vad.elapsed().as_millis() as u64;
+            _ => {
+                let handle = app_handle.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = super::models::ensure_vad_model(&handle).await {
+                        tracing::warn!(target: "pipeline", "VAD model download failed ({}), skipping VAD", e);
+                    }
+                });
+                (samples.to_vec(), false)
+            }
+        };
+        let vad_ms = t_vad.elapsed().as_millis() as u64;
 
-    // Checkpoint 2: cancelled before transcription?
-    if app_state.is_cancelled(recording_id) {
-        tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms, model_load_ms: 0, decode_ms: 0, inference_ms: 0, correction_ms: 0, paste_ms: 0, rss_before_mb: 0, rss_after_mb: 0 }));
-    }
+        if app_state.is_cancelled(recording_id) {
+            tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
+            return Ok((String::new(), PipelineTimings {
+                vad_ms,
+                ..PipelineTimings::default()
+            }));
+        }
 
-    // Phase: Transcription. Model preparation normally overlaps startup or
-    // recording; load_model remains the synchronized fallback and cache check.
-    let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
-    let t_transcribe = std::time::Instant::now();
-    // Combine the manual custom vocabulary with the code-aware vocabulary
-    // (when enabled). Both feed Whisper's initial prompt; the manual list comes
-    // first so user-typed terms take precedence within the context window.
-    let sanitized = custom_vocabulary.replace('\0', "");
-    let code_vocab = resolve_code_vocab_prompt(app_state);
-    let prompt = combine_prompts(&sanitized, &code_vocab);
-    let (text, model_load_ms, decode_ms) = {
-        let load_started = std::time::Instant::now();
-        let mut backend = app_state.backend.lock_or_recover();
-        backend.load_model(&model_name)?;
-        let model_load_ms = load_started.elapsed().as_millis() as u64;
-        let decode_started = std::time::Instant::now();
-        let text = transcribe_with_coreml_vad_retry(
-            backend.as_mut(), &model_name, &samples_for_transcription, samples,
-            vad_trimmed, &language, prompt.as_deref(), smart_punctuation,
-        )?;
-        let decode_ms = decode_started.elapsed().as_millis() as u64;
-        (text, model_load_ms, decode_ms)
+        let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
+        let t_transcribe = std::time::Instant::now();
+        let sanitized = custom_vocabulary.replace('\0', "");
+        let code_vocab = resolve_code_vocab_prompt(app_state);
+        let prompt = combine_prompts(&sanitized, &code_vocab);
+        let (text, model_load_ms, decode_ms) = {
+            let load_started = std::time::Instant::now();
+            let mut backend = app_state.backend.lock_or_recover();
+            backend.load_model(&model_name)?;
+            let model_load_ms = load_started.elapsed().as_millis() as u64;
+            let decode_started = std::time::Instant::now();
+            let text = transcribe_with_coreml_vad_retry(
+                backend.as_mut(), &model_name, &samples_for_transcription, samples,
+                vad_trimmed, &language, prompt.as_deref(), smart_punctuation,
+            )?;
+            let decode_ms = decode_started.elapsed().as_millis() as u64;
+            (text, model_load_ms, decode_ms)
+        };
+        let inference_ms = t_transcribe.elapsed().as_millis() as u64;
+        let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
+        tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
+        (
+            text,
+            PipelineTimings {
+                vad_ms,
+                model_load_ms,
+                decode_ms,
+                inference_ms,
+                rss_before_mb,
+                rss_after_mb,
+                ..PipelineTimings::default()
+            },
+        )
     };
-    let inference_ms = t_transcribe.elapsed().as_millis() as u64;
-    let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
-    tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
 
     // Phase: rule-based cleanup (filler removal + punctuation/spacing tidy).
     // Runs on the transcript before injection and file output so what the user
@@ -632,7 +672,8 @@ async fn run_transcription_pipeline(
     // Checkpoint 3: cancelled before text injection?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before injection (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings { vad_ms, model_load_ms, decode_ms, inference_ms, correction_ms, paste_ms: 0, rss_before_mb, rss_after_mb }));
+        timings.correction_ms = correction_ms;
+        return Ok((String::new(), timings));
     }
 
     // Phase: File output (optional) -- persist audio/transcript before injection.
@@ -684,7 +725,9 @@ async fn run_transcription_pipeline(
     let paste_ms = t_inject.elapsed().as_millis() as u64;
     tracing::info!(target: "pipeline", "inject (clipboard + paste): {:?}", t_inject.elapsed());
 
-    Ok((text, PipelineTimings { vad_ms, model_load_ms, decode_ms, inference_ms, correction_ms, paste_ms, rss_before_mb, rss_after_mb }))
+    timings.correction_ms = correction_ms;
+    timings.paste_ms = paste_ms;
+    Ok((text, timings))
     // _guard drops here, setting status to Idle
 }
 
@@ -746,7 +789,14 @@ pub async fn process_audio(
     guard.disarm();
 
     let t_total = std::time::Instant::now();
-    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
+    let pipeline_result = run_transcription_pipeline(
+        &samples,
+        &app_handle,
+        &state.app_state,
+        rid,
+        None,
+    )
+    .await;
     // Only emit idle if this recording wasn't cancelled/superseded.
     // Hold the dictation lock across the check+emit to prevent a concurrent
     // start from interleaving a "recording" status between our check and emit.
@@ -778,6 +828,9 @@ pub async fn process_audio(
         model_load_ms = timings.model_load_ms,
         decode_ms = timings.decode_ms,
         inference_ms = timings.inference_ms,
+        incremental_chunks = timings.incremental_chunks,
+        streaming_inference_ms = timings.streaming_inference_ms,
+        final_chunk_ms = timings.final_chunk_ms,
         correction_ms = timings.correction_ms,
         paste_ms = timings.paste_ms,
         total_ms = total_ms,
@@ -1403,7 +1456,7 @@ pub async fn start_native_recording(
     }
     // Check and update status in one lock; assign recording ID in the same
     // critical section so no concurrent cancel/start can slip between them.
-    let (rid, model_name) = {
+    let (rid, model_name, language, vad_sensitivity, custom_vocabulary, smart_punctuation, streaming_prompt_ready) = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         // Refuse if a file transcription holds the shared Whisper backend.
         // Checked under the dictation lock (which `transcribe_file` takes only
@@ -1440,7 +1493,17 @@ pub async fn start_native_recording(
             DictationStatus::Idle => {
                 let rid = state.app_state.next_recording_id();
                 dictation.status = DictationStatus::Recording;
-                (rid, dictation.model_name.clone())
+                (
+                    rid,
+                    dictation.model_name.clone(),
+                    dictation.language.clone(),
+                    dictation.vad_sensitivity,
+                    dictation.custom_vocabulary.clone(),
+                    dictation.smart_punctuation,
+                    !dictation.code_vocab_enabled
+                        || dictation.code_vocab_folder.trim().is_empty()
+                        || dictation.code_vocab_prompt.is_some(),
+                )
             }
         }
     };
@@ -1454,7 +1517,30 @@ pub async fn start_native_recording(
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(target: "pipeline", "start_native_recording: started");
-    spawn_model_preparation(app_handle.clone(), model_name, rid);
+    spawn_model_preparation(app_handle.clone(), model_name.clone(), rid);
+    if streaming_prompt_ready {
+        let sanitized = custom_vocabulary.replace('\0', "");
+        let code_vocab = resolve_code_vocab_prompt(&state.app_state);
+        let prompt = combine_prompts(&sanitized, &code_vocab);
+        streaming::start_session(
+            app_handle.clone(),
+            streaming::StreamingConfig {
+                recording_id: rid,
+                model_name,
+                language,
+                prompt,
+                smart_punctuation,
+                vad_threshold: 1.0 - (vad_sensitivity as f32 / 100.0),
+            },
+        )
+        .await;
+    } else {
+        tracing::info!(
+            target: "pipeline",
+            recording_id = rid,
+            "incremental transcription skipped until code vocabulary cache is ready"
+        );
+    }
 
     Ok(serde_json::json!({
         "type": "recording_started",
@@ -1492,6 +1578,7 @@ pub async fn stop_native_recording(
     keyboard::set_processing(true);
     tracing::info!(target: "pipeline", "stop_native_recording: stopping");
     let _ = app_handle.emit("recording-status-changed", "processing");
+    let streaming_session = streaming::begin_finish(&state.app_state, rid).await;
 
     // Guard resets status to Idle if stop_recording fails or samples are empty;
     // disarmed before handing off to run_transcription_pipeline (which has its own guard)
@@ -1512,6 +1599,7 @@ pub async fn stop_native_recording(
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
 
     if samples.is_empty() {
+        streaming::discard(streaming_session);
         tracing::info!(target: "pipeline", "stop_native_recording: no audio captured");
         // guard drops on return, resetting status to Idle
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
@@ -1529,6 +1617,7 @@ pub async fn stop_native_recording(
     const MIN_RECORDING_SAMPLES: usize = 4_800; // 0.3s at 16kHz
 
     if samples.len() < MIN_RECORDING_SAMPLES {
+        streaming::discard(streaming_session);
         tracing::info!(target: "pipeline", "stop_native_recording: recording too short ({}ms), discarding",
             samples.len() / 16); // samples / 16_000 * 1000
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
@@ -1544,7 +1633,15 @@ pub async fn stop_native_recording(
     // Hand off status management to the pipeline's own guard
     guard.disarm();
 
-    let pipeline_result = run_transcription_pipeline(&samples, &app_handle, &state.app_state, rid).await;
+    let incremental = streaming::finalize(app_handle.clone(), streaming_session, &samples).await;
+    let pipeline_result = run_transcription_pipeline(
+        &samples,
+        &app_handle,
+        &state.app_state,
+        rid,
+        incremental,
+    )
+    .await;
     // Only emit idle if this recording wasn't cancelled/superseded by a new one.
     // Hold the dictation lock across the check+emit to prevent a concurrent
     // start from interleaving a "recording" status between our check and emit.
@@ -1580,6 +1677,9 @@ pub async fn stop_native_recording(
         model_load_ms = timings.model_load_ms,
         decode_ms = timings.decode_ms,
         inference_ms = timings.inference_ms,
+        incremental_chunks = timings.incremental_chunks,
+        streaming_inference_ms = timings.streaming_inference_ms,
+        final_chunk_ms = timings.final_chunk_ms,
         correction_ms = timings.correction_ms,
         paste_ms = timings.paste_ms,
         total_ms = total_ms,
@@ -1635,6 +1735,7 @@ pub async fn cancel_native_recording(
         }
         (prev, rid)
     };
+    streaming::cancel(&state.app_state, rid).await;
 
     let stop_err = match prev_status {
         DictationStatus::Recording => {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod injector;
 mod keyboard;
 mod resource_monitor;
 mod state;
+mod streaming;
 pub mod telemetry;
 pub mod transcriber;
 mod vad;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -151,6 +151,10 @@ pub struct AppState {
     /// `configure_dictation`. Lives outside `DictationState` because the compiled
     /// Aho-Corasick automaton isn't serializable.
     pub correction_matcher: Mutex<Option<std::sync::Arc<crate::correction::CorrectionMatcher>>>,
+    /// At most one bounded incremental Whisper worker is attached to the active
+    /// recording. The handle owns no audio; it snapshots one fixed-size window
+    /// at a time and stores only reconciled text and timing counters.
+    pub streaming_session: tokio::sync::Mutex<Option<crate::streaming::StreamingSession>>,
 }
 
 impl AppState {
@@ -182,6 +186,7 @@ impl Default for AppState {
             cancelled_id: AtomicU64::new(0),
             file_transcribing: AtomicBool::new(false),
             correction_matcher: Mutex::new(None),
+            streaming_session: tokio::sync::Mutex::new(None),
         }
     }
 }

--- a/app/src-tauri/src/streaming.rs
+++ b/app/src-tauri/src/streaming.rs
@@ -1,0 +1,425 @@
+use crate::state::DictationStatus;
+use crate::{audio, transcriber, vad, MutexExt, State};
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use tauri::Manager;
+
+use transcriber::chunking::{
+    reconcile_overlapping_text, OVERLAP_SAMPLES, STEP_SAMPLES, WINDOW_SAMPLES,
+};
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Clone)]
+pub(crate) struct StreamingConfig {
+    pub recording_id: u64,
+    pub model_name: String,
+    pub language: String,
+    pub prompt: Option<String>,
+    pub smart_punctuation: bool,
+    pub vad_threshold: f32,
+}
+
+#[derive(Default)]
+struct StreamingProgress {
+    text: String,
+    processed_end: usize,
+    chunk_count: u32,
+    vad_ms: u64,
+    inference_ms: u64,
+    reliable: bool,
+    fallback_reason: Option<String>,
+}
+
+pub(crate) struct StreamingSession {
+    recording_id: u64,
+    config: StreamingConfig,
+    stop_tx: tokio::sync::watch::Sender<bool>,
+    join: tokio::task::JoinHandle<StreamingProgress>,
+}
+
+pub(crate) struct IncrementalTranscript {
+    pub text: String,
+    pub chunk_count: u32,
+    pub vad_ms: u64,
+    pub streaming_inference_ms: u64,
+    pub final_chunk_ms: u64,
+    pub rss_before_mb: u64,
+    pub rss_after_mb: u64,
+}
+
+#[derive(Default)]
+struct ChunkOutput {
+    text: String,
+    vad_ms: u64,
+    inference_ms: u64,
+    rss_before_mb: u64,
+    rss_after_mb: u64,
+}
+
+/// Start one sequential chunk worker for a Whisper recording. Other backends
+/// deliberately retain the existing batch path.
+pub(crate) async fn start_session(app_handle: tauri::AppHandle, config: StreamingConfig) {
+    if !transcriber::is_whisper_model(&config.model_name) {
+        return;
+    }
+
+    let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+    let recording_id = config.recording_id;
+    let task_config = config.clone();
+    let join = tokio::spawn(run_session(app_handle.clone(), task_config, stop_rx));
+    let session = StreamingSession {
+        recording_id,
+        config,
+        stop_tx,
+        join,
+    };
+
+    let state = app_handle.state::<State>();
+    let mut slot = state.app_state.streaming_session.lock().await;
+    if let Some(previous) = slot.take() {
+        let _ = previous.stop_tx.send(true);
+        previous.join.abort();
+        tracing::warn!(target: "pipeline", "incremental transcription: replaced stale session");
+    }
+    *slot = Some(session);
+    tracing::info!(
+        target: "pipeline",
+        recording_id,
+        window_ms = WINDOW_SAMPLES / 16,
+        step_ms = STEP_SAMPLES / 16,
+        overlap_ms = OVERLAP_SAMPLES / 16,
+        "incremental transcription started"
+    );
+}
+
+async fn run_session(
+    app_handle: tauri::AppHandle,
+    config: StreamingConfig,
+    mut stop_rx: tokio::sync::watch::Receiver<bool>,
+) -> StreamingProgress {
+    let mut progress = StreamingProgress {
+        reliable: true,
+        ..StreamingProgress::default()
+    };
+    let mut next_end = WINDOW_SAMPLES;
+
+    loop {
+        if let Ok(changed) = tokio::time::timeout(POLL_INTERVAL, stop_rx.changed()).await {
+            if changed.is_err() || *stop_rx.borrow() {
+                break;
+            }
+        }
+
+        if !session_is_current(&app_handle, config.recording_id) {
+            progress.reliable = false;
+            progress.fallback_reason = Some("recording session was superseded".to_string());
+            break;
+        }
+
+        let Some(available) = audio::recording_sample_count_16k() else {
+            continue;
+        };
+        if available < next_end {
+            continue;
+        }
+
+        // Never build a backlog. If capture advanced by more than one complete
+        // step while the worker was busy/suspended, abandon incremental output;
+        // the authoritative batch fallback will run after stop.
+        if worker_fell_behind(available, next_end) {
+            progress.reliable = false;
+            progress.fallback_reason = Some(format!(
+                "worker fell behind (available={available}, next_end={next_end})"
+            ));
+            break;
+        }
+
+        let window_start = next_end - WINDOW_SAMPLES;
+        let Some(window) = audio::snapshot_recording_window_16k(window_start, next_end) else {
+            continue;
+        };
+        match transcribe_window(app_handle.clone(), config.clone(), window).await {
+            Ok(chunk) => {
+                let reconciled = reconcile_overlapping_text(&progress.text, &chunk.text);
+                if !progress.text.is_empty()
+                    && !chunk.text.is_empty()
+                    && reconciled.overlap_words == 0
+                {
+                    progress.reliable = false;
+                    progress.fallback_reason = Some(format!(
+                        "chunk {} had no deterministic overlap",
+                        progress.chunk_count + 1
+                    ));
+                    break;
+                }
+                progress.text = reconciled.text;
+                progress.processed_end = next_end;
+                progress.chunk_count += 1;
+                progress.vad_ms = progress.vad_ms.saturating_add(chunk.vad_ms);
+                progress.inference_ms = progress.inference_ms.saturating_add(chunk.inference_ms);
+                tracing::info!(
+                    target: "pipeline",
+                    recording_id = config.recording_id,
+                    chunk_index = progress.chunk_count,
+                    window_start,
+                    window_end = next_end,
+                    vad_ms = chunk.vad_ms,
+                    inference_ms = chunk.inference_ms,
+                    "incremental chunk complete"
+                );
+                next_end = next_end.saturating_add(STEP_SAMPLES);
+            }
+            Err(error) => {
+                progress.reliable = false;
+                progress.fallback_reason = Some(error);
+                break;
+            }
+        }
+    }
+
+    if !progress.reliable {
+        tracing::warn!(
+            target: "pipeline",
+            recording_id = config.recording_id,
+            reason = progress.fallback_reason.as_deref().unwrap_or("unknown"),
+            "incremental transcription abandoned; batch fallback required"
+        );
+    }
+    progress
+}
+
+fn session_is_current(app_handle: &tauri::AppHandle, recording_id: u64) -> bool {
+    let state = app_handle.state::<State>();
+    let current_id = state.app_state.recording_id.load(Ordering::SeqCst);
+    let cancelled_id = state.app_state.cancelled_id.load(Ordering::SeqCst);
+    let dictation = state.app_state.dictation.lock_or_recover();
+    session_generation_is_current(current_id, cancelled_id, recording_id, dictation.status)
+}
+
+fn session_generation_is_current(
+    current_id: u64,
+    cancelled_id: u64,
+    recording_id: u64,
+    status: DictationStatus,
+) -> bool {
+    current_id == recording_id
+        && cancelled_id < recording_id
+        && matches!(
+            status,
+            DictationStatus::Recording | DictationStatus::Processing
+        )
+}
+
+fn worker_fell_behind(available: usize, next_end: usize) -> bool {
+    available >= next_end.saturating_add(STEP_SAMPLES)
+}
+
+async fn transcribe_window(
+    app_handle: tauri::AppHandle,
+    config: StreamingConfig,
+    samples: Vec<f32>,
+) -> Result<ChunkOutput, String> {
+    tokio::task::spawn_blocking(move || {
+        if samples.is_empty() {
+            return Ok(ChunkOutput::default());
+        }
+        let vad_path = vad::vad_model_path()
+            .filter(|path| path.exists())
+            .ok_or_else(|| "VAD model unavailable".to_string())?;
+        let vad_started = Instant::now();
+        let filtered = match vad::filter_speech(
+            &vad_path.to_string_lossy(),
+            &samples,
+            config.vad_threshold,
+        )? {
+            vad::VadResult::NoSpeech => {
+                return Ok(ChunkOutput {
+                    vad_ms: vad_started.elapsed().as_millis() as u64,
+                    ..ChunkOutput::default()
+                });
+            }
+            vad::VadResult::Speech(samples) => samples,
+        };
+        let vad_ms = vad_started.elapsed().as_millis() as u64;
+
+        let state = app_handle.state::<State>();
+        if state.app_state.recording_id.load(Ordering::SeqCst) != config.recording_id
+            || state.app_state.is_cancelled(config.recording_id)
+        {
+            return Err("recording session was superseded before inference".to_string());
+        }
+        {
+            let dictation = state.app_state.dictation.lock_or_recover();
+            if dictation.model_name != config.model_name {
+                return Err("model changed during recording".to_string());
+            }
+        }
+
+        let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
+        let inference_started = Instant::now();
+        let text = {
+            let mut backend = state.app_state.backend.lock_or_recover();
+            if backend.name() != "whisper" {
+                return Err("active backend changed during recording".to_string());
+            }
+            backend.load_model(&config.model_name)?;
+            backend.transcribe(
+                &filtered,
+                &config.language,
+                config.prompt.as_deref(),
+                config.smart_punctuation,
+            )?
+        };
+        let inference_ms = inference_started.elapsed().as_millis() as u64;
+        let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
+        Ok(ChunkOutput {
+            text,
+            vad_ms,
+            inference_ms,
+            rss_before_mb,
+            rss_after_mb,
+        })
+    })
+    .await
+    .map_err(|error| format!("incremental worker panicked: {error}"))?
+}
+
+/// Signal the worker before audio teardown so it cannot schedule another
+/// window. The returned handle is finalized after the immutable full buffer is
+/// available.
+pub(crate) async fn begin_finish(
+    app_state: &crate::state::AppState,
+    recording_id: u64,
+) -> Option<StreamingSession> {
+    let mut slot = app_state.streaming_session.lock().await;
+    let session = slot.take()?;
+    if session.recording_id != recording_id {
+        let _ = session.stop_tx.send(true);
+        session.join.abort();
+        return None;
+    }
+    let _ = session.stop_tx.send(true);
+    Some(session)
+}
+
+pub(crate) async fn cancel(app_state: &crate::state::AppState, recording_id: u64) {
+    let mut slot = app_state.streaming_session.lock().await;
+    if let Some(session) = slot.take() {
+        let _ = session.stop_tx.send(true);
+        session.join.abort();
+        tracing::info!(target: "pipeline", recording_id, "incremental transcription cancelled");
+    }
+}
+
+pub(crate) fn discard(session: Option<StreamingSession>) {
+    if let Some(session) = session {
+        let _ = session.stop_tx.send(true);
+        session.join.abort();
+    }
+}
+
+/// Reconcile the completed during-recording prefix with one bounded final tail.
+/// Returning `None` requests the unchanged full-buffer pipeline.
+pub(crate) async fn finalize(
+    app_handle: tauri::AppHandle,
+    session: Option<StreamingSession>,
+    full_samples: &[f32],
+) -> Option<IncrementalTranscript> {
+    let session = session?;
+    let config = session.config.clone();
+    let progress = match session.join.await {
+        Ok(progress) => progress,
+        Err(error) => {
+            tracing::warn!(target: "pipeline", recording_id = config.recording_id, error = %error, "incremental join failed; using batch fallback");
+            return None;
+        }
+    };
+    if !progress.reliable
+        || progress.chunk_count == 0
+        || progress.processed_end > full_samples.len()
+    {
+        return None;
+    }
+
+    let tail_start = progress.processed_end.saturating_sub(OVERLAP_SAMPLES);
+    let tail = full_samples[tail_start..].to_vec();
+    let final_started = Instant::now();
+    let final_chunk = match transcribe_window(app_handle, config.clone(), tail).await {
+        Ok(chunk) => chunk,
+        Err(error) => {
+            tracing::warn!(target: "pipeline", recording_id = config.recording_id, error, "incremental final chunk failed; using batch fallback");
+            return None;
+        }
+    };
+    let final_chunk_ms = final_started.elapsed().as_millis() as u64;
+    let reconciled = reconcile_overlapping_text(&progress.text, &final_chunk.text);
+    if !progress.text.is_empty() && !final_chunk.text.is_empty() && reconciled.overlap_words == 0 {
+        tracing::warn!(target: "pipeline", recording_id = config.recording_id, "incremental final chunk had no deterministic overlap; using batch fallback");
+        return None;
+    }
+    let text = reconciled.text;
+    if text.trim().is_empty() {
+        return None;
+    }
+
+    tracing::info!(
+        target: "pipeline",
+        recording_id = config.recording_id,
+        chunks = progress.chunk_count + 1,
+        processed_during_recording_samples = progress.processed_end,
+        final_tail_samples = full_samples.len().saturating_sub(tail_start),
+        streaming_inference_ms = progress.inference_ms,
+        final_chunk_ms,
+        "incremental transcription finalized"
+    );
+    Some(IncrementalTranscript {
+        text,
+        chunk_count: progress.chunk_count + 1,
+        vad_ms: progress.vad_ms.saturating_add(final_chunk.vad_ms),
+        streaming_inference_ms: progress.inference_ms,
+        final_chunk_ms,
+        rss_before_mb: final_chunk.rss_before_mb,
+        rss_after_mb: final_chunk.rss_after_mb,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{session_generation_is_current, worker_fell_behind, STEP_SAMPLES};
+    use crate::state::DictationStatus;
+
+    #[test]
+    fn stale_or_cancelled_generation_cannot_be_current() {
+        assert!(session_generation_is_current(
+            8,
+            7,
+            8,
+            DictationStatus::Recording
+        ));
+        assert!(!session_generation_is_current(
+            9,
+            7,
+            8,
+            DictationStatus::Recording
+        ));
+        assert!(!session_generation_is_current(
+            8,
+            8,
+            8,
+            DictationStatus::Recording
+        ));
+        assert!(!session_generation_is_current(
+            8,
+            7,
+            8,
+            DictationStatus::Idle
+        ));
+    }
+
+    #[test]
+    fn worker_never_queues_more_than_one_step() {
+        let next_end = 160_000;
+        assert!(!worker_fell_behind(next_end + STEP_SAMPLES - 1, next_end));
+        assert!(worker_fell_behind(next_end + STEP_SAMPLES, next_end));
+    }
+}

--- a/app/src-tauri/src/transcriber/chunking.rs
+++ b/app/src-tauri/src/transcriber/chunking.rs
@@ -1,0 +1,194 @@
+use super::WHISPER_SAMPLE_RATE;
+
+pub const WINDOW_SAMPLES: usize = 10 * WHISPER_SAMPLE_RATE as usize;
+pub const STEP_SAMPLES: usize = 8 * WHISPER_SAMPLE_RATE as usize;
+pub const OVERLAP_SAMPLES: usize = WINDOW_SAMPLES - STEP_SAMPLES;
+
+fn normalized_word(word: &str) -> String {
+    word.chars()
+        .filter(|character| character.is_alphanumeric() || *character == '\'')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn edit_distance(left: &[String], right: &[String]) -> usize {
+    let mut previous: Vec<usize> = (0..=right.len()).collect();
+    for (row, left_word) in left.iter().enumerate() {
+        let mut current = vec![row + 1; right.len() + 1];
+        for (column, right_word) in right.iter().enumerate() {
+            current[column + 1] = (previous[column + 1] + 1)
+                .min(current[column] + 1)
+                .min(previous[column] + usize::from(left_word != right_word));
+        }
+        previous = current;
+    }
+    previous[right.len()]
+}
+
+fn boundary_words_match(left: &str, right: &str) -> bool {
+    left == right
+        || (left.starts_with(right) && left.len().saturating_sub(right.len()) <= 2)
+        || (right.starts_with(left) && right.len().saturating_sub(left.len()) <= 2)
+}
+
+/// Deterministically reconcile a transcript boundary. The largest near-equal
+/// suffix/prefix pair within 12 words is emitted once. Earlier stable words are
+/// retained, while a later boundary word may complete a truncated token or
+/// remove punctuation that Whisper invented at the end of an audio window.
+pub struct ReconciledText {
+    pub text: String,
+    pub overlap_words: usize,
+}
+
+pub fn reconcile_overlapping_text(existing: &str, next: &str) -> ReconciledText {
+    let left: Vec<&str> = existing.split_whitespace().collect();
+    let right: Vec<&str> = next.split_whitespace().collect();
+    if left.is_empty() {
+        return ReconciledText {
+            text: next.trim().to_string(),
+            overlap_words: 0,
+        };
+    }
+    if right.is_empty() {
+        return ReconciledText {
+            text: existing.trim().to_string(),
+            overlap_words: 0,
+        };
+    }
+
+    let left_norm: Vec<String> = left.iter().map(|word| normalized_word(word)).collect();
+    let right_norm: Vec<String> = right.iter().map(|word| normalized_word(word)).collect();
+    let max_overlap = left.len().min(right.len()).min(12);
+    let mut best: Option<(usize, usize)> = None;
+    for count in 1..=max_overlap {
+        // Anchor the candidate's right edge so a longer fuzzy match cannot
+        // consume the first genuinely new word after the overlap.
+        if !right_norm
+            .get(count - 1)
+            .map(|right_word| boundary_words_match(left_norm.last().unwrap(), right_word))
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let distance = edit_distance(&left_norm[left_norm.len() - count..], &right_norm[..count]);
+        let acceptable = if count == 1 {
+            distance == 0
+        } else {
+            distance.saturating_mul(3) <= count
+        };
+        if !acceptable {
+            continue;
+        }
+        let candidate = (count, usize::MAX - distance);
+        if best.map(|current| candidate > current).unwrap_or(true) {
+            best = Some(candidate);
+        }
+    }
+
+    let overlap = best.map(|(count, _)| count).unwrap_or(0);
+    if overlap == 0 {
+        return ReconciledText {
+            text: format!("{} {}", existing.trim(), next.trim()),
+            overlap_words: 0,
+        };
+    }
+
+    let stable_len = left.len() - overlap;
+    let mut words: Vec<String> = left[..stable_len]
+        .iter()
+        .map(|word| (*word).to_string())
+        .collect();
+    for index in 0..overlap {
+        let earlier = left[stable_len + index];
+        let later = right[index];
+        let earlier_norm = &left_norm[stable_len + index];
+        let later_norm = &right_norm[index];
+        let earlier_terminal = earlier.ends_with(['.', '!', '?']);
+        let later_terminal = later.ends_with(['.', '!', '?']);
+        let choose_later = (earlier_norm == later_norm && earlier_terminal != later_terminal)
+            || (boundary_words_match(earlier_norm, later_norm)
+                && later_norm.len() > earlier_norm.len());
+        words.push(if choose_later { later } else { earlier }.to_string());
+    }
+    words.extend(right[overlap..].iter().map(|word| (*word).to_string()));
+    ReconciledText {
+        text: words.join(" "),
+        overlap_words: overlap,
+    }
+}
+
+pub fn merge_overlapping_text(existing: &str, next: &str) -> String {
+    reconcile_overlapping_text(existing, next).text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_overlapping_text, reconcile_overlapping_text};
+
+    #[test]
+    fn exact_overlap_is_emitted_once() {
+        assert_eq!(
+            merge_overlapping_text("one two three four", "three four five six"),
+            "one two three four five six"
+        );
+    }
+
+    #[test]
+    fn punctuation_and_case_do_not_duplicate_boundary() {
+        assert_eq!(
+            merge_overlapping_text("Hello, WORLD.", "world this continues"),
+            "Hello, world this continues"
+        );
+    }
+
+    #[test]
+    fn one_word_difference_in_long_overlap_is_reconciled() {
+        assert_eq!(
+            merge_overlapping_text(
+                "alpha the voice activity detector before being handed",
+                "the voice activity detectors before being handed to whisper"
+            ),
+            "alpha the voice activity detectors before being handed to whisper"
+        );
+    }
+
+    #[test]
+    fn unrelated_chunks_are_appended() {
+        assert_eq!(
+            merge_overlapping_text("one two", "three four"),
+            "one two three four"
+        );
+        assert_eq!(
+            reconcile_overlapping_text("one two", "three four").overlap_words,
+            0
+        );
+    }
+
+    #[test]
+    fn empty_side_is_stable() {
+        assert_eq!(merge_overlapping_text("", " next words "), "next words");
+        assert_eq!(
+            merge_overlapping_text("existing words", ""),
+            "existing words"
+        );
+    }
+
+    #[test]
+    fn repeated_phrase_chooses_largest_boundary_match() {
+        assert_eq!(
+            merge_overlapping_text("go now then go now", "then go now and stop"),
+            "go now then go now and stop"
+        );
+    }
+
+    #[test]
+    fn fuzzy_match_does_not_consume_first_new_word() {
+        assert_eq!(
+            merge_overlapping_text(
+                "a double tap mode for dictating code.",
+                "a double tap mode for dictating code comments and chat"
+            ),
+            "a double tap mode for dictating code comments and chat"
+        );
+    }
+}

--- a/app/src-tauri/src/transcriber/mod.rs
+++ b/app/src-tauri/src/transcriber/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub mod coreml;
+pub mod chunking;
 pub mod parakeet;
 pub mod whisper;
 
@@ -19,6 +20,10 @@ pub const COREML_MODEL_NAME: &str = "parakeet-tdt-0.6b-v3-coreml";
 
 pub fn is_coreml_model(model_name: &str) -> bool {
     model_name == COREML_MODEL_NAME
+}
+
+pub fn is_whisper_model(model_name: &str) -> bool {
+    !is_coreml_model(model_name) && !parakeet::is_parakeet_model(model_name)
 }
 
 /// Sample rate required by transcription models (16kHz).
@@ -161,6 +166,14 @@ mod tests {
     fn parse_wav_rejects_garbage() {
         let result = parse_wav_to_samples(b"not a wav file");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn incremental_classifier_selects_only_whisper_models() {
+        assert!(is_whisper_model("base.en"));
+        assert!(is_whisper_model("large-v3-turbo"));
+        assert!(!is_whisper_model(COREML_MODEL_NAME));
+        assert!(!is_whisper_model("parakeet-tdt-0.6b-v2-fp16"));
     }
 
 }

--- a/bench/README.md
+++ b/bench/README.md
@@ -14,7 +14,24 @@ bench/make_audio.sh
 cd app/src-tauri
 cargo run --release --example transcription_bench -- --engine coreml --iterations 5
 cargo run --release --example transcription_bench -- --engine parakeet --iterations 5
+
+# Whisper stop-latency comparison on the longest fixture. The first command-line
+# argument is a 16kHz mono WAV; the second is an installed Whisper model name.
+cargo run --release --example streaming_bench -- ../../bench/audio/xlong.wav base.en
 ```
+
+The streaming runner warms the model, times a full-buffer batch pass, then simulates the production 10-second window / 8-second step / 2-second overlap algorithm. During-recording chunk time is reported separately; `incremental_post_stop_ms` measures only the final tail that remains after stop. It also reports reference WER and incremental-vs-batch WER so latency improvements are never presented without an output comparison.
+
+### Issue #129 incremental result
+
+Measured on an Apple M4 Mac mini (24 GB) with `base.en` and the 28.50-second `xlong` fixture on 2026-07-18. Latencies are medians of five warm runs:
+
+| Path | Post-stop inference | Reference WER | Output coverage |
+| --- | ---: | ---: | --- |
+| Full-buffer batch | 298.0 ms | 25.3% | Truncated after "for dictating" |
+| Incremental, final tail | 95.4 ms | 13.3% | Complete through "throughout the day" |
+
+The final-tail path was 3.12x faster after stop. Three bounded chunks used a median ~433 ms of inference spread across the 28.5-second recording; no queued work or second model context was created. Incremental-vs-batch WER was 12.7%, reported because chunking changes decoding context rather than promising byte-identical output.
 
 ## Apple M4 results
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -3,7 +3,7 @@
 ## Overview
 
 ```
-cpal audio capture → f32 samples in memory → resample to 16kHz mono → backend inference → text
+cpal audio capture → f32 samples in memory → 16kHz windows/full buffer → backend inference → text
 ```
 
 Transcription processing is local. Network access occurs for model setup and may also be used to fetch a missing VAD asset in the background. New installs default to FluidAudio Core ML on the Apple Neural Engine, while Whisper/Metal and sherpa-onnx/CPU remain selectable.
@@ -51,6 +51,18 @@ The active backend is stored as `Mutex<Box<dyn TranscriptionBackend>>` in `AppSt
 - Model files are single `.bin` files (e.g., `ggml-base.en.bin`)
 - Model search paths are documented in `docs/onboarding.md`
 
+### Incremental Whisper path (`streaming.rs`, `transcriber/chunking.rs`)
+
+Long live recordings selected to the Whisper backend use true incremental output:
+
+- A single sequential worker snapshots one bounded 10-second window every 8 seconds (2-second overlap) while capture continues.
+- Every window passes through the same Silero VAD threshold and the existing cached Whisper backend. There is no second model/context and never more than one inference in flight.
+- Chunk text is reconciled by a deterministic word-boundary algorithm. It removes the largest near-equal suffix/prefix overlap within 12 words and retains the earlier surface form.
+- On stop, the worker is signalled before audio teardown and only the unprocessed tail plus the 2-second overlap is inferred. The reconciled result becomes the authoritative text used by the unchanged cleanup, voice-command, correction, file-output, clipboard, paste, history, and stats paths.
+- Short recordings (under the first 10-second window), non-Whisper backends, missing/failed VAD, stale sessions, model changes, worker lag, panics, or final-tail failures use the original full-buffer pipeline.
+
+The worker holds no queued audio. It reads the current buffer length, copies only one fixed window, awaits that inference, and abandons incremental mode if capture advances by more than one step. Recording IDs and cancellation generations prevent completed work from a stopped/cancelled session from being adopted by a newer recording.
+
 ## Model Options
 
 | Model | Setting Value | Backend | English-only | Speed |
@@ -65,11 +77,11 @@ The active backend is stored as `Mutex<Box<dyn TranscriptionBackend>>` in `AppSt
 
 ## Pipeline Orchestration (`lib.rs`)
 
-`run_transcription_pipeline()` is the shared entry point:
+`run_transcription_pipeline()` remains the single authoritative completion entry point:
 
 1. Read model/language/auto_paste from `DictationState` (single lock)
 2. Confirm the recording-start model preparation completed (or load synchronously as a fallback)
-3. Run transcription via the active backend
+3. Adopt a successfully finalized incremental Whisper transcript, or run the full-buffer backend fallback
 4. Inject text (clipboard + optional paste) on main thread
 5. Reset status to Idle
 

--- a/docs/features/vad.md
+++ b/docs/features/vad.md
@@ -65,6 +65,8 @@ In `run_transcription_pipeline()`, the VAD phase runs after pre-VAD diagnostics 
 
 The VAD execution time is logged as `vad_ms` in the structured telemetry output alongside `inference_ms`, `paste_ms`, and `total_ms`. This timing data is visible in the log viewer's Metrics tab. See [log-viewer.md](log-viewer.md) for details.
 
+For long live Whisper recordings, the same threshold is applied independently to each bounded incremental window and the final tail. If VAD is unavailable or fails for any incremental window, Murmur discards the partial work and runs the established full-buffer fallback; it never accepts unfiltered incremental text as authoritative output.
+
 ## Settings
 
 - `vadSensitivity: number` — Sensitivity value (0-100, default 50). Persisted to localStorage. Sent to Rust via `configure_dictation`.

--- a/docs/research-streaming-transcription.md
+++ b/docs/research-streaming-transcription.md
@@ -1,7 +1,9 @@
 # Research: Streaming/Chunked Whisper Transcription
 
 **Date:** 2026-03-04
-**Status:** Research complete — not yet implemented
+**Status:** Implemented for live Whisper dictation in issue #129 (2026-07-18)
+
+> Implementation update: the preview-only hybrid recommendation below was superseded. PR #205 was closed because it duplicated the Whisper model/context and still re-ran the full recording after stop, so it did not reduce stop-to-final latency. The shipped design reuses the existing cached backend, processes one bounded 10-second window every 8 seconds, reconciles a 2-second overlap, and transcribes only the remaining tail after stop. Any reliability failure returns to the original full-buffer path. The rest of this document is retained as the original feasibility record.
 
 ## Context
 


### PR DESCRIPTION
## Summary
- process one bounded 10-second Whisper window every 8 seconds during live recording, reusing the existing cached model/backend with no second context or cloud path
- reconcile 2-second overlaps deterministically and transcribe only the final tail after stop; reject lagging, stale, VAD-failed, model-changed, or unreconciled sessions to the original full-buffer fallback
- keep the existing authoritative cleanup, voice-command, correction, file-output, clipboard, paste, history, and stats completion path unchanged

## Benchmark
Apple M4 Mac mini, 24 GB, `base.en`, 28.50-second `xlong` fixture, median of 5 warm runs:

| Path | Post-stop inference | Reference WER |
| --- | ---: | ---: |
| Full-buffer batch | 298.0 ms | 25.3% |
| Incremental final tail | 95.4 ms | 13.3% |

- 3.12x lower post-stop inference latency
- 3 bounded during-recording chunks; median ~433 ms total inference spread across recording
- incremental-vs-batch WER: 12.7%; incremental output completed the fixture while the batch result truncated after "for dictating"

Reproduce:
```bash
./bench/make_audio.sh
cd app/src-tauri
cargo run --release --example streaming_bench -- ../../bench/audio/xlong.wav base.en
```

## Validation
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` (284 unit tests + installed-model Whisper integration; optional Core ML integration ignored by design)
- [x] `npx tsc --noEmit`
- [x] `npm test -- --run` (87 tests)
- [x] debug native `.app` built and launched
- [x] production native `.app` built
- [ ] physical microphone normal/long/rapid-cancel/clipboard smoke: blocked on this Mac mini because macOS exposes no input devices (`system_profiler SPAudioDataType` lists only Mac mini Speakers); the real Record UI was exercised and CoreAudio correctly reported `Failed to get input config`

Both debug and production DMG scripts failed after their `.app` bundles were created; the app bundles themselves exist and launch.

## Architecture notes
- no preview text and no duplicate final full-audio pass on successful incremental sessions
- exactly one chunk inference in flight; if the worker falls a full step behind it abandons incremental output rather than queueing work
- recording/cancellation generations and per-session handles prevent stale chunks from being adopted across rapid sessions
- any missing deterministic overlap forces the authoritative batch fallback instead of risking duplicate or dropped clipboard text
- non-Whisper backends and recordings shorter than 10 seconds retain the original batch path

Closes #129
