### PR TITLE
feat: unify per-app dictation context resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Read these before working on a feature:
 - **[docs/features/log-viewer.md](docs/features/log-viewer.md)** — Structured event system and log viewer
 - **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
 - **[docs/features/models.md](docs/features/models.md)** — Model management and download
+- **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 
 ## File Map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Read these before working on a feature:
 - **[docs/features/log-viewer.md](docs/features/log-viewer.md)** — Structured event system and log viewer
 - **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
 - **[docs/features/models.md](docs/features/models.md)** — Model management and download
+- **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 - **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -39,9 +39,8 @@ fn build_code_vocab_prompt(folder: &str) -> String {
     );
     tracing::info!(
         target: "pipeline",
-        "code vocab: scanned {} -> {} chars",
-        folder,
-        prompt.len()
+        prompt_chars = prompt.len(),
+        "code vocabulary scan completed"
     );
     prompt
 }
@@ -890,13 +889,58 @@ pub async fn get_status(state: tauri::State<'_, State>) -> Result<serde_json::Va
     }))
 }
 
+/// Privacy-safe shape for configuration telemetry. User-entered values (profile
+/// identities, vocabulary, command text, and filesystem paths) must never be
+/// formatted into a tracing message or field because pretty logs retain strings.
+#[derive(Debug, PartialEq, Eq)]
+struct ConfigurationLogMetadata {
+    option_count: u64,
+    app_profile_count: u64,
+    voice_command_count: u64,
+    custom_vocabulary_present: bool,
+    output_directory_present: bool,
+}
+
+impl ConfigurationLogMetadata {
+    fn from_options(options: &serde_json::Value) -> Self {
+        Self {
+            option_count: options.as_object().map_or(0, |object| object.len() as u64),
+            app_profile_count: options
+                .get("appProfiles")
+                .and_then(serde_json::Value::as_array)
+                .map_or(0, |profiles| profiles.len() as u64),
+            voice_command_count: options
+                .get("voiceCommands")
+                .and_then(serde_json::Value::as_array)
+                .map_or(0, |commands| commands.len() as u64),
+            custom_vocabulary_present: options
+                .get("customVocabulary")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|vocabulary| !vocabulary.trim().is_empty()),
+            output_directory_present: options
+                .get("outputDir")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|directory| !directory.trim().is_empty()),
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn configure_dictation(
     options: serde_json::Value,
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
-    tracing::info!(target: "pipeline", "configure_dictation: {}", options);
+    let log_metadata = ConfigurationLogMetadata::from_options(&options);
+    tracing::info!(
+        target: "pipeline",
+        option_count = log_metadata.option_count,
+        app_profile_count = log_metadata.app_profile_count,
+        voice_command_count = log_metadata.voice_command_count,
+        custom_vocabulary_present = log_metadata.custom_vocabulary_present,
+        output_directory_present = log_metadata.output_directory_present,
+        "configure_dictation"
+    );
 
     let model = options.get("model").and_then(|v| v.as_str()).map(String::from);
     let language = options.get("language").and_then(|v| v.as_str()).map(String::from);
@@ -1513,7 +1557,7 @@ pub async fn start_native_recording(
     tracing::info!(
         target: "pipeline",
         recording_id = rid,
-        frontmost_bundle_id = context.app.bundle_id.as_deref().unwrap_or("unknown"),
+        frontmost_app_detected = context.app.bundle_id.is_some(),
         matched_profile = context.matched_profile.is_some(),
         vocabulary_version = context.vocabulary.version,
         context_reads_enabled = context.context_capture.selected_text
@@ -1988,6 +2032,42 @@ mod tests {
         fn model_exists(&self) -> bool { true }
         fn models_dir(&self) -> Result<PathBuf, String> { Ok(std::env::temp_dir()) }
         fn reset(&mut self) {}
+    }
+
+    #[test]
+    fn configuration_log_metadata_never_contains_user_context_values() {
+        let options = serde_json::json!({
+            "appProfiles": [{
+                "bundleId": "com.private.SecretApp",
+                "label": "Secret profile",
+                "autoPasteOverride": true
+            }],
+            "customVocabulary": "private-customer-name",
+            "voiceCommands": [{
+                "phrase": "confidential phrase",
+                "replacement": "confidential replacement"
+            }],
+            "outputDir": "/Users/private/CustomerFiles"
+        });
+
+        let metadata = ConfigurationLogMetadata::from_options(&options);
+        assert_eq!(metadata.option_count, 4);
+        assert_eq!(metadata.app_profile_count, 1);
+        assert_eq!(metadata.voice_command_count, 1);
+        assert!(metadata.custom_vocabulary_present);
+        assert!(metadata.output_directory_present);
+
+        let rendered = format!("{metadata:?}");
+        for secret in [
+            "com.private.SecretApp",
+            "Secret profile",
+            "private-customer-name",
+            "confidential phrase",
+            "confidential replacement",
+            "/Users/private/CustomerFiles",
+        ] {
+            assert!(!rendered.contains(secret), "telemetry metadata leaked {secret}");
+        }
     }
 
     #[test]

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1,4 +1,5 @@
 use crate::{MutexExt, State};
+use crate::dictation_context::{self, DictationContextSnapshot, ResolverInputs, SessionOverrides};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
 use crate::{audio, audio_decode, injector, keyboard, streaming, vad};
@@ -105,6 +106,7 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
             // path hits none of the other two). rebuild_correction_matcher writes a
             // separate leaf mutex, so there's no deadlock with the held guard.
             rebuild_correction_matcher(app_state, &dictation);
+            app_state.bump_settings_revision();
         }
         whisper_prefix(&prompt)
     };
@@ -114,6 +116,57 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
         builtin
     } else {
         format!("{} {}", folder_prompt.trim(), builtin)
+    }
+}
+
+/// Build the code-vocabulary prompt represented by an already-locked settings
+/// generation. `None` means the folder cache is not ready for this generation.
+fn cached_code_vocab_prompt(dictation: &crate::state::DictationState) -> Option<String> {
+    if !dictation.code_vocab_enabled {
+        return Some(String::new());
+    }
+    let builtin = crate::vocab::builtin_terms_prompt();
+    if dictation.code_vocab_folder.trim().is_empty() {
+        return Some(builtin);
+    }
+    dictation.code_vocab_prompt.as_ref().map(|prompt| {
+        let folder_prompt = whisper_prefix(prompt);
+        if folder_prompt.trim().is_empty() {
+            builtin
+        } else {
+            format!("{} {}", folder_prompt.trim(), builtin)
+        }
+    })
+}
+
+/// Resolve one immutable context from a consistent settings/vocabulary
+/// generation. A concurrent settings change causes a retry rather than a mixed
+/// snapshot.
+fn resolve_live_context(
+    app_state: &AppState,
+    bundle_id: Option<&str>,
+) -> Arc<DictationContextSnapshot> {
+    loop {
+        let code_vocab = resolve_code_vocab_prompt(app_state);
+        let dictation = app_state.dictation.lock_or_recover();
+        let Some(current_code_vocab) = cached_code_vocab_prompt(&dictation) else {
+            continue;
+        };
+        if current_code_vocab != code_vocab {
+            continue;
+        }
+        let sanitized = dictation.custom_vocabulary.replace('\0', "");
+        let prompt = combine_prompts(&sanitized, &code_vocab);
+        let correction_matcher = app_state.correction_matcher.lock_or_recover().clone();
+        let vocabulary_version = app_state.settings_revision.load(Ordering::SeqCst);
+        return Arc::new(dictation_context::resolve(ResolverInputs {
+            bundle_id,
+            global: &dictation,
+            prompt,
+            correction_matcher,
+            vocabulary_version,
+            session_overrides: SessionOverrides::default(),
+        }));
     }
 }
 
