### PR TITLE
feat: auto-promote successful release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_run:
+    workflows: [Release Build]
+    types: [completed]
   workflow_dispatch:
     inputs:
       source_sha:
@@ -14,7 +17,7 @@ on:
         required: true
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: false
 
 permissions:
@@ -29,6 +32,9 @@ jobs:
       artifact-run-id: ${{ steps.resolve.outputs.artifact_run_id }}
       tag: ${{ steps.resolve.outputs.tag }}
       publish: ${{ steps.resolve.outputs.publish }}
+      eligible: ${{ steps.resolve.outputs.eligible }}
+      create-tag: ${{ steps.resolve.outputs.create_tag }}
+      already-published: ${{ steps.resolve.outputs.already_published }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,20 +46,60 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
           INPUT_ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_PATH: ${{ github.event.workflow_run.path }}
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+          ELIGIBLE=true
+          CREATE_TAG=false
+          ALREADY_PUBLISHED=false
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+            SOURCE_SHA="$WORKFLOW_RUN_SHA"
+            ARTIFACT_RUN_ID="$WORKFLOW_RUN_ID"
+            TAG=""
+            PUBLISH=false
+
+            SKIP_REASON=""
+            if [ "$WORKFLOW_RUN_NAME" != "Release Build" ] || \
+               [ "${WORKFLOW_RUN_PATH%%@*}" != ".github/workflows/release-build.yml" ]; then
+              SKIP_REASON="completed workflow is not the exact Release Build workflow"
+            elif [ "$WORKFLOW_RUN_CONCLUSION" != "success" ]; then
+              SKIP_REASON="Release Build did not succeed"
+            elif [ "$WORKFLOW_RUN_BRANCH" != "main" ]; then
+              SKIP_REASON="Release Build did not run on main"
+            elif [ "$WORKFLOW_RUN_EVENT" != "push" ]; then
+              SKIP_REASON="Release Build was not started by a trusted main push"
+            fi
+
+            if [ -n "$SKIP_REASON" ]; then
+              {
+                echo "source_sha=$SOURCE_SHA"
+                echo "artifact_run_id=$ARTIFACT_RUN_ID"
+                echo "tag="
+                echo "publish=false"
+                echo "eligible=false"
+                echo "create_tag=false"
+                echo "already_published=false"
+              } >> "$GITHUB_OUTPUT"
+              {
+                echo "### Automatic promotion skipped"
+                echo "$SKIP_REASON. No tag or release was created."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            PUBLISH=true
+          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
             TAG="$GITHUB_REF_NAME"
-            if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$'; then
+            if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
               echo "ERROR: invalid release tag: $TAG"
               exit 1
             fi
             SOURCE_SHA=$(git rev-list -n 1 "$TAG")
-            VERSION=$(jq -r '.version' app/src-tauri/tauri.conf.json)
-            CARGO_VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' app/src-tauri/Cargo.toml | head -1)
-            if [ "v$VERSION" != "$TAG" ] || [ "$CARGO_VERSION" != "$VERSION" ]; then
-              echo "ERROR: tag/config versions differ: tag=$TAG tauri=$VERSION cargo=$CARGO_VERSION"
-              exit 1
-            fi
 
             RUNS=$(gh api --method GET \
               "repos/${GITHUB_REPOSITORY}/actions/workflows/release-build.yml/runs" \
@@ -95,14 +141,137 @@ jobs:
             and (.event == "push" or .event == "workflow_dispatch")
             and .status == "completed"
             and .conclusion == "success"
-            and (.path | startswith(".github/workflows/release-build.yml"))
+            and ((.path | split("@")[0]) == ".github/workflows/release-build.yml")
           ' >/dev/null || {
             echo "ERROR: workflow run $ARTIFACT_RUN_ID is not a successful trusted-main Release Build for $SOURCE_SHA"
             exit 1
           }
           if [ "$PUBLISH" = "true" ] && [ "$(echo "$RUN" | jq -r .event)" != "push" ]; then
-            echo "ERROR: automatic tag publication requires the trusted main push build"
+            echo "ERROR: publication requires the trusted main push build"
             exit 1
+          fi
+
+          if [ "$PUBLISH" = "true" ]; then
+            git fetch --force origin \
+              '+refs/heads/main:refs/remotes/origin/main' \
+              '+refs/tags/*:refs/tags/*'
+            git cat-file -e "${SOURCE_SHA}^{commit}"
+            git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+              echo "ERROR: release commit is not on trusted main: $SOURCE_SHA"
+              exit 1
+            }
+
+            SUBJECT=$(git show -s --format=%s "$SOURCE_SHA")
+            if [[ "$SUBJECT" != "chore: bump version"* ]]; then
+              if [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+                {
+                  echo "source_sha=$SOURCE_SHA"
+                  echo "artifact_run_id=$ARTIFACT_RUN_ID"
+                  echo "tag="
+                  echo "publish=false"
+                  echo "eligible=false"
+                  echo "create_tag=false"
+                  echo "already_published=false"
+                } >> "$GITHUB_OUTPUT"
+                {
+                  echo "### Automatic promotion skipped"
+                  echo "The trusted main commit is not a version bump. No tag or release was created."
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              echo "ERROR: release tags must point to a 'chore: bump version' commit"
+              exit 1
+            fi
+
+            if ! VERSIONS=$(python3 - "$SOURCE_SHA" <<'PY'
+          import json
+          import re
+          import subprocess
+          import sys
+
+          sha = sys.argv[1]
+
+          def at(path: str) -> str:
+              return subprocess.check_output(
+                  ["git", "show", f"{sha}:{path}"], text=True
+              )
+
+          tauri_version = json.loads(at("app/src-tauri/tauri.conf.json"))["version"]
+          cargo = at("app/src-tauri/Cargo.toml")
+          package = re.search(r"^\[package\]\s*(.*?)(?=^\[|\Z)", cargo, re.M | re.S)
+          cargo_version = re.search(
+              r'^version\s*=\s*"([^"]+)"', package.group(1), re.M
+          ).group(1)
+          lock = at("app/src-tauri/Cargo.lock")
+          ui_package = next(
+              block
+              for block in re.split(r"^\[\[package\]\]\s*$", lock, flags=re.M)
+              if re.search(r'^name\s*=\s*"ui"\s*$', block, re.M)
+          )
+          lock_version = re.search(
+              r'^version\s*=\s*"([^"]+)"', ui_package, re.M
+          ).group(1)
+          print(tauri_version, cargo_version, lock_version)
+          PY
+            ); then
+              echo "ERROR: could not read release versions from $SOURCE_SHA"
+              exit 1
+            fi
+            read -r VERSION CARGO_VERSION LOCK_VERSION <<< "$VERSIONS"
+            if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+              echo "ERROR: invalid release version: $VERSION"
+              exit 1
+            fi
+            if [ "$CARGO_VERSION" != "$VERSION" ] || [ "$LOCK_VERSION" != "$VERSION" ]; then
+              echo "ERROR: release versions differ: tauri=$VERSION cargo=$CARGO_VERSION lock=$LOCK_VERSION"
+              exit 1
+            fi
+            RESOLVED_TAG="v$VERSION"
+            if [ -n "$TAG" ] && [ "$TAG" != "$RESOLVED_TAG" ]; then
+              echo "ERROR: tag/config versions differ: tag=$TAG expected=$RESOLVED_TAG"
+              exit 1
+            fi
+            TAG="$RESOLVED_TAG"
+
+            if git show-ref --verify --quiet "refs/tags/$TAG"; then
+              EXISTING_TAG_SHA=$(git rev-list -n 1 "$TAG")
+              if [ "$EXISTING_TAG_SHA" != "$SOURCE_SHA" ]; then
+                echo "ERROR: $TAG already points to $EXISTING_TAG_SHA, not $SOURCE_SHA"
+                exit 1
+              fi
+            elif [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+              CREATE_TAG=true
+            else
+              echo "ERROR: tag-triggered recovery could not resolve $TAG"
+              exit 1
+            fi
+
+            if RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null); then
+              echo "$RELEASE" | jq -e --arg tag "$TAG" '.tag_name == $tag' >/dev/null || {
+                echo "ERROR: existing release metadata conflicts with $TAG"
+                exit 1
+              }
+              if [ "$(echo "$RELEASE" | jq -r .draft)" = "false" ]; then
+                ALREADY_PUBLISHED=true
+              fi
+            fi
+          fi
+
+          if [ "$ALREADY_PUBLISHED" = "true" ]; then
+            {
+              echo "source_sha=$SOURCE_SHA"
+              echo "artifact_run_id=$ARTIFACT_RUN_ID"
+              echo "tag=$TAG"
+              echo "publish=true"
+              echo "eligible=true"
+              echo "create_tag=false"
+              echo "already_published=true"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "### Release already published"
+              echo "The same tag and source commit are already published; promotion is complete."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           ARTIFACTS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/artifacts")
@@ -119,16 +288,26 @@ jobs:
           echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
+          echo "eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+          echo "create_tag=$CREATE_TAG" >> "$GITHUB_OUTPUT"
+          echo "already_published=$ALREADY_PUBLISHED" >> "$GITHUB_OUTPUT"
           {
             echo "### Immutable promotion source"
             echo "- commit: \`$SOURCE_SHA\`"
             echo "- Release Build run: \`$ARTIFACT_RUN_ID\`"
             echo "- tag: \`${TAG:-rehearsal-only}\`"
             echo "- publish authorized: \`$PUBLISH\`"
+            echo "- create tag: \`$CREATE_TAG\`"
+            echo "- already published: \`$ALREADY_PUBLISHED\`"
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$ALREADY_PUBLISHED" = "true" ]; then
+            echo "The same tag and source commit are already published; promotion is complete." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   promote:
     needs: resolve
+    if: needs.resolve.outputs.eligible == 'true' && needs.resolve.outputs.already-published != 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -173,17 +352,57 @@ jobs:
             echo "No tag, draft release, release asset, updater manifest, or published release was created."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create draft release
+      - name: Create automatic release tag
+        if: needs.resolve.outputs.publish == 'true' && needs.resolve.outputs.create-tag == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$SOURCE_SHA"; then
+            EXISTING_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
+              --jq .object.sha)
+            if [ "$EXISTING_SHA" != "$SOURCE_SHA" ]; then
+              echo "ERROR: $TAG was created concurrently at $EXISTING_SHA, not $SOURCE_SHA"
+              exit 1
+            fi
+            echo "$TAG was already created at the expected source commit"
+          fi
+
+      - name: Create or reuse draft release
         if: needs.resolve.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.resolve.outputs.tag }}
         run: |
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes \
-            --draft
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            IS_DRAFT=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft --jq .isDraft)
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "ERROR: $TAG became published while promotion was running"
+              exit 1
+            fi
+            while IFS= read -r ASSET; do
+              if [ "$ASSET" = "latest-v2.json" ] || [ "$ASSET" = "latest.json" ]; then
+                continue
+              fi
+              if ! find artifacts/macos artifacts/linux -maxdepth 1 -type f \
+                  ! -name provenance.json -exec basename {} \; | grep -Fqx "$ASSET"; then
+                echo "ERROR: existing draft $TAG contains unexpected asset: $ASSET"
+                exit 1
+              fi
+            done < <(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq '.assets[].name')
+            echo "Reusing existing draft release $TAG"
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --generate-notes \
+              --draft
+          fi
 
       - name: Upload signed release assets
         if: needs.resolve.outputs.publish == 'true'
@@ -194,7 +413,7 @@ jobs:
           find artifacts/macos artifacts/linux -maxdepth 1 -type f ! -name provenance.json \
             -print0 | while IFS= read -r -d '' FILE; do
               echo "Uploading: $FILE"
-              gh release upload "$TAG" "$FILE" --repo "$GITHUB_REPOSITORY"
+              gh release upload "$TAG" "$FILE" --repo "$GITHUB_REPOSITORY" --clobber
             done
 
       - name: Verify uploaded updater signatures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 - The main window, settings, transcription history, recording controls, and log viewer now use the Sonic Canvas surface hierarchy and semantic palette in light and dark appearances (#141).
 - Release automation now builds signed macOS and Linux artifacts once on trusted `main`, keeps Cargo/CUDA cache ownership off tags and pull requests, and promotes only commit-SHA-matched artifacts with fail-closed updater-signature checks (#220).
+- Successful trusted version-bump builds now automatically create the matching tag and publish their already-verified artifacts; manual builds remain rehearsals and tag pushes remain a recovery path (#239).
 
 ### Fixed
 - Consecutive Core ML dictations now start with fresh Parakeet decoder state, preventing later one-shot recordings from collapsing to punctuation-only empty transcripts (#236).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -526,10 +526,13 @@ cd app && npx tsc --noEmit         # TypeScript check
    Linux CUDA packaging concurrently, including package launch smoke tests.
 3. The successful build stores macOS and Linux artifacts plus SHA-256
    provenance under names keyed by the exact commit SHA.
-4. After a separate final confirmation, push `vX.Y.Z` at that same commit.
-5. The tag workflow validates the tag/build/artifact/signature chain, promotes
-   the already-built assets, verifies the remote `.sig` files, generates
-   `latest-v2.json` and the legacy-safe `latest.json`, then publishes.
+4. The completed-build event verifies the trusted push, version-bump message,
+   matching versions, exact run ID, source SHA, and immutable artifacts.
+5. Promotion creates `vX.Y.Z` at that commit, verifies the remote `.sig` files,
+   generates `latest-v2.json` and the legacy-safe `latest.json`, then publishes.
+
+Manual build dispatches are rehearsal-only, and the tag trigger remains a
+recovery path protected by the same validation chain.
 
 Tag workflows never build or save Cargo/CUDA caches. See
 [`docs/release.md`](release.md) for trust boundaries, rehearsals, cache policy,

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,13 +1,14 @@
 # Release build and promotion
 
-Murmur builds signed release artifacts once on trusted `main`, then promotes
-those exact artifacts when a version tag is pushed. A tag does not compile the
-application and cannot save Cargo or CUDA caches.
+Murmur builds signed release artifacts once on trusted `main`, then automatically
+promotes those exact artifacts after the version-bump build succeeds. Promotion
+creates the matching version tag; neither automatic nor recovery tag runs compile
+the application or save Cargo or CUDA caches.
 
 ## Trust and cache policy
 
 - `Release Build` runs automatically only for a `main` push whose commit starts
-  with `chore: bump version`, or by an explicit `workflow_dispatch` on `main`.
+  with `chore: bump version`, or by an explicit `workflow_dispatch` rehearsal.
 - Frontend validation, macOS build/sign/notarization, and Linux CUDA packaging
   run concurrently. A workflow run is successful only when all three pass.
 - Linux release packaging is limited to the supported updater artifacts (`deb`
@@ -35,8 +36,10 @@ is disabled) so the updater can distinguish the deb and AppImage packages.
 Each artifact contains `provenance.json` with the exact commit SHA, workflow
 run ID, platform/updater names, sizes, and SHA-256 hashes. Promotion accepts one
 unexpired macOS artifact and one unexpired Linux artifact from a successful
-`Release Build` on `main` for the exact tag commit. Any tag, run, filename,
-hash, or updater-signature mismatch fails before a draft release is created.
+`Release Build` on `main` for the exact source commit. Automatic promotion also
+requires a successful `push` event, the version-bump commit prefix, and matching
+semver values in `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`. Any tag, run,
+filename, version, hash, or updater-signature mismatch fails before publication.
 
 The modern updater manifest is generated from the downloaded `.sig` files.
 After release-asset upload, the workflow downloads the remote `.sig` assets and
@@ -75,7 +78,8 @@ release targets are macOS <= 5 minutes, Linux <= 9 minutes, and total wall time
 
 ## Cold fallback
 
-If the automatic build for a version-bump commit fails, do not push a tag.
+If the automatic build for a version-bump commit fails, no tag or release is
+created. Do not push a tag.
 Correct the infrastructure problem and rerun the original workflow at the same
 commit (`gh run rerun <run-id> --failed`). A rerun preserves the trusted push
 event and exact source SHA. If `main` still points to the version-bump commit, a
@@ -85,12 +89,20 @@ being repaired.
 
 If artifacts expired or `main` has advanced, rerun the original version-bump
 workflow rather than building arbitrary PR or tag code with signing secrets.
-Promotion remains blocked until a successful build and both SHA-named artifacts
-exist for the tag commit.
+Promotion remains blocked until a successful trusted push build and both
+SHA-named artifacts exist for the version-bump commit.
 
-## Final release gate
+## Release authorization and recovery
 
-`prompts/PROMPT_RELEASE.md` requires a separate explicit confirmation after the
-trusted build succeeds and before creating or pushing `vX.Y.Z`. Pushing that
-tag is the real release action: it validates the tag SHA, promotes the stored
-artifacts, creates a draft, verifies remote updater integrity, and publishes.
+`prompts/PROMPT_RELEASE.md` requires explicit confirmation before pushing the
+version-bump commit. That push is the release action: after its exact trusted
+build succeeds, `Release` validates the run and three synchronized version files,
+downloads and verifies the immutable artifacts, creates `vX.Y.Z`, prepares the
+release, verifies remote updater integrity, and publishes.
+
+Manual `Release Build` dispatches remain non-publishing rehearsals, even when
+they succeed. The tag trigger remains an operator recovery path for an automatic
+promotion failure; it applies the same commit, build, version, artifact, and
+signature gates. Re-running promotion for an already-published tag at the same
+commit exits successfully without replacing the release, while a tag that points
+to a different commit fails closed.

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -1,6 +1,6 @@
 # Agent Startup — Release Mode
 
-You are starting a release session for the Murmur project. Work autonomously through preparation and the trusted release build. Stop for a separate explicit final confirmation before creating or pushing the tag, because the tag promotes and publishes the release.
+You are starting a release session for the Murmur project. Work autonomously through preparation, the trusted release build, and automatic promotion. Treat the version-bump push as the release authorization: after that exact trusted build succeeds, GitHub automatically creates the tag and publishes the release.
 
 ## 1. Load Context
 
@@ -47,12 +47,13 @@ Include the min_version decision in the release summary.
 Present a concise release summary:
 - Current version → New version (and why: major/minor/patch)
 - Bullet list of what's included (one line per meaningful commit, skip chores/docs)
-- Explain that pushing the version-bump commit starts a signed, non-publishing
-  `Release Build`; the tag/publish confirmation comes only after that build is green.
-- Ask: **"Ready to prepare the signed v{new_version} build on main? This will not create a tag or publish a release."**
+- Explain that pushing the version-bump commit starts the signed `Release Build`
+  and that a successful build automatically creates `v{new_version}` and publishes
+  its exact artifacts. A failed build never creates a tag or release.
+- Ask: **"Ready to release v{new_version}? This will push the version bump to main; if the signed build succeeds, GitHub will automatically tag and publish it."**
 
-Stop and wait for confirmation. This confirmation authorizes only the version
-bump, main push, and non-publishing build. Do not create or push a tag yet.
+Stop and wait for confirmation. This is the release confirmation: it authorizes
+the version bump, main push, and automatic tag/publish after all gates pass.
 
 ## 5. Build Trusted Artifacts
 
@@ -60,33 +61,29 @@ Run these steps in order:
 
 1. Bump `"version"` in `app/src-tauri/tauri.conf.json`
 2. Bump `version` (package field only) in `app/src-tauri/Cargo.toml`
-3. Commit: `git add app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml && git commit -m "chore: bump version to {new_version}"`
-4. Push: `git push origin main`
-5. Wait for the `Release Build` workflow on that exact commit to succeed.
-6. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
+3. Update the `ui` package version in `app/src-tauri/Cargo.lock`
+4. Commit all three version files with: `chore: bump version to {new_version}`
+5. Push: `git push origin main`
+6. Wait for the `Release Build` workflow on that exact commit to succeed.
+7. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
    artifacts named with the exact 40-character commit SHA, package smoke tests,
    and cache summaries. Do not continue if any job or artifact is missing.
 
-If the build fails, use the cold fallback in `docs/release.md`; do not tag.
+If the build fails, use the cold fallback in `docs/release.md`. Automation will
+not create a tag or release for a failed build.
 
-## 6. Final Tag and Publish Confirmation
+## 6. Verify Automatic Promotion
 
-Present the exact commit SHA, successful Release Build run URL/timings, artifact
-names, and proposed tag. Ask:
+Wait for the `Release` workflow started by the completed `Release Build`. Verify
+that it used the exact build run ID and commit SHA, created `v{new_version}` at
+that commit, validated both immutable artifacts and updater signatures, and
+published the GitHub Release.
 
-**"The signed artifacts are ready. Confirm pushing v{new_version}; this will promote and publish the GitHub Release."**
+If automatic promotion fails after the build succeeded, fix or rerun it. The
+tag-triggered workflow remains the recovery path: only push the matching tag
+manually after confirming the exact successful trusted-main build and source SHA.
 
-Stop and wait for explicit confirmation. A prior confirmation to prepare or
-build the release does not authorize the tag.
-
-## 7. Promote Release
-
-Only after the final confirmation:
-
-1. Tag the already-built commit: `git tag v{new_version}`
-2. Push the tag: `git push origin v{new_version}`
-3. Wait for the tag-triggered `Release` workflow to validate and publish the
-   immutable artifacts (normally under two minutes), then update its notes:
+Then update its notes:
    ```
    gh release edit v{new_version} --repo georgenijo/murmur-app --notes "$(cat <<'EOF'
    ## What's New
@@ -105,9 +102,9 @@ Only after the final confirmation:
    ```
    Write the notes yourself from the commit list in Step 3 — use clear, user-facing language (not raw commit messages). Omit any section that has no entries. Skip `chore:`, `docs:`, `test:` commits.
 
-## 8. Hand Off
+## 7. Hand Off
 
 Tell the user:
-- Tag pushed — GitHub Actions is promoting the already-built signed artifacts
-- Where to watch: `https://github.com/georgenijo/murmur-app/actions`
-- Release will publish automatically at: `https://github.com/georgenijo/murmur-app/releases`
+- Exact commit, build run, promotion run, tag, and release URLs
+- The signed build passed and GitHub automatically promoted its exact artifacts
+- The release is published at: `https://github.com/georgenijo/murmur-app/releases`

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -28,6 +28,9 @@ RELEASE_BUILD_GUARD = (
 TRUSTED_MAIN_CACHE_DEFAULT = (
     '"${{ github.event_name == \'push\' && github.ref == \'refs/heads/main\' }}\"'
 )
+SEMVER = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
 
 
 def job_block(workflow: str, job: str) -> str:
@@ -72,6 +75,45 @@ def should_run_release_build(
         event_name == "push"
         and (head_commit_message or "").startswith("chore: bump version")
     )
+
+
+def should_auto_promote(
+    *,
+    event_name: str,
+    workflow_name: str,
+    workflow_path: str,
+    conclusion: str,
+    head_branch: str,
+    source_event: str,
+    head_commit_message: Optional[str],
+) -> bool:
+    return (
+        event_name == "workflow_run"
+        and workflow_name == "Release Build"
+        and workflow_path.split("@", 1)[0] == ".github/workflows/release-build.yml"
+        and conclusion == "success"
+        and head_branch == "main"
+        and source_event == "push"
+        and (head_commit_message or "").startswith("chore: bump version")
+    )
+
+
+def release_tag_for_versions(
+    tauri_version: str, cargo_version: str, lock_version: str
+) -> str:
+    if not SEMVER.fullmatch(tauri_version):
+        raise AssertionError(f"invalid release version: {tauri_version}")
+    if cargo_version != tauri_version or lock_version != tauri_version:
+        raise AssertionError("tauri.conf.json, Cargo.toml, and Cargo.lock differ")
+    return f"v{tauri_version}"
+
+
+def tag_action(existing_sha: Optional[str], source_sha: str) -> str:
+    if existing_sha is None:
+        return "create"
+    if existing_sha != source_sha:
+        raise AssertionError("existing tag points to a different commit")
+    return "reuse"
 
 
 def validate_ci(ci: str) -> int:
@@ -210,20 +252,49 @@ def validate_release_profile(cargo_toml: str) -> None:
 
 def validate_promotion_policy(workflow: str) -> int:
     assert "tags:\n      - 'v*'" in workflow
+    assert "workflow_run:\n    workflows: [Release Build]\n    types: [completed]" in workflow
     assert "\n  workflow_dispatch:" in workflow
     assert "self-hosted" not in workflow
     assert "actions/cache" not in workflow
     assert "swatinem/rust-cache" not in workflow
     assert scalar(job_block(workflow, "promote"), "needs") == "resolve"
+    assert scalar(job_block(workflow, "promote"), "if") == (
+        "needs.resolve.outputs.eligible == 'true' && "
+        "needs.resolve.outputs.already-published != 'true'"
+    )
+    assert "github.event.workflow_run.head_sha || github.sha" in workflow
+    for gate in (
+        'WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}',
+        'WORKFLOW_RUN_PATH: ${{ github.event.workflow_run.path }}',
+        'WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}',
+        'WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}',
+        'WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}',
+        '[ "$WORKFLOW_RUN_NAME" != "Release Build" ]',
+        '[ "$WORKFLOW_RUN_CONCLUSION" != "success" ]',
+        '[ "$WORKFLOW_RUN_BRANCH" != "main" ]',
+        '[ "$WORKFLOW_RUN_EVENT" != "push" ]',
+        '[[ "$SUBJECT" != "chore: bump version"* ]]',
+    ):
+        assert gate in workflow
     assert "head_branch == \"main\"" in workflow
     assert ".head_sha == $sha" in workflow
     assert ".event == \"push\"" in workflow
-    assert "release-build.yml" in workflow
+    assert 'split("@")[0]) == ".github/workflows/release-build.yml"' in workflow
     assert "expired == false" in workflow
     assert "scripts/release_artifacts.py validate" in workflow
+    assert 'at("app/src-tauri/tauri.conf.json")' in workflow
+    assert 'at("app/src-tauri/Cargo.toml")' in workflow
+    assert 'at("app/src-tauri/Cargo.lock")' in workflow
+    assert "release versions differ" in workflow
+    assert "already_published=true" in workflow
+    assert "contains unexpected asset" in workflow
+    assert workflow.index("scripts/release_artifacts.py validate") < workflow.index(
+        "Create automatic release tag"
+    )
 
     publish_steps = (
-        "Create draft release",
+        "Create automatic release tag",
+        "Create or reuse draft release",
         "Upload signed release assets",
         "Verify uploaded updater signatures",
         "Generate updater channel manifests from verified signatures",
@@ -237,7 +308,29 @@ def validate_promotion_policy(workflow: str) -> int:
         workflow, "Report non-publishing promotion rehearsal", 6
     )
     assert "if: needs.resolve.outputs.publish != 'true'" in rehearsal
-    return len(publish_steps)
+    trusted = dict(
+        event_name="workflow_run",
+        workflow_name="Release Build",
+        workflow_path=".github/workflows/release-build.yml",
+        conclusion="success",
+        head_branch="main",
+        source_event="push",
+        head_commit_message="chore: bump version to 0.18.0",
+    )
+    auto_cases = (
+        trusted,
+        {**trusted, "source_event": "workflow_dispatch"},
+        {**trusted, "head_branch": "feature"},
+        {**trusted, "conclusion": "failure"},
+        {**trusted, "head_commit_message": "fix: ordinary main commit"},
+    )
+    expected = (True, False, False, False, False)
+    for case, result in zip(auto_cases, expected):
+        assert should_auto_promote(**case) is result
+    assert release_tag_for_versions("0.18.0", "0.18.0", "0.18.0") == "v0.18.0"
+    assert tag_action(None, "a" * 40) == "create"
+    assert tag_action("a" * 40, "a" * 40) == "reuse"
+    return len(publish_steps) + len(auto_cases)
 
 
 def main() -> None:

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import unittest
 
 from scripts.validate_workflow_policy import (
+    release_tag_for_versions,
+    should_auto_promote,
+    tag_action,
     validate_linux_cache_policy,
     validate_promotion_policy,
     validate_release_build,
@@ -13,6 +16,72 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_automatic_promotion_requires_workflow_run_trigger(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        mutated = workflow.replace(
+            "  workflow_run:\n    workflows: [Release Build]\n    types: [completed]\n",
+            "",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            validate_promotion_policy(mutated)
+
+    def test_automatic_promotion_requires_trusted_main_push_gates(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        for old, new in (
+            ('[ "$WORKFLOW_RUN_CONCLUSION" != "success" ]', "false"),
+            ('[ "$WORKFLOW_RUN_BRANCH" != "main" ]', "false"),
+            ('[ "$WORKFLOW_RUN_EVENT" != "push" ]', "false"),
+            ('[[ "$SUBJECT" != "chore: bump version"* ]]', "false"),
+        ):
+            with self.subTest(gate=old):
+                with self.assertRaises(AssertionError):
+                    validate_promotion_policy(workflow.replace(old, new, 1))
+
+    def test_automatic_promotion_decision_rejects_negative_cases(self) -> None:
+        base = dict(
+            event_name="workflow_run",
+            workflow_name="Release Build",
+            workflow_path=".github/workflows/release-build.yml",
+            conclusion="success",
+            head_branch="main",
+            source_event="push",
+            head_commit_message="chore: bump version to 0.18.0",
+        )
+        self.assertTrue(should_auto_promote(**base))
+        for key, value in (
+            ("event_name", "workflow_dispatch"),
+            ("workflow_name", "CI"),
+            ("workflow_path", ".github/workflows/other.yml"),
+            ("conclusion", "failure"),
+            ("head_branch", "feature"),
+            ("source_event", "workflow_dispatch"),
+            ("head_commit_message", "fix: ordinary main commit"),
+        ):
+            case = {**base, key: value}
+            with self.subTest(key=key):
+                self.assertFalse(should_auto_promote(**case))
+
+    def test_release_versions_must_match(self) -> None:
+        self.assertEqual(
+            release_tag_for_versions("0.18.0", "0.18.0", "0.18.0"), "v0.18.0"
+        )
+        for versions in (
+            ("0.18", "0.18", "0.18"),
+            ("0.18.0", "0.17.1", "0.18.0"),
+            ("0.18.0", "0.18.0", "0.17.1"),
+        ):
+            with self.subTest(versions=versions):
+                with self.assertRaises(AssertionError):
+                    release_tag_for_versions(*versions)
+
+    def test_existing_tag_must_match_source_commit(self) -> None:
+        source = "a" * 40
+        self.assertEqual(tag_action(None, source), "create")
+        self.assertEqual(tag_action(source, source), "reuse")
+        with self.assertRaises(AssertionError):
+            tag_action("b" * 40, source)
+
     def test_tag_workflow_rejects_cuda_cache_save_action(self) -> None:
         workflow = (ROOT / ".github/workflows/release.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
## Summary

- trigger `Release` when an exact `Release Build` completes successfully from a trusted `main` push
- require the version-bump commit prefix plus matching semver in `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`
- validate immutable SHA-named artifacts before creating the tag, then publish with retry-safe tag/draft handling
- retain manual non-publishing rehearsals and tag-triggered recovery; fail closed on conflicting tags, releases, or unexpected draft assets
- update the release runbook, architecture docs, release prompt, changelog, and negative policy coverage

## Safety behavior

- failed builds: no-op, no tag/release
- manually dispatched builds: no-op, no tag/release
- non-main builds: no-op, no tag/release
- ordinary non-version-bump commits: no-op, no tag/release
- existing matching published release: idempotent success
- existing conflicting tag/release: fail closed

## Verification

- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest discover -s tests -v` (21 passed)
- `npm test` (96 passed)
- `npm run build`
- `cargo test -- --test-threads=1` (287 unit tests + Whisper integration passed; optional Core ML fixture test ignored as designed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- exact workflow shell blocks parsed with `bash -n`
- live read-only idempotency resolution against v0.17.1 returned `already_published=true`
- non-publishing GitHub promotion rehearsal passed: https://github.com/georgenijo/murmur-app/actions/runs/29675407615 (all publication steps skipped)

Closes #239
