### PR TITLE
fix(ci): distinguish CUDA runtime from driver stub

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -318,7 +318,9 @@ jobs:
             cat /tmp/murmur-packaged-cuda-libraries.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          if find squashfs-root -type f -name 'libcuda*' -print -quit | grep -q .; then
+          # Match the NVIDIA driver library, not the legitimate CUDA runtime
+          # (libcudart.so), whose name shares the same prefix.
+          if find squashfs-root -type f -name 'libcuda.so*' -print -quit | grep -q .; then
             echo "ERROR: AppImage must not contain the runner-local NVIDIA driver stub"
             exit 1
           fi

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -123,6 +123,8 @@ def validate_release_build(workflow: str) -> int:
     assert "rpm" not in linux_build
     assert workflow.count("${{ needs.context.outputs.cache-write == 'true' }}") >= 3
     assert "AppImage must not contain the runner-local NVIDIA driver stub" in workflow
+    assert "-name 'libcuda.so*' -print -quit" in workflow
+    assert "-name 'libcuda*' -print -quit" not in workflow
     assert workflow.count(
         "LD_LIBRARY_PATH=\"$CUDA_DRIVER_STUB_DIR${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}\""
     ) == 2

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -107,6 +107,16 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate_release_build(mutated)
 
+    def test_cuda_driver_audit_does_not_reject_libcudart(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-build.yml").read_text()
+        mutated = workflow.replace(
+            "-name 'libcuda.so*' -print -quit",
+            "-name 'libcuda*' -print -quit",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            validate_release_build(mutated)
+
     def test_release_profile_must_retain_tauri_bundle_marker(self) -> None:
         cargo_toml = (ROOT / "app/src-tauri/Cargo.toml").read_text()
         with self.assertRaises(AssertionError):

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -107,7 +107,7 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate_release_build(mutated)
 
-    def test_cuda_driver_audit_does_not_reject_libcudart(self) -> None:
+    def test_cuda_driver_audit_rejects_broad_libcuda_glob(self) -> None:
         workflow = (ROOT / ".github/workflows/release-build.yml").read_text()
         mutated = workflow.replace(
             "-name 'libcuda.so*' -print -quit",


### PR DESCRIPTION
## Summary
- narrow the AppImage driver-stub audit from `libcuda*` to `libcuda.so*`
- preserve reporting of legitimate CUDA runtime libraries
- add a mutation test proving `libcudart.so` cannot trigger the driver-stub gate

## Evidence
Signed rehearsal [29662903647](https://github.com/georgenijo/murmur-app/actions/runs/29662903647) used linuxdeploy `a9f929f`, explicitly skipped `/home/runner/work/_temp/murmur-cuda-driver-stub/libcuda.so.1` in both bundler passes, and extracted only:

- `libcublas.so.12`
- `libcublasLt.so.12`
- `libcudart.so.12`

The previous `libcuda*` predicate falsely matched `libcudart.so.12`.

## Validation
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests.test_workflow_policy tests.test_release_artifacts` (16 tests)
- `git diff --check`

Relates to #220.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release packaging checks to identify NVIDIA driver stub libraries precisely while allowing the supported CUDA runtime library.
* **Tests**
  * Added validation to ensure release workflow checks remain specific and do not incorrectly reject compatible CUDA libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->