@@ -225,6 +278,7 @@ impl<'a> IdleGuard<'a> {
 impl Drop for IdleGuard<'_> {
     fn drop(&mut self) {
         if !self.disarmed {
+            self.app_state.clear_active_context(self.recording_id);
             // Lock first, then check recording_id — prevents TOCTOU where
             // a concurrent start advances the ID between our check and the
             // status write.
@@ -281,7 +335,8 @@ fn spawn_model_preparation(
             let dictation = state.app_state.dictation.lock_or_recover();
             state.app_state.recording_id.load(Ordering::SeqCst) == recording_id
                 && dictation.status == DictationStatus::Recording
-                && dictation.model_name == model_name
+                && state.app_state.active_context(recording_id)
+                    .is_some_and(|context| context.transcription.model_name == model_name)
         };
         if !is_active {
             return;
@@ -297,12 +352,17 @@ fn spawn_model_preparation(
             let dictation = state.app_state.dictation.lock_or_recover();
             state.app_state.recording_id.load(Ordering::SeqCst) == recording_id
                 && dictation.status == DictationStatus::Recording
-                && dictation.model_name == model_name
+                && state.app_state.active_context(recording_id)
+                    .is_some_and(|context| context.transcription.model_name == model_name)
         };
         if !is_still_active {
             return;
         }
 
+        if let Err(error) = transcriber::ensure_backend_for_model(&mut backend, &model_name) {
+            tracing::warn!(target: "pipeline", recording_id, error, "model_prepare_failed");
+            return;
+        }
         let cache_hit = backend.is_model_loaded(&model_name);
         let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
         let load_started = std::time::Instant::now();
@@ -454,39 +514,21 @@ async fn run_transcription_pipeline(
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
     recording_id: u64,
+    context: Arc<DictationContextSnapshot>,
     incremental: Option<streaming::IncrementalTranscript>,
 ) -> Result<(String, PipelineTimings), String> {
     // Guard resets status to Idle on any return path (error or success),
     // but only if this recording is still the active one
     let _guard = IdleGuard::new(app_state, recording_id);
 
-    // Read all needed state in one lock
-    let (model_name, language, auto_paste, paste_delay_ms, vad_sensitivity, custom_vocabulary, smart_punctuation, save_transcript, save_audio, output_dir, app_profiles, voice_commands_enabled, voice_command_pairs, cleanup_enabled, cleanup_remove_filler, cleanup_capitalize, correction_enabled) = {
-        let dictation = app_state.dictation.lock_or_recover();
-        (dictation.model_name.clone(), dictation.language.clone(), dictation.auto_paste, dictation.auto_paste_delay_ms, dictation.vad_sensitivity, dictation.custom_vocabulary.clone(), dictation.smart_punctuation, dictation.save_transcript, dictation.save_audio, dictation.output_dir.clone(), dictation.app_profiles.clone(), dictation.voice_commands_enabled, dictation.voice_command_pairs.clone(), dictation.cleanup_enabled, dictation.cleanup_remove_filler, dictation.cleanup_capitalize, dictation.correction_enabled)
-    };
-
-    // Per-app profiles: if the frontmost app has a matching profile, its overrides
-    // replace the global auto-paste / cleanup settings. The frontmost app is
-    // detected once (a single osascript call) and reused for both resolutions. No
-    // profiles (or no detected app) leaves the global values untouched.
-    let (profile_auto_paste, profile_cleanup) = if app_profiles.is_empty() {
-        (auto_paste, cleanup_enabled)
-    } else {
-        let bundle_id = crate::frontmost::frontmost_bundle_id();
-        let resolved_paste = crate::frontmost::resolve_auto_paste(auto_paste, bundle_id.as_deref(), &app_profiles);
-        let resolved_cleanup = crate::frontmost::resolve_cleanup(cleanup_enabled, bundle_id.as_deref(), &app_profiles);
-        if resolved_paste != auto_paste || resolved_cleanup != cleanup_enabled {
-            tracing::info!(target: "pipeline", "app profile override (frontmost={}): auto_paste {}->{}, cleanup {}->{}",
-                bundle_id.as_deref().unwrap_or("unknown"), auto_paste, resolved_paste, cleanup_enabled, resolved_cleanup);
-        }
-        (resolved_paste, resolved_cleanup)
-    };
+    let transcription = &context.transcription;
+    let transformations = &context.transformations;
+    let delivery = &context.delivery;
 
     // When saving to a file, suppress auto-paste into the focused app. The
     // clipboard write inside `inject_text` is unconditional, so text remains
     // copyable regardless of these toggles.
-    let effective_auto_paste = profile_auto_paste && !(save_transcript || save_audio);
+    let effective_auto_paste = delivery.auto_paste && !(delivery.save_transcript || delivery.save_audio);
 
     // Pre-VAD signal level logging for mic diagnosis
     let rms = audio::compute_rms(samples);
@@ -526,7 +568,7 @@ async fn run_transcription_pipeline(
     } else {
         // Batch fallback and all non-Whisper backends retain the pre-existing
         // full-buffer VAD + inference behavior.
-        let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
+        let vad_threshold = 1.0 - (transcription.vad_sensitivity as f32 / 100.0);
         let t_vad = std::time::Instant::now();
         let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
             Some(vad_path) if vad_path.exists() => {
@@ -583,18 +625,17 @@ async fn run_transcription_pipeline(
 
         let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
         let t_transcribe = std::time::Instant::now();
-        let sanitized = custom_vocabulary.replace('\0', "");
-        let code_vocab = resolve_code_vocab_prompt(app_state);
-        let prompt = combine_prompts(&sanitized, &code_vocab);
         let (text, model_load_ms, decode_ms) = {
             let load_started = std::time::Instant::now();
             let mut backend = app_state.backend.lock_or_recover();
-            backend.load_model(&model_name)?;
+            transcriber::ensure_backend_for_model(&mut backend, &transcription.model_name)?;
+            backend.load_model(&transcription.model_name)?;
             let model_load_ms = load_started.elapsed().as_millis() as u64;
             let decode_started = std::time::Instant::now();
             let text = transcribe_with_coreml_vad_retry(
-                backend.as_mut(), &model_name, &samples_for_transcription, samples,
-                vad_trimmed, &language, prompt.as_deref(), smart_punctuation,
+                backend.as_mut(), &transcription.model_name, &samples_for_transcription, samples,
+                vad_trimmed, &transcription.language, transcription.prompt.as_deref(),
+                transcription.smart_punctuation,
             )?;
             let decode_ms = decode_started.elapsed().as_millis() as u64;
             (text, model_load_ms, decode_ms)
@@ -617,30 +658,32 @@ async fn run_transcription_pipeline(
     };
 
     // Post-recognition transformation is backend-neutral and ordered in one
-    // authoritative entry point. The effective cleanup toggle has already folded
-    // in the existing per-app override; issue #245 will supply an opaque resolved
-    // context handle without moving profile resolution into this module.
-    let custom_commands: Vec<(String, String)> = voice_command_pairs
-        .into_iter()
-        .map(|vc| (vc.phrase, vc.replacement))
+    // authoritative entry point. Its stage config and resources come from the
+    // immutable recording-start snapshot rather than mutable app settings.
+    let custom_commands: Vec<(String, String)> = transformations
+        .voice_command_pairs
+        .iter()
+        .map(|vc| (vc.phrase.clone(), vc.replacement.clone()))
         .collect();
     let transform_context = crate::transcript_transform::TranscriptContext {
         session_id: app_state.next_transcript_session_id(),
         source: crate::transcript_transform::TranscriptSource::Live,
-        context_handle: None,
-        model: model_name.clone(),
-        language: language.clone(),
+        context_handle: Some(format!("recording:{recording_id}")),
+        model: transcription.model_name.clone(),
+        language: transcription.language.clone(),
         stages: crate::transcript_transform::TranscriptStageConfig {
-            cleanup_enabled: profile_cleanup,
-            cleanup_remove_filler,
-            cleanup_capitalize,
-            voice_commands_enabled,
-            smart_correction_enabled: correction_enabled,
+            cleanup_enabled: transformations.cleanup_enabled,
+            cleanup_remove_filler: transformations.cleanup_remove_filler,
+            cleanup_capitalize: transformations.cleanup_capitalize,
+            voice_commands_enabled: context
+                .enabled_command_groups
+                .built_in_voice_commands,
+            smart_correction_enabled: transformations.correction_enabled,
         },
     };
     let transform_resources = crate::transcript_transform::TranscriptTransformResources {
         custom_commands,
-        correction_matcher: app_state.correction_matcher.lock_or_recover().clone(),
+        correction_matcher: transformations.correction_matcher.clone(),
     };
     let transformed = crate::transcript_transform::transform_transcript(
         text,
@@ -664,9 +707,9 @@ async fn run_transcription_pipeline(
     // Phase: File output (optional) -- persist audio/transcript before injection.
     // Non-fatal: a write failure is logged and surfaced to the UI, but the text
     // is already on its way to the clipboard. Uses the original (pre-VAD) samples.
-    if save_audio || save_transcript {
+    if delivery.save_audio || delivery.save_transcript {
         if let Err(e) = crate::file_output::write_dictation_outputs(
-            samples, &text, save_audio, save_transcript, &output_dir,
+            samples, &text, delivery.save_audio, delivery.save_transcript, &delivery.output_dir,
         ) {
             tracing::warn!(target: "pipeline", "file output failed: {}", e);
             let _ = app_handle.emit(
@@ -680,6 +723,7 @@ async fn run_transcription_pipeline(
     let t_inject = std::time::Instant::now();
     if !text.is_empty() {
         let text_to_inject = text.clone();
+        let paste_delay_ms = delivery.paste_delay_ms;
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
         app_handle
             .run_on_main_thread(move || {
@@ -744,11 +788,16 @@ pub async fn process_audio(
             tracing::warn!(target: "pipeline", "process_audio: blocked — benchmark in progress");
             return Err("Cannot process audio while a benchmark is in progress.".to_string());
         }
+        if dictation.status != DictationStatus::Idle {
+            return Err("Cannot process audio while live dictation is active.".to_string());
+        }
         dictation.status = DictationStatus::Processing;
-        state.app_state.recording_id.load(Ordering::SeqCst)
+        state.app_state.next_recording_id()
     };
     keyboard::set_processing(true);
     let _ = app_handle.emit("recording-status-changed", "processing");
+    let bundle_id = crate::frontmost::frontmost_bundle_id();
+    let context = resolve_live_context(&state.app_state, bundle_id.as_deref());
 
     // Guard resets status to Idle if decode/parse fails before reaching the pipeline
     let mut guard = IdleGuard::new(&state.app_state, rid);
@@ -779,6 +828,7 @@ pub async fn process_audio(
         &app_handle,
         &state.app_state,
         rid,
+        Arc::clone(&context),
         None,
     )
     .await;
@@ -798,14 +848,8 @@ pub async fn process_audio(
     let audio_secs = samples.len() as f64 / 16_000.0;
     let word_count = if text.trim().is_empty() { 0 } else { text.split_whitespace().count() };
     let char_count = text.len();
-    let model_name = {
-        let d = state.app_state.dictation.lock_or_recover();
-        d.model_name.clone()
-    };
-    let backend_name = {
-        let b = state.app_state.backend.lock_or_recover();
-        b.name().to_string()
-    };
+    let model_name = context.transcription.model_name.clone();
+    let backend_name = transcriber::backend_name_for_model(&model_name).to_string();
     tracing::info!(
         target: "pipeline",
         recording_id = rid,
@@ -869,6 +913,7 @@ pub async fn configure_dictation(
     }
 
     let mut dictation = state.app_state.dictation.lock_or_recover();
+    let backend_change_can_apply_now = dictation.status == DictationStatus::Idle;
 
     let mut model_change_guard = if model
         .as_deref()
@@ -1032,6 +1077,7 @@ pub async fn configure_dictation(
     // Rebuild the correction matcher from the (now-updated) unified vocab +
     // correction settings. Built here on settings-change, never per-utterance.
     rebuild_correction_matcher(&state.app_state, &dictation);
+    state.app_state.bump_settings_revision();
 
     if let Some(idle_timeout) = options.get("idleTimeoutMinutes").and_then(|v| v.as_u64()) {
         let normalized = match idle_timeout {
@@ -1044,46 +1090,23 @@ pub async fn configure_dictation(
     // If model changed, swap/reset the backend so the next transcription loads
     // the right engine for the selected model.
     let mut idle_preparation = None;
-    if model_changed {
+    if model_changed && backend_change_can_apply_now {
         let new_model = dictation.model_name.clone();
         if transcriber::is_coreml_model(&new_model) {
             idle_preparation = Some(new_model.clone());
         }
         drop(dictation); // Release dictation lock first
         let mut backend = state.app_state.backend.lock_or_recover();
-        // Core ML must be classified first because its explicit model value also
-        // starts with "parakeet", which is the sherpa backend's broad sentinel.
-        let want_coreml = transcriber::is_coreml_model(&new_model);
-        let want_parakeet = transcriber::parakeet::is_parakeet_model(&new_model);
-        let desired_backend = if want_coreml {
-            "coreml"
-        } else if want_parakeet {
-            "parakeet"
-        } else {
-            "whisper"
-        };
-        if backend.name() != desired_backend {
-            *backend = if want_coreml {
-                #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-                {
-                    Box::new(transcriber::CoreMlBackend::new())
-                }
-                #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-                {
-                    return Err(
-                        "Core ML transcription is available only on macOS 14 or newer with Apple Silicon"
-                            .to_string(),
-                    );
-                }
-            } else if want_parakeet {
-                Box::new(transcriber::ParakeetBackend::new())
-            } else {
-                Box::new(transcriber::WhisperBackend::new())
-            };
-            tracing::info!(target: "pipeline", "Switched transcription backend to {}", backend.name());
-        } else {
+        if backend.name() == transcriber::backend_name_for_model(&new_model) {
             backend.reset();
+        } else {
+            transcriber::ensure_backend_for_model(&mut backend, &new_model)?;
         }
+    } else if model_changed {
+        tracing::info!(
+            target: "pipeline",
+            "model backend change deferred until the next recording generation"
+        );
     }
 
     if let Some(model_name) = idle_preparation {
@@ -1169,6 +1192,7 @@ fn begin_code_vocab_scan(app_state: &AppState, scan_id: &str, folder: &str) {
     if folder_changed || was_disabled {
         dictation.code_vocab_prompt = None;
         rebuild_correction_matcher(app_state, &dictation);
+        app_state.bump_settings_revision();
     }
 }
 
@@ -1190,6 +1214,7 @@ fn complete_code_vocab_scan(
         dictation.code_vocab_prompt = Some(prompt);
         dictation.code_vocab_scan_id = None;
         rebuild_correction_matcher(app_state, &dictation);
+        app_state.bump_settings_revision();
     } else if is_active {
         dictation.code_vocab_scan_id = None;
     }
@@ -1441,7 +1466,7 @@ pub async fn start_native_recording(
     }
     // Check and update status in one lock; assign recording ID in the same
     // critical section so no concurrent cancel/start can slip between them.
-    let (rid, model_name, language, vad_sensitivity, custom_vocabulary, smart_punctuation, streaming_prompt_ready) = {
+    let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         // Refuse if a file transcription holds the shared Whisper backend.
         // Checked under the dictation lock (which `transcribe_file` takes only
@@ -1478,54 +1503,46 @@ pub async fn start_native_recording(
             DictationStatus::Idle => {
                 let rid = state.app_state.next_recording_id();
                 dictation.status = DictationStatus::Recording;
-                (
-                    rid,
-                    dictation.model_name.clone(),
-                    dictation.language.clone(),
-                    dictation.vad_sensitivity,
-                    dictation.custom_vocabulary.clone(),
-                    dictation.smart_punctuation,
-                    !dictation.code_vocab_enabled
-                        || dictation.code_vocab_folder.trim().is_empty()
-                        || dictation.code_vocab_prompt.is_some(),
-                )
+                rid
             }
         }
     };
+    let bundle_id = crate::frontmost::frontmost_bundle_id();
+    let context = resolve_live_context(&state.app_state, bundle_id.as_deref());
+    state.app_state.set_active_context(rid, Arc::clone(&context));
+    tracing::info!(
+        target: "pipeline",
+        recording_id = rid,
+        frontmost_bundle_id = context.app.bundle_id.as_deref().unwrap_or("unknown"),
+        matched_profile = context.matched_profile.is_some(),
+        vocabulary_version = context.vocabulary.version,
+        context_reads_enabled = context.context_capture.selected_text
+            || context.context_capture.surrounding_screen_text
+            || context.context_capture.clipboard,
+        "dictation context resolved"
+    );
     tracing::info!(target: "pipeline", "start_native_recording: device={} recording_id={}", device_name.as_deref().unwrap_or("system_default"), rid);
     if let Err(e) = audio::start_recording(Some(app_handle.clone()), device_name) {
         tracing::error!(target: "audio", "start_native_recording: audio failed: {}", e);
+        state.app_state.clear_active_context(rid);
         let mut dictation = state.app_state.dictation.lock_or_recover();
-        dictation.status = DictationStatus::Idle;
+        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+            dictation.status = DictationStatus::Idle;
+        }
         return Err(e);
     }
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(target: "pipeline", "start_native_recording: started");
-    spawn_model_preparation(app_handle.clone(), model_name.clone(), rid);
-    if streaming_prompt_ready {
-        let sanitized = custom_vocabulary.replace('\0', "");
-        let code_vocab = resolve_code_vocab_prompt(&state.app_state);
-        let prompt = combine_prompts(&sanitized, &code_vocab);
-        streaming::start_session(
-            app_handle.clone(),
-            streaming::StreamingConfig {
-                recording_id: rid,
-                model_name,
-                language,
-                prompt,
-                smart_punctuation,
-                vad_threshold: 1.0 - (vad_sensitivity as f32 / 100.0),
-            },
-        )
-        .await;
-    } else {
-        tracing::info!(
-            target: "pipeline",
-            recording_id = rid,
-            "incremental transcription skipped until code vocabulary cache is ready"
-        );
-    }
+    spawn_model_preparation(app_handle.clone(), context.transcription.model_name.clone(), rid);
+    streaming::start_session(
+        app_handle.clone(),
+        streaming::StreamingConfig {
+            recording_id: rid,
+            context: Arc::clone(&context),
+        },
+    )
+    .await;
 
     Ok(serde_json::json!({
         "type": "recording_started",
@@ -1558,6 +1575,18 @@ pub async fn stop_native_recording(
                 dictation.status = DictationStatus::Processing;
                 state.app_state.recording_id.load(Ordering::SeqCst)
             }
+        }
+    };
+    let context = match state.app_state.active_context(rid) {
+        Some(context) => context,
+        None => {
+            let mut dictation = state.app_state.dictation.lock_or_recover();
+            if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+                dictation.status = DictationStatus::Idle;
+            }
+            keyboard::set_processing(false);
+            let _ = app_handle.emit("recording-status-changed", "idle");
+            return Err(format!("Missing dictation context for recording {rid}"));
         }
     };
     keyboard::set_processing(true);
@@ -1624,6 +1653,7 @@ pub async fn stop_native_recording(
         &app_handle,
         &state.app_state,
         rid,
+        Arc::clone(&context),
         incremental,
     )
     .await;
@@ -1646,14 +1676,8 @@ pub async fn stop_native_recording(
     let audio_secs = samples.len() as f64 / 16_000.0;
     let word_count = if text.trim().is_empty() { 0 } else { text.split_whitespace().count() };
     let char_count = text.len();
-    let model_name = {
-        let d = state.app_state.dictation.lock_or_recover();
-        d.model_name.clone()
-    };
-    let backend_name = {
-        let b = state.app_state.backend.lock_or_recover();
-        b.name().to_string()
-    };
+    let model_name = context.transcription.model_name.clone();
+    let backend_name = transcriber::backend_name_for_model(&model_name).to_string();
 
     tracing::info!(
         target: "pipeline",
@@ -1721,6 +1745,7 @@ pub async fn cancel_native_recording(
         (prev, rid)
     };
     streaming::cancel(&state.app_state, rid).await;
+    state.app_state.clear_active_context(rid);
 
     let stop_err = match prev_status {
         DictationStatus::Recording => {

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -1,0 +1,374 @@
+//! Immutable, per-recording dictation context resolution.
+//!
+//! The resolver is the only place where global settings, per-app profiles, and
+//! one-session overrides are combined. The resulting snapshot contains only the
+//! typed values consumed by the live pipeline; later settings or focus changes
+//! cannot alter an in-flight dictation.
+
+use crate::correction::CorrectionMatcher;
+use crate::state::{AppProfile, DictationState, VoiceCommand};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveAppIdentity {
+    pub bundle_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedAppProfile {
+    pub bundle_id: String,
+    pub label: String,
+    pub auto_paste_override: Option<bool>,
+    pub cleanup_override: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VocabularySource {
+    None,
+    Custom,
+    CodeAware,
+    CustomAndCodeAware,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VocabularyIdentity {
+    pub source: VocabularySource,
+    /// Monotonic configuration revision captured with the vocabulary inputs.
+    pub version: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnabledCommandGroups {
+    pub built_in_voice_commands: bool,
+    pub custom_voice_commands: bool,
+}
+
+/// Permissions to read user context as an input to dictation.
+///
+/// These are deliberately separate from clipboard-first output. A `false`
+/// `clipboard` value forbids reading clipboard contents as prompt context; it
+/// does not affect writing the final transcript to the clipboard or auto-paste.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ContextCapturePermissions {
+    pub selected_text: bool,
+    pub surrounding_screen_text: bool,
+    pub clipboard: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptionSettings {
+    pub model_name: String,
+    pub language: String,
+    pub vad_sensitivity: u32,
+    pub prompt: Option<String>,
+    pub smart_punctuation: bool,
+}
+
+#[derive(Clone)]
+pub struct TransformationSettings {
+    pub cleanup_enabled: bool,
+    pub cleanup_remove_filler: bool,
+    pub cleanup_capitalize: bool,
+    pub voice_command_pairs: Vec<VoiceCommand>,
+    pub correction_enabled: bool,
+    pub correction_matcher: Option<Arc<CorrectionMatcher>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeliverySettings {
+    pub auto_paste: bool,
+    pub paste_delay_ms: u64,
+    pub save_transcript: bool,
+    pub save_audio: bool,
+    pub output_dir: String,
+}
+
+#[derive(Clone)]
+pub struct DictationContextSnapshot {
+    pub app: ActiveAppIdentity,
+    pub matched_profile: Option<MatchedAppProfile>,
+    pub transcription: TranscriptionSettings,
+    pub transformations: TransformationSettings,
+    pub delivery: DeliverySettings,
+    pub vocabulary: VocabularyIdentity,
+    pub enabled_command_groups: EnabledCommandGroups,
+    pub context_capture: ContextCapturePermissions,
+}
+
+/// Ephemeral overrides supplied by the recording trigger. No caller supplies
+/// them today, but keeping them explicit makes precedence testable and avoids a
+/// second resolution path when session-specific behavior is introduced.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionOverrides {
+    pub auto_paste: Option<bool>,
+    pub cleanup_enabled: Option<bool>,
+}
+
+pub struct ResolverInputs<'a> {
+    pub bundle_id: Option<&'a str>,
+    pub global: &'a DictationState,
+    pub prompt: Option<String>,
+    pub correction_matcher: Option<Arc<CorrectionMatcher>>,
+    pub vocabulary_version: u64,
+    pub session_overrides: SessionOverrides,
+}
+
+/// Resolve global defaults -> matching app profiles -> one-session overrides.
+///
+/// Duplicate profiles intentionally preserve the legacy behavior: for each
+/// field, the first matching profile that supplies that override wins. A
+/// matching entry with `None` falls through to the next duplicate entry.
+pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
+    let global = inputs.global;
+    let auto_paste = inputs.session_overrides.auto_paste.unwrap_or_else(|| {
+        resolve_profile_override(
+            global.auto_paste,
+            inputs.bundle_id,
+            &global.app_profiles,
+            |profile| profile.auto_paste_override,
+        )
+    });
+    let cleanup_enabled = inputs.session_overrides.cleanup_enabled.unwrap_or_else(|| {
+        resolve_profile_override(
+            global.cleanup_enabled,
+            inputs.bundle_id,
+            &global.app_profiles,
+            |profile| profile.cleanup_override,
+        )
+    });
+    let matched_profile = inputs.bundle_id.and_then(|bundle_id| {
+        global
+            .app_profiles
+            .iter()
+            .find(|profile| profile.bundle_id == bundle_id)
+            .map(|profile| MatchedAppProfile {
+                bundle_id: profile.bundle_id.clone(),
+                label: profile.label.clone(),
+                auto_paste_override: profile.auto_paste_override,
+                cleanup_override: profile.cleanup_override,
+            })
+    });
+    let custom_vocab = !global.custom_vocabulary.trim().is_empty();
+    let code_vocab = global.code_vocab_enabled;
+    let source = match (custom_vocab, code_vocab) {
+        (false, false) => VocabularySource::None,
+        (true, false) => VocabularySource::Custom,
+        (false, true) => VocabularySource::CodeAware,
+        (true, true) => VocabularySource::CustomAndCodeAware,
+    };
+    let voice_commands = global.voice_commands_enabled;
+
+    DictationContextSnapshot {
+        app: ActiveAppIdentity {
+            bundle_id: inputs.bundle_id.map(str::to_string),
+        },
+        matched_profile,
+        transcription: TranscriptionSettings {
+            model_name: global.model_name.clone(),
+            language: global.language.clone(),
+            vad_sensitivity: global.vad_sensitivity,
+            prompt: inputs.prompt,
+            smart_punctuation: global.smart_punctuation,
+        },
+        transformations: TransformationSettings {
+            cleanup_enabled,
+            cleanup_remove_filler: global.cleanup_remove_filler,
+            cleanup_capitalize: global.cleanup_capitalize,
+            voice_command_pairs: global.voice_command_pairs.clone(),
+            correction_enabled: global.correction_enabled,
+            correction_matcher: inputs.correction_matcher,
+        },
+        delivery: DeliverySettings {
+            auto_paste,
+            paste_delay_ms: global.auto_paste_delay_ms,
+            save_transcript: global.save_transcript,
+            save_audio: global.save_audio,
+            output_dir: global.output_dir.clone(),
+        },
+        vocabulary: VocabularyIdentity {
+            source,
+            version: inputs.vocabulary_version,
+        },
+        enabled_command_groups: EnabledCommandGroups {
+            built_in_voice_commands: voice_commands,
+            custom_voice_commands: voice_commands && !global.voice_command_pairs.is_empty(),
+        },
+        // No selected-text, screen-text, or clipboard reads exist. Future
+        // features must add an explicit setting/profile override here first.
+        context_capture: ContextCapturePermissions::default(),
+    }
+}
+
+fn resolve_profile_override<T: Copy>(
+    global: T,
+    bundle_id: Option<&str>,
+    profiles: &[AppProfile],
+    get_override: impl Fn(&AppProfile) -> Option<T>,
+) -> T {
+    let Some(bundle_id) = bundle_id else {
+        return global;
+    };
+    profiles
+        .iter()
+        .filter(|profile| profile.bundle_id == bundle_id)
+        .find_map(get_override)
+        .unwrap_or(global)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(
+        bundle_id: &str,
+        auto_paste_override: Option<bool>,
+        cleanup_override: Option<bool>,
+    ) -> AppProfile {
+        AppProfile {
+            bundle_id: bundle_id.to_string(),
+            label: bundle_id.to_string(),
+            auto_paste_override,
+            cleanup_override,
+        }
+    }
+
+    fn resolve_test(
+        global: &DictationState,
+        bundle_id: Option<&str>,
+        session_overrides: SessionOverrides,
+    ) -> DictationContextSnapshot {
+        resolve(ResolverInputs {
+            bundle_id,
+            global,
+            prompt: None,
+            correction_matcher: None,
+            vocabulary_version: 7,
+            session_overrides,
+        })
+    }
+
+    #[test]
+    fn matching_profile_resolves_effective_values() {
+        let mut global = DictationState {
+            auto_paste: true,
+            cleanup_enabled: false,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![profile("com.apple.Terminal", Some(false), Some(true))];
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.apple.Terminal"),
+            SessionOverrides::default(),
+        );
+
+        assert!(!snapshot.delivery.auto_paste);
+        assert!(snapshot.transformations.cleanup_enabled);
+        assert_eq!(
+            snapshot
+                .matched_profile
+                .as_ref()
+                .map(|profile| profile.bundle_id.as_str()),
+            Some("com.apple.Terminal")
+        );
+    }
+
+    #[test]
+    fn no_match_or_app_identity_uses_global_values() {
+        let mut global = DictationState {
+            auto_paste: true,
+            cleanup_enabled: false,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![profile("com.apple.Terminal", Some(false), Some(true))];
+
+        for bundle_id in [None, Some("com.apple.Safari")] {
+            let snapshot = resolve_test(&global, bundle_id, SessionOverrides::default());
+            assert!(snapshot.delivery.auto_paste);
+            assert!(!snapshot.transformations.cleanup_enabled);
+            assert!(snapshot.matched_profile.is_none());
+        }
+    }
+
+    #[test]
+    fn session_overrides_have_highest_precedence() {
+        let mut global = DictationState {
+            auto_paste: false,
+            cleanup_enabled: true,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![profile("com.apple.Terminal", Some(true), Some(false))];
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.apple.Terminal"),
+            SessionOverrides {
+                auto_paste: Some(false),
+                cleanup_enabled: Some(true),
+            },
+        );
+
+        assert!(!snapshot.delivery.auto_paste);
+        assert!(snapshot.transformations.cleanup_enabled);
+    }
+
+    #[test]
+    fn duplicate_profiles_preserve_first_supplied_override_per_field() {
+        let mut global = DictationState {
+            auto_paste: true,
+            cleanup_enabled: true,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![
+            profile("com.apple.Terminal", None, Some(false)),
+            profile("com.apple.Terminal", Some(false), Some(true)),
+            profile("com.apple.Terminal", Some(true), None),
+        ];
+        global.app_profiles[0].label = "first match".to_string();
+        global.app_profiles[1].label = "second match".to_string();
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.apple.Terminal"),
+            SessionOverrides::default(),
+        );
+
+        assert!(!snapshot.delivery.auto_paste);
+        assert!(!snapshot.transformations.cleanup_enabled);
+        assert_eq!(snapshot.matched_profile.unwrap().label, "first match");
+    }
+
+    #[test]
+    fn resolved_snapshot_does_not_follow_later_settings_changes() {
+        let mut global = DictationState {
+            model_name: "base.en".to_string(),
+            auto_paste: false,
+            cleanup_enabled: false,
+            ..DictationState::default()
+        };
+        let snapshot = resolve_test(&global, None, SessionOverrides::default());
+
+        global.model_name = "small.en".to_string();
+        global.auto_paste = true;
+        global.cleanup_enabled = true;
+
+        assert_eq!(snapshot.transcription.model_name, "base.en");
+        assert!(!snapshot.delivery.auto_paste);
+        assert!(!snapshot.transformations.cleanup_enabled);
+    }
+
+    #[test]
+    fn context_capture_is_deny_by_default_without_disabling_clipboard_delivery() {
+        let global = DictationState {
+            auto_paste: true,
+            ..DictationState::default()
+        };
+        let snapshot = resolve_test(&global, None, SessionOverrides::default());
+
+        assert_eq!(
+            snapshot.context_capture,
+            ContextCapturePermissions::default()
+        );
+        assert!(snapshot.delivery.auto_paste);
+    }
+}

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -14,15 +14,18 @@ pub fn frontmost_bundle_id() -> Option<String> {
         r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#,
     ) {
         Ok(output) => output,
-        Err(error) => {
-            tracing::warn!(target: "pipeline", "frontmost_bundle_id: {error}");
+        Err(_) => {
+            tracing::warn!(target: "pipeline", "frontmost app query failed");
             return None;
         }
     };
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::warn!(target: "pipeline", "frontmost_bundle_id: osascript failed: {}", stderr.trim());
+        tracing::warn!(
+            target: "pipeline",
+            exit_code = output.status.code(),
+            "frontmost app query returned an error"
+        );
         return None;
     }
 

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -7,16 +7,18 @@
 
 /// Return the bundle identifier of the frontmost macOS app, e.g.
 /// `"com.apple.Terminal"`. Returns `None` on any failure so the caller can fall
-/// back to the global auto-paste setting.
+/// back to a global-only dictation context.
 #[cfg(target_os = "macos")]
 pub fn frontmost_bundle_id() -> Option<String> {
-    use std::process::Command;
-
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#)
-        .output()
-        .ok()?;
+    let output = match crate::injector::run_osascript_with_timeout(
+        r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#,
+    ) {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(target: "pipeline", "frontmost_bundle_id: {error}");
+            return None;
+        }
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -36,156 +38,4 @@ pub fn frontmost_bundle_id() -> Option<String> {
 #[cfg(not(target_os = "macos"))]
 pub fn frontmost_bundle_id() -> Option<String> {
     None
-}
-
-/// Resolve the effective auto-paste setting for the frontmost app.
-///
-/// Given the global `auto_paste` value, the detected frontmost `bundle_id`
-/// (if any), and the configured profiles, returns the override from the first
-/// matching profile that sets one, otherwise the global value. Kept pure so it
-/// can be unit-tested without invoking osascript.
-pub fn resolve_auto_paste(
-    auto_paste: bool,
-    bundle_id: Option<&str>,
-    profiles: &[crate::state::AppProfile],
-) -> bool {
-    let Some(bundle_id) = bundle_id else {
-        return auto_paste;
-    };
-    for profile in profiles {
-        if profile.bundle_id == bundle_id {
-            if let Some(override_value) = profile.auto_paste_override {
-                return override_value;
-            }
-        }
-    }
-    auto_paste
-}
-
-/// Resolve the effective transcript-cleanup setting for the frontmost app.
-///
-/// Mirrors [`resolve_auto_paste`]: returns the override from the first matching
-/// profile that sets one, otherwise the global `cleanup` value. Pure for testing.
-pub fn resolve_cleanup(
-    cleanup: bool,
-    bundle_id: Option<&str>,
-    profiles: &[crate::state::AppProfile],
-) -> bool {
-    let Some(bundle_id) = bundle_id else {
-        return cleanup;
-    };
-    for profile in profiles {
-        if profile.bundle_id == bundle_id {
-            if let Some(override_value) = profile.cleanup_override {
-                return override_value;
-            }
-        }
-    }
-    cleanup
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::state::AppProfile;
-
-    fn profile(bundle_id: &str, auto_paste_override: Option<bool>) -> AppProfile {
-        AppProfile {
-            bundle_id: bundle_id.to_string(),
-            label: bundle_id.to_string(),
-            auto_paste_override,
-            cleanup_override: None,
-        }
-    }
-
-    fn cleanup_profile(bundle_id: &str, cleanup_override: Option<bool>) -> AppProfile {
-        AppProfile {
-            bundle_id: bundle_id.to_string(),
-            label: bundle_id.to_string(),
-            auto_paste_override: None,
-            cleanup_override,
-        }
-    }
-
-    #[test]
-    fn no_frontmost_uses_global() {
-        let profiles = vec![profile("com.apple.Terminal", Some(false))];
-        assert!(resolve_auto_paste(true, None, &profiles));
-        assert!(!resolve_auto_paste(false, None, &profiles));
-    }
-
-    #[test]
-    fn unmatched_app_uses_global() {
-        let profiles = vec![profile("com.apple.Terminal", Some(false))];
-        assert!(resolve_auto_paste(true, Some("com.apple.Safari"), &profiles));
-    }
-
-    #[test]
-    fn matching_profile_override_wins() {
-        let profiles = vec![profile("com.apple.Terminal", Some(false))];
-        assert!(!resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
-    }
-
-    #[test]
-    fn matching_profile_can_force_on() {
-        let profiles = vec![profile("com.googlecode.iterm2", Some(true))];
-        assert!(resolve_auto_paste(false, Some("com.googlecode.iterm2"), &profiles));
-    }
-
-    #[test]
-    fn null_override_falls_through_to_global() {
-        let profiles = vec![profile("com.apple.Terminal", None)];
-        assert!(resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
-        assert!(!resolve_auto_paste(false, Some("com.apple.Terminal"), &profiles));
-    }
-
-    #[test]
-    fn first_matching_override_wins() {
-        let profiles = vec![
-            profile("com.apple.Terminal", None),
-            profile("com.apple.Terminal", Some(false)),
-        ];
-        // First profile has no override, so we fall through to the second.
-        assert!(!resolve_auto_paste(true, Some("com.apple.Terminal"), &profiles));
-    }
-
-    #[test]
-    fn cleanup_no_frontmost_uses_global() {
-        let profiles = vec![cleanup_profile("com.apple.Terminal", Some(false))];
-        assert!(resolve_cleanup(true, None, &profiles));
-        assert!(!resolve_cleanup(false, None, &profiles));
-    }
-
-    #[test]
-    fn cleanup_matching_profile_override_wins() {
-        // Force cleanup OFF in a code editor even though it's globally on.
-        let profiles = vec![cleanup_profile("com.microsoft.VSCode", Some(false))];
-        assert!(!resolve_cleanup(true, Some("com.microsoft.VSCode"), &profiles));
-    }
-
-    #[test]
-    fn cleanup_matching_profile_can_force_on() {
-        let profiles = vec![cleanup_profile("com.apple.mail", Some(true))];
-        assert!(resolve_cleanup(false, Some("com.apple.mail"), &profiles));
-    }
-
-    #[test]
-    fn cleanup_null_override_falls_through_to_global() {
-        let profiles = vec![cleanup_profile("com.apple.Terminal", None)];
-        assert!(resolve_cleanup(true, Some("com.apple.Terminal"), &profiles));
-        assert!(!resolve_cleanup(false, Some("com.apple.Terminal"), &profiles));
-    }
-
-    #[test]
-    fn cleanup_and_auto_paste_overrides_are_independent() {
-        // A profile can override one without touching the other.
-        let profiles = vec![AppProfile {
-            bundle_id: "com.apple.Terminal".to_string(),
-            label: "Terminal".to_string(),
-            auto_paste_override: Some(true),
-            cleanup_override: Some(false),
-        }];
-        assert!(resolve_auto_paste(false, Some("com.apple.Terminal"), &profiles));
-        assert!(!resolve_cleanup(true, Some("com.apple.Terminal"), &profiles));
-    }
 }

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -167,7 +167,7 @@ fn simulate_paste_osascript() -> Result<(), String> {
 }
 
 #[cfg(target_os = "macos")]
-fn run_osascript_with_timeout(script: &str) -> Result<std::process::Output, String> {
+pub(crate) fn run_osascript_with_timeout(script: &str) -> Result<std::process::Output, String> {
     use std::io::Read;
     use std::process::{Command, Stdio};
     use std::thread;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod benchmark;
 mod cleanup;
 mod commands;
 mod correction;
+mod dictation_context;
 mod file_output;
 mod frontmost;
 mod injector;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -1,8 +1,9 @@
-use std::sync::Mutex;
-use std::time::Instant;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use serde::{Deserialize, Serialize};
 use crate::transcriber::{TranscriptionBackend, WhisperBackend};
+use crate::MutexExt;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 pub use crate::transcriber::WHISPER_SAMPLE_RATE;
 
@@ -22,7 +23,8 @@ impl Default for DictationStatus {
 
 /// Per-app dictation profile. When the frontmost macOS app's bundle id matches
 /// `bundle_id`, each `*_override` (when `Some`) replaces the corresponding global
-/// setting at transcription time. `None` means "no override — use global".
+/// setting in the immutable recording-start snapshot. `None` means "no override
+/// — use global".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppProfile {
     pub bundle_id: String,
@@ -58,7 +60,7 @@ pub struct DictationState {
     pub save_transcript: bool,
     pub save_audio: bool,
     pub output_dir: String,
-    /// Per-app profiles that override auto-paste based on the frontmost app.
+    /// Per-app profiles resolved once from the frontmost app at recording start.
     pub app_profiles: Vec<AppProfile>,
     pub voice_commands_enabled: bool,
     /// User-defined voice commands applied after the built-in set.
@@ -129,6 +131,11 @@ impl Default for DictationState {
     }
 }
 
+struct ActiveDictationContext {
+    recording_id: u64,
+    snapshot: Arc<crate::dictation_context::DictationContextSnapshot>,
+}
+
 pub struct AppState {
     pub dictation: Mutex<DictationState>,
     /// Serializes recorder start/stop/cancel transitions. Audio startup waits
@@ -143,6 +150,11 @@ pub struct AppState {
     /// Monotonically increasing opaque ID assigned to every post-recognition
     /// transformation pass (live recordings and imported files).
     pub transcript_session_id: AtomicU64,
+    /// Monotonic revision for settings and vocabulary inputs captured by each
+    /// immutable dictation context snapshot.
+    pub settings_revision: AtomicU64,
+    /// The immutable context owned by the active recording generation.
+    active_context: Mutex<Option<ActiveDictationContext>>,
     /// Set to the recording_id of a cancelled recording. Pipeline checks
     /// `cancelled_id >= my_id` at checkpoints to discard cancelled work.
     pub cancelled_id: AtomicU64,
@@ -170,6 +182,47 @@ impl AppState {
         self.transcript_session_id.fetch_add(1, Ordering::SeqCst) + 1
     }
 
+    pub fn bump_settings_revision(&self) -> u64 {
+        self.settings_revision.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    pub fn set_active_context(
+        &self,
+        recording_id: u64,
+        snapshot: Arc<crate::dictation_context::DictationContextSnapshot>,
+    ) {
+        *self.active_context.lock_or_recover() = Some(ActiveDictationContext {
+            recording_id,
+            snapshot,
+        });
+    }
+
+    pub fn active_context(
+        &self,
+        recording_id: u64,
+    ) -> Option<Arc<crate::dictation_context::DictationContextSnapshot>> {
+        self.active_context
+            .lock_or_recover()
+            .as_ref()
+            .filter(|active| active.recording_id == recording_id)
+            .map(|active| Arc::clone(&active.snapshot))
+    }
+
+    /// Clear only the snapshot owned by `recording_id`. A stale guard must not
+    /// erase the context installed by a newer recording generation.
+    pub fn clear_active_context(&self, recording_id: u64) -> bool {
+        let mut active = self.active_context.lock_or_recover();
+        if active
+            .as_ref()
+            .is_some_and(|context| context.recording_id == recording_id)
+        {
+            *active = None;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Mark a recording as cancelled by storing its ID.
     pub fn cancel_recording(&self, id: u64) {
         self.cancelled_id.fetch_max(id, Ordering::SeqCst);
@@ -191,6 +244,8 @@ impl Default for AppState {
             idle_timeout_minutes: Mutex::new(5),
             recording_id: AtomicU64::new(0),
             transcript_session_id: AtomicU64::new(0),
+            settings_revision: AtomicU64::new(0),
+            active_context: Mutex::new(None),
             cancelled_id: AtomicU64::new(0),
             file_transcribing: AtomicBool::new(false),
             correction_matcher: Mutex::new(None),
@@ -202,6 +257,22 @@ impl Default for AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dictation_context::{resolve, ResolverInputs, SessionOverrides};
+
+    fn snapshot(model_name: &str) -> Arc<crate::dictation_context::DictationContextSnapshot> {
+        let settings = DictationState {
+            model_name: model_name.to_string(),
+            ..DictationState::default()
+        };
+        Arc::new(resolve(ResolverInputs {
+            bundle_id: None,
+            global: &settings,
+            prompt: None,
+            correction_matcher: None,
+            vocabulary_version: 0,
+            session_overrides: SessionOverrides::default(),
+        }))
+    }
 
     #[test]
     fn recording_transition_allows_only_one_audio_operation() {
@@ -217,5 +288,32 @@ mod tests {
         let state = AppState::default();
         assert_eq!(state.next_transcript_session_id(), 1);
         assert_eq!(state.next_transcript_session_id(), 2);
+    }
+
+    #[test]
+    fn stale_generation_cannot_read_or_clear_newer_context() {
+        let state = AppState::default();
+        state.set_active_context(2, snapshot("small.en"));
+
+        assert!(state.active_context(1).is_none());
+        assert!(!state.clear_active_context(1));
+        assert_eq!(
+            state.active_context(2).unwrap().transcription.model_name,
+            "small.en"
+        );
+        assert!(state.clear_active_context(2));
+        assert!(state.active_context(2).is_none());
+    }
+
+    #[test]
+    fn active_context_ignores_settings_changes_during_recording() {
+        let state = AppState::default();
+        state.set_active_context(1, snapshot("base.en"));
+        state.dictation.lock_or_recover().model_name = "small.en".to_string();
+
+        assert_eq!(
+            state.active_context(1).unwrap().transcription.model_name,
+            "base.en"
+        );
     }
 }

--- a/app/src-tauri/src/streaming.rs
+++ b/app/src-tauri/src/streaming.rs
@@ -1,6 +1,7 @@
 use crate::state::DictationStatus;
 use crate::{audio, transcriber, vad, MutexExt, State};
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::Manager;
 
@@ -12,11 +13,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[derive(Clone)]
 pub(crate) struct StreamingConfig {
     pub recording_id: u64,
-    pub model_name: String,
-    pub language: String,
-    pub prompt: Option<String>,
-    pub smart_punctuation: bool,
-    pub vad_threshold: f32,
+    pub context: Arc<crate::dictation_context::DictationContextSnapshot>,
 }
 
 #[derive(Default)]
@@ -59,7 +56,7 @@ struct ChunkOutput {
 /// Start one sequential chunk worker for a Whisper recording. Other backends
 /// deliberately retain the existing batch path.
 pub(crate) async fn start_session(app_handle: tauri::AppHandle, config: StreamingConfig) {
-    if !transcriber::is_whisper_model(&config.model_name) {
+    if !transcriber::is_whisper_model(&config.context.transcription.model_name) {
         return;
     }
 
@@ -230,7 +227,7 @@ async fn transcribe_window(
         let filtered = match vad::filter_speech(
             &vad_path.to_string_lossy(),
             &samples,
-            config.vad_threshold,
+            1.0 - (config.context.transcription.vad_sensitivity as f32 / 100.0),
         )? {
             vad::VadResult::NoSpeech => {
                 return Ok(ChunkOutput {
@@ -248,26 +245,18 @@ async fn transcribe_window(
         {
             return Err("recording session was superseded before inference".to_string());
         }
-        {
-            let dictation = state.app_state.dictation.lock_or_recover();
-            if dictation.model_name != config.model_name {
-                return Err("model changed during recording".to_string());
-            }
-        }
-
         let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
         let inference_started = Instant::now();
         let text = {
             let mut backend = state.app_state.backend.lock_or_recover();
-            if backend.name() != "whisper" {
-                return Err("active backend changed during recording".to_string());
-            }
-            backend.load_model(&config.model_name)?;
+            let transcription = &config.context.transcription;
+            transcriber::ensure_backend_for_model(&mut backend, &transcription.model_name)?;
+            backend.load_model(&transcription.model_name)?;
             backend.transcribe(
                 &filtered,
-                &config.language,
-                config.prompt.as_deref(),
-                config.smart_punctuation,
+                &transcription.language,
+                transcription.prompt.as_deref(),
+                transcription.smart_punctuation,
             )?
         };
         let inference_ms = inference_started.elapsed().as_millis() as u64;

--- a/app/src-tauri/src/transcriber/mod.rs
+++ b/app/src-tauri/src/transcriber/mod.rs
@@ -26,6 +26,48 @@ pub fn is_whisper_model(model_name: &str) -> bool {
     !is_coreml_model(model_name) && !parakeet::is_parakeet_model(model_name)
 }
 
+pub fn backend_name_for_model(model_name: &str) -> &'static str {
+    if is_coreml_model(model_name) {
+        "coreml"
+    } else if parakeet::is_parakeet_model(model_name) {
+        "parakeet"
+    } else {
+        "whisper"
+    }
+}
+
+/// Ensure the shared backend implementation matches the model selected by the
+/// immutable recording snapshot. This lets a settings change apply to the next
+/// session without changing the backend underneath the active one.
+pub fn ensure_backend_for_model(
+    backend: &mut Box<dyn TranscriptionBackend>,
+    model_name: &str,
+) -> Result<(), String> {
+    let desired = backend_name_for_model(model_name);
+    if backend.name() == desired {
+        return Ok(());
+    }
+    *backend = match desired {
+        "coreml" => {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            {
+                Box::new(CoreMlBackend::new())
+            }
+            #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+            {
+                return Err(
+                    "Core ML transcription is available only on macOS 14 or newer with Apple Silicon"
+                        .to_string(),
+                );
+            }
+        }
+        "parakeet" => Box::new(ParakeetBackend::new()),
+        _ => Box::new(WhisperBackend::new()),
+    };
+    tracing::info!(target: "pipeline", "Switched transcription backend to {}", backend.name());
+    Ok(())
+}
+
 /// Sample rate required by transcription models (16kHz).
 pub const WHISPER_SAMPLE_RATE: u32 = 16000;
 

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -1,0 +1,42 @@
+# Per-App Dictation Context
+
+Murmur resolves one immutable `DictationContextSnapshot` for every live recording. The snapshot is created when recording starts from the frontmost application's bundle identifier and the current backend configuration. Incremental transcription, batch fallback, transformations, file output, clipboard output, and auto-paste all use that same snapshot.
+
+## Resolution and precedence
+
+`dictation_context::resolve` is the only profile resolver. It applies values in this order:
+
+1. Global dictation settings
+2. Matching per-app profile overrides
+3. One-session overrides
+
+One-session overrides are an explicit, typed resolver input but no trigger supplies them yet. This keeps the precedence contract ready for future commands without adding a second app-detection or settings path.
+
+Profiles currently override only `autoPaste` and transcript cleanup. Existing stored profile objects remain valid; missing or `null` overrides still mean "use the global value." The settings UI prevents duplicates, but persisted or programmatic configuration can contain them. To preserve legacy behavior exactly, each field uses the first matching profile that provides that field; a `null` override falls through to the next duplicate.
+
+## Snapshot contents and lifetime
+
+The snapshot contains only typed values used by the live pipeline:
+
+- Active app bundle identifier and the first matched profile identity
+- Effective transcription, transformation, and delivery settings
+- Vocabulary source plus a monotonic configuration version
+- The resolved prompt and immutable correction matcher
+- Enabled command groups
+- Context-capture permissions
+
+`AppState` stores the snapshot with its `recording_id`. Stop and processing paths can retrieve only the matching generation. Cleanup also checks the generation, so a stale pipeline cannot read or clear a newer recording's snapshot. Focus changes and settings changes after recording starts affect only later recordings.
+
+## Privacy boundary
+
+Context capture is deny-by-default. The current snapshot never grants reading:
+
+- Selected text
+- Nearby or surrounding screen text
+- Clipboard contents as transcription context
+
+This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. A future context feature must add an explicit user setting/profile override and grant the corresponding capture permission in the resolver before any new read path is introduced.
+
+## Extension points
+
+Future app-specific model, language, vocabulary, command, formatting, or context-policy fields should be added to the profile schema and folded into `DictationContextSnapshot` by the single resolver. Pipeline stages should consume the snapshot rather than re-reading `DictationState` or detecting the frontmost app again.

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -59,7 +59,7 @@ Long live recordings selected to the Whisper backend use true incremental output
 - Every window passes through the same Silero VAD threshold and the existing cached Whisper backend. There is no second model/context and never more than one inference in flight.
 - Chunk text is reconciled by a deterministic word-boundary algorithm. It removes the largest near-equal suffix/prefix overlap within 12 words and retains the earlier surface form.
 - On stop, the worker is signalled before audio teardown and only the unprocessed tail plus the 2-second overlap is inferred. The reconciled result becomes the authoritative text used by the unchanged cleanup, voice-command, correction, file-output, clipboard, paste, history, and stats paths.
-- Short recordings (under the first 10-second window), non-Whisper backends, missing/failed VAD, stale sessions, model changes, worker lag, panics, or final-tail failures use the original full-buffer pipeline.
+- Short recordings (under the first 10-second window), non-Whisper backends, missing/failed VAD, stale sessions, worker lag, panics, or final-tail failures use the original full-buffer pipeline. A model setting change during recording applies to the next session; the active worker keeps its recording-start model snapshot.
 
 The worker holds no queued audio. It reads the current buffer length, copies only one fixed window, awaits that inference, and abandons incremental mode if capture advances by more than one step. Recording IDs and cancellation generations prevent completed work from a stopped/cancelled session from being adopted by a newer recording.
 
@@ -77,14 +77,14 @@ The worker holds no queued audio. It reads the current buffer length, copies onl
 
 ## Pipeline Orchestration (`commands/recording.rs`)
 
-`run_transcription_pipeline()` remains the single authoritative completion entry point:
+`run_transcription_pipeline()` remains the single authoritative completion entry point. `start_native_recording` resolves one immutable `DictationContextSnapshot` from the frontmost bundle identifier and current configuration; every live stage receives that snapshot instead of re-reading mutable settings:
 
-1. Read model/language/auto_paste from `DictationState` (single lock)
-2. Confirm the recording-start model preparation completed (or load synchronously as a fallback)
-3. Adopt a successfully finalized incremental Whisper transcript, or run the full-buffer backend fallback
-4. Run the backend-neutral transcript transformation pipeline
-5. Persist optional file output and inject text (clipboard + optional paste) on the main thread
-6. Reset status to Idle
+1. Capture app identity, matched profile, effective settings, vocabulary version, commands, and deny-by-default context permissions at recording start
+2. Confirm the snapshot's model preparation completed (or load synchronously as a fallback)
+3. Adopt a successfully finalized incremental Whisper transcript, or run the full-buffer backend fallback with the same snapshot
+4. Run the backend-neutral transcript transformation pipeline from the snapshot's stage settings and resources
+5. Persist optional file output and inject text (clipboard + optional paste) from the snapshot on the main thread
+6. Reset status to Idle and clear only the matching recording generation's snapshot
 
 Uses `IdleGuard` (RAII) to reset status on any early return or error — prevents the app from getting stuck in "processing" state.
 
@@ -100,7 +100,9 @@ Each stage receives immutable session/model/language metadata plus privacy-safe 
 
 Cleanup and voice commands are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. Imported-file transcription invokes the same entry point with all three stages disabled so its existing raw-ASR output remains unchanged.
 
-File persistence, clipboard/paste, history, and stats are intentionally outside the transformation pipeline. The context contains only an opaque optional handle for future resolved app context; app/profile resolution remains owned by the separate context architecture.
+File persistence, clipboard/paste, history, and stats are intentionally outside the transformation pipeline. Live transformation receives an opaque recording handle plus stage configuration and resources from the same immutable per-app snapshot; app/profile resolution remains owned by the context resolver.
+
+See [Per-App Dictation Context](per-app-profiles.md) for resolver precedence, duplicate-profile compatibility, lifetime, and privacy boundaries.
 
 ## Model Downloads (`commands/models.rs`)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -81,6 +81,12 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |
 | `outputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved transcript/audio files. Empty means the app default (`Documents/Murmur`, created on first write). Set via a folder picker (`dialog:allow-open`). |
 
+## Per-App Profiles
+
+`appProfiles` is an array of `{ bundleId, label, autoPasteOverride, cleanupOverride }`. Boolean overrides replace the corresponding global value for a matching frontmost bundle identifier; `null` means "use global." Existing persisted entries are migrated by filling missing override fields with `null`.
+
+At recording start, the backend resolves one immutable context using global settings → matching profile → one-session overrides. Settings or focus changes during recording apply only to the next session. See [Per-App Dictation Context](../features/per-app-profiles.md).
+
 ---
 
 ## System Settings


### PR DESCRIPTION
## Summary
- resolve one typed, immutable dictation context at recording start from global settings, the active app profile, and explicit session overrides
- carry the same generation-keyed snapshot through incremental/batch transcription, the merged ordered transformation pipeline, file output, clipboard delivery, and auto-paste
- preserve legacy duplicate-profile field resolution and existing clipboard-first output while making all context reads deny-by-default
- document resolver precedence, lifetime, privacy boundaries, and extension points for future app-specific behavior

## Validation
- `cd app && npx tsc --noEmit`
- `cd app/src-tauri && cargo check`
- `cd app/src-tauri && cargo test -- --test-threads=1` (294 unit tests + Whisper integration passed after rebasing onto #257; optional Core ML integration ignored by design)
- native debug-app smoke: resolver completed with `context_reads_enabled=false`; start reached the host CoreAudio device boundary and the UI surfaced the device error while returning to Ready

Closes #245
