### PR TITLE
feat: preview incremental Whisper transcript in overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Long Whisper recordings now show a session-scoped provisional transcript in the notch overlay after each reliable incremental chunk. The privacy-safe preview can be disabled in Settings; final clipboard and auto-paste delivery remain unchanged and occur exactly once after stop (#243).
+
 ### Changed
 - Post-recognition cleanup, voice commands, and Smart Correction now run through one ordered, backend-neutral transformation pipeline with privacy-safe per-stage timing/change telemetry and explicit failure policy (#244).
 

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1,7 +1,7 @@
 use crate::{MutexExt, State};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
-use crate::{audio, audio_decode, injector, keyboard, streaming, vad};
+use crate::{audio, audio_decode, injector, keyboard, partial_transcript, streaming, vad};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
@@ -420,6 +420,12 @@ pub(crate) struct PipelineTimings {
     pub incremental_chunks: u32,
     pub streaming_inference_ms: u64,
     pub final_chunk_ms: u64,
+    pub incremental_attempted: bool,
+    pub incremental_completed: bool,
+    pub incremental_fell_back: bool,
+    pub start_to_first_partial_ms: Option<u64>,
+    pub partial_update_count: u32,
+    pub last_partial_at: Option<std::time::Instant>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -454,7 +460,7 @@ async fn run_transcription_pipeline(
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
     recording_id: u64,
-    incremental: Option<streaming::IncrementalTranscript>,
+    incremental: streaming::IncrementalFinalization,
 ) -> Result<(String, PipelineTimings), String> {
     // Guard resets status to Idle on any return path (error or success),
     // but only if this recording is still the active one
@@ -500,7 +506,21 @@ async fn run_transcription_pipeline(
         return Ok((String::new(), PipelineTimings::default()));
     }
 
-    let (text, mut timings) = if let Some(incremental) = incremental {
+    let streaming::IncrementalFinalization {
+        transcript: incremental_transcript,
+        metrics: incremental_metrics,
+    } = incremental;
+    let partial_metric_timings = || PipelineTimings {
+        incremental_attempted: incremental_metrics.attempted,
+        incremental_completed: incremental_metrics.completed,
+        incremental_fell_back: incremental_metrics.fell_back,
+        start_to_first_partial_ms: incremental_metrics.start_to_first_partial_ms,
+        partial_update_count: incremental_metrics.partial_update_count,
+        last_partial_at: incremental_metrics.last_partial_at,
+        ..PipelineTimings::default()
+    };
+
+    let (text, mut timings) = if let Some(incremental) = incremental_transcript {
         tracing::info!(
             target: "pipeline",
             recording_id,
@@ -520,7 +540,7 @@ async fn run_transcription_pipeline(
                 incremental_chunks: incremental.chunk_count,
                 streaming_inference_ms: incremental.streaming_inference_ms,
                 final_chunk_ms: incremental.final_chunk_ms,
-                ..PipelineTimings::default()
+                ..partial_metric_timings()
             },
         )
     } else {
@@ -544,7 +564,7 @@ async fn run_transcription_pipeline(
                             samples.len(), t_vad.elapsed());
                         return Ok((String::new(), PipelineTimings {
                             vad_ms: t_vad.elapsed().as_millis() as u64,
-                            ..PipelineTimings::default()
+                            ..partial_metric_timings()
                         }));
                     }
                     Ok(vad::VadResult::Speech(trimmed)) => {
@@ -577,7 +597,7 @@ async fn run_transcription_pipeline(
             tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
             return Ok((String::new(), PipelineTimings {
                 vad_ms,
-                ..PipelineTimings::default()
+                ..partial_metric_timings()
             }));
         }
 
@@ -611,7 +631,7 @@ async fn run_transcription_pipeline(
                 inference_ms,
                 rss_before_mb,
                 rss_after_mb,
-                ..PipelineTimings::default()
+                ..partial_metric_timings()
             },
         )
     };
@@ -779,7 +799,7 @@ pub async fn process_audio(
         &app_handle,
         &state.app_state,
         rid,
-        None,
+        streaming::IncrementalFinalization::default(),
     )
     .await;
     // Only emit idle if this recording wasn't cancelled/superseded.
@@ -1500,6 +1520,7 @@ pub async fn start_native_recording(
         return Err(e);
     }
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
+    partial_transcript::emit_session_started(&app_handle, rid);
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(target: "pipeline", "start_native_recording: started");
     spawn_model_preparation(app_handle.clone(), model_name.clone(), rid);
@@ -1529,7 +1550,8 @@ pub async fn start_native_recording(
 
     Ok(serde_json::json!({
         "type": "recording_started",
-        "state": "recording"
+        "state": "recording",
+        "recordingId": rid
     }))
 }
 
@@ -1572,6 +1594,11 @@ pub async fn stop_native_recording(
     // Phase: Audio teardown + 16kHz resample
     let t_total = std::time::Instant::now();
     let samples = audio::stop_recording().map_err(|e| {
+        partial_transcript::emit_clear(
+            &app_handle,
+            rid,
+            partial_transcript::PartialTranscriptClearReason::Error,
+        );
         tracing::error!(target: "audio", "stop_native_recording: stop_recording failed: {}", e);
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
@@ -1585,6 +1612,11 @@ pub async fn stop_native_recording(
 
     if samples.is_empty() {
         streaming::discard(streaming_session);
+        partial_transcript::emit_clear(
+            &app_handle,
+            rid,
+            partial_transcript::PartialTranscriptClearReason::Finalized,
+        );
         tracing::info!(target: "pipeline", "stop_native_recording: no audio captured");
         // guard drops on return, resetting status to Idle
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
@@ -1603,6 +1635,11 @@ pub async fn stop_native_recording(
 
     if samples.len() < MIN_RECORDING_SAMPLES {
         streaming::discard(streaming_session);
+        partial_transcript::emit_clear(
+            &app_handle,
+            rid,
+            partial_transcript::PartialTranscriptClearReason::Finalized,
+        );
         tracing::info!(target: "pipeline", "stop_native_recording: recording too short ({}ms), discarding",
             samples.len() / 16); // samples / 16_000 * 1000
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
@@ -1637,10 +1674,25 @@ pub async fn stop_native_recording(
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
     }
-    let (text, timings) = pipeline_result.map_err(|e| {
-        tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", e);
-        e
-    })?;
+    let (text, timings) = match pipeline_result {
+        Ok(result) => {
+            partial_transcript::emit_clear(
+                &app_handle,
+                rid,
+                partial_transcript::PartialTranscriptClearReason::Finalized,
+            );
+            result
+        }
+        Err(error) => {
+            partial_transcript::emit_clear(
+                &app_handle,
+                rid,
+                partial_transcript::PartialTranscriptClearReason::Error,
+            );
+            tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", error);
+            return Err(error);
+        }
+    };
 
     let total_ms = t_total.elapsed().as_millis() as u64;
     let audio_secs = samples.len() as f64 / 16_000.0;
@@ -1654,6 +1706,10 @@ pub async fn stop_native_recording(
         let b = state.app_state.backend.lock_or_recover();
         b.name().to_string()
     };
+    let last_partial_to_final_ms = timings
+        .last_partial_at
+        .map(|at| at.elapsed().as_millis() as u64)
+        .unwrap_or(0);
 
     tracing::info!(
         target: "pipeline",
@@ -1663,6 +1719,13 @@ pub async fn stop_native_recording(
         decode_ms = timings.decode_ms,
         inference_ms = timings.inference_ms,
         incremental_chunks = timings.incremental_chunks,
+        incremental_attempted = timings.incremental_attempted,
+        incremental_completed = timings.incremental_completed,
+        incremental_fell_back = timings.incremental_fell_back,
+        start_to_first_partial_ms = timings.start_to_first_partial_ms.unwrap_or(0),
+        had_partial = timings.start_to_first_partial_ms.is_some(),
+        partial_update_count = timings.partial_update_count,
+        last_partial_to_final_ms,
         streaming_inference_ms = timings.streaming_inference_ms,
         final_chunk_ms = timings.final_chunk_ms,
         correction_ms = timings.correction_ms,
@@ -1683,6 +1746,7 @@ pub async fn stop_native_recording(
     let recording_secs = samples.len() / 16_000;
     if !text.is_empty() {
         let _ = app_handle.emit("transcription-complete", serde_json::json!({
+            "recordingId": rid,
             "text": text,
             "duration": recording_secs
         }));
@@ -1721,6 +1785,11 @@ pub async fn cancel_native_recording(
         (prev, rid)
     };
     streaming::cancel(&state.app_state, rid).await;
+    partial_transcript::emit_clear(
+        &app_handle,
+        rid,
+        partial_transcript::PartialTranscriptClearReason::Cancelled,
+    );
 
     let stop_err = match prev_status {
         DictationStatus::Recording => {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod file_output;
 mod frontmost;
 mod injector;
 mod keyboard;
+mod partial_transcript;
 mod platform;
 mod resource_monitor;
 mod state;

--- a/app/src-tauri/src/partial_transcript.rs
+++ b/app/src-tauri/src/partial_transcript.rs
@@ -1,0 +1,117 @@
+use tauri::Emitter;
+
+pub(crate) const CONTRACT_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RecordingSessionStarted {
+    contract_version: u8,
+    recording_id: u64,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PartialTranscriptUpdate {
+    contract_version: u8,
+    recording_id: u64,
+    text: String,
+    chunk_index: u32,
+    processed_audio_ms: u64,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PartialTranscriptClearReason {
+    Cancelled,
+    Error,
+    Fallback,
+    Finalized,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PartialTranscriptCleared {
+    contract_version: u8,
+    recording_id: u64,
+    reason: PartialTranscriptClearReason,
+}
+
+pub(crate) fn emit_session_started(app: &tauri::AppHandle, recording_id: u64) {
+    let _ = app.emit(
+        "recording-session-started",
+        RecordingSessionStarted {
+            contract_version: CONTRACT_VERSION,
+            recording_id,
+        },
+    );
+}
+
+pub(crate) fn emit_update(
+    app: &tauri::AppHandle,
+    recording_id: u64,
+    text: String,
+    chunk_index: u32,
+    processed_audio_ms: u64,
+) {
+    let _ = app.emit(
+        "partial-transcript",
+        PartialTranscriptUpdate {
+            contract_version: CONTRACT_VERSION,
+            recording_id,
+            text,
+            chunk_index,
+            processed_audio_ms,
+        },
+    );
+}
+
+pub(crate) fn emit_clear(
+    app: &tauri::AppHandle,
+    recording_id: u64,
+    reason: PartialTranscriptClearReason,
+) {
+    let _ = app.emit(
+        "partial-transcript-cleared",
+        PartialTranscriptCleared {
+            contract_version: CONTRACT_VERSION,
+            recording_id,
+            reason,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_contract_is_versioned_and_camel_case() {
+        let value = serde_json::to_value(PartialTranscriptUpdate {
+            contract_version: CONTRACT_VERSION,
+            recording_id: 42,
+            text: "provisional words".to_string(),
+            chunk_index: 3,
+            processed_audio_ms: 26_000,
+        })
+        .unwrap();
+
+        assert_eq!(value["contractVersion"], CONTRACT_VERSION);
+        assert_eq!(value["recordingId"], 42);
+        assert_eq!(value["chunkIndex"], 3);
+        assert_eq!(value["processedAudioMs"], 26_000);
+        assert!(value.get("recording_id").is_none());
+    }
+
+    #[test]
+    fn clear_contract_has_privacy_safe_reason_only() {
+        let value = serde_json::to_value(PartialTranscriptCleared {
+            contract_version: CONTRACT_VERSION,
+            recording_id: 9,
+            reason: PartialTranscriptClearReason::Fallback,
+        })
+        .unwrap();
+
+        assert_eq!(value["reason"], "fallback");
+        assert!(value.get("text").is_none());
+    }
+}

--- a/app/src-tauri/src/streaming.rs
+++ b/app/src-tauri/src/streaming.rs
@@ -1,5 +1,5 @@
 use crate::state::DictationStatus;
-use crate::{audio, transcriber, vad, MutexExt, State};
+use crate::{audio, partial_transcript, transcriber, vad, MutexExt, State};
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 use tauri::Manager;
@@ -26,6 +26,9 @@ struct StreamingProgress {
     chunk_count: u32,
     vad_ms: u64,
     inference_ms: u64,
+    start_to_first_partial_ms: Option<u64>,
+    partial_update_count: u32,
+    last_partial_at: Option<Instant>,
     reliable: bool,
     fallback_reason: Option<String>,
 }
@@ -48,6 +51,22 @@ pub(crate) struct IncrementalTranscript {
 }
 
 #[derive(Default)]
+pub(crate) struct IncrementalMetrics {
+    pub attempted: bool,
+    pub completed: bool,
+    pub fell_back: bool,
+    pub start_to_first_partial_ms: Option<u64>,
+    pub partial_update_count: u32,
+    pub last_partial_at: Option<Instant>,
+}
+
+#[derive(Default)]
+pub(crate) struct IncrementalFinalization {
+    pub transcript: Option<IncrementalTranscript>,
+    pub metrics: IncrementalMetrics,
+}
+
+#[derive(Default)]
 struct ChunkOutput {
     text: String,
     vad_ms: u64,
@@ -65,8 +84,14 @@ pub(crate) async fn start_session(app_handle: tauri::AppHandle, config: Streamin
 
     let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
     let recording_id = config.recording_id;
+    let recording_started_at = Instant::now();
     let task_config = config.clone();
-    let join = tokio::spawn(run_session(app_handle.clone(), task_config, stop_rx));
+    let join = tokio::spawn(run_session(
+        app_handle.clone(),
+        task_config,
+        stop_rx,
+        recording_started_at,
+    ));
     let session = StreamingSession {
         recording_id,
         config,
@@ -96,6 +121,7 @@ async fn run_session(
     app_handle: tauri::AppHandle,
     config: StreamingConfig,
     mut stop_rx: tokio::sync::watch::Receiver<bool>,
+    recording_started_at: Instant,
 ) -> StreamingProgress {
     let mut progress = StreamingProgress {
         reliable: true,
@@ -152,11 +178,35 @@ async fn run_session(
                     ));
                     break;
                 }
-                progress.text = reconciled.text;
+                // Inference can outlive cancellation, a model change, or a
+                // newer recording. Revalidate after reconciliation and before
+                // adopting or publishing any provisional text.
+                if !session_config_is_current(&app_handle, &config) {
+                    progress.reliable = false;
+                    progress.fallback_reason =
+                        Some("recording session was superseded after inference".to_string());
+                    break;
+                }
+                let previous_text = std::mem::replace(&mut progress.text, reconciled.text);
                 progress.processed_end = next_end;
                 progress.chunk_count += 1;
                 progress.vad_ms = progress.vad_ms.saturating_add(chunk.vad_ms);
                 progress.inference_ms = progress.inference_ms.saturating_add(chunk.inference_ms);
+                if should_publish_partial(&previous_text, &progress.text) {
+                    let now = Instant::now();
+                    progress
+                        .start_to_first_partial_ms
+                        .get_or_insert_with(|| recording_started_at.elapsed().as_millis() as u64);
+                    progress.partial_update_count += 1;
+                    progress.last_partial_at = Some(now);
+                    partial_transcript::emit_update(
+                        &app_handle,
+                        config.recording_id,
+                        progress.text.clone(),
+                        progress.chunk_count,
+                        (next_end / 16) as u64,
+                    );
+                }
                 tracing::info!(
                     target: "pipeline",
                     recording_id = config.recording_id,
@@ -178,10 +228,20 @@ async fn run_session(
     }
 
     if !progress.reliable {
+        partial_transcript::emit_clear(
+            &app_handle,
+            config.recording_id,
+            partial_transcript::PartialTranscriptClearReason::Fallback,
+        );
         tracing::warn!(
             target: "pipeline",
             recording_id = config.recording_id,
             reason = progress.fallback_reason.as_deref().unwrap_or("unknown"),
+            start_to_first_partial_ms = progress.start_to_first_partial_ms.unwrap_or(0),
+            had_partial = progress.start_to_first_partial_ms.is_some(),
+            partial_update_count = progress.partial_update_count,
+            incremental_completed = false,
+            incremental_fell_back = true,
             "incremental transcription abandoned; batch fallback required"
         );
     }
@@ -194,6 +254,19 @@ fn session_is_current(app_handle: &tauri::AppHandle, recording_id: u64) -> bool 
     let cancelled_id = state.app_state.cancelled_id.load(Ordering::SeqCst);
     let dictation = state.app_state.dictation.lock_or_recover();
     session_generation_is_current(current_id, cancelled_id, recording_id, dictation.status)
+}
+
+fn session_config_is_current(app_handle: &tauri::AppHandle, config: &StreamingConfig) -> bool {
+    let state = app_handle.state::<State>();
+    let current_id = state.app_state.recording_id.load(Ordering::SeqCst);
+    let cancelled_id = state.app_state.cancelled_id.load(Ordering::SeqCst);
+    let dictation = state.app_state.dictation.lock_or_recover();
+    session_generation_is_current(
+        current_id,
+        cancelled_id,
+        config.recording_id,
+        dictation.status,
+    ) && dictation.model_name == config.model_name
 }
 
 fn session_generation_is_current(
@@ -212,6 +285,10 @@ fn session_generation_is_current(
 
 fn worker_fell_behind(available: usize, next_end: usize) -> bool {
     available >= next_end.saturating_add(STEP_SAMPLES)
+}
+
+fn should_publish_partial(previous: &str, cumulative: &str) -> bool {
+    !cumulative.trim().is_empty() && previous != cumulative
 }
 
 async fn transcribe_window(
@@ -324,43 +401,105 @@ pub(crate) async fn finalize(
     app_handle: tauri::AppHandle,
     session: Option<StreamingSession>,
     full_samples: &[f32],
-) -> Option<IncrementalTranscript> {
-    let session = session?;
+) -> IncrementalFinalization {
+    let Some(session) = session else {
+        return IncrementalFinalization::default();
+    };
     let config = session.config.clone();
     let progress = match session.join.await {
         Ok(progress) => progress,
         Err(error) => {
             tracing::warn!(target: "pipeline", recording_id = config.recording_id, error = %error, "incremental join failed; using batch fallback");
-            return None;
+            partial_transcript::emit_clear(
+                &app_handle,
+                config.recording_id,
+                partial_transcript::PartialTranscriptClearReason::Fallback,
+            );
+            return IncrementalFinalization {
+                metrics: IncrementalMetrics {
+                    attempted: true,
+                    fell_back: true,
+                    ..IncrementalMetrics::default()
+                },
+                ..IncrementalFinalization::default()
+            };
         }
     };
-    if !progress.reliable
-        || progress.chunk_count == 0
-        || progress.processed_end > full_samples.len()
-    {
-        return None;
+    let mut metrics = IncrementalMetrics {
+        attempted: true,
+        start_to_first_partial_ms: progress.start_to_first_partial_ms,
+        partial_update_count: progress.partial_update_count,
+        last_partial_at: progress.last_partial_at,
+        ..IncrementalMetrics::default()
+    };
+    if !progress.reliable || progress.processed_end > full_samples.len() {
+        metrics.fell_back = true;
+        partial_transcript::emit_clear(
+            &app_handle,
+            config.recording_id,
+            partial_transcript::PartialTranscriptClearReason::Fallback,
+        );
+        return IncrementalFinalization {
+            transcript: None,
+            metrics,
+        };
+    }
+    if progress.chunk_count == 0 {
+        return IncrementalFinalization {
+            transcript: None,
+            metrics,
+        };
     }
 
     let tail_start = progress.processed_end.saturating_sub(OVERLAP_SAMPLES);
     let tail = full_samples[tail_start..].to_vec();
     let final_started = Instant::now();
-    let final_chunk = match transcribe_window(app_handle, config.clone(), tail).await {
+    let final_chunk = match transcribe_window(app_handle.clone(), config.clone(), tail).await {
         Ok(chunk) => chunk,
         Err(error) => {
             tracing::warn!(target: "pipeline", recording_id = config.recording_id, error, "incremental final chunk failed; using batch fallback");
-            return None;
+            metrics.fell_back = true;
+            partial_transcript::emit_clear(
+                &app_handle,
+                config.recording_id,
+                partial_transcript::PartialTranscriptClearReason::Fallback,
+            );
+            return IncrementalFinalization {
+                transcript: None,
+                metrics,
+            };
         }
     };
     let final_chunk_ms = final_started.elapsed().as_millis() as u64;
     let reconciled = reconcile_overlapping_text(&progress.text, &final_chunk.text);
     if !progress.text.is_empty() && !final_chunk.text.is_empty() && reconciled.overlap_words == 0 {
         tracing::warn!(target: "pipeline", recording_id = config.recording_id, "incremental final chunk had no deterministic overlap; using batch fallback");
-        return None;
+        metrics.fell_back = true;
+        partial_transcript::emit_clear(
+            &app_handle,
+            config.recording_id,
+            partial_transcript::PartialTranscriptClearReason::Fallback,
+        );
+        return IncrementalFinalization {
+            transcript: None,
+            metrics,
+        };
     }
     let text = reconciled.text;
     if text.trim().is_empty() {
-        return None;
+        metrics.fell_back = true;
+        partial_transcript::emit_clear(
+            &app_handle,
+            config.recording_id,
+            partial_transcript::PartialTranscriptClearReason::Fallback,
+        );
+        return IncrementalFinalization {
+            transcript: None,
+            metrics,
+        };
     }
+
+    metrics.completed = true;
 
     tracing::info!(
         target: "pipeline",
@@ -372,20 +511,25 @@ pub(crate) async fn finalize(
         final_chunk_ms,
         "incremental transcription finalized"
     );
-    Some(IncrementalTranscript {
-        text,
-        chunk_count: progress.chunk_count + 1,
-        vad_ms: progress.vad_ms.saturating_add(final_chunk.vad_ms),
-        streaming_inference_ms: progress.inference_ms,
-        final_chunk_ms,
-        rss_before_mb: final_chunk.rss_before_mb,
-        rss_after_mb: final_chunk.rss_after_mb,
-    })
+    IncrementalFinalization {
+        transcript: Some(IncrementalTranscript {
+            text,
+            chunk_count: progress.chunk_count + 1,
+            vad_ms: progress.vad_ms.saturating_add(final_chunk.vad_ms),
+            streaming_inference_ms: progress.inference_ms,
+            final_chunk_ms,
+            rss_before_mb: final_chunk.rss_before_mb,
+            rss_after_mb: final_chunk.rss_after_mb,
+        }),
+        metrics,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{session_generation_is_current, worker_fell_behind, STEP_SAMPLES};
+    use super::{
+        session_generation_is_current, should_publish_partial, worker_fell_behind, STEP_SAMPLES,
+    };
     use crate::state::DictationStatus;
 
     #[test]
@@ -421,5 +565,16 @@ mod tests {
         let next_end = 160_000;
         assert!(!worker_fell_behind(next_end + STEP_SAMPLES - 1, next_end));
         assert!(worker_fell_behind(next_end + STEP_SAMPLES, next_end));
+    }
+
+    #[test]
+    fn publishes_only_new_non_empty_cumulative_text() {
+        assert!(should_publish_partial("", "first reliable words"));
+        assert!(should_publish_partial(
+            "first reliable words",
+            "first reliable words then more"
+        ));
+        assert!(!should_publish_partial("same words", "same words"));
+        assert!(!should_publish_partial("same words", "  "));
     }
 }

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -9,6 +9,7 @@ import { STORAGE_KEY, DEFAULT_SETTINGS, loadSettings, saveSettings } from '../li
 import type { Settings } from '../lib/settings';
 import { buildConfigureOptions } from '../lib/dictation';
 import type { DictationResponse } from '../lib/dictation';
+import { usePartialTranscript } from '../lib/hooks/usePartialTranscript';
 import {
   HOTKEY_MISS_FLASH_MS,
   isHotkeyTapRejectedPayload,
@@ -27,6 +28,14 @@ function formatElapsed(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function latestPreviewText(text: string, maxCharacters = 96): string {
+  const normalized = text.trim();
+  if (normalized.length <= maxCharacters) return normalized;
+  const suffix = normalized.slice(-maxCharacters);
+  const firstBoundary = suffix.indexOf(' ');
+  return `…${(firstBoundary >= 0 ? suffix.slice(firstBoundary + 1) : suffix).trim()}`;
 }
 
 function PowerIcon({ stroke }: { stroke: string }) {
@@ -72,6 +81,10 @@ export function OverlayWidget() {
   const [expanded, setExpanded] = useState(false);
   const [autoPaste, setAutoPaste] = useState(false);
   const [fileOutputEnabled, setFileOutputEnabled] = useState(false);
+  const [liveTranscriptPreview, setLiveTranscriptPreview] = useState(
+    DEFAULT_SETTINGS.liveTranscriptPreview,
+  );
+  const [previewModel, setPreviewModel] = useState(DEFAULT_SETTINGS.model);
   const [elapsed, setElapsed] = useState(0);
   const notchHeightRef = useRef(0);
   const [notchHeight, setNotchHeight] = useState(0);
@@ -89,6 +102,7 @@ export function OverlayWidget() {
   const audioLevelRef = useRef(0);
   const hotkeyMissFeedbackRef = useRef(false);
   const barRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const partialTranscript = usePartialTranscript(liveTranscriptPreview, previewModel);
 
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { lockedRef.current = lockedMode; }, [lockedMode]);
@@ -99,6 +113,8 @@ export function OverlayWidget() {
     setDisabled(settings.disabled);
     setAutoPaste(settings.autoPaste);
     setFileOutputEnabled(settings.saveTranscript || settings.saveAudio);
+    setLiveTranscriptPreview(settings.liveTranscriptPreview);
+    setPreviewModel(settings.model);
     hotkeyMissFeedbackRef.current = settings.hotkeyMissFeedback;
     if (!settings.hotkeyMissFeedback) setShowHotkeyMiss(false);
   }, []);
@@ -613,6 +629,10 @@ export function OverlayWidget() {
   }, []);
 
   const topH = notchHeight || 37;
+  const previewText = liveTranscriptPreview
+    && (status === 'recording' || status === 'processing')
+    ? latestPreviewText(partialTranscript.text)
+    : '';
   const effectiveAutoPaste = autoPaste && !fileOutputEnabled;
   const autoPastePaused = autoPaste && fileOutputEnabled;
   const autoPasteLabel = autoPastePaused
@@ -695,8 +715,21 @@ export function OverlayWidget() {
             </span>
           )}
 
-          {/* Spacer */}
-          <div className="flex-1" />
+          {previewText ? (
+            <div
+              aria-label="Provisional transcript preview"
+              className="min-w-0 flex-1 flex items-center gap-1.5 mx-2 pointer-events-none"
+            >
+              <span className="shrink-0 text-[8px] uppercase tracking-[0.12em] text-amber-300/75">
+                Draft
+              </span>
+              <span className="min-w-0 truncate text-[10px] text-white/70">
+                {previewText}
+              </span>
+            </div>
+          ) : (
+            <div className="flex-1" />
+          )}
 
           {/* Right side — waveform (only when active) */}
           {showHotkeyMiss ? (

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -928,6 +928,33 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
             value={settings.vadSensitivity}
             onCommit={(value) => onUpdateSettings({ vadSensitivity: value })}
           />
+
+          <div className="flex items-center justify-between gap-6">
+            <div>
+              <label className="block text-sm font-medium text-on-surface">
+                Live Transcript Preview
+              </label>
+              <p className="mt-1 text-xs text-on-surface-variant">
+                Show provisional Whisper text in the overlay during long recordings
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.liveTranscriptPreview}
+              aria-label="Live transcript preview"
+              onClick={() => onUpdateSettings({ liveTranscriptPreview: !settings.liveTranscriptPreview })}
+              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                settings.liveTranscriptPreview ? 'bg-primary' : 'bg-surface-container-highest'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
+                  settings.liveTranscriptPreview ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
         </div>
 
         {/* Recording Trigger */}

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -9,6 +9,7 @@ export interface DictationResponse {
   error?: string;
   /** Decoded audio length in seconds (file transcription only). */
   duration?: number;
+  recordingId?: number;
 }
 
 export async function initDictation(): Promise<DictationResponse> {

--- a/app/src/lib/hooks/usePartialTranscript.test.ts
+++ b/app/src/lib/hooks/usePartialTranscript.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PARTIAL_TRANSCRIPT_CONTRACT_VERSION,
+  createPartialTranscriptState,
+  partialTranscriptReducer,
+  type PartialTranscriptClearReason,
+  type PartialTranscriptState,
+} from './usePartialTranscript';
+
+const session = (recordingId: number) => ({
+  contractVersion: PARTIAL_TRANSCRIPT_CONTRACT_VERSION,
+  recordingId,
+});
+
+function withPartial(
+  state: PartialTranscriptState,
+  recordingId: number,
+  text: string,
+  chunkIndex: number,
+): PartialTranscriptState {
+  return partialTranscriptReducer(state, {
+    type: 'partialReceived',
+    payload: {
+      ...session(recordingId),
+      text,
+      chunkIndex,
+      processedAudioMs: chunkIndex * 8_000 + 2_000,
+    },
+  });
+}
+
+function started(recordingId = 7, enabled = true): PartialTranscriptState {
+  return partialTranscriptReducer(createPartialTranscriptState(enabled, 'base.en'), {
+    type: 'sessionStarted',
+    payload: session(recordingId),
+  });
+}
+
+describe('partialTranscriptReducer', () => {
+  it('adopts cumulative updates in chunk order', () => {
+    const first = withPartial(started(), 7, 'one reliable chunk', 1);
+    const second = withPartial(first, 7, 'one reliable chunk followed by another', 2);
+
+    expect(first.text).toBe('one reliable chunk');
+    expect(second.text).toBe('one reliable chunk followed by another');
+    expect(second.chunkIndex).toBe(2);
+    expect(second.processedAudioMs).toBe(18_000);
+  });
+
+  it('rejects stale recording IDs and out-of-order chunks', () => {
+    const current = withPartial(started(8), 8, 'current words', 2);
+    const staleSession = withPartial(current, 7, 'stale words', 3);
+    const staleChunk = withPartial(current, 8, 'older chunk', 1);
+
+    expect(staleSession).toBe(current);
+    expect(staleChunk).toBe(current);
+  });
+
+  it.each<PartialTranscriptClearReason>([
+    'cancelled',
+    'fallback',
+    'finalized',
+    'error',
+  ])('clears the matching session for %s', (reason) => {
+    const current = withPartial(started(), 7, 'provisional words', 1);
+    const cleared = partialTranscriptReducer(current, {
+      type: 'sessionCleared',
+      payload: { ...session(7), reason },
+    });
+
+    expect(cleared.activeRecordingId).toBeNull();
+    expect(cleared.text).toBe('');
+  });
+
+  it('ignores a stale clear after a newer recording starts', () => {
+    const old = withPartial(started(7), 7, 'old words', 1);
+    const newer = partialTranscriptReducer(old, {
+      type: 'sessionStarted',
+      payload: session(8),
+    });
+    const staleClear = partialTranscriptReducer(newer, {
+      type: 'sessionCleared',
+      payload: { ...session(7), reason: 'cancelled' },
+    });
+
+    expect(staleClear.activeRecordingId).toBe(8);
+    expect(staleClear).toBe(newer);
+  });
+
+  it('clears on the generic final/cancel status fallback', () => {
+    const current = withPartial(started(), 7, 'provisional words', 1);
+    const cleared = partialTranscriptReducer(current, { type: 'clearActive' });
+
+    expect(cleared.activeRecordingId).toBeNull();
+    expect(cleared.text).toBe('');
+  });
+
+  it('clears and rejects updates while disabled', () => {
+    const current = withPartial(started(), 7, 'sensitive words', 1);
+    const disabled = partialTranscriptReducer(current, {
+      type: 'settingsChanged',
+      enabled: false,
+      model: 'base.en',
+    });
+    const ignored = withPartial(disabled, 7, 'more sensitive words', 2);
+
+    expect(disabled.text).toBe('');
+    expect(disabled.activeRecordingId).toBe(7);
+    expect(ignored).toBe(disabled);
+  });
+
+  it('clears and invalidates the session when the model changes', () => {
+    const current = withPartial(started(), 7, 'model-bound words', 1);
+    const changed = partialTranscriptReducer(current, {
+      type: 'settingsChanged',
+      enabled: true,
+      model: 'small.en',
+    });
+
+    expect(changed.activeRecordingId).toBeNull();
+    expect(changed.text).toBe('');
+    expect(changed.model).toBe('small.en');
+  });
+});

--- a/app/src/lib/hooks/usePartialTranscript.ts
+++ b/app/src/lib/hooks/usePartialTranscript.ts
@@ -1,0 +1,207 @@
+import { useEffect, useReducer } from 'react';
+import { listen } from '@tauri-apps/api/event';
+
+export const PARTIAL_TRANSCRIPT_CONTRACT_VERSION = 1 as const;
+
+export interface RecordingSessionStartedPayload {
+  contractVersion: typeof PARTIAL_TRANSCRIPT_CONTRACT_VERSION;
+  recordingId: number;
+}
+
+export interface PartialTranscriptPayload extends RecordingSessionStartedPayload {
+  text: string;
+  chunkIndex: number;
+  processedAudioMs: number;
+}
+
+export type PartialTranscriptClearReason =
+  | 'cancelled'
+  | 'error'
+  | 'fallback'
+  | 'finalized';
+
+export interface PartialTranscriptClearedPayload extends RecordingSessionStartedPayload {
+  reason: PartialTranscriptClearReason;
+}
+
+export interface PartialTranscriptState {
+  activeRecordingId: number | null;
+  text: string;
+  chunkIndex: number;
+  processedAudioMs: number;
+  enabled: boolean;
+  model: string;
+}
+
+export type PartialTranscriptAction =
+  | { type: 'sessionStarted'; payload: RecordingSessionStartedPayload }
+  | { type: 'partialReceived'; payload: PartialTranscriptPayload }
+  | { type: 'sessionCleared'; payload: PartialTranscriptClearedPayload }
+  | { type: 'clearActive' }
+  | { type: 'settingsChanged'; enabled: boolean; model: string };
+
+export function createPartialTranscriptState(
+  enabled: boolean,
+  model: string,
+): PartialTranscriptState {
+  return {
+    activeRecordingId: null,
+    text: '',
+    chunkIndex: 0,
+    processedAudioMs: 0,
+    enabled,
+    model,
+  };
+}
+
+function clearSession(
+  state: PartialTranscriptState,
+  activeRecordingId: number | null = null,
+): PartialTranscriptState {
+  return {
+    ...state,
+    activeRecordingId,
+    text: '',
+    chunkIndex: 0,
+    processedAudioMs: 0,
+  };
+}
+
+export function partialTranscriptReducer(
+  state: PartialTranscriptState,
+  action: PartialTranscriptAction,
+): PartialTranscriptState {
+  switch (action.type) {
+    case 'sessionStarted':
+      return clearSession(state, action.payload.recordingId);
+    case 'partialReceived': {
+      const { payload } = action;
+      if (
+        !state.enabled ||
+        payload.recordingId !== state.activeRecordingId ||
+        payload.chunkIndex <= state.chunkIndex
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        text: payload.text,
+        chunkIndex: payload.chunkIndex,
+        processedAudioMs: payload.processedAudioMs,
+      };
+    }
+    case 'sessionCleared':
+      return action.payload.recordingId === state.activeRecordingId
+        ? clearSession(state)
+        : state;
+    case 'clearActive':
+      return clearSession(state);
+    case 'settingsChanged': {
+      if (action.model !== state.model) {
+        return {
+          ...clearSession(state),
+          enabled: action.enabled,
+          model: action.model,
+        };
+      }
+      return {
+        ...(action.enabled ? state : clearSession(state, state.activeRecordingId)),
+        enabled: action.enabled,
+      };
+    }
+  }
+}
+
+function hasCurrentContract(value: Record<string, unknown>): boolean {
+  return value.contractVersion === PARTIAL_TRANSCRIPT_CONTRACT_VERSION;
+}
+
+export function isRecordingSessionStartedPayload(
+  payload: unknown,
+): payload is RecordingSessionStartedPayload {
+  if (!payload || typeof payload !== 'object') return false;
+  const value = payload as Record<string, unknown>;
+  return hasCurrentContract(value)
+    && typeof value.recordingId === 'number'
+    && Number.isSafeInteger(value.recordingId)
+    && value.recordingId > 0;
+}
+
+export function isPartialTranscriptPayload(
+  payload: unknown,
+): payload is PartialTranscriptPayload {
+  if (!isRecordingSessionStartedPayload(payload)) return false;
+  const value = payload as unknown as Record<string, unknown>;
+  return typeof value.text === 'string'
+    && typeof value.chunkIndex === 'number'
+    && Number.isSafeInteger(value.chunkIndex)
+    && value.chunkIndex > 0
+    && typeof value.processedAudioMs === 'number'
+    && Number.isFinite(value.processedAudioMs)
+    && value.processedAudioMs >= 0;
+}
+
+export function isPartialTranscriptClearedPayload(
+  payload: unknown,
+): payload is PartialTranscriptClearedPayload {
+  if (!isRecordingSessionStartedPayload(payload)) return false;
+  const reason = (payload as PartialTranscriptClearedPayload).reason;
+  return reason === 'cancelled'
+    || reason === 'error'
+    || reason === 'fallback'
+    || reason === 'finalized';
+}
+
+export function usePartialTranscript(enabled: boolean, model: string) {
+  const [state, dispatch] = useReducer(
+    partialTranscriptReducer,
+    createPartialTranscriptState(enabled, model),
+  );
+
+  useEffect(() => {
+    dispatch({ type: 'settingsChanged', enabled, model });
+  }, [enabled, model]);
+
+  useEffect(() => {
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+    const register = (promise: Promise<() => void>) => {
+      promise.then((unlisten) => {
+        if (disposed) unlisten();
+        else unlisteners.push(unlisten);
+      });
+    };
+
+    register(listen<unknown>('recording-session-started', (event) => {
+      if (isRecordingSessionStartedPayload(event.payload)) {
+        dispatch({ type: 'sessionStarted', payload: event.payload });
+      }
+    }));
+    register(listen<unknown>('partial-transcript', (event) => {
+      if (isPartialTranscriptPayload(event.payload)) {
+        dispatch({ type: 'partialReceived', payload: event.payload });
+      }
+    }));
+    register(listen<unknown>('partial-transcript-cleared', (event) => {
+      if (isPartialTranscriptClearedPayload(event.payload)) {
+        dispatch({ type: 'sessionCleared', payload: event.payload });
+      }
+    }));
+    register(listen<unknown>('recording-cancelled', () => {
+      dispatch({ type: 'clearActive' });
+    }));
+    register(listen<unknown>('transcription-complete', () => {
+      dispatch({ type: 'clearActive' });
+    }));
+    register(listen<unknown>('recording-status-changed', (event) => {
+      if (event.payload === 'idle') dispatch({ type: 'clearActive' });
+    }));
+
+    return () => {
+      disposed = true;
+      unlisteners.forEach((unlisten) => unlisten());
+    };
+  }, []);
+
+  return state;
+}

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -74,7 +74,7 @@ export function useSettings() {
       });
     }
 
-    if ('autoPaste' in updates || 'disabled' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'hotkeyMissFeedback' in updates) {
+    if ('model' in updates || 'autoPaste' in updates || 'disabled' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'hotkeyMissFeedback' in updates || 'liveTranscriptPreview' in updates) {
       // Notify the overlay window (separate React context) so its quick-settings
       // controls reflect changes made here. The diff-guard in applyExternalSettings
       // prevents this window from re-applying its own change.

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -41,6 +41,7 @@ describe('loadSettings', () => {
     expect(settings.autoPaste).toBe(DEFAULT_SETTINGS.autoPaste);
     expect(settings.recordingMode).toBe('double_tap');
     expect(settings.hotkeyMissFeedback).toBe(false);
+    expect(settings.liveTranscriptPreview).toBe(true);
   });
 
   it('validates the opt-in hotkey timing feedback setting', () => {
@@ -55,6 +56,20 @@ describe('loadSettings', () => {
       hotkeyMissFeedback: 'yes',
     }));
     expect(loadSettings().hotkeyMissFeedback).toBe(false);
+  });
+
+  it('preserves and validates the live transcript preview setting', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      liveTranscriptPreview: false,
+    }));
+    expect(loadSettings().liveTranscriptPreview).toBe(false);
+
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      liveTranscriptPreview: 'yes',
+    }));
+    expect(loadSettings().liveTranscriptPreview).toBe(true);
   });
 
   it('migrates legacy "hotkey" recordingMode to "hold_down"', () => {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -71,6 +71,7 @@ export interface Settings {
   autoPasteDelayMs: number;
   recordingMode: RecordingMode;
   hotkeyMissFeedback: boolean;
+  liveTranscriptPreview: boolean;
   microphone: string;
   launchAtLogin: boolean;
   vadSensitivity: number;
@@ -204,6 +205,7 @@ export const DEFAULT_SETTINGS: Settings = {
   autoPasteDelayMs: 50,
   recordingMode: 'hold_down',
   hotkeyMissFeedback: false,
+  liveTranscriptPreview: true,
   microphone: 'system_default',
   launchAtLogin: false,
   vadSensitivity: 50,
@@ -384,6 +386,9 @@ export function loadSettings(): Settings {
 
       if (typeof parsed.hotkeyMissFeedback !== 'boolean') {
         parsed.hotkeyMissFeedback = DEFAULT_SETTINGS.hotkeyMissFeedback;
+      }
+      if (typeof parsed.liveTranscriptPreview !== 'boolean') {
+        parsed.liveTranscriptPreview = DEFAULT_SETTINGS.liveTranscriptPreview;
       }
 
       // codeVocabEnabled gates the Rust scan — coerce non-booleans (or a missing

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -83,10 +83,10 @@ The overlay has three visual states driven by `recording-status-changed` Tauri e
 Small mic SVG icon at 40% white opacity. Compact width.
 
 ### Recording
-Expanded width. Red pulsing dot on the left, animated 7-bar waveform on the right. The waveform responds to real-time audio levels.
+Expanded width. Red pulsing dot on the left, animated 7-bar waveform on the right. The waveform responds to real-time audio levels. During long Whisper recordings, the middle of the existing top bar shows the latest suffix of cumulative incremental text with a `Draft` label after the first reliable chunk. The preview is one line, uses no additional window area, and has pointer events disabled.
 
 ### Processing
-Same expanded width. Spinning circle on the left; the waveform is hidden (visible only while recording).
+Same expanded width. Spinning circle on the left; the waveform is hidden (visible only while recording). A provisional preview may remain visible until the authoritative final result completes, then clears.
 
 ### Hotkey Timing Miss (optional)
 
@@ -154,6 +154,9 @@ The observer is intentionally leaked (`std::mem::forget`) for app-lifetime obser
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `recording-status-changed` | String | Drives visual state transitions |
+| `recording-session-started` | `{ contractVersion, recordingId }` | Selects the active session and clears any older preview |
+| `partial-transcript` | `{ contractVersion, recordingId, text, chunkIndex, processedAudioMs }` | Supplies cumulative in-memory provisional text for the active session only |
+| `partial-transcript-cleared` | `{ contractVersion, recordingId, reason }` | Session-scoped cleanup on cancellation, fallback, error, or finalization |
 | `audio-level` | Number (RMS 0.0-1.0) | Real-time audio level for waveform |
 | `notch-info-changed` | `{ notch_width, notch_height }` or `null` | Display configuration changed |
 | `app-disabled-changed` | Boolean | Global-disable state changed (updates the top-bar mic + speaker-slash) |
@@ -162,6 +165,10 @@ The observer is intentionally leaked (`std::mem::forget`) for app-lifetime obser
 | `open-settings` | (none) | Overlay gear asks the main window to open the Settings panel |
 
 The entire overlay surface is a Tauri drag region (`data-tauri-drag-region`), allowing the user to reposition it. Overlay position save/restore is currently disabled (TODO: re-enable after notch positioning is stable).
+
+## Live transcript preview
+
+`liveTranscriptPreview` is a local Settings boolean and defaults to enabled. Turning it off clears visible provisional text immediately and ignores further partial updates while disabled. The overlay tracks the active `recordingId`, rejects stale or out-of-order chunks, and clears on cancellation, incremental fallback, final completion, model change, idle/error, or a newer recording. The preview stays inside the existing non-focusable, non-activating top-bar bounds, so it neither expands the idle island nor adds a click dead-zone.
 
 ## Transparent window caveat
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -58,10 +58,13 @@ Long live recordings selected to the Whisper backend use true incremental output
 - A single sequential worker snapshots one bounded 10-second window every 8 seconds (2-second overlap) while capture continues.
 - Every window passes through the same Silero VAD threshold and the existing cached Whisper backend. There is no second model/context and never more than one inference in flight.
 - Chunk text is reconciled by a deterministic word-boundary algorithm. It removes the largest near-equal suffix/prefix overlap within 12 words and retains the earlier surface form.
+- After reconciliation, the worker validates the recording ID, cancellation generation, status, and selected model again before publishing a versioned `partial-transcript` event. Its camelCase payload is `{ contractVersion, recordingId, text, chunkIndex, processedAudioMs }`; the text is cumulative and remains in memory only.
 - On stop, the worker is signalled before audio teardown and only the unprocessed tail plus the 2-second overlap is inferred. The reconciled result becomes the authoritative text used by the unchanged cleanup, voice-command, correction, file-output, clipboard, paste, history, and stats paths.
 - Short recordings (under the first 10-second window), non-Whisper backends, missing/failed VAD, stale sessions, model changes, worker lag, panics, or final-tail failures use the original full-buffer pipeline.
 
 The worker holds no queued audio. It reads the current buffer length, copies only one fixed window, awaits that inference, and abandons incremental mode if capture advances by more than one step. Recording IDs and cancellation generations prevent completed work from a stopped/cancelled session from being adopted by a newer recording.
+
+The backend also emits versioned `recording-session-started` and `partial-transcript-cleared` lifecycle events. Clears are recording-ID scoped, so a late cancellation or fallback from an older session cannot erase or update a newer preview. Fallback clears provisional text immediately while the existing full-buffer path remains authoritative. Partial contents are never written to logs, history, stats, settings, files, the clipboard, or auto-paste; telemetry records only first-partial latency, update count, last-partial-to-final latency, and completed/fallback flags.
 
 ## Model Options
 


### PR DESCRIPTION
Closes #243

## Summary
- emit versioned, backend-neutral recording session, cumulative partial transcript, and session-scoped clear events from the incremental path
- reject stale, cancelled, out-of-order, and model-mismatched work before publishing or rendering provisional text
- render a one-line Draft preview inside the existing non-activating overlay bar, with a local setting to disable it immediately
- keep the authoritative final pipeline as the only writer to files, history, stats, clipboard, and auto-paste; add privacy-safe latency/count/fallback telemetry only

## Validation
- `npm test`: 13 files, 107 tests passed
- `npx tsc --noEmit`: passed
- `cargo check`: passed
- `cargo test -- --test-threads=1`: 300 unit tests passed after rebasing onto main; Whisper integration passed; optional Core ML integration ignored by its existing environment gate
- `git diff --check`: passed
- GitHub CI `ci-pass`, Linux, macOS Rust, and typecheck: passed
- debug native `.app` bundle rebuilt successfully; updater signing then reported the expected missing local private key after the bundle was complete

## Native evidence and limitation
A temporary local-only event harness broadcast the exact production Tauri payloads into the real native overlay and was fully removed before this commit. It showed successive cumulative Draft states in the unchanged top bar, session replacement/stale-event rejection, and cancellation/idle cleanup. The clipboard stayed exactly `MURMUR-PARTIAL-SENTINEL-243` throughout partial events. The final rebuilt bundle contains no harness marker or fixture text.

This Mac exposes only Mac mini Speakers and no CoreAudio input device. A real Start Recording attempt therefore failed before capture with `Failed to get input config: A backend-specific error has occurred: An unknown error unknown to the coreaudio-rs API occurred`. I am not claiming microphone or exactly-once final-paste coverage from this host.

Repro on a Mac with an input device: enable Live Transcript Preview, focus an empty TextEdit document with auto-paste enabled, record speech for at least 26 seconds, confirm at least two cumulative Draft updates, stop once, and confirm exactly one authoritative final paste. Start another long recording and cancel to confirm immediate cleanup. For fallback cleanup, change the selected Whisper model while a long recording is active, then confirm the provisional text clears and only the existing batch final path delivers text.

## Auxiliary review status
CodeRabbit was rate-limited and returned no findings. The optional Claude Code Review workflow was retried once and failed both times before performing a review (`subtype: success`, `is_error: true`, zero turns/cost); all required repository CI checks are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live, provisional transcript preview in the notch overlay during dictation.
  * Added a **Live Transcript Preview** setting, enabled by default and configurable in Settings.
  * Preview text clears automatically when recording ends, is canceled, fails, or changes sessions.
  * Final clipboard and auto-paste behavior remains unchanged and occurs once after stopping.

* **Documentation**
  * Documented preview behavior, lifecycle events, fallback handling, and privacy safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->