### PR TITLE
fix(onboarding): detect already-downloaded models in setup assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Release automation now builds signed macOS and Linux artifacts once on trusted `main`, keeps Cargo/CUDA cache ownership off tags and pull requests, and promotes only commit-SHA-matched artifacts with fail-closed updater-signature checks (#220).
 
 ### Fixed
+- The setup assistant's model step now detects every already-downloaded model, badges installed rows, and offers Continue instead of Download for them; the wizard is also skipped entirely when permissions are granted and any model exists on disk (#240).
 - Consecutive Core ML dictations now start with fresh Parakeet decoder state, preventing later one-shot recordings from collapsing to punctuation-only empty transcripts (#236).
 - `murmur-diag` now reads and source-labels both release and dev log streams without duplicate file ingestion, keeps cross-build correlation isolated, and uses one documented user-level MCP registration instead of per-worktree registrations (#191).
 - Code-vocabulary scans now keep the View-all dialog keyboard focus contained and restore the opener on close, correlate live progress by scan ID, and report superseded results when settings change during a walk instead of presenting non-adopted terms as complete (#209).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,6 +30,7 @@ import { ModelDownloader } from './components/ModelDownloader';
 import { OnboardingFlow } from './components/onboarding/OnboardingFlow';
 import { isOnboardingComplete, markOnboardingComplete, resetOnboarding } from './lib/onboarding';
 import { checkAccessibilityPermission, checkMicrophonePermissionStatus, checkModelExists } from './lib/dictation';
+import { AVAILABLE_MODEL_OPTIONS } from './lib/settings';
 
 function App() {
   // --- Diagnostic: track when main window becomes visible/focused ---
@@ -70,8 +71,11 @@ function App() {
   }, []);
 
   // Setup-assistant gate. Runs when the completion flag is absent, but
-  // grandfathers existing installs: if both permissions and the model are
+  // grandfathers existing installs: if both permissions and *any* model are
   // already in place, set the flag silently so upgrades never see the wizard.
+  // Checking every model (not just the settings default) keeps a fresh webview
+  // data store (e.g. tauri dev vs installed app) from re-running the wizard
+  // when models are already on disk (#240).
   const [onboardingState, setOnboardingState] = useState<'unknown' | 'needed' | 'done'>('unknown');
   useEffect(() => {
     if (isOnboardingComplete()) {
@@ -79,17 +83,20 @@ function App() {
       return;
     }
     (async () => {
-      const [micStatus, axGranted, modelExists] = await Promise.all([
+      const [micStatus, axGranted, modelsOnDisk] = await Promise.all([
         checkMicrophonePermissionStatus().catch(() => 'unknown' as const),
         checkAccessibilityPermission().catch(() => false),
-        checkModelExists(settings.model).catch(() => false),
+        Promise.all(
+          AVAILABLE_MODEL_OPTIONS.map((option) => checkModelExists(option.value).catch(() => false)),
+        ),
       ]);
-      if (micStatus === 'granted' && axGranted && modelExists) {
-        flog.info('main', 'Onboarding grandfathered: permissions and model already present');
+      const anyModelExists = modelsOnDisk.some(Boolean);
+      if (micStatus === 'granted' && axGranted && anyModelExists) {
+        flog.info('main', 'Onboarding grandfathered: permissions and a model already present');
         markOnboardingComplete();
         setOnboardingState('done');
       } else {
-        flog.info('main', 'Onboarding needed', { micStatus, axGranted, modelExists });
+        flog.info('main', 'Onboarding needed', { micStatus, axGranted, anyModelExists });
         setOnboardingState('needed');
       }
     })();

--- a/app/src/components/ModelDownloader.tsx
+++ b/app/src/components/ModelDownloader.tsx
@@ -15,8 +15,12 @@ const MODEL_DESCRIPTIONS: Record<string, string> = {
   'base.en': 'Good balance of speed and accuracy',
 };
 
-/** Subset of models shown on the initial download screen (first = default). */
-const DOWNLOAD_MODEL_KEYS: ModelOption[] = [
+/**
+ * Subset of models shown on the initial download screen (first = default).
+ * Exported so embedders (the onboarding wizard) can probe exactly the rows
+ * the panel renders for on-disk existence.
+ */
+export const DOWNLOAD_MODEL_KEYS: ModelOption[] = [
   'parakeet-tdt-0.6b-v3-coreml',
   'parakeet-tdt-0.6b-v2-fp16',
   'large-v3-turbo',
@@ -33,6 +37,13 @@ interface Props {
   onComplete: (model: ModelOption) => void;
   /** Notifies embedders when a download starts/stops (e.g. to lock navigation). */
   onDownloadingChange?: (downloading: boolean) => void;
+  /**
+   * Per-model on-disk status from the embedder's probe. Installed rows show an
+   * "Installed" chip instead of the size, and selecting one turns the primary
+   * button into Continue (completes without downloading). Omitted = unknown,
+   * every row behaves as before.
+   */
+  installedModels?: Partial<Record<ModelOption, boolean>>;
 }
 
 type DownloadState =
@@ -45,7 +56,7 @@ type DownloadState =
  * Used by the standalone first-launch gate (ModelDownloader) and embedded in
  * the onboarding wizard's model step (OnboardingFlow).
  */
-export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChange }: Props) {
+export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChange, installedModels }: Props) {
   const [selected, setSelected] = useState<ModelOption>(
     MODELS.some((model) => model.name === initialModel) ? initialModel : MODELS[0].name
   );
@@ -101,6 +112,7 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
   const progressPercent = progress ? modelDownloadPercent(progress) : null;
 
   const isDownloading = downloadState.phase === 'downloading';
+  const selectedInstalled = installedModels?.[selected] === true;
 
   return (
     <div>
@@ -120,9 +132,15 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
                 <span className="text-sm font-medium text-on-surface">
                   {model.label}
                 </span>
-                <span className="text-xs text-on-surface-variant font-mono">
-                  {model.size}
-                </span>
+                {installedModels?.[model.name] ? (
+                  <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-medium text-primary">
+                    Installed
+                  </span>
+                ) : (
+                  <span className="text-xs text-on-surface-variant font-mono">
+                    {model.size}
+                  </span>
+                )}
               </div>
               <p className="text-xs text-on-surface-variant mt-0.5">
                 {model.description}
@@ -171,13 +189,17 @@ export function ModelDownloadPanel({ initialModel, onComplete, onDownloadingChan
           </div>
         )}
 
+        {/* An installed selection completes immediately — same path a finished
+            download takes — so nothing on disk is ever re-downloaded. */}
         <button
-          onClick={handleDownload}
+          onClick={selectedInstalled ? () => onComplete(selected) : handleDownload}
           disabled={isDownloading}
           className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-on-primary transition-colors hover:bg-primary-dim disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isDownloading
             ? progress ? modelDownloadLabel(progress) : 'Starting...'
+            : selectedInstalled
+            ? 'Continue'
             : downloadState.phase === 'error'
             ? 'Retry Download'
             : 'Download'}

--- a/app/src/components/onboarding/OnboardingFlow.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.tsx
@@ -10,7 +10,7 @@ import {
   resetMicrophonePermission,
   type MicPermissionStatus,
 } from '../../lib/dictation';
-import { ModelDownloadPanel } from '../ModelDownloader';
+import { DOWNLOAD_MODEL_KEYS, ModelDownloadPanel } from '../ModelDownloader';
 import type { DoubleTapKey, ModelOption, RecordingMode } from '../../lib/settings';
 
 type Step = 'welcome' | 'microphone' | 'accessibility' | 'model' | 'done';
@@ -56,8 +56,12 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
   const [axGranted, setAxGranted] = useState<boolean | null>(null);
   const [axRequested, setAxRequested] = useState(false);
   const [axError, setAxError] = useState<string | null>(null);
-  // null = not checked yet; the model step shows a spinner-less blank until known.
-  const [modelInstalled, setModelInstalled] = useState<boolean | null>(null);
+  // Per-model on-disk status for every option the download panel offers.
+  // null = not probed yet; the model step shows a spinner-less blank until known.
+  const [installedModels, setInstalledModels] = useState<Partial<Record<ModelOption, boolean>> | null>(null);
+  // Whether the model step finished with a model on disk (Continue or download);
+  // drives the done-step summary row.
+  const [modelInstalled, setModelInstalled] = useState(false);
   const [installedModel, setInstalledModel] = useState<ModelOption>(initialModel);
   // Lock Back while a download is in flight: unmounting the panel wouldn't stop
   // the Rust download_model command, and re-entering the step could start a
@@ -96,16 +100,39 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
     };
   }, [refreshPermissions]);
 
-  // Check whether the selected model is already on disk when entering the
-  // model step (re-run of the wizard, or a partially completed first launch).
+  // Probe every offered model when entering the model step (re-run of the
+  // wizard, or a fresh webview data store next to an installed app), so any
+  // already-downloaded model shows as Installed instead of just the settings
+  // default (#240).
   useEffect(() => {
     if (step !== 'model') return;
-    checkModelExists(initialModel)
-      .then(setModelInstalled)
-      // Fail open (skip the download) — matches the standalone gate's behavior;
-      // a genuine fresh install resolves to `false` rather than throwing.
-      .catch(() => setModelInstalled(true));
-  }, [step, initialModel]);
+    let stale = false;
+    Promise.all(
+      DOWNLOAD_MODEL_KEYS.map((model) =>
+        checkModelExists(model).then(
+          (exists) => [model, exists] as const,
+          // Fail open per row (skip the download) — matches the standalone
+          // gate's behavior; a genuine fresh install resolves to `false`
+          // rather than throwing.
+          () => [model, true] as const,
+        ),
+      ),
+    ).then((entries) => {
+      if (!stale) {
+        setInstalledModels(Object.fromEntries(entries) as Partial<Record<ModelOption, boolean>>);
+      }
+    });
+    return () => {
+      stale = true;
+    };
+  }, [step]);
+
+  // If the settings model is missing but another offered model is on disk,
+  // pre-select an installed one so the primary action is Continue, not Download.
+  const preferredModel =
+    installedModels === null || installedModels[initialModel]
+      ? initialModel
+      : DOWNLOAD_MODEL_KEYS.find((model) => installedModels[model]) ?? initialModel;
 
   const stepIndex = STEP_ORDER.indexOf(step);
   const goNext = () => setStep(STEP_ORDER[Math.min(stepIndex + 1, STEP_ORDER.length - 1)]);
@@ -353,17 +380,13 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
               runs offline.
             </p>
 
-            {modelInstalled === null ? (
+            {installedModels === null ? (
               <div className="h-24" />
-            ) : modelInstalled ? (
-              <div>
-                <GrantedCard label="Model already installed" />
-                <WizardFooter onBack={goBack} onNext={goNext} nextEnabled nextLabel="Continue" />
-              </div>
             ) : (
               <div>
                 <ModelDownloadPanel
-                  initialModel={initialModel}
+                  initialModel={preferredModel}
+                  installedModels={installedModels}
                   onDownloadingChange={setModelDownloading}
                   onComplete={(model) => {
                     setInstalledModel(model);

--- a/app/src/lib/onboarding.ts
+++ b/app/src/lib/onboarding.ts
@@ -3,8 +3,8 @@
  *
  * The setup assistant (OnboardingFlow) runs when this flag is absent. Existing
  * installs are grandfathered at mount: if the mic + accessibility permissions
- * and the selected model are already in place, App sets the flag silently so
- * upgrades never see the wizard. Stored in localStorage alongside settings,
+ * and any model are already in place, App sets the flag silently so upgrades
+ * never see the wizard. Stored in localStorage alongside settings,
  * stats, and history.
  */
 


### PR DESCRIPTION
## Summary

Closes #240

The setup assistant's model step probed only the settings-default model via `checkModelExists(initialModel)`, so other downloaded models were invisible: no per-row installed state, selecting an installed model still offered **Download**, and a fresh webview data store (`tauri dev` vs installed app) re-ran the wizard even with models on disk.

## Changes

- **`OnboardingFlow.tsx`** — On entering the model step, probe every model the download panel offers (parallel `Promise.all`, per-row fail-open: a probe error counts as installed so nothing is force re-downloaded). The step now always renders the model picker once probed; the old settings-default-only `GrantedCard` collapse is replaced by per-row state. When the settings model is missing but another offered model is installed, an installed one is pre-selected. The `modelDownloading` Back-lock and 1s permission polling are unchanged; permissions steps untouched.
- **`ModelDownloader.tsx`** — `ModelDownloadPanel` accepts an optional `installedModels` map: installed rows show an "Installed" chip in place of the size label, and selecting one turns the primary button into **Continue**, which calls `onComplete(selected)` directly (same path as a finished download) without downloading. Omitting the prop (standalone gate) leaves behavior unchanged. `DOWNLOAD_MODEL_KEYS` is exported so the wizard probes exactly the rows the panel renders.
- **`App.tsx`** — The grandfather gate now checks whether *any* `AVAILABLE_MODEL_OPTIONS` model exists on disk (each probe fail-closed, as before), so the wizard is skipped when permissions are granted and any model is installed — fixing the dev-server re-trigger. Genuinely fresh installs still see the wizard.
- **`lib/onboarding.ts`** — Doc comment updated to match the new gate semantics.
- **`CHANGELOG.md`** — Entry under [Unreleased] → Fixed.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 96 tests, 12 files, all passing
- No Rust changes (`check_specific_model_exists` already existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)