### PR TITLE
fix(ci): exclude CUDA driver stub from AppImage

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -127,6 +127,21 @@ runs:
           exit 1
         }
 
+    # Tauri's binary-releases mirror currently serves a July 2024 linuxdeploy
+    # build that predates LINUXDEPLOY_EXCLUDED_LIBRARIES. Seed Tauri's tool cache
+    # with a checksum-pinned upstream build so the runner-only CUDA driver stub
+    # is available for dependency resolution but cannot enter the AppImage.
+    - name: Install driver-stub-aware linuxdeploy
+      shell: bash
+      run: |
+        LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+        LINUXDEPLOY_SHA256="e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf"
+        LINUXDEPLOY_PATH="$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage"
+        mkdir -p "$(dirname "$LINUXDEPLOY_PATH")"
+        curl --fail --location --retry 3 "$LINUXDEPLOY_URL" --output "$LINUXDEPLOY_PATH"
+        echo "$LINUXDEPLOY_SHA256  $LINUXDEPLOY_PATH" | sha256sum --check --strict
+        chmod +x "$LINUXDEPLOY_PATH"
+
     - name: Save CUDA toolkit cache
       if: steps.cuda-cache.outputs.cache-hit != 'true' && inputs.cuda-cache-save-if == 'true'
       uses: actions/cache/save@v4

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -148,6 +148,20 @@ def validate_linux_cache_policy(action: str) -> None:
     assert "CUDA_DRIVER_STUB_DIR=$STUB_DIR" in action
     assert "LINUXDEPLOY_EXCLUDED_LIBRARIES=libcuda.so.1" in action
 
+    linuxdeploy = named_step_block(
+        action, "Install driver-stub-aware linuxdeploy", 4
+    )
+    assert (
+        "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/"
+        "linuxdeploy-x86_64.AppImage"
+    ) in linuxdeploy
+    assert (
+        'LINUXDEPLOY_SHA256="e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf"'
+        in linuxdeploy
+    )
+    assert 'LINUXDEPLOY_PATH="$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage"' in linuxdeploy
+    assert "sha256sum --check --strict" in linuxdeploy
+
     prepare = named_step_block(action, "Prepare CUDA cache restore path", 4)
     assert 'sudo mkdir -p "/usr/local/cuda-${CUDA_MM}"' in prepare
     assert 'sudo chown -R "$(id -u):$(id -g)"' in prepare

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -68,6 +68,16 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate_linux_cache_policy(mutated)
 
+    def test_linuxdeploy_override_must_be_checksum_pinned(self) -> None:
+        action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
+        mutated = action.replace(
+            "sha256sum --check --strict",
+            'echo "linuxdeploy checksum validation skipped"',
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            validate_linux_cache_policy(mutated)
+
     def test_cuda_stub_paths_reject_empty_loader_segments(self) -> None:
         action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
         mutated_action = action.replace(


### PR DESCRIPTION
## Summary
- seed Tauri's linuxdeploy cache with the upstream build that supports `LINUXDEPLOY_EXCLUDED_LIBRARIES`
- checksum-pin the linuxdeploy binary so upstream asset drift fails closed
- extend release workflow policy tests to require the pinned override and checksum verification

## Root cause
Signed release-build run [29662064035](https://github.com/georgenijo/murmur-app/actions/runs/29662064035) proved Tauri's mirrored July 2024 linuxdeploy build (`659c9db`) predates the exclusion environment variable. It resolved and copied the runner-only `libcuda.so.1` stub into the AppImage, which the post-build audit correctly rejected. Both Linux package launch smokes had passed before that audit.

## Validation
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests.test_workflow_policy tests.test_release_artifacts` (15 tests)
- `git diff --check`

Relates to #220.
