### PR TITLE
feat: format spoken CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Read these before working on a feature:
 - **[docs/onboarding.md](docs/onboarding.md)** — Setup, permissions, model installation, logs
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
+- **[docs/features/cli-command-formatting.md](docs/features/cli-command-formatting.md)** — Spoken CLI detection, grammar, lexicon, safety
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript
 - **[docs/features/vad.md](docs/features/vad.md)** — VAD speech filtering
 - **[docs/features/overlay.md](docs/features/overlay.md)** — Dynamic Island overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - Long Whisper recordings now show a session-scoped provisional transcript in the notch overlay after each reliable incremental chunk. The privacy-safe preview can be disabled in Settings; final clipboard and auto-paste delivery remain unchanged and occur exactly once after stop (#243).
+- **Spoken CLI command formatting** — likely npm/npx, Git, Cargo, Docker, kubectl, and other developer commands now receive deterministic local formatting for versions, flags, paths, operators, quotes, and small canonical aliases. Detection is prefix/trigger/profile bounded, project `package.json` names extend the local lexicon, and ordinary prose remains unchanged (#256).
 
 ### Changed
 - Post-recognition cleanup, voice commands, and Smart Correction now run through one ordered, backend-neutral transformation pipeline with privacy-safe per-stage timing/change telemetry and explicit failure policy (#244).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Read these before working on a feature:
 - **[docs/features/onboarding-flow.md](docs/features/onboarding-flow.md)** — First-launch setup assistant (permissions wizard + model download)
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
+- **[docs/features/cli-command-formatting.md](docs/features/cli-command-formatting.md)** — Spoken CLI detection, grammar, lexicon, safety
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript
 - **[docs/features/vad.md](docs/features/vad.md)** — VAD speech filtering
 - **[docs/features/overlay.md](docs/features/overlay.md)** — Dynamic Island overlay

--- a/app/src-tauri/src/cli_command.rs
+++ b/app/src-tauri/src/cli_command.rs
@@ -1,0 +1,801 @@
+//! Deterministic spoken CLI recognition and canonical formatting.
+//!
+//! Activation is deliberately conservative: an utterance must start with an
+//! explicit command trigger, start with a known tool plus command-shaped
+//! evidence, or come from a profile that explicitly enables CLI formatting.
+//! Text that does not activate is returned byte-for-byte unchanged.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliFormattingMode {
+    Auto,
+    Enabled,
+    Disabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Alias {
+    spoken: Vec<String>,
+    written: String,
+}
+
+/// Local, in-memory command lexicon. Built-ins cover common CLI spellings;
+/// project vocabulary and approved user mappings can extend it without adding
+/// whole-command templates to the formatter.
+#[derive(Debug, Clone)]
+pub(crate) struct CliLexicon {
+    aliases: Vec<Alias>,
+}
+
+const BUILTIN_ALIASES: &[(&str, &str)] = &[
+    ("n p m", "npm"),
+    ("n p x", "npx"),
+    ("p n p m", "pnpm"),
+    ("node js", "node"),
+    ("cc usage", "ccusage"),
+    ("create vite", "create-vite"),
+    ("react typescript", "react-ts"),
+    ("test threads", "test-threads"),
+    ("tauri", "tauri"),
+    ("type script", "typescript"),
+    ("java script", "javascript"),
+    ("zero", "0"),
+    ("one", "1"),
+    ("two", "2"),
+    ("three", "3"),
+    ("four", "4"),
+    ("five", "5"),
+    ("six", "6"),
+    ("seven", "7"),
+    ("eight", "8"),
+    ("nine", "9"),
+    ("ten", "10"),
+];
+
+const KNOWN_TOOLS: &[&str] = &[
+    "npm", "npx", "pnpm", "yarn", "bun", "git", "cargo", "rustup", "docker", "kubectl", "node",
+    "deno", "python", "python3", "pip", "pip3", "go", "make", "cmake", "curl", "wget",
+];
+
+const PROSE_FOLLOWERS: &[&str] = &[
+    "and", "are", "can", "does", "has", "is", "means", "should", "was", "will",
+];
+
+impl CliLexicon {
+    pub(crate) fn from_context(
+        prompt: Option<&str>,
+        approved_mappings: &[(String, String)],
+    ) -> Self {
+        let mut aliases = Vec::new();
+
+        // Existing custom voice-command pairs are user-approved. Only atom-like
+        // replacements are useful as lexicon entries; sentences remain owned by
+        // the voice-command stage that runs before this formatter.
+        for (spoken, written) in approved_mappings {
+            if is_shell_atom(written) {
+                add_alias(&mut aliases, spoken, written);
+            }
+        }
+
+        // CLI-specific aliases win over generic project casing (for example the
+        // project vocabulary writes `Tauri`, while an npm script is `tauri`).
+        for (spoken, written) in BUILTIN_ALIASES {
+            add_alias(&mut aliases, spoken, written);
+        }
+
+        // Project/code-vocabulary terms are already captured in the immutable
+        // recording context. Derive a spoken form for structured identifiers.
+        if let Some(prompt) = prompt {
+            for term in prompt.split_whitespace() {
+                add_term_alias(&mut aliases, term);
+            }
+        }
+
+        aliases.sort_by(|a, b| b.spoken.len().cmp(&a.spoken.len()));
+        let mut seen = std::collections::HashSet::new();
+        aliases.retain(|alias| seen.insert(alias.spoken.clone()));
+        Self { aliases }
+    }
+
+    #[cfg(test)]
+    fn builtins() -> Self {
+        Self::from_context(None, &[])
+    }
+
+    fn resolve(&self, words: &[String], start: usize) -> Option<(&str, usize)> {
+        self.aliases.iter().find_map(|alias| {
+            let end = start.checked_add(alias.spoken.len())?;
+            if end > words.len() {
+                return None;
+            }
+            words[start..end]
+                .iter()
+                .zip(&alias.spoken)
+                .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
+                .then_some((alias.written.as_str(), alias.spoken.len()))
+        })
+    }
+}
+
+fn add_alias(aliases: &mut Vec<Alias>, spoken: &str, written: &str) {
+    let spoken = spoken
+        .split_whitespace()
+        .map(|word| word.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let written = written.trim();
+    if !spoken.is_empty() && !written.is_empty() {
+        aliases.push(Alias {
+            spoken,
+            written: written.to_string(),
+        });
+    }
+}
+
+fn add_term_alias(aliases: &mut Vec<Alias>, term: &str) {
+    let term = term.trim_matches(|ch: char| ch == ',' || ch == ';');
+    if term.is_empty() || !is_shell_atom(term) {
+        return;
+    }
+    let spoken = derive_spoken_form(term);
+    if !spoken.is_empty() {
+        add_alias(aliases, &spoken, term);
+    }
+}
+
+fn is_shell_atom(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && !value.chars().any(char::is_whitespace)
+        && value
+            .chars()
+            .all(|ch| ch.is_alphanumeric() || "_-./:@".contains(ch))
+}
+
+fn derive_spoken_form(written: &str) -> String {
+    let mut out = String::new();
+    let mut previous: Option<char> = None;
+    for ch in written.chars() {
+        let separator = match ch {
+            '_' | '-' => Some(" "),
+            '/' => Some(" slash "),
+            '.' => Some(" dot "),
+            ':' => Some(" colon "),
+            '@' => Some(" at "),
+            _ => None,
+        };
+        if let Some(separator) = separator {
+            out.push_str(separator);
+            previous = None;
+            continue;
+        }
+        if ch.is_uppercase()
+            && previous.is_some_and(|prev| prev.is_lowercase() || prev.is_numeric())
+        {
+            out.push(' ');
+        }
+        out.extend(ch.to_lowercase());
+        previous = Some(ch);
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Canonicalize one likely command. Non-activated input is returned exactly as
+/// received, including whitespace and Unicode surface forms.
+pub(crate) fn canonicalize_cli(
+    input: &str,
+    mode: CliFormattingMode,
+    lexicon: &CliLexicon,
+) -> String {
+    let mut words = input
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if words.is_empty() {
+        return input.to_string();
+    }
+
+    let trigger_words = explicit_trigger_len(&words);
+    let explicit = trigger_words > 0;
+    if explicit {
+        words.drain(0..trigger_words);
+        if words.is_empty() {
+            return input.to_string();
+        }
+    }
+
+    let activated = explicit
+        || match mode {
+            CliFormattingMode::Disabled => false,
+            CliFormattingMode::Enabled => profile_activation(&words, lexicon),
+            CliFormattingMode::Auto => automatic_activation(&words, lexicon),
+        };
+    if !activated {
+        return input.to_string();
+    }
+
+    strip_sentence_punctuation(&mut words);
+    let formatted = format_words(&words, lexicon);
+    apply_command_idioms(formatted)
+}
+
+fn explicit_trigger_len(words: &[String]) -> usize {
+    if starts_with(words, &["terminal", "command"]) || starts_with(words, &["shell", "command"]) {
+        2
+    } else if starts_with(words, &["command"]) {
+        1
+    } else {
+        0
+    }
+}
+
+fn automatic_activation(words: &[String], lexicon: &CliLexicon) -> bool {
+    let Some((tool, consumed)) = known_tool(words, lexicon) else {
+        return false;
+    };
+    let remainder = &words[consumed..];
+    if remainder.is_empty() {
+        return false;
+    }
+    let next = clean_detection_word(&remainder[0]);
+    if PROSE_FOLLOWERS.contains(&next.as_str()) {
+        return false;
+    }
+    contains_spoken_syntax(remainder)
+        || remainder.iter().any(|word| {
+            word.contains('-') || word.contains('/') || word.contains('@') || word.contains('=')
+        })
+        || known_action(tool, &next)
+        || matches!(tool, "npx" | "pnpm" | "yarn" | "bun")
+}
+
+fn profile_activation(words: &[String], lexicon: &CliLexicon) -> bool {
+    if automatic_activation(words, lexicon) {
+        return true;
+    }
+    if words.len() < 2 {
+        return false;
+    }
+    // Enabling a CLI profile is an explicit user choice to treat a multi-token
+    // utterance as command text. The formatter still applies only bounded token
+    // and symbol rules; it never performs a free-form prose rewrite.
+    true
+}
+
+fn known_tool<'a>(words: &[String], lexicon: &'a CliLexicon) -> Option<(&'a str, usize)> {
+    if let Some((resolved, consumed)) = lexicon.resolve(words, 0) {
+        if KNOWN_TOOLS.contains(&resolved) {
+            return Some((resolved, consumed));
+        }
+    }
+    let first = clean_detection_word(words.first()?);
+    KNOWN_TOOLS
+        .iter()
+        .find(|tool| **tool == first)
+        .map(|tool| (*tool, 1))
+}
+
+fn known_action(tool: &str, action: &str) -> bool {
+    let actions: &[&str] = match tool {
+        "npm" | "pnpm" | "yarn" | "bun" => &[
+            "add", "audit", "build", "exec", "install", "publish", "remove", "run", "start",
+            "test", "update",
+        ],
+        "git" => &[
+            "add",
+            "bisect",
+            "branch",
+            "checkout",
+            "cherry-pick",
+            "clone",
+            "commit",
+            "diff",
+            "fetch",
+            "log",
+            "merge",
+            "pull",
+            "push",
+            "rebase",
+            "remote",
+            "reset",
+            "restore",
+            "revert",
+            "show",
+            "stash",
+            "status",
+            "switch",
+            "tag",
+        ],
+        "cargo" => &[
+            "add", "bench", "build", "check", "clean", "clippy", "doc", "fix", "fmt", "install",
+            "metadata", "new", "publish", "remove", "run", "test", "tree", "update",
+        ],
+        "docker" => &[
+            "build",
+            "compose",
+            "container",
+            "exec",
+            "image",
+            "inspect",
+            "login",
+            "logs",
+            "network",
+            "ps",
+            "pull",
+            "push",
+            "run",
+            "stop",
+            "tag",
+            "volume",
+        ],
+        "kubectl" => &[
+            "apply",
+            "config",
+            "create",
+            "delete",
+            "describe",
+            "edit",
+            "exec",
+            "explain",
+            "get",
+            "logs",
+            "patch",
+            "port-forward",
+            "rollout",
+            "scale",
+            "set",
+            "top",
+            "wait",
+        ],
+        "rustup" => &[
+            "component",
+            "default",
+            "doc",
+            "install",
+            "override",
+            "run",
+            "show",
+            "target",
+            "toolchain",
+            "update",
+        ],
+        "go" => &[
+            "build", "clean", "env", "fmt", "generate", "get", "install", "list", "mod", "run",
+            "test", "tool", "version", "vet", "work",
+        ],
+        _ => &[],
+    };
+    actions.contains(&action)
+}
+
+fn contains_spoken_syntax(words: &[String]) -> bool {
+    (0..words.len()).any(|index| {
+        starts_with_at(words, index, &["at", "latest"])
+            || starts_with_at(words, index, &["dash"])
+            || starts_with_at(words, index, &["slash"])
+            || starts_with_at(words, index, &["dot"])
+            || starts_with_at(words, index, &["colon"])
+            || starts_with_at(words, index, &["equals"])
+            || starts_with_at(words, index, &["pipe"])
+            || starts_with_at(words, index, &["redirect"])
+            || starts_with_at(words, index, &["double", "quote"])
+            || starts_with_at(words, index, &["single", "quote"])
+            || starts_with_at(words, index, &["new", "line"])
+    })
+}
+
+fn strip_sentence_punctuation(words: &mut [String]) {
+    let Some(last) = words.last_mut() else {
+        return;
+    };
+    if last.len() > 1
+        && last.chars().last().is_some_and(|ch| {
+            matches!(ch, ',' | ';' | '?' | '!') || (ch == '.' && !last.contains('/'))
+        })
+    {
+        last.pop();
+    }
+}
+
+#[derive(Default)]
+struct CommandBuilder {
+    output: String,
+}
+
+impl CommandBuilder {
+    fn word(&mut self, word: &str) {
+        if word.is_empty() {
+            return;
+        }
+        let joined = self
+            .output
+            .chars()
+            .last()
+            .is_some_and(|ch| matches!(ch, ' ' | '\n' | '/' | '.' | ':' | '@' | '='));
+        if !self.output.is_empty() && !joined {
+            self.output.push(' ');
+        }
+        self.output.push_str(word);
+    }
+
+    fn attached(&mut self, value: &str) {
+        while self.output.ends_with(' ') {
+            self.output.pop();
+        }
+        self.output.push_str(value);
+    }
+
+    fn operator(&mut self, value: &str) {
+        while self.output.ends_with(' ') {
+            self.output.pop();
+        }
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output.push(' ');
+        }
+        self.output.push_str(value);
+        self.output.push(' ');
+    }
+
+    fn newline(&mut self) {
+        while self.output.ends_with(' ') {
+            self.output.pop();
+        }
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output.push('\n');
+        }
+    }
+
+    fn finish(mut self) -> String {
+        while self.output.ends_with(' ') {
+            self.output.pop();
+        }
+        self.output
+    }
+}
+
+fn format_words(words: &[String], lexicon: &CliLexicon) -> String {
+    let mut out = CommandBuilder::default();
+    let mut index = 0;
+    while index < words.len() {
+        if starts_with_at(words, index, &["new", "line"])
+            || starts_with_at(words, index, &["next", "line"])
+        {
+            out.newline();
+            index += 2;
+            continue;
+        }
+        if let Some((quote, trigger_len)) = quote_trigger(words, index) {
+            if let Some((content, consumed)) = quoted_content(words, index + trigger_len, quote) {
+                out.word(&format!("{quote}{content}{quote}"));
+                index += trigger_len + consumed;
+                continue;
+            }
+        }
+        if starts_with_at(words, index, &["pipe"]) {
+            out.operator("|");
+            index += 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["append", "redirect"])
+            || starts_with_at(words, index, &["append", "to"])
+        {
+            out.operator(">>");
+            index += 2;
+            continue;
+        }
+        if starts_with_at(words, index, &["redirect", "to"])
+            || starts_with_at(words, index, &["greater", "than"])
+        {
+            out.operator(">");
+            index += 2;
+            continue;
+        }
+        if starts_with_at(words, index, &["less", "than"])
+            || starts_with_at(words, index, &["redirect", "from"])
+        {
+            out.operator("<");
+            index += 2;
+            continue;
+        }
+        if starts_with_at(words, index, &["equals"]) || starts_with_at(words, index, &["equal"]) {
+            out.attached("=");
+            index += 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["slash"])
+            || starts_with_at(words, index, &["forward", "slash"])
+        {
+            out.attached("/");
+            index += usize::from(words[index].eq_ignore_ascii_case("forward")) + 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["dot"]) || starts_with_at(words, index, &["period"]) {
+            out.attached(".");
+            index += 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["colon"]) {
+            out.attached(":");
+            index += 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["at"])
+            && index + 1 < words.len()
+            && is_version_word(&words[index + 1])
+        {
+            out.attached("@");
+            index += 1;
+            continue;
+        }
+        if starts_with_at(words, index, &["dash", "dash"]) {
+            if index + 2 >= words.len() || words[index + 2].eq_ignore_ascii_case("dash") {
+                out.word("--");
+                index += 2;
+                continue;
+            }
+            let (flag, consumed) = resolve_atom(words, index + 2, lexicon);
+            out.word(&format!("--{flag}"));
+            index += 2 + consumed;
+            continue;
+        }
+        if starts_with_at(words, index, &["dash"]) && index + 1 < words.len() {
+            let (flag, consumed) = resolve_atom(words, index + 1, lexicon);
+            let prefix = if flag.chars().count() == 1 { "-" } else { "--" };
+            out.word(&format!("{prefix}{flag}"));
+            index += 1 + consumed;
+            continue;
+        }
+        let (atom, consumed) = resolve_atom(words, index, lexicon);
+        let atom = if index == 0
+            && KNOWN_TOOLS
+                .iter()
+                .any(|tool| atom.eq_ignore_ascii_case(tool))
+        {
+            atom.to_ascii_lowercase()
+        } else {
+            atom
+        };
+        out.word(&atom);
+        index += consumed;
+    }
+    out.finish()
+}
+
+fn resolve_atom(words: &[String], index: usize, lexicon: &CliLexicon) -> (String, usize) {
+    lexicon
+        .resolve(words, index)
+        .map(|(written, consumed)| (written.to_string(), consumed))
+        .unwrap_or_else(|| (words[index].clone(), 1))
+}
+
+fn apply_command_idioms(command: String) -> String {
+    command
+        .lines()
+        .map(|line| {
+            let mut words = line
+                .split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if words.len() >= 4 && words[0] == "npx" && words[1].starts_with("create-vite") {
+                let flag = words[2..]
+                    .iter()
+                    .position(|word| word.starts_with('-'))
+                    .map(|position| position + 2)
+                    .unwrap_or(words.len());
+                if flag > 3 {
+                    let app_name = words[2..flag].join("-");
+                    words.splice(2..flag, [app_name]);
+                }
+            }
+            words.join(" ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn quote_trigger(words: &[String], index: usize) -> Option<(char, usize)> {
+    if starts_with_at(words, index, &["double", "quote"])
+        || starts_with_at(words, index, &["open", "quote"])
+    {
+        Some(('"', 2))
+    } else if starts_with_at(words, index, &["single", "quote"]) {
+        Some(('\'', 2))
+    } else if starts_with_at(words, index, &["quote"]) {
+        Some(('"', 1))
+    } else {
+        None
+    }
+}
+
+fn quoted_content(words: &[String], start: usize, quote: char) -> Option<(String, usize)> {
+    let mut index = start;
+    let mut content = Vec::new();
+    while index < words.len() {
+        let closing = match quote {
+            '\'' => starts_with_at(words, index, &["single", "quote"]),
+            _ => {
+                starts_with_at(words, index, &["double", "quote"])
+                    || starts_with_at(words, index, &["close", "quote"])
+                    || starts_with_at(words, index, &["quote"])
+            }
+        };
+        if closing {
+            let closing_len = if words[index].eq_ignore_ascii_case("quote") {
+                1
+            } else {
+                2
+            };
+            return Some((content.join(" "), index - start + closing_len));
+        }
+        content.push(words[index].clone());
+        index += 1;
+    }
+    None
+}
+
+fn is_version_word(word: &str) -> bool {
+    let word = clean_detection_word(word);
+    matches!(
+        word.as_str(),
+        "latest" | "next" | "beta" | "canary" | "stable"
+    ) || word.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+}
+
+fn clean_detection_word(word: &str) -> String {
+    word.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '-' && ch != '_')
+        .to_ascii_lowercase()
+}
+
+fn starts_with(words: &[String], expected: &[&str]) -> bool {
+    starts_with_at(words, 0, expected)
+}
+
+fn starts_with_at(words: &[String], index: usize, expected: &[&str]) -> bool {
+    let Some(slice) = words.get(index..index.saturating_add(expected.len())) else {
+        return false;
+    };
+    slice
+        .iter()
+        .zip(expected)
+        .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn auto(input: &str) -> String {
+        canonicalize_cli(input, CliFormattingMode::Auto, &CliLexicon::builtins())
+    }
+
+    #[test]
+    fn issue_golden_examples_are_exact() {
+        let fixtures = [
+            ("npx cc usage at latest", "npx ccusage@latest"),
+            ("NPM run Tauri dev", "npm run tauri dev"),
+            (
+                "npx create vite at latest my app dash dash template react typescript",
+                "npx create-vite@latest my-app --template react-ts",
+            ),
+            (
+                "git checkout dash b feature slash streaming",
+                "git checkout -b feature/streaming",
+            ),
+            (
+                "cargo test dash dash dash test threads equals one",
+                "cargo test -- --test-threads=1",
+            ),
+        ];
+        for (spoken, expected) in fixtures {
+            assert_eq!(auto(spoken), expected, "fixture: {spoken}");
+        }
+    }
+
+    #[test]
+    fn ordinary_prose_is_byte_for_byte_unchanged() {
+        let fixtures = [
+            "I use git and cargo every day.",
+            "Git is useful, but Docker is not a verb here.",
+            "cargo cults are a historical topic",
+            "Please send it at noon — pipe is a noun.",
+            "  npm is a package manager, not this sentence.  ",
+        ];
+        for prose in fixtures {
+            assert_eq!(
+                auto(prose).as_bytes(),
+                prose.as_bytes(),
+                "fixture: {prose:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_trigger_formats_unknown_tools() {
+        assert_eq!(
+            auto("command mytool dash dash config path slash file"),
+            "mytool --config path/file"
+        );
+    }
+
+    #[test]
+    fn enabled_profile_supports_unknown_tools_without_rewriting_plain_text() {
+        let lexicon = CliLexicon::builtins();
+        assert_eq!(
+            canonicalize_cli(
+                "mytool dash dash unicode café",
+                CliFormattingMode::Enabled,
+                &lexicon,
+            ),
+            "mytool --unicode café"
+        );
+        assert_eq!(
+            canonicalize_cli(
+                "ordinary Unicode café 日本語",
+                CliFormattingMode::Enabled,
+                &lexicon
+            ),
+            "ordinary Unicode café 日本語"
+        );
+    }
+
+    #[test]
+    fn disabled_profile_still_allows_explicit_trigger_only() {
+        let lexicon = CliLexicon::builtins();
+        assert_eq!(
+            canonicalize_cli(
+                "git checkout dash b test",
+                CliFormattingMode::Disabled,
+                &lexicon
+            ),
+            "git checkout dash b test"
+        );
+        assert_eq!(
+            canonicalize_cli(
+                "command git checkout dash b test",
+                CliFormattingMode::Disabled,
+                &lexicon
+            ),
+            "git checkout -b test"
+        );
+    }
+
+    #[test]
+    fn canonical_output_is_idempotent() {
+        let fixtures = [
+            "npx ccusage@latest",
+            "npm run tauri dev",
+            "git checkout -b feature/streaming",
+            "cargo test -- --test-threads=1",
+            "docker run --name café image:latest",
+        ];
+        for command in fixtures {
+            assert_eq!(auto(command), command, "fixture: {command}");
+        }
+    }
+
+    #[test]
+    fn punctuation_quotes_redirects_and_unicode_are_safe() {
+        assert_eq!(
+            auto("kubectl get pods pipe grep double quote café 日本語 double quote redirect to output dot txt"),
+            "kubectl get pods | grep \"café 日本語\" > output.txt"
+        );
+    }
+
+    #[test]
+    fn context_terms_and_approved_atom_mappings_extend_the_lexicon() {
+        let lexicon = CliLexicon::from_context(
+            Some("deployPreview custom_script"),
+            &[("my package".to_string(), "@scope/pkg".to_string())],
+        );
+        assert_eq!(
+            canonicalize_cli(
+                "command deploy preview dash dash task custom script",
+                CliFormattingMode::Auto,
+                &lexicon,
+            ),
+            "deployPreview --task custom_script"
+        );
+        assert_eq!(
+            canonicalize_cli("command npx my package", CliFormattingMode::Auto, &lexicon),
+            "npx @scope/pkg"
+        );
+    }
+}

--- a/app/src-tauri/src/cli_command.rs
+++ b/app/src-tauri/src/cli_command.rs
@@ -56,8 +56,9 @@ const KNOWN_TOOLS: &[&str] = &[
     "deno", "python", "python3", "pip", "pip3", "go", "make", "cmake", "curl", "wget",
 ];
 
-const PROSE_FOLLOWERS: &[&str] = &[
-    "and", "are", "can", "does", "has", "is", "means", "should", "was", "will",
+const PROSE_MARKERS: &[&str] = &[
+    "and", "are", "can", "does", "has", "helps", "is", "makes", "means", "provides",
+    "should", "then", "uses", "was", "will",
 ];
 
 impl CliLexicon {
@@ -185,6 +186,40 @@ pub(crate) fn canonicalize_cli(
     mode: CliFormattingMode,
     lexicon: &CliLexicon,
 ) -> String {
+    if input.as_bytes().iter().any(|byte| matches!(byte, b'\n' | b'\r')) {
+        return canonicalize_lines(input, mode, lexicon);
+    }
+    canonicalize_line(input, mode, lexicon)
+}
+
+/// Keep physical line endings as immutable command-span boundaries. This also
+/// preserves newlines produced by the earlier voice-command stage and makes an
+/// already-canonical multiline command idempotent.
+fn canonicalize_lines(input: &str, mode: CliFormattingMode, lexicon: &CliLexicon) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut start = 0;
+    let bytes = input.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !matches!(bytes[index], b'\n' | b'\r') {
+            index += 1;
+            continue;
+        }
+        output.push_str(&canonicalize_line(&input[start..index], mode, lexicon));
+        if bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n') {
+            output.push_str("\r\n");
+            index += 2;
+        } else {
+            output.push(bytes[index] as char);
+            index += 1;
+        }
+        start = index;
+    }
+    output.push_str(&canonicalize_line(&input[start..], mode, lexicon));
+    output
+}
+
+fn canonicalize_line(input: &str, mode: CliFormattingMode, lexicon: &CliLexicon) -> String {
     let mut words = input
         .split_whitespace()
         .map(str::to_string)
@@ -236,7 +271,13 @@ fn automatic_activation(words: &[String], lexicon: &CliLexicon) -> bool {
         return false;
     }
     let next = clean_detection_word(&remainder[0]);
-    if PROSE_FOLLOWERS.contains(&next.as_str()) {
+    if PROSE_MARKERS.contains(&next.as_str())
+        || remainder
+            .iter()
+            .skip(1)
+            .map(|word| clean_detection_word(word))
+            .any(|word| PROSE_MARKERS.contains(&word.as_str()))
+    {
         return false;
     }
     contains_spoken_syntax(remainder)
@@ -694,6 +735,10 @@ mod tests {
         let fixtures = [
             "I use git and cargo every day.",
             "Git is useful, but Docker is not a verb here.",
+            "Git status is useful in scripts.",
+            "cargo test and Docker builds are topics.",
+            "docker run is a common phrase.",
+            "npx makes scaffolding easier.",
             "cargo cults are a historical topic",
             "Please send it at noon — pipe is a noun.",
             "  npm is a package manager, not this sentence.  ",
@@ -769,6 +814,17 @@ mod tests {
         for command in fixtures {
             assert_eq!(auto(command), command, "fixture: {command}");
         }
+    }
+
+    #[test]
+    fn physical_lines_bound_command_spans_and_preserve_line_endings() {
+        let input = "git status\r\nordinary Git prose.\ncargo test -- --test-threads=1";
+        assert_eq!(auto(input).as_bytes(), input.as_bytes());
+
+        assert_eq!(
+            auto("git checkout dash b feature slash streaming\nordinary Git prose."),
+            "git checkout -b feature/streaming\nordinary Git prose."
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -690,6 +690,7 @@ async fn run_transcription_pipeline(
         context_handle: Some(format!("recording:{recording_id}")),
         model: transcription.model_name.clone(),
         language: transcription.language.clone(),
+        cli_formatting_mode: transformations.cli_formatting_mode,
         stages: crate::transcript_transform::TranscriptStageConfig {
             cleanup_enabled: transformations.cleanup_enabled,
             cleanup_remove_filler: transformations.cleanup_remove_filler,
@@ -698,11 +699,17 @@ async fn run_transcription_pipeline(
                 .enabled_command_groups
                 .built_in_voice_commands,
             smart_correction_enabled: transformations.correction_enabled,
+            cli_command_enabled: true,
         },
     };
+    let cli_lexicon = crate::cli_command::CliLexicon::from_context(
+        transcription.prompt.as_deref(),
+        &custom_commands,
+    );
     let transform_resources = crate::transcript_transform::TranscriptTransformResources {
         custom_commands,
         correction_matcher: transformations.correction_matcher.clone(),
+        cli_lexicon,
     };
     let transformed = crate::transcript_transform::transform_transcript(
         text,
@@ -710,6 +717,11 @@ async fn run_transcription_pipeline(
         transform_resources,
     )
     .map_err(|error| error.to_string())?;
+    tracing::info!(
+        target: "pipeline",
+        changed = transformed.was_changed(),
+        "transcript_transform_complete"
+    );
     let correction_ms = transformed
         .stage_duration_ms(crate::transcript_transform::SMART_CORRECTION_STAGE);
     let text = transformed.text;
@@ -1065,9 +1077,9 @@ pub async fn configure_dictation(
         dictation.output_dir = output_dir.to_string();
     }
 
-    // Per-app profiles: array of { bundleId, label, autoPasteOverride }. A
-    // missing/null autoPasteOverride means "no override". Entries without a
-    // bundleId are skipped. Replaces the whole list when the key is present.
+    // Per-app profiles carry nullable delivery/transformation overrides. A
+    // missing/null value means "no override". Entries without a bundleId are
+    // skipped. Replaces the whole list when the key is present.
     if let Some(profiles) = options.get("appProfiles").and_then(|v| v.as_array()) {
         dictation.app_profiles = profiles
             .iter()
@@ -1084,7 +1096,16 @@ pub async fn configure_dictation(
                 // null/absent -> None (use global); otherwise the boolean override.
                 let auto_paste_override = p.get("autoPasteOverride").and_then(|v| v.as_bool());
                 let cleanup_override = p.get("cleanupOverride").and_then(|v| v.as_bool());
-                Some(crate::state::AppProfile { bundle_id, label, auto_paste_override, cleanup_override })
+                let cli_formatting_override = p
+                    .get("cliFormattingOverride")
+                    .and_then(|v| v.as_bool());
+                Some(crate::state::AppProfile {
+                    bundle_id,
+                    label,
+                    auto_paste_override,
+                    cleanup_override,
+                    cli_formatting_override,
+                })
             })
             .collect();
     }
@@ -2038,6 +2059,7 @@ pub async fn transcribe_file(
         context_handle: None,
         model: model_name.clone(),
         language: language.clone(),
+        cli_formatting_mode: crate::cli_command::CliFormattingMode::Auto,
         stages: crate::transcript_transform::TranscriptStageConfig::verbatim(),
     };
     let text = crate::transcript_transform::transform_transcript(

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -688,8 +688,6 @@ async fn run_transcription_pipeline(
         session_id: app_state.next_transcript_session_id(),
         source: crate::transcript_transform::TranscriptSource::Live,
         context_handle: Some(format!("recording:{recording_id}")),
-        model: transcription.model_name.clone(),
-        language: transcription.language.clone(),
         cli_formatting_mode: transformations.cli_formatting_mode,
         stages: crate::transcript_transform::TranscriptStageConfig {
             cleanup_enabled: transformations.cleanup_enabled,
@@ -2057,8 +2055,6 @@ pub async fn transcribe_file(
         session_id: state.app_state.next_transcript_session_id(),
         source: crate::transcript_transform::TranscriptSource::File,
         context_handle: None,
-        model: model_name.clone(),
-        language: language.clone(),
         cli_formatting_mode: crate::cli_command::CliFormattingMode::Auto,
         stages: crate::transcript_transform::TranscriptStageConfig::verbatim(),
     };
@@ -2131,7 +2127,8 @@ mod tests {
             "appProfiles": [{
                 "bundleId": "com.private.SecretApp",
                 "label": "Secret profile",
-                "autoPasteOverride": true
+                "autoPasteOverride": true,
+                "cliFormattingOverride": false
             }],
             "customVocabulary": "private-customer-name",
             "voiceCommands": [{

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -5,6 +5,7 @@
 //! typed values consumed by the live pipeline; later settings or focus changes
 //! cannot alter an in-flight dictation.
 
+use crate::cli_command::CliFormattingMode;
 use crate::correction::CorrectionMatcher;
 use crate::state::{AppProfile, DictationState, VoiceCommand};
 use std::sync::Arc;
@@ -20,6 +21,7 @@ pub struct MatchedAppProfile {
     pub label: String,
     pub auto_paste_override: Option<bool>,
     pub cleanup_override: Option<bool>,
+    pub cli_formatting_override: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,6 +74,7 @@ pub struct TransformationSettings {
     pub voice_command_pairs: Vec<VoiceCommand>,
     pub correction_enabled: bool,
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
+    pub cli_formatting_mode: CliFormattingMode,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +105,7 @@ pub struct DictationContextSnapshot {
 pub struct SessionOverrides {
     pub auto_paste: Option<bool>,
     pub cleanup_enabled: Option<bool>,
+    pub cli_formatting_enabled: Option<bool>,
 }
 
 pub struct ResolverInputs<'a> {
@@ -136,6 +140,15 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
             |profile| profile.cleanup_override,
         )
     });
+    let cli_formatting_mode = match inputs.session_overrides.cli_formatting_enabled.or_else(|| {
+        resolve_profile_optional(inputs.bundle_id, &global.app_profiles, |profile| {
+            profile.cli_formatting_override
+        })
+    }) {
+        Some(true) => CliFormattingMode::Enabled,
+        Some(false) => CliFormattingMode::Disabled,
+        None => CliFormattingMode::Auto,
+    };
     let matched_profile = inputs.bundle_id.and_then(|bundle_id| {
         global
             .app_profiles
@@ -146,6 +159,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
                 label: profile.label.clone(),
                 auto_paste_override: profile.auto_paste_override,
                 cleanup_override: profile.cleanup_override,
+                cli_formatting_override: profile.cli_formatting_override,
             })
     });
     let custom_vocab = !global.custom_vocabulary.trim().is_empty();
@@ -177,6 +191,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
             voice_command_pairs: global.voice_command_pairs.clone(),
             correction_enabled: global.correction_enabled,
             correction_matcher: inputs.correction_matcher,
+            cli_formatting_mode,
         },
         delivery: DeliverySettings {
             auto_paste,
@@ -197,6 +212,18 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         // features must add an explicit setting/profile override here first.
         context_capture: ContextCapturePermissions::default(),
     }
+}
+
+fn resolve_profile_optional<T: Copy>(
+    bundle_id: Option<&str>,
+    profiles: &[AppProfile],
+    get_override: impl Fn(&AppProfile) -> Option<T>,
+) -> Option<T> {
+    let bundle_id = bundle_id?;
+    profiles
+        .iter()
+        .filter(|profile| profile.bundle_id == bundle_id)
+        .find_map(get_override)
 }
 
 fn resolve_profile_override<T: Copy>(
@@ -229,6 +256,7 @@ mod tests {
             label: bundle_id.to_string(),
             auto_paste_override,
             cleanup_override,
+            cli_formatting_override: None,
         }
     }
 
@@ -305,6 +333,7 @@ mod tests {
             SessionOverrides {
                 auto_paste: Some(false),
                 cleanup_enabled: Some(true),
+                cli_formatting_enabled: None,
             },
         );
 
@@ -355,6 +384,40 @@ mod tests {
         assert_eq!(snapshot.transcription.model_name, "base.en");
         assert!(!snapshot.delivery.auto_paste);
         assert!(!snapshot.transformations.cleanup_enabled);
+    }
+
+    #[test]
+    fn cli_profile_override_resolves_auto_enabled_and_disabled_modes() {
+        let mut global = DictationState::default();
+        assert_eq!(
+            resolve_test(&global, None, SessionOverrides::default())
+                .transformations
+                .cli_formatting_mode,
+            CliFormattingMode::Auto
+        );
+
+        let mut enabled = profile("com.apple.Terminal", None, None);
+        enabled.cli_formatting_override = Some(true);
+        let mut disabled = profile("com.apple.mail", None, None);
+        disabled.cli_formatting_override = Some(false);
+        global.app_profiles = vec![enabled, disabled];
+
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.apple.Terminal"),
+                SessionOverrides::default(),
+            )
+            .transformations
+            .cli_formatting_mode,
+            CliFormattingMode::Enabled
+        );
+        assert_eq!(
+            resolve_test(&global, Some("com.apple.mail"), SessionOverrides::default(),)
+                .transformations
+                .cli_formatting_mode,
+            CliFormattingMode::Disabled
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -333,12 +333,16 @@ mod tests {
             SessionOverrides {
                 auto_paste: Some(false),
                 cleanup_enabled: Some(true),
-                cli_formatting_enabled: None,
+                cli_formatting_enabled: Some(false),
             },
         );
 
         assert!(!snapshot.delivery.auto_paste);
         assert!(snapshot.transformations.cleanup_enabled);
+        assert_eq!(
+            snapshot.transformations.cli_formatting_mode,
+            CliFormattingMode::Disabled
+        );
     }
 
     #[test]
@@ -416,6 +420,20 @@ mod tests {
             resolve_test(&global, Some("com.apple.mail"), SessionOverrides::default(),)
                 .transformations
                 .cli_formatting_mode,
+            CliFormattingMode::Disabled
+        );
+
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.apple.Terminal"),
+                SessionOverrides {
+                    cli_formatting_enabled: Some(false),
+                    ..SessionOverrides::default()
+                },
+            )
+            .transformations
+            .cli_formatting_mode,
             CliFormattingMode::Disabled
         );
     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod audio;
 mod audio_decode;
 mod benchmark;
 mod cleanup;
+mod cli_command;
 mod commands;
 mod correction;
 mod dictation_context;

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -35,6 +35,11 @@ pub struct AppProfile {
     /// verbatim output in a code editor, or force cleanup in an email client).
     #[serde(default)]
     pub cleanup_override: Option<bool>,
+    /// Override spoken CLI canonicalization for this app. `None` keeps bounded
+    /// automatic detection; `Some(true)` enables profile-mode detection and
+    /// `Some(false)` disables implicit formatting (explicit "command" still works).
+    #[serde(default)]
+    pub cli_formatting_override: Option<bool>,
 }
 
 /// A user-defined voice command: when `phrase` is spoken (matched

--- a/app/src-tauri/src/transcript_transform.rs
+++ b/app/src-tauri/src/transcript_transform.rs
@@ -9,11 +9,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::cleanup::CleanupOptions;
+use crate::cli_command::{canonicalize_cli, CliFormattingMode, CliLexicon};
 use crate::correction::CorrectionMatcher;
 
 pub(crate) const CLEANUP_STAGE: &str = "cleanup";
 pub(crate) const VOICE_COMMANDS_STAGE: &str = "voice_commands";
 pub(crate) const SMART_CORRECTION_STAGE: &str = "smart_correction";
+pub(crate) const CLI_COMMAND_STAGE: &str = "cli_command";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TranscriptSource {
@@ -42,6 +44,7 @@ pub(crate) struct TranscriptStageConfig {
     pub cleanup_capitalize: bool,
     pub voice_commands_enabled: bool,
     pub smart_correction_enabled: bool,
+    pub cli_command_enabled: bool,
 }
 
 impl TranscriptStageConfig {
@@ -52,6 +55,7 @@ impl TranscriptStageConfig {
             cleanup_capitalize: false,
             voice_commands_enabled: false,
             smart_correction_enabled: false,
+            cli_command_enabled: false,
         }
     }
 }
@@ -68,6 +72,7 @@ pub(crate) struct TranscriptContext {
     pub context_handle: Option<String>,
     pub model: String,
     pub language: String,
+    pub cli_formatting_mode: CliFormattingMode,
     pub stages: TranscriptStageConfig,
 }
 
@@ -165,11 +170,18 @@ trait TranscriptTransform: Send + Sync {
 }
 
 pub(crate) struct TranscriptPipelineOutput {
+    /// Original ASR text retained only for the lifetime of this pipeline result.
+    /// It is never serialized, persisted, or logged.
+    pub original_text: String,
     pub text: String,
     pub stages: Vec<StageReport>,
 }
 
 impl TranscriptPipelineOutput {
+    pub(crate) fn was_changed(&self) -> bool {
+        self.original_text != self.text
+    }
+
     pub(crate) fn stage_duration_ms(&self, stage: &str) -> u64 {
         self.stages
             .iter()
@@ -188,13 +200,19 @@ impl TranscriptPipeline {
     }
 
     fn standard(resources: TranscriptTransformResources) -> Self {
+        let TranscriptTransformResources {
+            custom_commands,
+            correction_matcher,
+            cli_lexicon,
+        } = resources;
         Self::new(vec![
             Box::new(CleanupStage),
-            Box::new(VoiceCommandsStage {
-                custom_commands: resources.custom_commands,
-            }),
+            Box::new(VoiceCommandsStage { custom_commands }),
             Box::new(SmartCorrectionStage {
-                matcher: resources.correction_matcher,
+                matcher: correction_matcher,
+            }),
+            Box::new(CliCommandStage {
+                lexicon: cli_lexicon,
             }),
         ])
     }
@@ -204,6 +222,7 @@ impl TranscriptPipeline {
         mut text: String,
         context: &TranscriptContext,
     ) -> Result<TranscriptPipelineOutput, TranscriptPipelineError> {
+        let original_text = text.clone();
         let mut reports = Vec::with_capacity(self.stages.len());
 
         for stage in &self.stages {
@@ -266,6 +285,7 @@ impl TranscriptPipeline {
         }
 
         Ok(TranscriptPipelineOutput {
+            original_text,
             text,
             stages: reports,
         })
@@ -296,6 +316,7 @@ fn log_stage(context: &TranscriptContext, report: &StageReport) {
 pub(crate) struct TranscriptTransformResources {
     pub custom_commands: Vec<(String, String)>,
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
+    pub cli_lexicon: CliLexicon,
 }
 
 impl TranscriptTransformResources {
@@ -303,6 +324,7 @@ impl TranscriptTransformResources {
         Self {
             custom_commands: Vec::new(),
             correction_matcher: None,
+            cli_lexicon: CliLexicon::from_context(None, &[]),
         }
     }
 }
@@ -375,6 +397,32 @@ struct SmartCorrectionStage {
     matcher: Option<Arc<CorrectionMatcher>>,
 }
 
+struct CliCommandStage {
+    lexicon: CliLexicon,
+}
+
+impl TranscriptTransform for CliCommandStage {
+    fn name(&self) -> &'static str {
+        CLI_COMMAND_STAGE
+    }
+
+    fn failure_policy(&self) -> StageFailurePolicy {
+        StageFailurePolicy::Required
+    }
+
+    fn enabled(&self, context: &TranscriptContext) -> bool {
+        context.source == TranscriptSource::Live && context.stages.cli_command_enabled
+    }
+
+    fn transform(&self, text: &str, context: &TranscriptContext) -> Result<String, StageError> {
+        Ok(canonicalize_cli(
+            text,
+            context.cli_formatting_mode,
+            &self.lexicon,
+        ))
+    }
+}
+
 impl TranscriptTransform for SmartCorrectionStage {
     fn name(&self) -> &'static str {
         SMART_CORRECTION_STAGE
@@ -412,6 +460,7 @@ mod tests {
             context_handle: None,
             model: "test-model".to_string(),
             language: "en".to_string(),
+            cli_formatting_mode: CliFormattingMode::Auto,
             stages,
         }
     }
@@ -423,6 +472,7 @@ mod tests {
             cleanup_capitalize: true,
             voice_commands_enabled: true,
             smart_correction_enabled: true,
+            cli_command_enabled: true,
         }
     }
 
@@ -439,6 +489,7 @@ mod tests {
         TranscriptTransformResources {
             custom_commands: vec![("my email".to_string(), "test@example.com".to_string())],
             correction_matcher: with_matcher.then(correction_matcher),
+            cli_lexicon: CliLexicon::from_context(None, &[]),
         }
     }
 
@@ -531,7 +582,12 @@ mod tests {
                 .iter()
                 .map(|report| report.stage)
                 .collect::<Vec<_>>(),
-            vec![CLEANUP_STAGE, VOICE_COMMANDS_STAGE, SMART_CORRECTION_STAGE]
+            vec![
+                CLEANUP_STAGE,
+                VOICE_COMMANDS_STAGE,
+                SMART_CORRECTION_STAGE,
+                CLI_COMMAND_STAGE,
+            ]
         );
     }
 
@@ -543,6 +599,7 @@ mod tests {
             cleanup_capitalize: true,
             voice_commands_enabled: false,
             smart_correction_enabled: false,
+            cli_command_enabled: false,
         };
         let output = transform_transcript(
             "um the the cat , world .".to_string(),
@@ -561,6 +618,7 @@ mod tests {
             cleanup_capitalize: false,
             voice_commands_enabled: true,
             smart_correction_enabled: false,
+            cli_command_enabled: false,
         };
         let output = transform_transcript(
             "hello new line my email".to_string(),
@@ -579,6 +637,7 @@ mod tests {
             cleanup_capitalize: false,
             voice_commands_enabled: false,
             smart_correction_enabled: true,
+            cli_command_enabled: false,
         };
         let output = transform_transcript(
             "use effect".to_string(),
@@ -597,16 +656,41 @@ mod tests {
             context_handle: None,
             model: "test-model".to_string(),
             language: "auto".to_string(),
+            cli_formatting_mode: CliFormattingMode::Auto,
             stages: TranscriptStageConfig::verbatim(),
         };
         let raw = "um hello new line use effect   ";
         let output = transform_transcript(raw.to_string(), &context, resources(true)).unwrap();
         assert_eq!(output.text.as_bytes(), raw.as_bytes());
-        assert_eq!(output.stages.len(), 3);
+        assert_eq!(output.original_text.as_bytes(), raw.as_bytes());
+        assert_eq!(output.stages.len(), 4);
         assert!(output
             .stages
             .iter()
             .all(|stage| stage.outcome == StageOutcome::Skipped));
+    }
+
+    #[test]
+    fn cli_stage_runs_after_correction_and_keeps_original_in_memory() {
+        let stages = TranscriptStageConfig {
+            cleanup_enabled: false,
+            cleanup_remove_filler: false,
+            cleanup_capitalize: false,
+            voice_commands_enabled: false,
+            smart_correction_enabled: true,
+            cli_command_enabled: true,
+        };
+        let raw = "NPM run Tauri dev";
+        let output = transform_transcript(
+            raw.to_string(),
+            &live_context(stages),
+            TranscriptTransformResources::empty(),
+        )
+        .unwrap();
+        assert_eq!(output.original_text, raw);
+        assert_eq!(output.text, "npm run tauri dev");
+        assert_eq!(output.stages[2].stage, SMART_CORRECTION_STAGE);
+        assert_eq!(output.stages[3].stage, CLI_COMMAND_STAGE);
     }
 
     struct AppendStage {

--- a/app/src-tauri/src/transcript_transform.rs
+++ b/app/src-tauri/src/transcript_transform.rs
@@ -60,7 +60,9 @@ impl TranscriptStageConfig {
     }
 }
 
-/// Immutable metadata and stage selection for one transformation pass.
+/// Immutable privacy-safe metadata and stage selection for one transformation
+/// pass. User-configured model/language values and transcript resources are not
+/// carried here because stage telemetry must not log settings values.
 ///
 /// `context_handle` is deliberately opaque. Issue #245 can populate it with a
 /// resolved per-app snapshot identifier without this module knowing how app
@@ -70,8 +72,6 @@ pub(crate) struct TranscriptContext {
     pub session_id: u64,
     pub source: TranscriptSource,
     pub context_handle: Option<String>,
-    pub model: String,
-    pub language: String,
     pub cli_formatting_mode: CliFormattingMode,
     pub stages: TranscriptStageConfig,
 }
@@ -299,8 +299,6 @@ fn log_stage(context: &TranscriptContext, report: &StageReport) {
         source = context.source.as_str(),
         source_file = context.source == TranscriptSource::File,
         context_handle_present = context.context_handle.is_some(),
-        model = context.model.as_str(),
-        language = context.language.as_str(),
         stage = report.stage,
         duration_us = report.duration_us,
         changed = report.changed,
@@ -458,8 +456,6 @@ mod tests {
             session_id: 7,
             source: TranscriptSource::Live,
             context_handle: None,
-            model: "test-model".to_string(),
-            language: "en".to_string(),
             cli_formatting_mode: CliFormattingMode::Auto,
             stages,
         }
@@ -654,8 +650,6 @@ mod tests {
             session_id: 11,
             source: TranscriptSource::File,
             context_handle: None,
-            model: "test-model".to_string(),
-            language: "auto".to_string(),
             cli_formatting_mode: CliFormattingMode::Auto,
             stages: TranscriptStageConfig::verbatim(),
         };

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -485,7 +485,11 @@ pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
             Ok(e) => e,
             Err(e) => {
                 #[cfg(not(test))]
-                tracing::warn!(target: "pipeline", "vocab: skipping unreadable dir {}: {}", dir.display(), e);
+                tracing::warn!(
+                    target: "pipeline",
+                    error_kind = ?e.kind(),
+                    "vocab: skipping unreadable directory"
+                );
                 let _ = e;
                 continue;
             }
@@ -553,7 +557,11 @@ pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
                 }
                 Err(e) => {
                     #[cfg(not(test))]
-                    tracing::warn!(target: "pipeline", "vocab: skipping unreadable file {}: {}", path.display(), e);
+                    tracing::warn!(
+                        target: "pipeline",
+                        error_kind = ?e.kind(),
+                        "vocab: skipping unreadable file"
+                    );
                     let _ = e;
                 }
             }
@@ -647,7 +655,7 @@ mod tests {
         let terms = extract_package_json_terms(
             r#"{
                 "name": "@acme/my-app",
-                "scripts": {"tauri:dev": "tauri dev", "test": "vitest"},
+                "scripts": {"tauri:dev": "cd /Users/private/CustomerProject && secret-setting", "test": "vitest"},
                 "dependencies": {"ccusage": "1.0.0"},
                 "devDependencies": {"create-vite": "latest"},
                 "description": "private prose must not become vocabulary"
@@ -658,6 +666,8 @@ mod tests {
             vec!["@acme/my-app", "tauri:dev", "test", "ccusage", "create-vite"]
         );
         assert!(!terms.iter().any(|term| term.contains("private")));
+        assert!(!terms.iter().any(|term| term.contains("CustomerProject")));
+        assert!(!terms.iter().any(|term| term.contains("secret-setting")));
     }
 
     #[test]

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -88,6 +88,53 @@ pub fn is_source_file(path: &Path) -> bool {
     }
 }
 
+/// Project manifests are scanned only for their local package/script names.
+/// Their dependency bodies are not treated as source text.
+fn is_package_manifest(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("package.json"))
+}
+
+/// Extract command-relevant names from a package manifest. This is intentionally
+/// narrow: package name, script keys, and dependency keys only. Script bodies
+/// can contain arbitrary user text and are never retained as vocabulary.
+pub fn extract_package_json_terms(source: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(source) else {
+        return Vec::new();
+    };
+    let mut terms = Vec::new();
+    if let Some(name) = value.get("name").and_then(|name| name.as_str()) {
+        push_manifest_term(&mut terms, name);
+    }
+    for section in [
+        "scripts",
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ] {
+        if let Some(entries) = value.get(section).and_then(|entries| entries.as_object()) {
+            for name in entries.keys() {
+                push_manifest_term(&mut terms, name);
+            }
+        }
+    }
+    terms
+}
+
+fn push_manifest_term(terms: &mut Vec<String>, term: &str) {
+    let term = term.trim();
+    if !term.is_empty()
+        && !term.chars().any(char::is_whitespace)
+        && term
+            .chars()
+            .all(|ch| ch.is_alphanumeric() || "_-./:@".contains(ch))
+    {
+        terms.push(term.to_string());
+    }
+}
+
 /// Directory names we never descend into while walking a project. These hold
 /// dependencies, build output, or VCS data — not the user's own identifiers.
 const SKIP_DIRS: &[&str] = &[
@@ -265,6 +312,10 @@ impl VocabAccumulator {
         for ident in extract_identifiers(source) {
             self.add_identifier(&ident);
         }
+    }
+
+    pub fn add_written_term(&mut self, term: &str) {
+        self.add_identifier(term);
     }
 
     /// Fold a single already-extracted identifier into the tallies.
@@ -466,7 +517,7 @@ pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
                 continue;
             }
 
-            if !file_type.is_file() || !is_source_file(&path) {
+            if !file_type.is_file() || (!is_source_file(&path) && !is_package_manifest(&path)) {
                 continue;
             }
 
@@ -491,7 +542,13 @@ pub fn collect_source_files<F: FnMut(&Path, usize), G: FnMut(&Path)>(
                     // iteration. Then hand the callback the running distinct-term
                     // count so it never has to re-extract (which would double the
                     // tokenization CPU on a large walk).
-                    vocab.add_source(&contents);
+                    if is_package_manifest(&path) {
+                        for term in extract_package_json_terms(&contents) {
+                            vocab.add_written_term(&term);
+                        }
+                    } else {
+                        vocab.add_source(&contents);
+                    }
                     on_file(&path, vocab.len());
                 }
                 Err(e) => {
@@ -583,6 +640,29 @@ mod tests {
         // Multi-byte chars must not cause a byte-boundary panic.
         let ids = extract_identifiers("über naïve fooBar café");
         assert!(has(&ids, "fooBar"), "got {:?}", ids);
+    }
+
+    #[test]
+    fn package_manifest_extracts_only_command_relevant_names() {
+        let terms = extract_package_json_terms(
+            r#"{
+                "name": "@acme/my-app",
+                "scripts": {"tauri:dev": "tauri dev", "test": "vitest"},
+                "dependencies": {"ccusage": "1.0.0"},
+                "devDependencies": {"create-vite": "latest"},
+                "description": "private prose must not become vocabulary"
+            }"#,
+        );
+        assert_eq!(
+            terms,
+            vec!["@acme/my-app", "tauri:dev", "test", "ccusage", "create-vite"]
+        );
+        assert!(!terms.iter().any(|term| term.contains("private")));
+    }
+
+    #[test]
+    fn malformed_package_manifest_is_ignored() {
+        assert!(extract_package_json_terms("{not json").is_empty());
     }
 
     #[test]
@@ -840,6 +920,24 @@ mod tests {
         assert!(outcome.total_bytes > 0);
         // The accumulator folded both files' identifiers (fooBar, barBaz, useWidget).
         assert!(outcome.vocab.len() >= 3, "got {} terms", outcome.vocab.len());
+    }
+
+    #[test]
+    fn walk_adds_package_scripts_and_dependencies_to_project_vocabulary() {
+        let dir = scratch_dir("package_json");
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"scripts":{"tauri:dev":"tauri dev"},"dependencies":{"ccusage":"1"}}"#,
+        )
+        .unwrap();
+
+        let outcome = collect_source_files(&dir, |_, _| {}, |_| {});
+        let ranked = outcome.vocab.ranked(10);
+        assert!(ranked.iter().any(|term| term.term == "tauri:dev"));
+        assert!(ranked.iter().any(|term| term.term == "ccusage"));
+        assert_eq!(outcome.files_read, 1);
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -154,7 +154,13 @@ function AppProfilesEditor({ profiles, onChange }: {
     }
     onChange([
       ...profiles,
-      { bundleId: trimmedId, label: label.trim(), autoPasteOverride: null, cleanupOverride: null },
+      {
+        bundleId: trimmedId,
+        label: label.trim(),
+        autoPasteOverride: null,
+        cleanupOverride: null,
+        cliFormattingOverride: null,
+      },
     ]);
     setBundleId('');
     setLabel('');
@@ -178,6 +184,11 @@ function AppProfilesEditor({ profiles, onChange }: {
       p.bundleId === id ? { ...p, cleanupOverride: cycle(p.cleanupOverride) } : p));
   };
 
+  const cycleCliFormatting = (id: string) => {
+    onChange(profiles.map((p) =>
+      p.bundleId === id ? { ...p, cliFormattingOverride: cycle(p.cliFormattingOverride) } : p));
+  };
+
   const chipLabel = (kind: string, value: boolean | null) =>
     value === null ? `${kind}: Default` : value ? `${kind}: On` : `${kind}: Off`;
 
@@ -191,9 +202,9 @@ function AppProfilesEditor({ profiles, onChange }: {
   return (
     <div>
       <p className="mb-2 text-xs text-on-surface-variant">
-        Override auto-paste and transcript cleanup for specific apps by bundle id
+        Override auto-paste, transcript cleanup, and command formatting for specific apps by bundle id
         (e.g. <span className="font-mono">com.apple.Terminal</span>). The frontmost
-        app when you finish dictating decides the behavior. Each toggle cycles
+        app when you start dictating decides the behavior. Each toggle cycles
         Default → On → Off.
       </p>
 
@@ -242,6 +253,14 @@ function AppProfilesEditor({ profiles, onChange }: {
                   className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cleanupOverride)}`}
                 >
                   {chipLabel('Clean', p.cleanupOverride)}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => cycleCliFormatting(p.bundleId)}
+                  aria-label={`CLI formatting for ${p.label || p.bundleId}: ${chipLabel('CLI', p.cliFormattingOverride)}`}
+                  className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cliFormattingOverride)}`}
+                >
+                  {chipLabel('CLI', p.cliFormattingOverride)}
                 </button>
               </div>
             </li>
@@ -1266,7 +1285,7 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
         )}
         </SettingsSection>
 
-        <SettingsSection pageId="profiles" activePage={activeCat} title="Per-App Profiles" subtitle="Auto-paste + cleanup per frontmost app">
+        <SettingsSection pageId="profiles" activePage={activeCat} title="Per-App Profiles" subtitle="Auto-paste, cleanup + CLI per frontmost app">
           <AppProfilesEditor
             profiles={settings.appProfiles}
             onChange={(next) => onUpdateSettings({ appProfiles: next })}

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -30,6 +30,32 @@ describe('loadSettings', () => {
     expect(settings.autoPaste).toBe(true);
   });
 
+  it('migrates and validates per-app CLI formatting overrides', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      appProfiles: [
+        {
+          bundleId: 'com.apple.Terminal',
+          label: 'Terminal',
+          autoPasteOverride: null,
+          cleanupOverride: false,
+          cliFormattingOverride: true,
+        },
+        {
+          bundleId: 'com.apple.mail',
+          label: 'Mail',
+          autoPasteOverride: null,
+          cleanupOverride: null,
+          cliFormattingOverride: 'yes',
+        },
+      ],
+    }));
+
+    const [terminal, mail] = loadSettings().appProfiles;
+    expect(terminal.cliFormattingOverride).toBe(true);
+    expect(mail.cliFormattingOverride).toBeNull();
+  });
+
   it('fills missing fields from defaults', () => {
     localStorage.setItem('dictation-settings', JSON.stringify({
       model: 'base.en',

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -48,12 +48,19 @@ describe('loadSettings', () => {
           cleanupOverride: null,
           cliFormattingOverride: 'yes',
         },
+        {
+          bundleId: 'com.apple.TextEdit',
+          label: 'Legacy profile',
+          autoPasteOverride: false,
+          cleanupOverride: null,
+        },
       ],
     }));
 
-    const [terminal, mail] = loadSettings().appProfiles;
+    const [terminal, mail, legacy] = loadSettings().appProfiles;
     expect(terminal.cliFormattingOverride).toBe(true);
     expect(mail.cliFormattingOverride).toBeNull();
+    expect(legacy.cliFormattingOverride).toBeNull();
   });
 
   it('fills missing fields from defaults', () => {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -12,6 +12,7 @@ export interface AppProfile {
   label: string;
   autoPasteOverride: boolean | null;
   cleanupOverride: boolean | null;
+  cliFormattingOverride: boolean | null;
 }
 
 /**
@@ -331,9 +332,9 @@ export function loadSettings(): Settings {
         parsed.outputDir = DEFAULT_SETTINGS.outputDir;
       }
 
-      // appProfiles drives per-app auto-paste overrides. Drop malformed entries
-      // and coerce a non-array back to the empty default so the Rust side and UI
-      // never see a bad shape.
+      // appProfiles drives per-app delivery and transformation overrides. Drop
+      // malformed entries and coerce a non-array back to the empty default so
+      // the Rust side and UI never see a bad shape.
       if (!Array.isArray(parsed.appProfiles)) {
         parsed.appProfiles = DEFAULT_SETTINGS.appProfiles;
       } else {
@@ -347,6 +348,8 @@ export function loadSettings(): Settings {
               typeof p.autoPasteOverride === 'boolean' ? p.autoPasteOverride : null,
             cleanupOverride:
               typeof p.cleanupOverride === 'boolean' ? p.cleanupOverride : null,
+            cliFormattingOverride:
+              typeof p.cliFormattingOverride === 'boolean' ? p.cliFormattingOverride : null,
           }));
       }
 

--- a/docs/features/cli-command-formatting.md
+++ b/docs/features/cli-command-formatting.md
@@ -4,13 +4,15 @@ Murmur formats likely terminal/developer commands as text after recognition. It 
 
 ## Activation boundary
 
-The CLI stage is conservative and bounded to one utterance:
+The CLI stage is conservative and bounded to command-shaped lines at the utterance boundary:
 
 - An explicit leading trigger: `command`, `shell command`, or `terminal command`.
 - A known tool at the start of the utterance plus command-shaped evidence, such as a known subcommand or a spoken symbol.
 - A matching per-app profile with **CLI: On**. This explicit user choice treats a multi-token utterance as command text, including unknown tools.
 
 **CLI: Off** disables implicit detection for that app; an explicit command trigger still works. Text that does not activate is returned byte-for-byte unchanged. Mentions such as “I use git and cargo every day” and “npm is a package manager” are ordinary prose, not commands.
+
+Physical line endings are immutable boundaries. Each line is considered independently, so a command line can be canonicalized without rewriting adjacent prose, and existing LF/CRLF endings remain unchanged.
 
 ## Transformation order
 
@@ -55,4 +57,5 @@ Code-vocabulary scans also read only the package name, script keys, and dependen
 - Activated spans are formatted, copied, and optionally pasted as text only.
 - Canonical commands are idempotent.
 - Non-activated whitespace, punctuation, and Unicode remain byte-for-byte unchanged.
+- Existing LF/CRLF command boundaries remain byte-for-byte unchanged.
 - Imported-file transcription remains raw and does not run CLI formatting.

--- a/docs/features/cli-command-formatting.md
+++ b/docs/features/cli-command-formatting.md
@@ -1,0 +1,58 @@
+# Spoken CLI Command Formatting
+
+Murmur formats likely terminal/developer commands as text after recognition. It never executes them.
+
+## Activation boundary
+
+The CLI stage is conservative and bounded to one utterance:
+
+- An explicit leading trigger: `command`, `shell command`, or `terminal command`.
+- A known tool at the start of the utterance plus command-shaped evidence, such as a known subcommand or a spoken symbol.
+- A matching per-app profile with **CLI: On**. This explicit user choice treats a multi-token utterance as command text, including unknown tools.
+
+**CLI: Off** disables implicit detection for that app; an explicit command trigger still works. Text that does not activate is returned byte-for-byte unchanged. Mentions such as “I use git and cargo every day” and “npm is a package manager” are ordinary prose, not commands.
+
+## Transformation order
+
+CLI canonicalization is the final deterministic transformation:
+
+```text
+raw transcript → cleanup → voice commands → Smart Correction → CLI formatting → final text
+```
+
+Running after Smart Correction lets vocabulary resolve technical names first. The CLI stage then owns final separators, flags, paths, versions, and command-family casing. The pipeline keeps the original and final text together only in memory for reporting and tests; neither value is added to structured logs by this stage.
+
+## Grammar and lexicon
+
+The generic spoken-symbol grammar is separate from alias data. It recognizes bounded forms including:
+
+- `at latest` → `@latest`
+- `dash b` → `-b`; `dash dash template` → `--template`
+- `slash`, `dot`, `colon`, and `equals`
+- `pipe`, redirects, single/double quotes, and explicit `new line`
+
+The local lexicon layers:
+
+1. User-approved atom mappings from existing custom voice commands
+2. Small built-in tool/package/script aliases
+3. Terms captured by the immutable code-vocabulary snapshot
+
+Code-vocabulary scans also read only the package name, script keys, and dependency keys from `package.json`. Script bodies and unrelated manifest prose are not retained. This lets project-local packages and scripts extend the formatter without hard-coded whole-command sentences.
+
+## Examples
+
+| Spoken | Written |
+|---|---|
+| `npx cc usage at latest` | `npx ccusage@latest` |
+| `NPM run Tauri dev` | `npm run tauri dev` |
+| `npx create vite at latest my app dash dash template react typescript` | `npx create-vite@latest my-app --template react-ts` |
+| `git checkout dash b feature slash streaming` | `git checkout -b feature/streaming` |
+| `cargo test dash dash dash test threads equals one` | `cargo test -- --test-threads=1` |
+
+## Safety properties
+
+- Deterministic and fully local; no natural-language model or cloud service.
+- Activated spans are formatted, copied, and optionally pasted as text only.
+- Canonical commands are idempotent.
+- Non-activated whitespace, punctuation, and Unicode remain byte-for-byte unchanged.
+- Imported-file transcription remains raw and does not run CLI formatting.

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -12,7 +12,7 @@ Murmur resolves one immutable `DictationContextSnapshot` for every live recordin
 
 One-session overrides are an explicit, typed resolver input but no trigger supplies them yet. This keeps the precedence contract ready for future commands without adding a second app-detection or settings path.
 
-Profiles currently override only `autoPaste` and transcript cleanup. Existing stored profile objects remain valid; missing or `null` overrides still mean "use the global value." The settings UI prevents duplicates, but persisted or programmatic configuration can contain them. To preserve legacy behavior exactly, each field uses the first matching profile that provides that field; a `null` override falls through to the next duplicate.
+Profiles currently override `autoPaste`, transcript cleanup, and CLI formatting. Existing stored profile objects remain valid; missing or `null` overrides still mean "use the global/automatic value." CLI defaults to conservative automatic detection; On enables command-shaped unknown tools for that profile, while Off disables implicit detection but preserves the explicit spoken `command` trigger. The settings UI prevents duplicates, but persisted or programmatic configuration can contain them. To preserve legacy behavior exactly, each field uses the first matching profile that provides that field; a `null` override falls through to the next duplicate.
 
 ## Snapshot contents and lifetime
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -96,16 +96,17 @@ Uses `IdleGuard` (RAII) to reset status on any early return or error — prevent
 `transform_transcript()` is the authoritative post-recognition entry point for both live and imported-file transcription. It owns a fixed internal sequence:
 
 ```text
-raw transcript → cleanup → voice commands → Smart Correction → final text
+raw transcript → cleanup → voice commands → Smart Correction → CLI formatting → final text
 ```
 
 Each stage receives immutable session/model/language metadata plus privacy-safe enablement flags and produces privacy-safe execution metadata (`duration_us`, changed/not-changed, outcome, and required/optional failure policy). Structured logs never include transcript text, custom replacement values, or correction vocabulary.
 
-Cleanup and voice commands are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. Imported-file transcription invokes the same entry point with all three stages disabled so its existing raw-ASR output remains unchanged.
+Cleanup, voice commands, and CLI formatting are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. The CLI stage uses conservative prefix/trigger/profile activation and returns non-command prose byte-for-byte unchanged. Imported-file transcription invokes the same entry point with every stage disabled so its existing raw-ASR output remains unchanged.
 
 File persistence, clipboard/paste, history, and stats are intentionally outside the transformation pipeline. Live transformation receives an opaque recording handle plus stage configuration and resources from the same immutable per-app snapshot; app/profile resolution remains owned by the context resolver.
 
 See [Per-App Dictation Context](per-app-profiles.md) for resolver precedence, duplicate-profile compatibility, lifetime, and privacy boundaries.
+See [Spoken CLI Command Formatting](cli-command-formatting.md) for activation, grammar, local lexicon layering, and safety guarantees.
 
 ## Model Downloads (`commands/models.rs`)
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -99,7 +99,7 @@ Uses `IdleGuard` (RAII) to reset status on any early return or error — prevent
 raw transcript → cleanup → voice commands → Smart Correction → CLI formatting → final text
 ```
 
-Each stage receives immutable session/model/language metadata plus privacy-safe enablement flags and produces privacy-safe execution metadata (`duration_us`, changed/not-changed, outcome, and required/optional failure policy). Structured logs never include transcript text, custom replacement values, or correction vocabulary.
+Each stage receives immutable session/source metadata plus privacy-safe enablement flags and produces privacy-safe execution metadata (`duration_us`, changed/not-changed, outcome, and required/optional failure policy). Structured stage logs never include transcript text, model/language settings, app/profile values, custom replacement values, correction vocabulary, package/script names, or project paths.
 
 Cleanup, voice commands, and CLI formatting are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. The CLI stage uses conservative prefix/trigger/profile activation and returns non-command prose byte-for-byte unchanged. Imported-file transcription invokes the same entry point with every stage disabled so its existing raw-ASR output remains unchanged.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -83,7 +83,9 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 
 ## Per-App Profiles
 
-`appProfiles` is an array of `{ bundleId, label, autoPasteOverride, cleanupOverride }`. Boolean overrides replace the corresponding global value for a matching frontmost bundle identifier; `null` means "use global." Existing persisted entries are migrated by filling missing override fields with `null`.
+`appProfiles` is an array of `{ bundleId, label, autoPasteOverride, cleanupOverride, cliFormattingOverride }`. Boolean overrides replace the corresponding global/automatic value for a matching frontmost bundle identifier; `null` means "use global/automatic." Existing persisted entries are migrated by filling missing override fields with `null`.
+
+`cliFormattingOverride` uses the immutable recording-start context. `true` enables profile-mode CLI recognition, `false` disables implicit CLI formatting for that app, and `null` keeps conservative automatic recognition. An explicit spoken `command` trigger remains available in every mode.
 
 At recording start, the backend resolves one immutable context using global settings → matching profile → one-session overrides. Settings or focus changes during recording apply only to the next session. See [Per-App Dictation Context](../features/per-app-profiles.md).
 


### PR DESCRIPTION
Closes #256

## Summary

- add a deterministic final transcript stage for canonical CLI formatting, with activation bounded to an explicit command trigger, a known tool at the utterance boundary, or an enabled per-app CLI profile
- keep spoken-symbol grammar separate from an extendable local alias lexicon sourced from small built-ins, approved atom mappings, immutable code vocabulary, and narrowly parsed `package.json` names
- add a tri-state per-app CLI formatting override plus settings migration/UI, privacy-safe in-memory change reporting, and feature/reference documentation

## Safety

- ordinary non-activated prose is returned byte-for-byte unchanged
- imported-file transcription keeps all transformation stages disabled
- original/final comparison exists in memory only; transcript text is not persisted or logged by this stage
- tests cover false positives, idempotence, quoting, punctuation, Unicode, profile modes, and stage ordering

## Validation

- `cargo test -- --test-threads=1` — 308 unit tests + Whisper integration passed; optional CoreML fixture ignored because its model cache/env fixture is not configured
- `cargo check -q`
- `npm test -- --run` — 97 tests passed
- `npx tsc --noEmit`
- `git diff --check origin/main...HEAD`
- clean native app-only debug bundle: `npx tauri build --debug --bundles app --config src-tauri/tauri.dev.conf.json --config '{"bundle":{"createUpdaterArtifacts":false}}'`
- native UI smoke on the exact rebuilt `.app`: Per-App Profiles showed the corrected CLI subtitle, created a Terminal profile, and cycled `CLI: Default` to `CLI: On`
- real microphone-path dictation could not start on this Mac: `Failed to get input config: A backend-specific error has occurred: An unknown error unknown to the coreaudio-rs API occurred`; the exact code-command transformations are instead covered by in-process golden pipeline tests
