### PR TITLE
fix: reset Core ML decoder state between dictations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Release automation now builds signed macOS and Linux artifacts once on trusted `main`, keeps Cargo/CUDA cache ownership off tags and pull requests, and promotes only commit-SHA-matched artifacts with fail-closed updater-signature checks (#220).
 
 ### Fixed
+- Consecutive Core ML dictations now start with fresh Parakeet decoder state, preventing later one-shot recordings from collapsing to punctuation-only empty transcripts (#236).
 - `murmur-diag` now reads and source-labels both release and dev log streams without duplicate file ingestion, keeps cross-build correlation isolated, and uses one documented user-level MCP registration instead of per-worktree registrations (#191).
 - Code-vocabulary scans now keep the View-all dialog keyboard focus contained and restore the opener on close, correlate live progress by scan ID, and report superseded results when settings change during a walk instead of presenting non-adopted terms as complete (#209).
 - Global modifier hotkeys now recover when macOS disables the underlying event tap, avoid stale modifier-state dead zones after system context changes, and no longer process mouse movement or perform main-thread key-name translation on the modifier hot path (#194, fixes #137).

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1360,8 +1360,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6181071acbec602782db378d0677cccfa48c60bc8d759524c4bfe57188a234dc"
+source = "git+https://github.com/FluidInference/fluidaudio-rs?rev=2d1083314104c812944b5150866d1e334db8eed7#2d1083314104c812944b5150866d1e334db8eed7"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ block2 = "0.6"
 core-graphics = "0.25"
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
-fluidaudio-rs = { version = "=0.14.1", default-features = false, features = ["asr"] }
+fluidaudio-rs = { git = "https://github.com/FluidInference/fluidaudio-rs", rev = "2d1083314104c812944b5150866d1e334db8eed7", default-features = false, features = ["asr"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rdev = { git = "https://github.com/georgenijo/rdev", rev = "9f510e406327b797eaf2acdc30adcda3dc1e1bb3", features = ["x11"] }

--- a/app/src-tauri/tests/coreml_transcription_integration.rs
+++ b/app/src-tauri/tests/coreml_transcription_integration.rs
@@ -23,12 +23,19 @@ fn transcribes_with_installed_coreml_model() {
     let samples = parse_wav_to_samples(&wav).expect("fixture must be 16 kHz mono 16-bit PCM");
     let mut backend = CoreMlBackend::new();
     backend.load_model(COREML_MODEL_NAME).unwrap();
-    let text = backend
+    let first = backend
         .transcribe(&samples, "auto", None, true)
         .expect("Core ML transcription failed");
+    let second = backend
+        .transcribe(&samples, "auto", None, true)
+        .expect("second Core ML transcription failed");
 
     assert!(
-        !text.trim().is_empty(),
-        "Core ML returned an empty transcript"
+        !first.trim().is_empty(),
+        "first Core ML transcription returned empty"
+    );
+    assert_eq!(
+        first, second,
+        "consecutive one-shot Core ML calls must not leak decoder state"
     );
 }


### PR DESCRIPTION
Closes #236

## What changed

- Pin FluidAudio to upstream merge commit 2d1083314104c812944b5150866d1e334db8eed7, which creates fresh Parakeet TDT decoder state for every one-shot transcription.
- Extend the opt-in Core ML integration test to call the same loaded backend twice and require identical, non-empty output.
- Document the production fix in the changelog.

Upstream fix: https://github.com/FluidInference/fluidaudio-rs/pull/15

## Why

Murmur 0.17.0 kept decoder state across independent dictations. Terminal punctuation and recurrent state from one recording could contaminate the next recording, often reducing short dictations to a period that Murmur correctly normalized to empty. Audio capture and paste injection were healthy; the persistent decoder state was the failure.

## Verification

- cargo check
- cargo test -- --test-threads=1: 287 Rust tests passed; Whisper integration passed
- npx tsc --noEmit
- npm test -- --run: 96 frontend tests passed
- npm run build
- Targeted rustfmt check for the changed Rust test
- MacBook Apple Silicon hardware test with the installed Parakeet Core ML model: one loaded backend transcribed the same fixture twice with identical non-empty output; 1 passed in 0.53s