### PR TITLE
feat: apply Sonic Canvas component reskin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Optional **Hotkey Timing Feedback** flashes the overlay amber when a bare-modifier tap times out before its second tap in Double-Tap or Both mode. The setting is off by default, and intentional holds, modifier shortcuts, processing skips, and valid double-taps remain silent (#154).
 
 ### Changed
+- The main window, settings, transcription history, recording controls, and log viewer now use the Sonic Canvas surface hierarchy and semantic palette in light and dark appearances (#141).
 - Release automation now builds signed macOS and Linux artifacts once on trusted `main`, keeps Cargo/CUDA cache ownership off tags and pull requests, and promotes only commit-SHA-matched artifacts with fail-closed updater-signature checks (#220).
 
 ### Fixed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -220,15 +220,15 @@ function App() {
 
       <div className="flex-1 flex overflow-hidden">
         <main className={`flex-1 flex-col overflow-hidden p-4 gap-4 ${isSettingsOpen ? 'hidden' : 'flex'}`}>
-          <div className="shrink-0 flex gap-1 p-1 self-start bg-stone-100 dark:bg-stone-800 rounded-lg">
+          <div className="shrink-0 flex gap-1 p-1 self-start bg-surface-container rounded-xl">
             {(['record', 'file'] as const).map((tab) => (
               <button
                 key={tab}
                 onClick={() => setMainTab(tab)}
                 className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
                   mainTab === tab
-                    ? 'bg-white text-stone-900 shadow-sm dark:bg-stone-700 dark:text-stone-100'
-                    : 'text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200'
+                    ? 'bg-surface-container-lowest text-on-surface shadow-sm'
+                    : 'text-on-surface-variant hover:text-on-surface'
                 }`}
               >
                 {tab === 'record' ? 'Record' : 'Transcribe File'}
@@ -249,7 +249,7 @@ function App() {
                 </div>
               )}
 
-              <RecordingControls status={status} initialized={initialized} onStart={handleStart} onStop={handleStop} />
+              <RecordingControls status={status} initialized={initialized} onStart={handleStart} onStop={handleStop} triggerKey={settings.doubleTapKey} />
 
               <Suspense fallback={null}><UsageDashboard statsVersion={combinedStatsVersion} /></Suspense>
 

--- a/app/src/components/AboutModal.tsx
+++ b/app/src/components/AboutModal.tsx
@@ -21,39 +21,39 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-stone-900/50 z-50"
+        className="fixed inset-0 z-50 bg-black/50"
         onClick={onClose}
       />
 
       {/* Modal */}
       <div className="fixed inset-0 flex items-center justify-center z-50 pointer-events-none">
-        <div className="bg-white dark:bg-stone-800 rounded-2xl shadow-xl p-6 w-72 text-center pointer-events-auto">
+        <div className="bg-surface-container-lowest rounded-2xl shadow-xl p-6 w-72 text-center pointer-events-auto">
           {/* Icon */}
-          <div className="w-16 h-16 mx-auto mb-4 bg-stone-800 rounded-2xl flex items-center justify-center">
-            <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+          <div className="w-16 h-16 mx-auto mb-4 bg-primary rounded-2xl flex items-center justify-center">
+            <svg className="w-10 h-10 text-on-primary" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z"/>
               <path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/>
             </svg>
           </div>
 
-          <h2 className="text-xl font-bold text-stone-900 dark:text-stone-100 mb-1">
+          <h2 className="text-xl font-bold text-on-surface mb-1">
             Murmur
           </h2>
-          <p className="text-sm text-stone-500 dark:text-stone-400 mb-4">
+          <p className="text-sm text-on-surface-variant mb-4">
             Version {version}
           </p>
 
-          <p className="text-sm text-stone-600 dark:text-stone-300 mb-4">
+          <p className="text-sm text-on-surface mb-4">
             Privacy-first voice-to-text powered by Whisper AI. All processing happens locally on your device.
           </p>
 
-          <p className="text-xs text-stone-400 dark:text-stone-500">
+          <p className="text-xs text-on-surface-variant">
             © 2026 Murmur
           </p>
 
           <button
             onClick={onClose}
-            className="mt-4 px-4 py-2 bg-stone-100 dark:bg-stone-700 text-stone-700 dark:text-stone-300 rounded-lg hover:bg-stone-200 dark:hover:bg-stone-600 transition-colors"
+            className="mt-4 rounded-lg bg-surface-container px-4 py-2 text-on-surface transition-colors hover:bg-surface-container-high focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           >
             Close
           </button>

--- a/app/src/components/ModelDownloader.tsx
+++ b/app/src/components/ModelDownloader.tsx
@@ -112,19 +112,19 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
               disabled={isDownloading}
               className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
                 selected === model.name
-                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400'
-                  : 'border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-800 hover:border-stone-300 dark:hover:border-stone-600'
+                  ? 'border-primary bg-surface-container-low'
+                  : 'border-outline-variant/20 bg-surface-container-lowest hover:border-primary/50'
               } ${isDownloading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
               <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-stone-800 dark:text-stone-100">
+                <span className="text-sm font-medium text-on-surface">
                   {model.label}
                 </span>
-                <span className="text-xs text-stone-400 dark:text-stone-500 font-mono">
+                <span className="text-xs text-on-surface-variant font-mono">
                   {model.size}
                 </span>
               </div>
-              <p className="text-xs text-stone-500 dark:text-stone-400 mt-0.5">
+              <p className="text-xs text-on-surface-variant mt-0.5">
                 {model.description}
               </p>
             </button>
@@ -133,7 +133,7 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
 
         {isDownloading && (
           <div className="mb-4">
-            <div className="flex justify-between text-xs text-stone-500 dark:text-stone-400 mb-1">
+            <div className="flex justify-between text-xs text-on-surface-variant mb-1">
               <span>{progress ? modelDownloadLabel(progress) : 'Starting...'}</span>
               {progressPercent !== null ? (
                 <span>{progressPercent}%</span>
@@ -141,14 +141,14 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
                 <span>Working...</span>
               )}
             </div>
-            <div className="w-full h-2 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
+            <div className="w-full h-2 bg-surface-container-highest rounded-full overflow-hidden">
               <div
                 role="progressbar"
                 aria-valuenow={progressPercent ?? undefined}
                 aria-valuemin={0}
                 aria-valuemax={100}
                 aria-valuetext={progressPercent === null ? 'Model installation in progress' : undefined}
-                className={`h-full bg-blue-500 rounded-full ${
+                className={`h-full bg-primary rounded-full ${
                   progressPercent === null
                     ? 'model-download-indeterminate'
                     : 'transition-all duration-200'
@@ -157,7 +157,7 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
               />
             </div>
             {progress && progress.total > 0 && progress.phase !== 'installing' && (
-              <p className="text-xs text-stone-400 dark:text-stone-500 mt-1 text-right">
+              <p className="text-xs text-on-surface-variant mt-1 text-right">
                 {(progress.received / 1024 / 1024).toFixed(1)} /{' '}
                 {(progress.total / 1024 / 1024).toFixed(1)} MB
               </p>
@@ -166,15 +166,15 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
         )}
 
         {downloadState.phase === 'error' && (
-          <div className="mb-4 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-            <p className="text-sm text-red-600 dark:text-red-400">{downloadState.message}</p>
+          <div className="mb-4 rounded-lg border border-error/30 bg-error/10 px-4 py-3">
+            <p className="text-sm text-error">{downloadState.message}</p>
           </div>
         )}
 
         <button
           onClick={handleDownload}
           disabled={isDownloading}
-          className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+          className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-on-primary transition-colors hover:bg-primary-dim disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isDownloading
             ? progress ? modelDownloadLabel(progress) : 'Starting...'
@@ -192,12 +192,12 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
  */
 export function ModelDownloader({ initialModel, onComplete }: Props) {
   return (
-    <div className="h-screen bg-stone-50 dark:bg-stone-900 flex flex-col items-center justify-center p-8">
+    <div className="h-screen bg-background flex flex-col items-center justify-center p-8">
       <div className="w-full max-w-md">
-        <h1 className="text-xl font-semibold text-stone-800 dark:text-stone-100 mb-1">
+        <h1 className="text-xl font-semibold text-on-surface mb-1">
           Download a Model
         </h1>
-        <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
+        <p className="text-sm text-on-surface-variant mb-6">
           A model file is required for transcription. Choose one to download.
         </p>
         <ModelDownloadPanel initialModel={initialModel} onComplete={onComplete} />

--- a/app/src/components/RecordingControls.tsx
+++ b/app/src/components/RecordingControls.tsx
@@ -1,20 +1,28 @@
 import { DictationStatus } from '../lib/types';
+import type { DoubleTapKey } from '../lib/settings';
 
 interface RecordingControlsProps {
   status: DictationStatus;
   initialized: boolean;
   onStart: () => void;
   onStop: () => void;
+  triggerKey: DoubleTapKey;
 }
 
-export function RecordingControls({ status, initialized, onStart, onStop }: RecordingControlsProps) {
+const HOTKEY_LABELS: Record<DoubleTapKey, string> = {
+  shift_l: '⇧ Shift',
+  alt_l: '⌥ Option',
+  ctrl_r: '⌃ Control',
+};
+
+export function RecordingControls({ status, initialized, onStart, onStop, triggerKey }: RecordingControlsProps) {
   return (
-    <div className="shrink-0 flex justify-center gap-3">
+    <div className="shrink-0 flex flex-col items-center gap-2">
       {status === 'recording' ? (
         <button
           onClick={onStop}
           disabled={!initialized}
-          className="flex items-center gap-2 px-6 py-3 bg-red-500 hover:bg-red-600 active:bg-red-700 text-white font-medium rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 rounded-xl bg-error px-7 py-3 text-on-primary shadow-lg shadow-error/20 transition-[filter,transform] hover:brightness-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <rect x="5" y="5" width="10" height="10" rx="1" />
@@ -25,13 +33,18 @@ export function RecordingControls({ status, initialized, onStart, onStop }: Reco
         <button
           onClick={onStart}
           disabled={!initialized || status === 'processing'}
-          className="flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-dim active:bg-primary-dim text-on-primary font-medium rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 rounded-xl bg-[linear-gradient(135deg,var(--murmur-primary),var(--murmur-primary-dim))] px-7 py-3 font-semibold text-on-primary shadow-lg shadow-primary/20 transition-[filter,transform] hover:brightness-105 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <circle cx="10" cy="10" r="6" />
           </svg>
           {status === 'processing' ? 'Processing...' : 'Start Recording'}
         </button>
+      )}
+      {status === 'idle' && (
+        <p className="text-xs text-on-surface-variant">
+          Press <kbd className="font-[inherit] font-semibold text-on-surface">{HOTKEY_LABELS[triggerKey]}</kbd> to begin
+        </p>
       )}
     </div>
   );

--- a/app/src/components/SonicCanvasComponents.test.tsx
+++ b/app/src/components/SonicCanvasComponents.test.tsx
@@ -1,0 +1,129 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecordingControls } from './RecordingControls';
+import { HistoryPanel } from './history/HistoryPanel';
+
+describe('Sonic Canvas component details', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['shift_l', '⇧ Shift'],
+    ['alt_l', '⌥ Option'],
+    ['ctrl_r', '⌃ Control'],
+  ] as const)('shows the configured %s hotkey hint', async (triggerKey, label) => {
+    await act(async () => {
+      root.render(
+        <RecordingControls
+          status="idle"
+          initialized
+          onStart={vi.fn()}
+          onStop={vi.fn()}
+          triggerKey={triggerKey}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain(`Press ${label} to begin`);
+  });
+
+  it('shows a word-count badge on each history card', async () => {
+    await act(async () => {
+      root.render(
+        <HistoryPanel
+          entries={[{
+            id: 'one',
+            text: 'Semantic surfaces stay calm',
+            timestamp: Date.UTC(2026, 6, 18, 12),
+            duration: 3.1949375,
+          }]}
+          onClearHistory={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('4 words');
+    expect(container.textContent).toContain('3s');
+    expect(container.textContent).not.toContain('3.1949375s');
+  });
+
+  it('preserves the idle and recording button actions', async () => {
+    const onStart = vi.fn();
+    const onStop = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <RecordingControls
+          status="idle"
+          initialized
+          onStart={onStart}
+          onStop={onStop}
+          triggerKey="shift_l"
+        />,
+      );
+    });
+    await act(async () => container.querySelector('button')?.click());
+    expect(onStart).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(
+        <RecordingControls
+          status="recording"
+          initialized
+          onStart={onStart}
+          onStop={onStop}
+          triggerKey="shift_l"
+        />,
+      );
+    });
+    await act(async () => container.querySelector('button')?.click());
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+
+  it('preserves history copy and confirmed clear actions', async () => {
+    const onClearHistory = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    localStorage.setItem('dictation-history', 'saved');
+
+    await act(async () => {
+      root.render(
+        <HistoryPanel
+          entries={[{
+            id: 'one',
+            text: 'Keep every interaction working',
+            timestamp: Date.UTC(2026, 6, 18, 12),
+            duration: 3,
+          }]}
+          onClearHistory={onClearHistory}
+        />,
+      );
+    });
+
+    const [copyButton, clearButton] = Array.from(container.querySelectorAll('button'));
+    await act(async () => copyButton.click());
+    expect(writeText).toHaveBeenCalledWith('Keep every interaction working');
+
+    await act(async () => clearButton.click());
+    expect(onClearHistory).toHaveBeenCalledOnce();
+    expect(localStorage.getItem('dictation-history')).toBeNull();
+  });
+});

--- a/app/src/components/StatsBar.tsx
+++ b/app/src/components/StatsBar.tsx
@@ -13,20 +13,42 @@ export function StatsBar({ statsVersion }: StatsBarProps) {
   const tokens = getApproxTokens(stats);
 
   return (
-    <div className="shrink-0 flex gap-2 px-4 py-2">
-      <Chip label="Total Words" value={stats.totalWords.toLocaleString()} />
-      <Chip label="Avg WPM" value={wpm > 0 ? wpm.toLocaleString() : '—'} />
-      <Chip label="Recordings" value={stats.totalRecordings.toLocaleString()} />
-      <Chip label="Approx Tokens" value={tokens > 0 ? tokens.toLocaleString() : '—'} />
+    <div className="grid shrink-0 grid-cols-4 gap-2 bg-background px-4 py-3">
+      <StatCard label="Total Words" value={stats.totalWords.toLocaleString()} icon="words" />
+      <StatCard label="Avg WPM" value={wpm > 0 ? wpm.toLocaleString() : '—'} icon="speed" />
+      <StatCard label="Recordings" value={stats.totalRecordings.toLocaleString()} icon="recordings" />
+      <StatCard label="Approx Tokens" value={tokens > 0 ? tokens.toLocaleString() : '—'} icon="tokens" />
     </div>
   );
 }
 
-function Chip({ label, value }: { label: string; value: string }) {
+type StatIcon = 'words' | 'speed' | 'recordings' | 'tokens';
+
+function StatIconGraphic({ icon }: { icon: StatIcon }) {
+  if (icon === 'speed') {
+    return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 15a8 8 0 1116 0M12 15l4-4M7 18h10" />;
+  }
+  if (icon === 'recordings') {
+    return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 15a3 3 0 003-3V6a3 3 0 10-6 0v6a3 3 0 003 3zm5-3a5 5 0 01-10 0m5 5v3m-3 0h6" />;
+  }
+  if (icon === 'tokens') {
+    return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M8 7h8M8 12h5M8 17h8M5 4h14a1 1 0 011 1v14a1 1 0 01-1 1H5a1 1 0 01-1-1V5a1 1 0 011-1z" />;
+  }
+  return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M5 6h14M5 10h14M5 14h9M5 18h11" />;
+}
+
+function StatCard({ label, value, icon }: { label: string; value: string; icon: StatIcon }) {
   return (
-    <div className="flex-1 flex flex-col items-center px-3 py-2 rounded-lg bg-surface-container-low">
-      <span className="text-xs font-semibold text-on-surface tabular-nums">{value}</span>
-      <span className="text-[10px] text-on-surface-variant mt-0.5 leading-none">{label}</span>
+    <div className="flex min-w-0 items-center gap-2.5 rounded-xl bg-surface-container-low p-2.5 shadow-sm">
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-container-lowest text-primary">
+        <svg aria-hidden="true" className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <StatIconGraphic icon={icon} />
+        </svg>
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-[10px] font-semibold uppercase tracking-wider text-on-surface-variant">{label}</span>
+        <span className="mt-0.5 block truncate text-lg font-bold leading-none tabular-nums text-on-surface">{value}</span>
+      </span>
     </div>
   );
 }

--- a/app/src/components/StatusHeader.tsx
+++ b/app/src/components/StatusHeader.tsx
@@ -8,11 +8,11 @@ interface StatusHeaderProps {
   isSettingsOpen: boolean;
 }
 
-function getStatusColor(status: DictationStatus, initialized: boolean): string {
-  if (status === 'recording') return 'text-red-500 dark:text-red-400';
-  if (status === 'processing') return 'text-amber-600 dark:text-amber-500';
-  if (initialized) return 'text-emerald-600 dark:text-emerald-500';
-  return 'text-stone-400 dark:text-stone-500';
+function getStatusDotColor(status: DictationStatus, initialized: boolean): string {
+  if (status === 'recording') return 'bg-error';
+  if (status === 'processing') return 'bg-amber-500';
+  if (initialized) return 'bg-emerald-500';
+  return 'bg-outline-variant';
 }
 
 function getStatusText(status: DictationStatus, initialized: boolean, duration: number): string {
@@ -23,38 +23,31 @@ function getStatusText(status: DictationStatus, initialized: boolean, duration: 
 }
 
 export function StatusHeader({ status, initialized, recordingDuration, onSettingsToggle, isSettingsOpen }: StatusHeaderProps) {
-  const statusColor = getStatusColor(status, initialized);
+  const statusDotColor = getStatusDotColor(status, initialized);
   const statusText = getStatusText(status, initialized, recordingDuration);
 
   return (
     <header
       data-tauri-drag-region
-      className="shrink-0 flex items-center justify-between px-4 py-3 bg-surface-container-low/90 backdrop-blur-sm"
+      className="flex shrink-0 items-center justify-between bg-background/90 px-4 py-3 backdrop-blur-sm"
     >
-      <span className="text-sm font-semibold text-on-surface">Murmur</span>
+      <span className="text-sm font-bold tracking-tight text-primary">Murmur</span>
 
       <div className="flex items-center gap-3">
-        <div className={`flex items-center gap-1.5 text-sm font-medium ${statusColor}`}>
-          {status === 'processing' ? (
-            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-          ) : (
-            <svg className={`w-4 h-4 ${status === 'recording' ? 'animate-pulse' : ''}`} fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z"/>
-              <path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/>
-            </svg>
-          )}
+        <div className="flex items-center gap-2 rounded-full bg-surface-container-low px-3 py-1.5 text-xs font-semibold text-on-surface">
+          <span
+            aria-hidden="true"
+            className={`h-2 w-2 rounded-full ${statusDotColor} ${status === 'recording' || status === 'processing' ? 'animate-pulse' : ''}`}
+          />
           <span>{statusText}</span>
         </div>
 
         <button
           onClick={onSettingsToggle}
-          className={`p-1.5 rounded-md transition-colors ${
+          className={`p-1.5 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
             isSettingsOpen
               ? 'text-on-surface bg-surface-container-high'
-              : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container'
+              : 'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface'
           }`}
           aria-label="Toggle settings"
           aria-expanded={isSettingsOpen}

--- a/app/src/components/TranscriptionView.tsx
+++ b/app/src/components/TranscriptionView.tsx
@@ -8,7 +8,7 @@ interface TranscriptionViewProps {
 
 export function TranscriptionView({ historyEntries, onClearHistory }: TranscriptionViewProps) {
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex flex-1 flex-col overflow-hidden rounded-2xl bg-surface-container-low p-3">
       <HistoryPanel
         entries={historyEntries}
         onClearHistory={onClearHistory}

--- a/app/src/components/UpdateModal.tsx
+++ b/app/src/components/UpdateModal.tsx
@@ -35,38 +35,39 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-stone-900/50 z-50"
+        className="fixed inset-0 z-50 bg-black/50"
         onClick={!isForced && !isBusy ? onDismiss : undefined}
       />
 
       {/* Modal */}
       <div className="fixed inset-0 flex items-center justify-center z-50 pointer-events-none">
-        <div className="bg-white dark:bg-stone-800 rounded-2xl shadow-xl p-6 w-96 pointer-events-auto relative">
+        <div className="bg-surface-container-lowest rounded-2xl shadow-xl p-6 w-96 pointer-events-auto relative">
           {/* Close button — shown on non-forced error and non-forced available states */}
           {((isError && !isForced) || (status.phase === 'available' && !isForced)) && (
             <button
               onClick={onDismiss}
-              className="absolute top-4 right-4 p-1 rounded-md hover:bg-stone-100 dark:hover:bg-stone-700 transition-colors"
+              aria-label="Close update dialog"
+              className="absolute right-4 top-4 rounded-md p-1 text-on-surface-variant transition-colors hover:bg-surface-container hover:text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             >
-              <svg className="w-4 h-4 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           )}
 
           {/* Icon */}
-          <div className="w-12 h-12 mx-auto mb-4 bg-blue-100 dark:bg-blue-900/30 rounded-xl flex items-center justify-center">
-            <svg className="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+            <svg className="h-6 w-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
           </div>
 
-          <h2 className="text-lg font-semibold text-stone-900 dark:text-stone-100 text-center mb-1">
+          <h2 className="text-lg font-semibold text-on-surface text-center mb-1">
             {isForced ? 'Required Update' : 'Update Available'}
           </h2>
 
           {version && (
-            <p className="text-sm text-stone-500 dark:text-stone-400 text-center mb-3">
+            <p className="text-sm text-on-surface-variant text-center mb-3">
               Version {version}
             </p>
           )}
@@ -79,7 +80,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
 
           {/* Release notes */}
           {status.phase === 'available' && status.notes && (
-            <div className="mb-4 max-h-32 overflow-y-auto px-3 py-2 bg-stone-50 dark:bg-stone-900 rounded-lg text-xs text-stone-600 dark:text-stone-400 [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:mb-1 [&_h1]:mt-2 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:mb-1 [&_h2]:mt-2 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:mb-1 [&_h3]:mt-1 [&_p]:my-1 [&_ul]:my-1 [&_ul]:pl-4 [&_ul]:list-disc [&_ol]:my-1 [&_ol]:pl-4 [&_ol]:list-decimal [&_li]:my-0 [&_a]:text-blue-600 [&_a]:underline dark:[&_a]:text-blue-400 [&_code]:bg-stone-200 dark:[&_code]:bg-stone-700 [&_code]:px-1 [&_code]:rounded">
+            <div className="mb-4 max-h-32 overflow-y-auto rounded-lg bg-background px-3 py-2 text-xs text-on-surface-variant [&_a]:text-primary [&_a]:underline [&_code]:rounded [&_code]:bg-surface-container-high [&_code]:px-1 [&_h1]:mb-1 [&_h1]:mt-2 [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:mb-1 [&_h2]:mt-2 [&_h2]:text-xs [&_h2]:font-semibold [&_h3]:mb-1 [&_h3]:mt-1 [&_h3]:text-xs [&_h3]:font-medium [&_li]:my-0 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-4">
               <Markdown rehypePlugins={[rehypeSanitize]}>{status.notes}</Markdown>
             </div>
           )}
@@ -87,13 +88,13 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
           {/* Download progress */}
           {isDownloading && (
             <div className="mb-4">
-              <div className="flex justify-between text-xs text-stone-500 dark:text-stone-400 mb-1">
+              <div className="flex justify-between text-xs text-on-surface-variant mb-1">
                 <span>Downloading...</span>
                 <span>{status.progress}%</span>
               </div>
-              <div className="w-full h-2 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-surface-container-highest">
                 <div
-                  className="h-full bg-blue-500 rounded-full transition-all duration-200"
+                  className="h-full bg-primary rounded-full transition-all duration-200"
                   style={{ width: `${status.progress}%` }}
                 />
               </div>
@@ -102,7 +103,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
 
           {/* Ready / installing state */}
           {isReady && (
-            <p className="text-sm text-stone-600 dark:text-stone-300 text-center mb-4">
+            <p className="text-sm text-on-surface text-center mb-4">
               Installing and relaunching...
             </p>
           )}
@@ -119,7 +120,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
             {(status.phase === 'available' || isError) && (
               <button
                 onClick={onDownload}
-                className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                className="w-full py-2 px-4 bg-primary hover:bg-primary-dim text-on-primary text-sm font-medium rounded-lg transition-colors"
               >
                 {isError ? 'Retry' : 'Update Now'}
               </button>
@@ -129,13 +130,13 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
               <>
                 <button
                   onClick={onSkip}
-                  className="w-full py-2 px-4 border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 text-sm font-medium rounded-lg hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"
+                  className="w-full rounded-lg border border-outline-variant/20 bg-surface-container-lowest px-4 py-2 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
                 >
                   Skip This Version
                 </button>
                 <button
                   onClick={onDismiss}
-                  className="w-full py-2 px-4 text-stone-500 dark:text-stone-400 text-sm hover:text-stone-700 dark:hover:text-stone-200 transition-colors"
+                  className="w-full px-4 py-2 text-sm text-on-surface-variant transition-colors hover:text-primary"
                 >
                   Later
                 </button>
@@ -145,7 +146,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
             {(status.phase === 'available' || isError) && isForced && (
               <button
                 onClick={() => exit(0)}
-                className="w-full py-2 px-4 border border-red-300 dark:border-red-700 bg-white dark:bg-stone-700 text-red-600 dark:text-red-400 text-sm font-medium rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                className="w-full rounded-lg border border-error/30 bg-surface-container-lowest px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/10"
               >
                 Quit
               </button>

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -27,17 +27,18 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
   };
 
   const formatDuration = (seconds: number): string => {
-    if (seconds < 60) {
-      return `${seconds}s`;
+    const wholeSeconds = Math.round(seconds);
+    if (wholeSeconds < 60) {
+      return `${wholeSeconds}s`;
     }
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
+    const mins = Math.floor(wholeSeconds / 60);
+    const secs = wholeSeconds % 60;
     return `${mins}m ${secs}s`;
   };
 
   if (entries.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center text-stone-400 dark:text-stone-500">
+      <div className="flex-1 flex flex-col items-center justify-center text-on-surface-variant">
         <svg
           className="w-12 h-12 mb-3"
           fill="none"
@@ -63,27 +64,30 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Scrollable list */}
-      <div className="flex-1 overflow-y-auto space-y-2">
-        {sortedEntries.map((entry) => (
-          <button
-            key={entry.id}
-            onClick={() => handleCopy(entry)}
-            className={`w-full text-left p-3 rounded-lg border transition-all ${
-              copiedId === entry.id
-                ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-300 dark:border-emerald-700'
-                : 'bg-stone-50 dark:bg-stone-700/50 border-stone-200 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-700'
-            }`}
-          >
+      <div className="flex-1 overflow-y-auto space-y-3 px-0.5 py-0.5">
+        {sortedEntries.map((entry) => {
+          const wordCount = entry.text.trim() ? entry.text.trim().split(/\s+/).length : 0;
+          return (
+            <button
+              key={entry.id}
+              onClick={() => handleCopy(entry)}
+              aria-label={`Copy transcription from ${formatTimestamp(entry.timestamp)}`}
+              className={`group w-full rounded-xl p-3.5 text-left shadow-sm transition-[box-shadow,background-color] hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                copiedId === entry.id
+                  ? 'bg-emerald-50 dark:bg-emerald-950/40'
+                  : 'bg-surface-container-lowest hover:bg-surface-container-low'
+              }`}
+            >
             {/* Header row with timestamp and duration */}
             <div className="flex items-center justify-between mb-1 gap-2">
               <div className="flex items-center gap-2 min-w-0">
-                <span className="text-xs text-stone-500 dark:text-stone-400 shrink-0">
+                <span className="shrink-0 text-xs text-on-surface-variant">
                   {formatTimestamp(entry.timestamp)}
                 </span>
                 {(entry.source ?? 'recording') === 'file' ? (
                   <span
                     title={entry.sourceName}
-                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 min-w-0 max-w-[180px]"
+                    className="inline-flex max-w-[180px] min-w-0 items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary"
                   >
                     <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
@@ -91,7 +95,7 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
                     <span className="truncate">{entry.sourceName || 'File'}</span>
                   </span>
                 ) : (
-                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-stone-200 text-stone-600 dark:bg-stone-600 dark:text-stone-300 shrink-0">
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-surface-container px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
                     <svg className="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-14 0m7 7v3m-4 0h8m-4-6a3 3 0 01-3-3V5a3 3 0 016 0v4a3 3 0 01-3 3z" />
                     </svg>
@@ -100,7 +104,10 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
                 )}
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                <span className="text-xs text-stone-400 dark:text-stone-500">
+                <span className="rounded-full bg-surface-container px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
+                  {wordCount} {wordCount === 1 ? 'word' : 'words'}
+                </span>
+                <span className="text-xs text-on-surface-variant">
                   {formatDuration(entry.duration)}
                 </span>
                 {copiedId === entry.id ? (
@@ -109,7 +116,7 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
                   </span>
                 ) : (
                   <svg
-                    className="w-3.5 h-3.5 text-stone-400 dark:text-stone-500"
+                    className="h-3.5 w-3.5 text-on-surface-variant opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -125,18 +132,19 @@ export function HistoryPanel({ entries, onClearHistory }: HistoryPanelProps) {
               </div>
             </div>
             {/* Text content */}
-            <p className="text-sm text-stone-900 dark:text-stone-100 overflow-y-auto max-h-32">
+            <p className="max-h-32 overflow-y-auto text-sm leading-relaxed text-on-surface">
               {entry.text}
             </p>
-          </button>
-        ))}
+            </button>
+          );
+        })}
       </div>
 
       {/* Clear history button */}
-      <div className="shrink-0 pt-3 border-t border-stone-200 dark:border-stone-700 mt-3">
+      <div className="mt-3 shrink-0 pt-1">
         <button
           onClick={handleClear}
-          className="w-full px-3 py-2 text-sm text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg transition-colors"
+          className="w-full rounded-lg bg-surface-container-lowest px-3 py-2 text-sm font-medium text-on-surface-variant shadow-sm transition-colors hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
           Clear History
         </button>

--- a/app/src/components/log-viewer/EventRow.tsx
+++ b/app/src/components/log-viewer/EventRow.tsx
@@ -17,9 +17,9 @@ export function EventRow({ event }: EventRowProps) {
   const timeStr = event.timestamp.replace(/.*T/, '').replace('Z', '');
 
   return (
-    <div>
+    <div className={event.level === 'error' ? 'bg-error/10' : ''}>
       <div
-        className={`flex items-baseline gap-2 py-1 px-1 ${hasData ? 'cursor-pointer hover:bg-surface-container-low' : ''}`}
+        className={`grid grid-cols-[88px_52px_88px_minmax(0,1fr)] items-baseline gap-2 px-3 py-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${hasData ? 'cursor-pointer hover:bg-surface-container-low' : ''}`}
         onClick={() => hasData && setExpanded(!expanded)}
         {...(hasData && {
           role: 'button',
@@ -36,23 +36,23 @@ export function EventRow({ event }: EventRowProps) {
         <span className="text-on-surface-variant shrink-0 tabular-nums text-[11px]">
           {timeStr}
         </span>
-        <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold shrink-0 ${streamColors.bg} ${streamColors.text}`}>
-          {event.stream}
-        </span>
-        <span className={`text-[10px] font-medium shrink-0 uppercase ${levelColor}`}>
+        <span className={`text-[10px] font-semibold uppercase ${levelColor}`}>
           {event.level}
         </span>
-        <span className="text-on-surface text-xs break-all flex-1">
-          {event.summary}
+        <span className={`inline-flex w-fit items-center rounded px-1.5 py-0.5 text-[10px] font-semibold ${streamColors.bg} ${streamColors.text}`}>
+          {event.stream}
         </span>
-        {hasData && (
-          <span className={`text-on-surface-variant text-xs shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}>
-            &#9656;
-          </span>
-        )}
+        <span className="flex min-w-0 items-start gap-1 text-xs text-on-surface">
+          <span className="min-w-0 flex-1 break-all">{event.summary}</span>
+          {hasData && (
+            <span className={`shrink-0 text-on-surface-variant transition-transform ${expanded ? 'rotate-90' : ''}`}>
+              &#9656;
+            </span>
+          )}
+        </span>
       </div>
       {expanded && hasData && (
-        <pre className="mx-1 mb-1 px-3 py-2 bg-surface-container-low rounded text-[11px] text-on-surface-variant overflow-x-auto">
+        <pre className="mx-3 mb-2 overflow-x-auto rounded-lg bg-surface-container-low px-3 py-2 text-[11px] text-on-surface-variant">
           {JSON.stringify(event.data, null, 2)}
         </pre>
       )}

--- a/app/src/components/log-viewer/LogViewerApp.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.tsx
@@ -70,16 +70,17 @@ export function LogViewerApp() {
       <div className="shrink-0 bg-surface-container-low px-4 py-3">
         <div className="flex items-center justify-between mb-3">
           {/* Tabs */}
-          <div className="flex gap-1">
+          <div className="flex gap-1 rounded-xl bg-surface-container p-1">
             {(['events', 'metrics'] as Tab[]).map((t) => (
               <button
                 key={t}
                 onClick={() => setTab(t)}
-                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-[background-color,box-shadow,color] ${
                   tab === t
-                    ? 'bg-primary text-on-primary'
-                    : 'text-on-surface-variant hover:bg-surface-container hover:text-on-surface'
+                    ? 'bg-surface-container-lowest text-on-surface shadow-sm'
+                    : 'text-on-surface-variant hover:text-on-surface'
                 }`}
+                aria-pressed={tab === t}
               >
                 {t.charAt(0).toUpperCase() + t.slice(1)}
               </button>
@@ -89,13 +90,13 @@ export function LogViewerApp() {
           <div className="flex gap-2">
             <button
               onClick={handleCopyAll}
-              className="px-3 py-1 rounded-md text-xs font-medium border border-outline-variant/10 bg-surface-container-lowest text-on-surface hover:bg-surface-container transition-colors"
+              className="rounded-lg border border-outline-variant/10 bg-surface-container-lowest px-3 py-1.5 text-xs font-medium text-on-surface-variant shadow-sm transition-colors hover:bg-surface-container hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             >
               Copy All
             </button>
             <button
               onClick={clear}
-              className="px-3 py-1 rounded-md text-xs font-medium border border-outline-variant/10 bg-surface-container-lowest text-on-surface hover:bg-surface-container transition-colors"
+              className="rounded-lg border border-outline-variant/10 bg-surface-container-lowest px-3 py-1.5 text-xs font-medium text-on-surface-variant shadow-sm transition-colors hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             >
               Clear
             </button>

--- a/app/src/components/log-viewer/MetricsView.tsx
+++ b/app/src/components/log-viewer/MetricsView.tsx
@@ -56,18 +56,18 @@ function StatCard({ label, value, average, color, unit = 'ms' }: StatCardProps) 
   const trend = diff > average * 0.1 ? 'up' : diff < -average * 0.1 ? 'down' : 'flat';
 
   return (
-    <div className="flex-1 rounded-lg border border-stone-200 dark:border-stone-700 p-3 min-w-0">
+    <div className="min-w-0 flex-1 rounded-xl bg-surface-container-lowest p-3 shadow-sm">
       <div className="flex items-center gap-2 mb-1">
         <span className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />
-        <span className="text-[11px] text-stone-500 dark:text-stone-400 truncate">{label}</span>
+        <span className="truncate text-[11px] text-on-surface-variant">{label}</span>
       </div>
       <div className="flex items-baseline gap-1.5">
-        <span className="text-lg font-semibold tabular-nums text-stone-900 dark:text-stone-100">
+        <span className="text-lg font-semibold tabular-nums text-on-surface">
           {value}
         </span>
-        <span className="text-[11px] text-stone-400 dark:text-stone-500">{unit}</span>
+        <span className="text-[11px] text-on-surface-variant">{unit}</span>
         <span className={`text-[10px] ml-auto ${
-          trend === 'up' ? 'text-red-500' : trend === 'down' ? 'text-emerald-500' : 'text-stone-400 dark:text-stone-500'
+          trend === 'up' ? 'text-error' : trend === 'down' ? 'text-emerald-500' : 'text-on-surface-variant'
         }`}>
           {trend === 'up' ? '\u25B2' : trend === 'down' ? '\u25BC' : '\u2014'} avg {average}{unit}
         </span>
@@ -79,19 +79,19 @@ function StatCard({ label, value, average, color, unit = 'ms' }: StatCardProps) 
 // --- Line Chart ---
 
 const SERIES_CONFIG: Record<string, { color: string; label: string }> = {
-  total:     { color: '#57534e', label: 'Total' },      // stone-600
-  inference: { color: '#f59e0b', label: 'Inference' },   // amber-500
-  vad:       { color: '#a8a29e', label: 'VAD' },         // stone-400
-  paste:     { color: '#64748b', label: 'Paste' },       // slate-500
+  total:     { color: 'var(--murmur-primary)', label: 'Total' },
+  inference: { color: '#d97706', label: 'Inference' },
+  vad:       { color: 'var(--murmur-outline-variant)', label: 'VAD' },
+  paste:     { color: '#64748b', label: 'Paste' },
 };
 
 type SeriesKey = 'total' | 'inference' | 'vad' | 'paste';
 const ALL_SERIES: SeriesKey[] = ['total', 'inference', 'vad', 'paste'];
 
-const MEMORY_COLOR = '#ef4444';    // red-500
-const HEAP_COLOR = '#f59e0b';      // amber-500
-const EXTERNAL_COLOR = '#8b5cf6';  // violet-500
-const CPU_COLOR = '#3b82f6';       // blue-500
+const MEMORY_COLOR = 'var(--murmur-error)';
+const HEAP_COLOR = '#d97706';
+const EXTERNAL_COLOR = '#7c3aed';
+const CPU_COLOR = 'var(--murmur-primary)';
 
 interface Series {
   key: string;
@@ -139,7 +139,7 @@ function LineChart({ series, height = 140 }: { series: Series[]; height?: number
             x2={chartW - padding.right} y2={toY(tick)}
             stroke="currentColor" strokeOpacity={0.08}
           />
-          <text x={padding.left - 8} y={toY(tick) + 3.5} textAnchor="end" className="fill-stone-400 dark:fill-stone-500" fontSize="9">
+          <text x={padding.left - 8} y={toY(tick) + 3.5} textAnchor="end" className="fill-on-surface-variant" fontSize="9">
             {tick}
           </text>
         </g>
@@ -147,7 +147,7 @@ function LineChart({ series, height = 140 }: { series: Series[]; height?: number
 
       {/* X-axis labels (transcription index) */}
       {Array.from({ length: count }, (_, i) => (
-        <text key={i} x={toX(i)} y={chartH - 4} textAnchor="middle" className="fill-stone-300 dark:fill-stone-600" fontSize="8">
+        <text key={i} x={toX(i)} y={chartH - 4} textAnchor="middle" className="fill-on-surface-variant opacity-70" fontSize="8">
           {i + 1}
         </text>
       ))}
@@ -221,7 +221,7 @@ function LiveChart({ series, height = 160, label }: { series: Series[]; height?:
   return (
     <svg viewBox={`0 0 ${chartW} ${chartH}`} className="w-full" preserveAspectRatio="xMidYMid meet">
       {label && (
-        <text x={padding.left} y={14} className="fill-stone-500 dark:fill-stone-400" fontSize="10" fontWeight="500">
+        <text x={padding.left} y={14} className="fill-on-surface-variant" fontSize="10" fontWeight="500">
           {label}
         </text>
       )}
@@ -242,7 +242,7 @@ function LiveChart({ series, height = 160, label }: { series: Series[]; height?:
             x2={chartW - padding.right} y2={toY(tick)}
             stroke="currentColor" strokeOpacity={0.06}
           />
-          <text x={padding.left - 8} y={toY(tick) + 3.5} textAnchor="end" className="fill-stone-400 dark:fill-stone-500" fontSize="9">
+          <text x={padding.left - 8} y={toY(tick) + 3.5} textAnchor="end" className="fill-on-surface-variant" fontSize="9">
             {tick}
           </text>
         </g>
@@ -255,7 +255,7 @@ function LiveChart({ series, height = 160, label }: { series: Series[]; height?:
           x={padding.left + slot * xStep}
           y={chartH - 4}
           textAnchor="middle"
-          className="fill-stone-400 dark:fill-stone-500"
+          className="fill-on-surface-variant"
           fontSize="9"
         >
           {label}
@@ -304,7 +304,7 @@ function LiveChart({ series, height = 160, label }: { series: Series[]; height?:
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-[11px] font-medium text-stone-400 dark:text-stone-500 uppercase tracking-wider">
+    <div className="text-[11px] font-medium uppercase tracking-wider text-on-surface-variant">
       {children}
     </div>
   );
@@ -314,16 +314,16 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function SimpleStatCard({ label, value, color, unit = 'MB' }: { label: string; value: number; color: string; unit?: string }) {
   return (
-    <div className="flex-1 rounded-lg border border-stone-200 dark:border-stone-700 p-3 min-w-0">
+    <div className="min-w-0 flex-1 rounded-xl bg-surface-container-lowest p-3 shadow-sm">
       <div className="flex items-center gap-2 mb-1">
         <span className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />
-        <span className="text-[11px] text-stone-500 dark:text-stone-400 truncate">{label}</span>
+        <span className="truncate text-[11px] text-on-surface-variant">{label}</span>
       </div>
       <div className="flex items-baseline gap-1.5">
-        <span className="text-lg font-semibold tabular-nums text-stone-900 dark:text-stone-100">
+        <span className="text-lg font-semibold tabular-nums text-on-surface">
           {value}
         </span>
-        <span className="text-[11px] text-stone-400 dark:text-stone-500">{unit}</span>
+        <span className="text-[11px] text-on-surface-variant">{unit}</span>
       </div>
     </div>
   );
@@ -346,7 +346,7 @@ export function MetricsView({ events, resourceReadings }: MetricsViewProps) {
 
   if (metrics.length === 0 && resourceReadings.length === 0) {
     return (
-      <div className="flex items-center justify-center h-48 text-stone-400 dark:text-stone-500 text-sm">
+      <div className="flex h-48 items-center justify-center text-sm text-on-surface-variant">
         No data yet. System metrics will appear shortly.
       </div>
     );
@@ -391,8 +391,8 @@ export function MetricsView({ events, resourceReadings }: MetricsViewProps) {
                   onClick={() => toggle(key)}
                   className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
                     active
-                      ? 'ring-1 ring-stone-300 dark:ring-stone-600 text-stone-700 dark:text-stone-300'
-                      : 'text-stone-400 dark:text-stone-600'
+                      ? 'bg-surface-container-lowest text-on-surface ring-1 ring-outline-variant/20 shadow-sm'
+                      : 'text-on-surface-variant opacity-60'
                   }`}
                 >
                   <span

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -29,10 +29,10 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
   return (
     <div className="mt-3">
       <div className="flex items-center justify-between mb-1">
-        <label className="text-xs text-stone-600 dark:text-stone-400">
+        <label className="text-xs text-on-surface-variant">
           Paste Delay
         </label>
-        <span className="text-xs font-medium text-stone-700 dark:text-stone-300">
+        <span className="text-xs font-medium text-on-surface">
           {draft}ms
         </span>
       </div>
@@ -44,9 +44,9 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
         value={draft}
         onChange={(e) => setDraft(Number(e.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
+        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-primary"
       />
-      <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+      <p className="mt-1 text-xs text-on-surface-variant">
         Delay before paste. Increase if paste lands in the wrong window.
       </p>
     </div>
@@ -69,7 +69,7 @@ function CustomVocabularyTextarea({ value, onCommit }: { value: string; onCommit
 
   return (
     <div>
-      <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+      <label className="block text-sm font-medium text-on-surface mb-2">
         Custom Vocabulary
       </label>
       <textarea
@@ -82,17 +82,17 @@ function CustomVocabularyTextarea({ value, onCommit }: { value: string; onCommit
         autoCorrect="off"
         autoCapitalize="off"
         spellCheck={false}
-        className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500 resize-y"
+        className="w-full resize-y rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
       />
       <div className="mt-1.5 flex items-start justify-between gap-2">
-        <p className="text-xs text-stone-500 dark:text-stone-400">
+        <p className="text-xs text-on-surface-variant">
           Comma-separated. Whisper models only.
         </p>
         {draft.trim().length > 0 && (() => {
           const displayCount = tokenCount ?? Math.ceil(draft.trim().length / 4);
           const isEstimate = tokenCount === null;
           return (
-            <span className={`text-xs tabular-nums whitespace-nowrap ${displayCount > 200 ? 'text-amber-600 dark:text-amber-400' : 'text-stone-400 dark:text-stone-500'}`}>
+            <span className={`whitespace-nowrap text-xs tabular-nums ${displayCount > 200 ? 'text-amber-600 dark:text-amber-400' : 'text-on-surface-variant'}`}>
               {isEstimate ? `~${displayCount}` : displayCount} tokens
             </span>
           );
@@ -109,10 +109,10 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <label className="text-xs text-stone-600 dark:text-stone-400">
+        <label className="text-xs text-on-surface-variant">
           Sensitivity
         </label>
-        <span className="text-xs font-medium text-stone-700 dark:text-stone-300">
+        <span className="text-xs font-medium text-on-surface">
           {draft}%
         </span>
       </div>
@@ -124,9 +124,9 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
         value={draft}
         onChange={(e) => setDraft(Number(e.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-stone-800 dark:accent-stone-300"
+        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-primary"
       />
-      <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+      <p className="mt-1 text-xs text-on-surface-variant">
         Higher = keeps more audio. Lower = trims silence more aggressively.
       </p>
     </div>
@@ -183,14 +183,14 @@ function AppProfilesEditor({ profiles, onChange }: {
 
   const chipClass = (value: boolean | null) =>
     value === null
-      ? 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-600 dark:text-stone-300'
+      ? 'border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant'
       : value
         ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
         : 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400';
 
   return (
     <div>
-      <p className="mb-2 text-xs text-stone-500 dark:text-stone-400">
+      <p className="mb-2 text-xs text-on-surface-variant">
         Override auto-paste and transcript cleanup for specific apps by bundle id
         (e.g. <span className="font-mono">com.apple.Terminal</span>). The frontmost
         app when you finish dictating decides the behavior. Each toggle cycles
@@ -202,16 +202,16 @@ function AppProfilesEditor({ profiles, onChange }: {
           {profiles.map((p) => (
             <li
               key={p.bundleId}
-              className="flex flex-col gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
+              className="flex flex-col gap-2 rounded-lg bg-surface-container-lowest px-2.5 py-2 shadow-sm"
             >
               <div className="flex items-center gap-2">
                 <div className="min-w-0 flex-1">
                   {p.label && (
-                    <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
+                    <div className="text-xs font-medium text-on-surface truncate">
                       {p.label}
                     </div>
                   )}
-                  <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
+                  <div className="text-xs font-mono text-on-surface-variant truncate">
                     {p.bundleId}
                   </div>
                 </div>
@@ -219,7 +219,7 @@ function AppProfilesEditor({ profiles, onChange }: {
                   type="button"
                   onClick={() => handleRemove(p.bundleId)}
                   aria-label={`Remove profile for ${p.label || p.bundleId}`}
-                  className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
+                  className="shrink-0 rounded-md p-1 text-on-surface-variant transition-colors hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 >
                   <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -259,7 +259,7 @@ function AppProfilesEditor({ profiles, onChange }: {
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck={false}
-          className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+          className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
         />
         <div className="flex gap-2">
           <input
@@ -272,13 +272,13 @@ function AppProfilesEditor({ profiles, onChange }: {
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
-            className="flex-1 min-w-0 px-3 py-2 text-xs font-mono rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+            className="min-w-0 flex-1 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 font-mono text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
           />
           <button
             type="button"
             onClick={handleAdd}
             disabled={!bundleId.trim()}
-            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Add
           </button>
@@ -316,7 +316,7 @@ function VoiceCommandsEditor({ commands, onChange }: {
 
   return (
     <div className="mt-3">
-      <p className="mb-2 text-xs text-stone-500 dark:text-stone-400">
+      <p className="mb-2 text-xs text-on-surface-variant">
         Add your own spoken phrases. When you say the phrase it's replaced by the
         text (case-insensitive). Runs after the built-in commands.
       </p>
@@ -326,13 +326,13 @@ function VoiceCommandsEditor({ commands, onChange }: {
           {commands.map((c) => (
             <li
               key={c.phrase}
-              className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-stone-200 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/40"
+              className="flex items-center gap-2 rounded-lg bg-surface-container-lowest px-2.5 py-2 shadow-sm"
             >
               <div className="min-w-0 flex-1">
-                <div className="text-xs font-medium text-stone-700 dark:text-stone-300 truncate">
+                <div className="text-xs font-medium text-on-surface truncate">
                   “{c.phrase}”
                 </div>
-                <div className="text-xs font-mono text-stone-500 dark:text-stone-400 truncate">
+                <div className="text-xs font-mono text-on-surface-variant truncate">
                   → {c.replacement || '(empty)'}
                 </div>
               </div>
@@ -340,7 +340,7 @@ function VoiceCommandsEditor({ commands, onChange }: {
                 type="button"
                 onClick={() => handleRemove(c.phrase)}
                 aria-label={`Remove voice command ${c.phrase}`}
-                className="shrink-0 p-1 rounded-md text-stone-400 hover:text-red-600 hover:bg-stone-100 dark:hover:bg-stone-600 transition-colors"
+                className="shrink-0 rounded-md p-1 text-on-surface-variant transition-colors hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -361,7 +361,7 @@ function VoiceCommandsEditor({ commands, onChange }: {
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck={false}
-          className="w-full px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+          className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
         />
         <div className="flex gap-2">
           <input
@@ -374,13 +374,13 @@ function VoiceCommandsEditor({ commands, onChange }: {
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
-            className="flex-1 min-w-0 px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-stone-500"
+            className="min-w-0 flex-1 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
           />
           <button
             type="button"
             onClick={handleAdd}
             disabled={!phrase.trim()}
-            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Add
           </button>
@@ -618,7 +618,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               onClick={() => setActiveCat(c.id)}
               className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
                 activeCat === c.id
-                  ? 'bg-surface-container-high text-on-surface font-medium'
+                  ? 'bg-surface-container-high text-primary font-medium'
                   : 'text-on-surface-variant hover:bg-surface-container'
               }`}
             >
@@ -635,10 +635,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {supportsCoreMl && (
           <div className="flex items-center justify-between gap-6">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Apple Neural Engine
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 {useNeuralEngine
                   ? 'Parakeet v3 via Core ML (fastest)'
                   : 'Enable to switch to the Core ML transcription path'}
@@ -655,12 +655,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                   ? 'parakeet-tdt-0.6b-v2-fp16'
                   : 'parakeet-tdt-0.6b-v3-coreml',
               })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
-                useNeuralEngine ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                useNeuralEngine ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   useNeuralEngine ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -670,7 +670,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Model Selector */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Transcription Model
           </label>
           <Select
@@ -679,7 +679,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             disabled={isRecording}
             items={AVAILABLE_MODEL_OPTIONS.map((m) => ({ value: m.value, label: `${m.label} (${m.size})` }))}
           />
-          <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+          <p className="mt-1 text-xs text-on-surface-variant">
             Larger models are more accurate but slower.
           </p>
           {isRecording && (
@@ -705,7 +705,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           {/* Download in progress */}
           {modelDownload.phase === 'downloading' && (
             <div className="mt-2">
-              <div className="flex justify-between text-xs text-stone-500 dark:text-stone-400 mb-1">
+              <div className="flex justify-between text-xs text-on-surface-variant mb-1">
                 <span>{activeModelDownload ? modelDownloadLabel(activeModelDownload) : 'Starting...'}</span>
                 {downloadProgressPercent !== null ? (
                   <span>{downloadProgressPercent}%</span>
@@ -722,7 +722,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                   aria-valuetext={downloadProgressPercent === null
                     ? 'Model installation in progress'
                     : `Download progress: ${downloadProgressPercent} percent`}
-                  className={`h-full bg-blue-500 rounded-full ${
+                  className={`h-full rounded-full bg-primary ${
                     downloadProgressPercent === null
                       ? 'model-download-indeterminate'
                       : 'transition-all duration-200'
@@ -751,7 +751,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Language Selector */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Language
           </label>
           <Select
@@ -761,7 +761,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             items={LANGUAGE_OPTIONS}
           />
           {isEnglishOnlyModel ? (
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               English only model — switch to Whisper Large Turbo for other languages.
             </p>
           ) : isRecording ? (
@@ -769,7 +769,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               Stop recording before changing language
             </p>
           ) : (
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               Auto Detect lets Whisper identify the language each recording.
             </p>
           )}
@@ -778,10 +778,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {/* Smart Punctuation Toggle */}
         <div className="flex items-center justify-between">
           <div>
-            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+            <label className="block text-sm font-medium text-on-surface">
               Smart Punctuation
             </label>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               Add periods, commas, and capitalization to transcriptions.
             </p>
           </div>
@@ -791,12 +791,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             aria-checked={settings.smartPunctuation}
             aria-label="Smart punctuation"
             onClick={() => onUpdateSettings({ smartPunctuation: !settings.smartPunctuation })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-              settings.smartPunctuation ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+              settings.smartPunctuation ? 'bg-primary' : 'bg-surface-container-highest'
             }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                 settings.smartPunctuation ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
@@ -805,7 +805,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Microphone Selector */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Microphone
           </label>
           <Select
@@ -827,7 +827,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Idle Timeout */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Release Model After Inactivity
           </label>
           <Select
@@ -836,7 +836,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             disabled={isRecording}
             items={IDLE_TIMEOUT_OPTIONS.map((o) => ({ value: String(o.value), label: o.label }))}
           />
-          <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+          <p className="mt-1 text-xs text-on-surface-variant">
             Free memory by unloading the model when idle. Set to Never to keep it loaded.
           </p>
         </div>
@@ -844,10 +844,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {/* Transcript Cleanup Toggle */}
         <div className="flex items-center justify-between">
           <div>
-            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+            <label className="block text-sm font-medium text-on-surface">
               Transcript Cleanup
             </label>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               Strip filler words (um, uh) and tidy spacing before pasting.
             </p>
           </div>
@@ -857,12 +857,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             aria-checked={settings.cleanupEnabled}
             aria-label="Transcript cleanup"
             onClick={() => onUpdateSettings({ cleanupEnabled: !settings.cleanupEnabled })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-              settings.cleanupEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+              settings.cleanupEnabled ? 'bg-primary' : 'bg-surface-container-highest'
             }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                 settings.cleanupEnabled ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
@@ -873,7 +873,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {settings.cleanupEnabled && (
           <div className="ml-3 pl-3 space-y-3">
             <div className="flex items-center justify-between">
-              <label className="text-xs text-stone-600 dark:text-stone-400">
+              <label className="text-xs text-on-surface-variant">
                 Remove filler words (um, uh)
               </label>
               <button
@@ -882,19 +882,19 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 aria-checked={settings.cleanupRemoveFiller}
                 aria-label="Remove filler words"
                 onClick={() => onUpdateSettings({ cleanupRemoveFiller: !settings.cleanupRemoveFiller })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                  settings.cleanupRemoveFiller ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                  settings.cleanupRemoveFiller ? 'bg-primary' : 'bg-surface-container-highest'
                 }`}
               >
                 <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
                     settings.cleanupRemoveFiller ? 'translate-x-4' : 'translate-x-1'
                   }`}
                 />
               </button>
             </div>
             <div className="flex items-center justify-between">
-              <label className="text-xs text-stone-600 dark:text-stone-400">
+              <label className="text-xs text-on-surface-variant">
                 Capitalize sentences
               </label>
               <button
@@ -903,12 +903,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 aria-checked={settings.cleanupCapitalize}
                 aria-label="Capitalize sentences"
                 onClick={() => onUpdateSettings({ cleanupCapitalize: !settings.cleanupCapitalize })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                  settings.cleanupCapitalize ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                  settings.cleanupCapitalize ? 'bg-primary' : 'bg-surface-container-highest'
                 }`}
               >
                 <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
                     settings.cleanupCapitalize ? 'translate-x-4' : 'translate-x-1'
                   }`}
                 />
@@ -921,7 +921,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <SettingsSection pageId="recording" activePage={activeCat} title="Recording" subtitle="Trigger mode, shortcut key">
         {/* Voice Detection */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Voice Detection
           </label>
           <VadSensitivitySlider
@@ -932,7 +932,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Recording Trigger */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             Recording Trigger
           </label>
           <div className="flex gap-2">
@@ -943,8 +943,8 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 onClick={() => onUpdateSettings({ recordingMode: option.value as RecordingMode })}
                 className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
                   settings.recordingMode === option.value
-                    ? 'bg-stone-800 dark:bg-stone-200 text-white dark:text-stone-900 border-stone-800 dark:border-stone-200'
-                    : 'bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 border-stone-300 dark:border-stone-600 hover:bg-stone-50 dark:hover:bg-stone-600'
+                    ? 'bg-primary text-on-primary border-primary'
+                    : 'bg-surface-container-lowest text-on-surface border-outline-variant/20 hover:bg-surface-container'
                 } ${isRecording ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 {option.label}
@@ -974,7 +974,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
         {/* Trigger Key Selector */}
         <div>
-          <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          <label className="block text-sm font-medium text-on-surface mb-2">
             {keyLabel}
           </label>
           <Select
@@ -983,7 +983,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             disabled={isRecording}
             items={DOUBLE_TAP_KEY_OPTIONS}
           />
-          <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+          <p className="mt-1 text-xs text-on-surface-variant">
             {keyHelpText}
           </p>
         </div>
@@ -991,10 +991,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {(isDoubleTap || isBoth) && (
           <div className="flex items-center justify-between gap-6">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Hotkey Timing Feedback
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Flash the overlay when a tap misses the double-tap window
               </p>
             </div>
@@ -1004,12 +1004,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.hotkeyMissFeedback}
               aria-label="Hotkey timing feedback"
               onClick={() => onUpdateSettings({ hotkeyMissFeedback: !settings.hotkeyMissFeedback })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.hotkeyMissFeedback ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.hotkeyMissFeedback ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.hotkeyMissFeedback ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1023,10 +1023,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Auto-Paste
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Automatically paste transcription (requires Accessibility permission)
               </p>
             </div>
@@ -1036,12 +1036,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.autoPaste}
               aria-label="Auto paste"
               onClick={() => onUpdateSettings({ autoPaste: !settings.autoPaste })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.autoPaste ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.autoPaste ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.autoPaste ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1088,10 +1088,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {/* Save Transcript to File Toggle */}
         <div className="flex items-center justify-between">
           <div>
-            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+            <label className="block text-sm font-medium text-on-surface">
               Save Transcript to File
             </label>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               Write each transcription to a .txt file
             </p>
           </div>
@@ -1101,12 +1101,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             aria-checked={settings.saveTranscript}
             aria-label="Save transcript to file"
             onClick={() => onUpdateSettings({ saveTranscript: !settings.saveTranscript })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-              settings.saveTranscript ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+              settings.saveTranscript ? 'bg-primary' : 'bg-surface-container-highest'
             }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                 settings.saveTranscript ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
@@ -1117,10 +1117,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Save Audio to File
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Write each recording to a .wav file
               </p>
             </div>
@@ -1130,12 +1130,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.saveAudio}
               aria-label="Save audio to file"
               onClick={() => onUpdateSettings({ saveAudio: !settings.saveAudio })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.saveAudio ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.saveAudio ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.saveAudio ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1144,29 +1144,29 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
           {saveToFile && (
             <div className="mt-3">
-              <label className="block text-xs text-stone-600 dark:text-stone-400 mb-1">
+              <label className="block text-xs text-on-surface-variant mb-1">
                 Output Folder
               </label>
-              <div className="px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/50 text-stone-700 dark:text-stone-300 break-all">
+              <div className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">
                 {settings.outputDir || 'Documents/Murmur (default)'}
               </div>
               <div className="mt-2 flex items-center gap-3">
                 <button
                   onClick={handleChooseFolder}
-                  className="text-xs font-medium text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-200 underline hover:no-underline transition-colors"
+                  className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
                 >
                   Choose Folder
                 </button>
                 {settings.outputDir && (
                   <button
                     onClick={() => onUpdateSettings({ outputDir: '' })}
-                    className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-500 dark:hover:text-stone-300 underline hover:no-underline transition-colors"
+                    className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
                   >
                     Reset to default
                   </button>
                 )}
               </div>
-              <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-2 text-xs text-on-surface-variant">
                 Text is still copied to the clipboard, but auto-paste is paused while saving to file.
               </p>
             </div>
@@ -1177,10 +1177,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Launch at Login
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Automatically start when you log in
               </p>
             </div>
@@ -1190,12 +1190,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.launchAtLogin}
               aria-label="Launch at login"
               onClick={() => onUpdateSettings({ launchAtLogin: !settings.launchAtLogin })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.launchAtLogin ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.launchAtLogin ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.launchAtLogin ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1206,10 +1206,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {/* Voice Commands Toggle */}
         <div className="flex items-center justify-between">
           <div>
-            <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+            <label className="block text-sm font-medium text-on-surface">
               Voice Commands
             </label>
-            <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            <p className="mt-1 text-xs text-on-surface-variant">
               Spoken tokens like "new line", "period", or "scratch that" transform the text before pasting.
             </p>
           </div>
@@ -1219,12 +1219,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             aria-checked={settings.voiceCommandsEnabled}
             aria-label="Voice commands"
             onClick={() => onUpdateSettings({ voiceCommandsEnabled: !settings.voiceCommandsEnabled })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-              settings.voiceCommandsEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+              settings.voiceCommandsEnabled ? 'bg-primary' : 'bg-surface-container-highest'
             }`}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                 settings.voiceCommandsEnabled ? 'translate-x-6' : 'translate-x-1'
               }`}
             />
@@ -1257,10 +1257,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Code-Aware Vocabulary
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Bias transcription toward common dev terms (useEffect, kubectl, stderr) — works out of the box, no folder needed. Optionally add a project folder for your own identifiers. With Smart Correction on (below), these terms are also fixed in the transcript on every model, including Parakeet.
               </p>
             </div>
@@ -1270,12 +1270,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.codeVocabEnabled}
               aria-label="Code-aware vocabulary"
               onClick={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.codeVocabEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.codeVocabEnabled ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.codeVocabEnabled ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1284,23 +1284,23 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
 
           {settings.codeVocabEnabled && (
             <div className="mt-3">
-              <label className="block text-xs text-stone-600 dark:text-stone-400 mb-1">
+              <label className="block text-xs text-on-surface-variant mb-1">
                 Project Folder (optional)
               </label>
-              <div className="px-3 py-2 text-xs rounded-lg border border-stone-300 dark:border-stone-600 bg-stone-50 dark:bg-stone-700/50 text-stone-700 dark:text-stone-300 break-all">
+              <div className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">
                 {settings.codeVocabFolder || 'No folder — built-in dev terms only'}
               </div>
               <div className="mt-2 flex items-center gap-3">
                 <button
                   onClick={handleChooseCodeVocabFolder}
-                  className="text-xs font-medium text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-200 underline hover:no-underline transition-colors"
+                  className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
                 >
                   Choose Folder
                 </button>
                 {settings.codeVocabFolder && (
                   <button
                     onClick={handleClearCodeVocabFolder}
-                    className="text-xs font-medium text-stone-500 hover:text-stone-800 dark:text-stone-500 dark:hover:text-stone-300 underline hover:no-underline transition-colors"
+                    className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
                   >
                     Clear
                   </button>
@@ -1317,7 +1317,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 onCancel={vocabScan.cancel}
               />
 
-              <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-2 text-xs text-on-surface-variant">
                 Optional. When set, the folder is scanned once for your identifiers (dependency and build directories are skipped) and layered on top of the built-in terms. Re-select to rescan after big code changes.
               </p>
             </div>
@@ -1328,10 +1328,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-stone-700 dark:text-stone-300">
+              <label className="block text-sm font-medium text-on-surface">
                 Smart Correction
               </label>
-              <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+              <p className="mt-1 text-xs text-on-surface-variant">
                 Fix vocabulary in the transcript after recognition, on every model. Turns "use effect" into useEffect and, with Code-Aware on, "standard error" into stderr.
               </p>
             </div>
@@ -1341,12 +1341,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
               aria-checked={settings.correctionEnabled}
               aria-label="Smart correction"
               onClick={() => onUpdateSettings({ correctionEnabled: !settings.correctionEnabled })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                settings.correctionEnabled ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.correctionEnabled ? 'bg-primary' : 'bg-surface-container-highest'
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
                   settings.correctionEnabled ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -1356,10 +1356,10 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           {settings.correctionEnabled && (
             <div className="mt-3 flex items-center justify-between gap-4">
               <div>
-                <label className="block text-xs font-medium text-stone-700 dark:text-stone-300">
+                <label className="block text-xs font-medium text-on-surface">
                   Sounds-like matching
                 </label>
-                <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+                <p className="mt-1 text-xs text-on-surface-variant">
                   Also recover close mishearings near your vocabulary (e.g. "red pivot" → "rePivot"). Turn off if you see unwanted swaps.
                 </p>
               </div>
@@ -1369,12 +1369,12 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
                 aria-checked={settings.correctionFuzzy}
                 aria-label="Sounds-like matching"
                 onClick={() => onUpdateSettings({ correctionFuzzy: !settings.correctionFuzzy })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 ${
-                  settings.correctionFuzzy ? 'bg-stone-800 dark:bg-stone-300' : 'bg-stone-300 dark:bg-stone-500'
+                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                  settings.correctionFuzzy ? 'bg-primary' : 'bg-surface-container-highest'
                 }`}
               >
                 <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
                     settings.correctionFuzzy ? 'translate-x-4' : 'translate-x-1'
                   }`}
                 />
@@ -1391,7 +1391,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <SettingsSection pageId="about" activePage={activeCat} title="About" subtitle="Stats, logs, updates">
         {/* Model Info */}
         <div>
-          <div className="text-sm text-stone-600 dark:text-stone-400">
+          <div className="text-sm text-on-surface-variant">
             <p><strong>Model:</strong> {selectedModel?.label}</p>
             <p><strong>Backend:</strong> {selectedModel?.backend === 'coreml' ? 'FluidAudio (Apple Neural Engine)' : selectedModel?.backend === 'parakeet' ? 'sherpa-onnx (CPU)' : 'Whisper (Metal GPU)'}</p>
             <p><strong>Size:</strong> {selectedModel?.size}</p>
@@ -1406,7 +1406,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             className={`w-full px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
               confirmReset
                 ? 'border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40'
-                : 'border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600'
+                : 'border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary'
             }`}
           >
             {confirmReset ? 'Confirm Reset' : 'Reset Stats'}
@@ -1417,7 +1417,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <button
             onClick={onViewLogs}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"
+            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors"
           >
             View Logs
           </button>
@@ -1427,11 +1427,11 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         <div>
           <button
             onClick={onRerunSetup}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors"
+            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors"
           >
             Run Setup Assistant
           </button>
-          <p className="mt-1.5 text-xs text-stone-400 dark:text-stone-500">
+          <p className="mt-1.5 text-xs text-on-surface-variant">
             Re-check permissions and the model step by step — useful if a
             permission was revoked or stopped working.
           </p>
@@ -1442,7 +1442,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
           <button
             onClick={onCheckForUpdate}
             disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {updateStatus.phase === 'checking' ? 'Checking...' : 'Check for Updates'}
           </button>
@@ -1452,7 +1452,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             </p>
           )}
           {updateStatus.phase === 'available' && (
-            <p className="mt-1.5 text-xs text-blue-600 dark:text-blue-400">
+            <p className="mt-1.5 text-xs text-primary">
               v{updateStatus.version} available
             </p>
           )}
@@ -1466,7 +1466,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         {/* Version */}
         {version && (
           <div className="text-center">
-            <span className="text-xs text-stone-400 dark:text-stone-500">v{version}</span>
+            <span className="text-xs text-on-surface-variant">v{version}</span>
           </div>
         )}
         </SettingsSection>

--- a/app/src/components/settings/SettingsSection.tsx
+++ b/app/src/components/settings/SettingsSection.tsx
@@ -52,7 +52,7 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
         aria-expanded={expanded}
         aria-controls={contentId}
         onClick={handleToggle}
-        className="flex w-full items-center justify-between py-3 text-sm font-semibold text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 rounded-sm"
+        className={`flex w-full items-center justify-between rounded-sm py-3 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${expanded ? 'text-primary' : 'text-on-surface hover:text-primary'}`}
       >
         <span className="text-left">
           {title}
@@ -61,9 +61,7 @@ export function SettingsSection({ title, subtitle, defaultExpanded = true, child
           )}
         </span>
         <svg
-          className={`w-4 h-4 text-on-surface-variant shrink-0 transition-transform duration-200 ${
-            expanded ? 'rotate-180' : ''
-          }`}
+          className={`w-4 h-4 shrink-0 transition-transform duration-200 ${expanded ? 'rotate-180 text-primary' : 'text-on-surface-variant'}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/app/src/components/ui/Select.tsx
+++ b/app/src/components/ui/Select.tsx
@@ -175,14 +175,14 @@ export function Select<T extends string = string>({
         aria-selected={isSelected}
         onClick={() => selectOption(option)}
         onMouseEnter={() => setHighlightedIndex(index)}
-        className={`px-3 py-2 text-sm cursor-pointer flex items-center justify-between ${
-          isHighlighted ? 'bg-stone-100 dark:bg-stone-600' : ''
-        } ${isSelected ? 'font-medium' : ''} text-stone-900 dark:text-stone-100`}
+        className={`flex cursor-pointer items-center justify-between px-3 py-2 text-sm text-on-surface ${
+          isHighlighted ? 'bg-surface-container' : ''
+        } ${isSelected ? 'font-medium' : ''}`}
       >
         <span className="truncate">{option.label}</span>
         {isSelected && (
           <svg
-            className="w-4 h-4 text-stone-500 dark:text-stone-400 shrink-0 ml-2"
+            className="ml-2 h-4 w-4 shrink-0 text-primary"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -224,13 +224,13 @@ export function Select<T extends string = string>({
         aria-label={ariaLabel}
         disabled={disabled}
         onClick={() => (isOpen ? close() : open())}
-        className={`w-full px-3 py-2 rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 text-stone-900 dark:text-stone-100 text-sm text-left focus:ring-2 focus:ring-stone-500 focus:border-transparent transition-colors flex items-center justify-between ${
+        className={`flex w-full items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-left text-sm text-on-surface transition-colors focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary ${
           disabled ? 'opacity-50 cursor-not-allowed' : ''
         }`}
       >
         <span className="truncate">{displayLabel}</span>
         <svg
-          className={`w-4 h-4 text-stone-400 shrink-0 ml-2 transition-transform ${
+          className={`ml-2 h-4 w-4 shrink-0 text-on-surface-variant transition-transform ${
             isOpen ? 'rotate-180' : ''
           }`}
           fill="none"
@@ -251,7 +251,7 @@ export function Select<T extends string = string>({
           ref={listboxRef}
           role="listbox"
           id={`${id}-listbox`}
-          className="absolute z-10 mt-1 w-full max-h-60 overflow-auto rounded-lg border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-700 shadow-lg py-1"
+          className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-outline-variant/30 bg-surface-container-lowest py-1 shadow-lg"
         >
           {isGrouped(items)
             ? items.map((group, gi) => (
@@ -262,7 +262,7 @@ export function Select<T extends string = string>({
                   >
                     <span
                       id={`${id}-group-${gi}`}
-                      className="block px-3 py-1.5 text-xs font-semibold text-stone-500 dark:text-stone-400 uppercase tracking-wider select-none"
+                      className="block select-none px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-on-surface-variant"
                     >
                       {group.label}
                     </span>


### PR DESCRIPTION
## Summary
- apply the Sonic Canvas semantic surface hierarchy to the main window, history, settings, modal, and model-download components
- redesign recording status/controls, four-card stats, history cards/actions/badges, and the log viewer Events/Metrics surfaces
- preserve existing interactions and add focused tests for all configured hotkey hints, recording callbacks, and history copy/clear behavior

## Test plan
- [x] `npm test` — 96 tests passed
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` — 287 tests passed
- [x] exact native debug bundle built and launched via `/Users/george-mac-mini/Documents/code/murmur-app-issue-141/app/src-tauri/target/debug/bundle/macos/Local Dictation Dev.app`
- [x] native light/dark verification: main/settings, populated history + copied state, recording control/hotkey hint, log Events/error rows, and Metrics cards/charts
- [x] controls exercised: settings navigation/toggles, history copy, log-viewer tabs, and recording start callback (CoreAudio input unavailable on the host; error surfaced correctly)

Closes #141
