### PR TITLE
feat: add local per-app writing styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Per-app **Writing Styles** add explicit Inherit, Conversational, Polished prose, Code / technical, Verbatim, and Notes policies using only local deterministic transforms. Styles resolve once in the immutable recording context, never infer app type or capture app content, and preserve existing delivery behavior (#250).
 - Long Whisper recordings now show a session-scoped provisional transcript in the notch overlay after each reliable incremental chunk. The privacy-safe preview can be disabled in Settings; final clipboard and auto-paste delivery remain unchanged and occur exactly once after stop (#243).
 - **Spoken CLI command formatting** — likely npm/npx, Git, Cargo, Docker, kubectl, and other developer commands now receive deterministic local formatting for versions, flags, paths, operators, quotes, and small canonical aliases. Detection is prefix/trigger/profile bounded, project `package.json` names extend the local lexicon, and ordinary prose remains unchanged (#256).
 - Optional **Smart Formatting** turns clear spoken enumerations into lists, applies explicitly cued email/URL/symbol/quote/paragraph grammar, and handles bounded same-utterance restatements locally. It is independently controllable per app, bypasses CLI/code/verbatim contexts, leaves imported-file transcription raw, and keeps delivery final-only (#252).

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -698,7 +698,7 @@ async fn run_transcription_pipeline(
                 .built_in_voice_commands,
             smart_correction_enabled: transformations.correction_enabled,
             smart_formatting_enabled: transformations.smart_formatting_enabled,
-            cli_command_enabled: true,
+            cli_command_enabled: transformations.cli_formatting_enabled,
         },
     };
     let cli_lexicon = crate::cli_command::CliLexicon::from_context(
@@ -956,6 +956,19 @@ impl ConfigurationLogMetadata {
     }
 }
 
+fn parse_writing_style(value: Option<&serde_json::Value>) -> Option<crate::state::WritingStyle> {
+    match value.and_then(serde_json::Value::as_str) {
+        Some("conversational") => Some(crate::state::WritingStyle::Conversational),
+        Some("polished") => Some(crate::state::WritingStyle::Polished),
+        Some("code_technical") => Some(crate::state::WritingStyle::CodeTechnical),
+        Some("verbatim") => Some(crate::state::WritingStyle::Verbatim),
+        Some("notes") => Some(crate::state::WritingStyle::Notes),
+        // Missing, null, malformed, and the legacy-facing Inherit spelling all
+        // preserve the existing resolver path.
+        _ => None,
+    }
+}
+
 #[tauri::command]
 pub async fn configure_dictation(
     options: serde_json::Value,
@@ -1101,6 +1114,7 @@ pub async fn configure_dictation(
                 let smart_formatting_override = p
                     .get("smartFormattingOverride")
                     .and_then(|v| v.as_bool());
+                let writing_style = parse_writing_style(p.get("writingStyle"));
                 Some(crate::state::AppProfile {
                     bundle_id,
                     label,
@@ -1108,6 +1122,7 @@ pub async fn configure_dictation(
                     cleanup_override,
                     cli_formatting_override,
                     smart_formatting_override,
+                    writing_style,
                 })
             })
             .collect();
@@ -1610,6 +1625,8 @@ pub async fn start_native_recording(
         recording_id = rid,
         frontmost_app_detected = context.app.bundle_id.is_some(),
         matched_profile = context.matched_profile.is_some(),
+        writing_style = context.writing_style.as_str(),
+        writing_style_code = context.writing_style.code(),
         vocabulary_version = context.vocabulary.version,
         context_reads_enabled = context.context_capture.selected_text
             || context.context_capture.surrounding_screen_text
@@ -2168,6 +2185,39 @@ mod tests {
         ] {
             assert!(!rendered.contains(secret), "telemetry metadata leaked {secret}");
         }
+    }
+
+    #[test]
+    fn writing_style_parser_accepts_only_stable_explicit_enum_values() {
+        let cases = [
+            (
+                serde_json::json!("conversational"),
+                Some(crate::state::WritingStyle::Conversational),
+            ),
+            (
+                serde_json::json!("polished"),
+                Some(crate::state::WritingStyle::Polished),
+            ),
+            (
+                serde_json::json!("code_technical"),
+                Some(crate::state::WritingStyle::CodeTechnical),
+            ),
+            (
+                serde_json::json!("verbatim"),
+                Some(crate::state::WritingStyle::Verbatim),
+            ),
+            (
+                serde_json::json!("notes"),
+                Some(crate::state::WritingStyle::Notes),
+            ),
+            (serde_json::Value::Null, None),
+            (serde_json::json!("terminal"), None),
+            (serde_json::json!(true), None),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(parse_writing_style(Some(&value)), expected);
+        }
+        assert_eq!(parse_writing_style(None), None);
     }
 
     #[test]

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -7,7 +7,7 @@
 
 use crate::cli_command::CliFormattingMode;
 use crate::correction::CorrectionMatcher;
-use crate::state::{AppProfile, DictationState, VoiceCommand};
+use crate::state::{AppProfile, DictationState, VoiceCommand, WritingStyle};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,6 +23,7 @@ pub struct MatchedAppProfile {
     pub cleanup_override: Option<bool>,
     pub cli_formatting_override: Option<bool>,
     pub smart_formatting_override: Option<bool>,
+    pub writing_style: Option<WritingStyle>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +77,7 @@ pub struct TransformationSettings {
     pub correction_enabled: bool,
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
     pub cli_formatting_mode: CliFormattingMode,
+    pub cli_formatting_enabled: bool,
     pub smart_formatting_enabled: bool,
 }
 
@@ -98,6 +100,7 @@ pub struct DictationContextSnapshot {
     pub vocabulary: VocabularyIdentity,
     pub enabled_command_groups: EnabledCommandGroups,
     pub context_capture: ContextCapturePermissions,
+    pub writing_style: WritingStyle,
 }
 
 /// Ephemeral overrides supplied by the recording trigger. No caller supplies
@@ -127,6 +130,14 @@ pub struct ResolverInputs<'a> {
 /// matching entry with `None` falls through to the next duplicate entry.
 pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
     let global = inputs.global;
+    let writing_style =
+        resolve_profile_optional(inputs.bundle_id, &global.app_profiles, |profile| {
+            profile
+                .writing_style
+                .filter(|style| *style != WritingStyle::Inherit)
+        })
+        .unwrap_or(WritingStyle::Inherit);
+    let style = StylePolicy::for_style(writing_style);
     let auto_paste = inputs.session_overrides.auto_paste.unwrap_or_else(|| {
         resolve_profile_override(
             global.auto_paste,
@@ -137,27 +148,31 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
     });
     let cleanup_enabled = inputs.session_overrides.cleanup_enabled.unwrap_or_else(|| {
         resolve_profile_override(
-            global.cleanup_enabled,
+            style.cleanup_enabled.unwrap_or(global.cleanup_enabled),
             inputs.bundle_id,
             &global.app_profiles,
             |profile| profile.cleanup_override,
         )
     });
-    let cli_formatting_mode = match inputs.session_overrides.cli_formatting_enabled.or_else(|| {
+    let cli_override = inputs.session_overrides.cli_formatting_enabled.or_else(|| {
         resolve_profile_optional(inputs.bundle_id, &global.app_profiles, |profile| {
             profile.cli_formatting_override
         })
-    }) {
+    });
+    let cli_formatting_mode = match cli_override {
         Some(true) => CliFormattingMode::Enabled,
         Some(false) => CliFormattingMode::Disabled,
-        None => CliFormattingMode::Auto,
+        None => style.cli_formatting_mode.unwrap_or(CliFormattingMode::Auto),
     };
+    let cli_formatting_enabled = cli_override.is_some() || style.cli_formatting_enabled;
     let smart_formatting_enabled = inputs
         .session_overrides
         .smart_formatting_enabled
         .unwrap_or_else(|| {
             resolve_profile_override(
-                global.smart_formatting_enabled,
+                style
+                    .smart_formatting_enabled
+                    .unwrap_or(global.smart_formatting_enabled),
                 inputs.bundle_id,
                 &global.app_profiles,
                 |profile| profile.smart_formatting_override,
@@ -175,6 +190,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
                 cleanup_override: profile.cleanup_override,
                 cli_formatting_override: profile.cli_formatting_override,
                 smart_formatting_override: profile.smart_formatting_override,
+                writing_style: profile.writing_style,
             })
     });
     let custom_vocab = !global.custom_vocabulary.trim().is_empty();
@@ -185,7 +201,9 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         (false, true) => VocabularySource::CodeAware,
         (true, true) => VocabularySource::CustomAndCodeAware,
     };
-    let voice_commands = global.voice_commands_enabled;
+    let voice_commands = style
+        .voice_commands_enabled
+        .unwrap_or(global.voice_commands_enabled);
 
     DictationContextSnapshot {
         app: ActiveAppIdentity {
@@ -201,12 +219,19 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         },
         transformations: TransformationSettings {
             cleanup_enabled,
-            cleanup_remove_filler: global.cleanup_remove_filler,
-            cleanup_capitalize: global.cleanup_capitalize,
+            cleanup_remove_filler: style
+                .cleanup_remove_filler
+                .unwrap_or(global.cleanup_remove_filler),
+            cleanup_capitalize: style
+                .cleanup_capitalize
+                .unwrap_or(global.cleanup_capitalize),
             voice_command_pairs: global.voice_command_pairs.clone(),
-            correction_enabled: global.correction_enabled,
+            correction_enabled: style
+                .correction_enabled
+                .unwrap_or(global.correction_enabled),
             correction_matcher: inputs.correction_matcher,
             cli_formatting_mode,
+            cli_formatting_enabled,
             smart_formatting_enabled,
         },
         delivery: DeliverySettings {
@@ -227,6 +252,80 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         // No selected-text, screen-text, or clipboard reads exist. Future
         // features must add an explicit setting/profile override here first.
         context_capture: ContextCapturePermissions::default(),
+        writing_style,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StylePolicy {
+    cleanup_enabled: Option<bool>,
+    cleanup_remove_filler: Option<bool>,
+    cleanup_capitalize: Option<bool>,
+    voice_commands_enabled: Option<bool>,
+    correction_enabled: Option<bool>,
+    smart_formatting_enabled: Option<bool>,
+    cli_formatting_mode: Option<CliFormattingMode>,
+    cli_formatting_enabled: bool,
+}
+
+impl StylePolicy {
+    fn for_style(style: WritingStyle) -> Self {
+        let inherit = Self {
+            cleanup_enabled: None,
+            cleanup_remove_filler: None,
+            cleanup_capitalize: None,
+            voice_commands_enabled: None,
+            correction_enabled: None,
+            smart_formatting_enabled: None,
+            cli_formatting_mode: None,
+            cli_formatting_enabled: true,
+        };
+        match style {
+            WritingStyle::Inherit => inherit,
+            WritingStyle::Conversational => Self {
+                cleanup_enabled: Some(true),
+                cleanup_remove_filler: Some(true),
+                cleanup_capitalize: Some(true),
+                smart_formatting_enabled: Some(false),
+                cli_formatting_mode: Some(CliFormattingMode::Disabled),
+                ..inherit
+            },
+            WritingStyle::Polished => Self {
+                cleanup_enabled: Some(true),
+                cleanup_remove_filler: Some(true),
+                cleanup_capitalize: Some(true),
+                correction_enabled: Some(true),
+                smart_formatting_enabled: Some(true),
+                cli_formatting_mode: Some(CliFormattingMode::Disabled),
+                ..inherit
+            },
+            WritingStyle::CodeTechnical => Self {
+                cleanup_enabled: Some(false),
+                voice_commands_enabled: Some(false),
+                correction_enabled: Some(true),
+                smart_formatting_enabled: Some(false),
+                cli_formatting_mode: Some(CliFormattingMode::Enabled),
+                ..inherit
+            },
+            WritingStyle::Verbatim => Self {
+                cleanup_enabled: Some(false),
+                voice_commands_enabled: Some(false),
+                correction_enabled: Some(false),
+                smart_formatting_enabled: Some(false),
+                cli_formatting_mode: Some(CliFormattingMode::Disabled),
+                cli_formatting_enabled: false,
+                ..inherit
+            },
+            WritingStyle::Notes => Self {
+                cleanup_enabled: Some(true),
+                cleanup_remove_filler: Some(true),
+                cleanup_capitalize: Some(false),
+                correction_enabled: Some(true),
+                smart_formatting_enabled: Some(true),
+                cli_formatting_mode: Some(CliFormattingMode::Disabled),
+                ..inherit
+            },
+        }
     }
 }
 
@@ -262,6 +361,31 @@ fn resolve_profile_override<T: Copy>(
 mod tests {
     use super::*;
 
+    fn transform_with_snapshot(raw: &str, snapshot: &DictationContextSnapshot) -> String {
+        let context = crate::transcript_transform::TranscriptContext {
+            session_id: 1,
+            source: crate::transcript_transform::TranscriptSource::Live,
+            context_handle: Some("test-context".to_string()),
+            cli_formatting_mode: snapshot.transformations.cli_formatting_mode,
+            stages: crate::transcript_transform::TranscriptStageConfig {
+                cleanup_enabled: snapshot.transformations.cleanup_enabled,
+                cleanup_remove_filler: snapshot.transformations.cleanup_remove_filler,
+                cleanup_capitalize: snapshot.transformations.cleanup_capitalize,
+                voice_commands_enabled: snapshot.enabled_command_groups.built_in_voice_commands,
+                smart_correction_enabled: snapshot.transformations.correction_enabled,
+                smart_formatting_enabled: snapshot.transformations.smart_formatting_enabled,
+                cli_command_enabled: snapshot.transformations.cli_formatting_enabled,
+            },
+        };
+        crate::transcript_transform::transform_transcript(
+            raw.to_string(),
+            &context,
+            crate::transcript_transform::TranscriptTransformResources::empty(),
+        )
+        .unwrap()
+        .text
+    }
+
     fn profile(
         bundle_id: &str,
         auto_paste_override: Option<bool>,
@@ -274,6 +398,7 @@ mod tests {
             cleanup_override,
             cli_formatting_override: None,
             smart_formatting_override: None,
+            writing_style: None,
         }
     }
 
@@ -501,5 +626,303 @@ mod tests {
             ContextCapturePermissions::default()
         );
         assert!(snapshot.delivery.auto_paste);
+    }
+
+    #[test]
+    fn writing_styles_resolve_only_typed_transformation_policy() {
+        let mut global = DictationState {
+            model_name: "small.en".to_string(),
+            language: "es".to_string(),
+            auto_paste: true,
+            save_transcript: true,
+            output_dir: "/tmp/murmur-style-test".to_string(),
+            cleanup_enabled: false,
+            voice_commands_enabled: true,
+            smart_formatting_enabled: false,
+            correction_enabled: false,
+            ..DictationState::default()
+        };
+        let mut profile = profile("com.example.Editor", None, None);
+        profile.writing_style = Some(WritingStyle::CodeTechnical);
+        global.app_profiles = vec![profile];
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.example.Editor"),
+            SessionOverrides::default(),
+        );
+
+        assert_eq!(snapshot.writing_style, WritingStyle::CodeTechnical);
+        assert!(!snapshot.transformations.cleanup_enabled);
+        assert!(!snapshot.enabled_command_groups.built_in_voice_commands);
+        assert!(!snapshot.transformations.smart_formatting_enabled);
+        assert!(snapshot.transformations.correction_enabled);
+        assert_eq!(
+            snapshot.transformations.cli_formatting_mode,
+            CliFormattingMode::Enabled
+        );
+        assert!(snapshot.transformations.cli_formatting_enabled);
+        assert_eq!(snapshot.transcription.model_name, "small.en");
+        assert_eq!(snapshot.transcription.language, "es");
+        assert!(snapshot.delivery.auto_paste);
+        assert!(snapshot.delivery.save_transcript);
+        assert_eq!(snapshot.delivery.output_dir, "/tmp/murmur-style-test");
+        assert_eq!(
+            snapshot.context_capture,
+            ContextCapturePermissions::default()
+        );
+    }
+
+    #[test]
+    fn named_styles_have_transparent_deterministic_effects() {
+        let mut global = DictationState {
+            cleanup_enabled: false,
+            cleanup_remove_filler: false,
+            cleanup_capitalize: false,
+            voice_commands_enabled: true,
+            correction_enabled: false,
+            smart_formatting_enabled: false,
+            ..DictationState::default()
+        };
+
+        let cases = [
+            (WritingStyle::Conversational, true, true, false, false, true),
+            (WritingStyle::Polished, true, true, true, true, true),
+            (WritingStyle::Notes, true, true, true, true, true),
+            (WritingStyle::CodeTechnical, false, false, false, true, true),
+            (WritingStyle::Verbatim, false, false, false, false, false),
+        ];
+
+        for (style, cleanup, commands, prose, correction, cli_stage) in cases {
+            let mut app = profile("com.example.App", None, None);
+            app.writing_style = Some(style);
+            global.app_profiles = vec![app];
+            let snapshot = resolve_test(
+                &global,
+                Some("com.example.App"),
+                SessionOverrides::default(),
+            );
+            assert_eq!(snapshot.writing_style, style);
+            assert_eq!(snapshot.transformations.cleanup_enabled, cleanup);
+            assert_eq!(
+                snapshot.enabled_command_groups.built_in_voice_commands,
+                commands
+            );
+            assert_eq!(snapshot.transformations.smart_formatting_enabled, prose);
+            assert_eq!(snapshot.transformations.correction_enabled, correction);
+            assert_eq!(snapshot.transformations.cli_formatting_enabled, cli_stage);
+        }
+    }
+
+    #[test]
+    fn inherit_and_unclassified_apps_preserve_current_behavior() {
+        let mut global = DictationState {
+            cleanup_enabled: true,
+            cleanup_remove_filler: false,
+            cleanup_capitalize: false,
+            voice_commands_enabled: true,
+            correction_enabled: false,
+            smart_formatting_enabled: true,
+            ..DictationState::default()
+        };
+        let mut terminal = profile("com.apple.Terminal", None, None);
+        terminal.writing_style = Some(WritingStyle::Inherit);
+        global.app_profiles = vec![terminal];
+
+        for bundle_id in [Some("com.apple.Terminal"), Some("com.apple.dt.Xcode"), None] {
+            let snapshot = resolve_test(&global, bundle_id, SessionOverrides::default());
+            assert_eq!(snapshot.writing_style, WritingStyle::Inherit);
+            assert!(snapshot.transformations.cleanup_enabled);
+            assert!(!snapshot.transformations.cleanup_remove_filler);
+            assert!(!snapshot.transformations.cleanup_capitalize);
+            assert!(snapshot.enabled_command_groups.built_in_voice_commands);
+            assert!(!snapshot.transformations.correction_enabled);
+            assert!(snapshot.transformations.smart_formatting_enabled);
+            assert_eq!(
+                snapshot.transformations.cli_formatting_mode,
+                CliFormattingMode::Auto
+            );
+            assert!(snapshot.transformations.cli_formatting_enabled);
+        }
+    }
+
+    #[test]
+    fn duplicate_profiles_preserve_per_field_fallthrough_for_style() {
+        let mut first = profile("com.example.Editor", None, Some(false));
+        first.label = "first identity".to_string();
+        let mut second = profile("com.example.Editor", Some(false), None);
+        second.writing_style = Some(WritingStyle::Polished);
+        let mut global = DictationState {
+            auto_paste: true,
+            cleanup_enabled: false,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![first, second];
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.example.Editor"),
+            SessionOverrides::default(),
+        );
+
+        assert_eq!(snapshot.writing_style, WritingStyle::Polished);
+        assert_eq!(snapshot.matched_profile.unwrap().label, "first identity");
+        assert!(!snapshot.delivery.auto_paste);
+        // First profile's explicit field still wins over the later style policy.
+        assert!(!snapshot.transformations.cleanup_enabled);
+        assert!(snapshot.transformations.smart_formatting_enabled);
+    }
+
+    #[test]
+    fn explicit_profile_and_session_overrides_fine_tune_style() {
+        let mut app = profile("com.example.Editor", None, Some(true));
+        app.writing_style = Some(WritingStyle::Verbatim);
+        app.smart_formatting_override = Some(true);
+        app.cli_formatting_override = Some(true);
+        let mut global = DictationState::default();
+        global.app_profiles = vec![app];
+
+        let snapshot = resolve_test(
+            &global,
+            Some("com.example.Editor"),
+            SessionOverrides {
+                cleanup_enabled: Some(false),
+                smart_formatting_enabled: Some(false),
+                cli_formatting_enabled: Some(false),
+                ..SessionOverrides::default()
+            },
+        );
+
+        assert!(!snapshot.transformations.cleanup_enabled);
+        assert!(!snapshot.transformations.smart_formatting_enabled);
+        assert_eq!(
+            snapshot.transformations.cli_formatting_mode,
+            CliFormattingMode::Disabled
+        );
+        assert!(snapshot.transformations.cli_formatting_enabled);
+    }
+
+    #[test]
+    fn resolved_style_snapshot_is_immutable() {
+        let mut app = profile("com.example.Editor", None, None);
+        app.writing_style = Some(WritingStyle::Polished);
+        let mut global = DictationState::default();
+        global.app_profiles = vec![app];
+        let snapshot = resolve_test(
+            &global,
+            Some("com.example.Editor"),
+            SessionOverrides::default(),
+        );
+
+        global.app_profiles[0].writing_style = Some(WritingStyle::Verbatim);
+
+        assert_eq!(snapshot.writing_style, WritingStyle::Polished);
+        assert!(snapshot.transformations.cleanup_enabled);
+        assert!(snapshot.transformations.smart_formatting_enabled);
+    }
+
+    #[test]
+    fn style_transform_outputs_use_only_reviewed_deterministic_stages() {
+        let mut global = DictationState {
+            cleanup_enabled: false,
+            voice_commands_enabled: false,
+            correction_enabled: false,
+            smart_formatting_enabled: false,
+            ..DictationState::default()
+        };
+
+        let cases = [
+            (
+                "com.example.Chat",
+                WritingStyle::Conversational,
+                "um the tasks are first review second ship",
+                "The tasks are first review second ship",
+            ),
+            (
+                "com.apple.mail",
+                WritingStyle::Polished,
+                "um the tasks are first review second ship",
+                "The tasks are:\n1. Review\n2. Ship",
+            ),
+            (
+                "com.microsoft.VSCode",
+                WritingStyle::CodeTechnical,
+                "NPM run Tauri dev",
+                "npm run tauri dev",
+            ),
+            (
+                "com.apple.Notes",
+                WritingStyle::Notes,
+                "um the notes are first review second ship",
+                "the notes are:\n1. Review\n2. Ship",
+            ),
+            (
+                "com.apple.Terminal",
+                WritingStyle::Verbatim,
+                "  um command NPM new line  ",
+                "  um command NPM new line  ",
+            ),
+        ];
+
+        for (bundle_id, style, raw, expected) in cases {
+            let mut app = profile(bundle_id, None, None);
+            app.writing_style = Some(style);
+            global.app_profiles = vec![app];
+            let snapshot = resolve_test(&global, Some(bundle_id), SessionOverrides::default());
+            assert_eq!(transform_with_snapshot(raw, &snapshot), expected);
+        }
+    }
+
+    #[test]
+    fn writing_style_telemetry_values_are_stable_and_content_free() {
+        let styles = [
+            (WritingStyle::Inherit, "inherit", 0),
+            (WritingStyle::Conversational, "conversational", 1),
+            (WritingStyle::Polished, "polished", 2),
+            (WritingStyle::CodeTechnical, "code_technical", 3),
+            (WritingStyle::Verbatim, "verbatim", 4),
+            (WritingStyle::Notes, "notes", 5),
+        ];
+        for (style, name, code) in styles {
+            assert_eq!(style.as_str(), name);
+            assert_eq!(style.code(), code);
+        }
+    }
+
+    #[test]
+    fn verbatim_and_inherit_preserve_false_positive_inputs_byte_for_byte() {
+        let raw = "  um NPM new line command cargo test first second  ";
+        let mut app = profile("com.example.Verbatim", None, None);
+        app.writing_style = Some(WritingStyle::Verbatim);
+        let mut global = DictationState {
+            cleanup_enabled: false,
+            voice_commands_enabled: false,
+            correction_enabled: false,
+            smart_formatting_enabled: false,
+            ..DictationState::default()
+        };
+        global.app_profiles = vec![app];
+
+        let verbatim = resolve_test(
+            &global,
+            Some("com.example.Verbatim"),
+            SessionOverrides::default(),
+        );
+        assert_eq!(
+            transform_with_snapshot(raw, &verbatim).as_bytes(),
+            raw.as_bytes()
+        );
+
+        // A terminal/editor-looking bundle id does not imply a style.
+        let inherit = resolve_test(
+            &global,
+            Some("com.apple.Terminal"),
+            SessionOverrides::default(),
+        );
+        assert_eq!(inherit.writing_style, WritingStyle::Inherit);
+        assert_eq!(
+            transform_with_snapshot(raw, &inherit).as_bytes(),
+            raw.as_bytes()
+        );
     }
 }

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -25,6 +25,41 @@ impl Default for DictationStatus {
 /// `bundle_id`, each `*_override` (when `Some`) replaces the corresponding global
 /// setting in the immutable recording-start snapshot. `None` means "no override
 /// — use global".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WritingStyle {
+    Inherit,
+    Conversational,
+    Polished,
+    CodeTechnical,
+    Verbatim,
+    Notes,
+}
+
+impl WritingStyle {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::Conversational => "conversational",
+            Self::Polished => "polished",
+            Self::CodeTechnical => "code_technical",
+            Self::Verbatim => "verbatim",
+            Self::Notes => "notes",
+        }
+    }
+
+    pub fn code(self) -> u64 {
+        match self {
+            Self::Inherit => 0,
+            Self::Conversational => 1,
+            Self::Polished => 2,
+            Self::CodeTechnical => 3,
+            Self::Verbatim => 4,
+            Self::Notes => 5,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppProfile {
     pub bundle_id: String,
@@ -44,6 +79,10 @@ pub struct AppProfile {
     /// inherits the global setting; code/verbatim profiles can force it off.
     #[serde(default)]
     pub smart_formatting_override: Option<bool>,
+    /// Explicit local writing style. `None` is Inherit and preserves the
+    /// pre-style resolver path byte-for-byte.
+    #[serde(default)]
+    pub writing_style: Option<WritingStyle>,
 }
 
 /// A user-defined voice command: when `phrase` is spoken (matched

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -6,7 +6,8 @@ import { getVersion } from '@tauri-apps/api/app';
 import {
   Settings, RecordingMode, DEFAULT_SETTINGS,
   AVAILABLE_MODEL_OPTIONS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
-  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, AppProfile, VoiceCommand,
+  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, WRITING_STYLE_OPTIONS,
+  AppProfile, VoiceCommand, WritingStyle, WritingStyleChoice,
 } from '../../lib/settings';
 import { Select } from '../ui/Select';
 import { SettingsSection } from './SettingsSection';
@@ -133,9 +134,26 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
   );
 }
 
-// Per-app profiles: simple add/remove list mapping a macOS bundle id to an
-// auto-paste override. The override cycles Default -> On -> Off so the whole
-// control fits in one tap-through button.
+const WRITING_STYLE_SUMMARIES: Record<WritingStyleChoice, string> = {
+  inherit: 'Uses your current global behavior and the fine-tuning controls below.',
+  conversational: 'Removes filler and repeated words, tidies capitalization, and keeps your wording.',
+  polished: 'Cleans speech and applies explicitly spoken lists, punctuation, symbols, and corrections.',
+  code_technical: 'Preserves technical wording and enables deterministic command formatting.',
+  verbatim: 'Leaves recognized text unchanged, including filler, spacing, and spoken command words.',
+  notes: 'Removes filler, keeps note-like capitalization, and turns explicit list, paragraph, and line cues into structure.',
+};
+
+const WRITING_STYLE_CATEGORIES: Record<WritingStyleChoice, string> = {
+  inherit: 'Cleanup, corrections, prose structure, and command formatting all inherit.',
+  conversational: 'Cleanup on · Prose structure off · Automatic command formatting off',
+  polished: 'Cleanup on · Vocabulary corrections on · Prose structure on · Automatic command formatting off',
+  code_technical: 'Cleanup off · Vocabulary corrections on · Prose structure off · Command formatting on',
+  verbatim: 'Cleanup, corrections, prose structure, and command formatting all off',
+  notes: 'Cleanup on · Vocabulary corrections on · Prose structure on · Automatic command formatting off',
+};
+
+// Per-app profiles map a macOS bundle id to an explicit writing style plus
+// independent delivery/transformation overrides.
 function AppProfilesEditor({ profiles, onChange }: {
   profiles: AppProfile[];
   onChange: (next: AppProfile[]) => void;
@@ -161,6 +179,7 @@ function AppProfilesEditor({ profiles, onChange }: {
         cleanupOverride: null,
         smartFormattingOverride: null,
         cliFormattingOverride: null,
+        writingStyle: null,
       },
     ]);
     setBundleId('');
@@ -195,6 +214,13 @@ function AppProfilesEditor({ profiles, onChange }: {
       p.bundleId === id ? { ...p, smartFormattingOverride: cycle(p.smartFormattingOverride) } : p));
   };
 
+  const changeWritingStyle = (id: string, choice: WritingStyleChoice) => {
+    onChange(profiles.map((p) =>
+      p.bundleId === id
+        ? { ...p, writingStyle: choice === 'inherit' ? null : choice as WritingStyle }
+        : p));
+  };
+
   const chipLabel = (kind: string, value: boolean | null) =>
     value === null ? `${kind}: Default` : value ? `${kind}: On` : `${kind}: Off`;
 
@@ -208,10 +234,10 @@ function AppProfilesEditor({ profiles, onChange }: {
   return (
     <div>
       <p className="mb-2 text-xs text-on-surface-variant">
-        Override auto-paste, transcript cleanup, smart prose formatting, and command formatting for specific apps by bundle id
+        Choose a local writing style and optional fine-tuning for specific apps by bundle id
         (e.g. <span className="font-mono">com.apple.Terminal</span>). The frontmost
-        app when you start dictating decides the behavior. Each toggle cycles
-        Default → On → Off.
+        app when you start dictating selects the profile. Murmur never classifies
+        apps automatically or reads their screen, selection, or clipboard content.
       </p>
 
       {profiles.length > 0 && (
@@ -243,6 +269,26 @@ function AppProfilesEditor({ profiles, onChange }: {
                   </svg>
                 </button>
               </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-on-surface">
+                  Writing style
+                </label>
+                <Select
+                  value={p.writingStyle ?? 'inherit'}
+                  onChange={(choice) => changeWritingStyle(p.bundleId, choice)}
+                  items={WRITING_STYLE_OPTIONS}
+                  aria-label={`Writing style for ${p.label || p.bundleId}`}
+                />
+                <p className="mt-1 text-xs text-on-surface-variant">
+                  {WRITING_STYLE_SUMMARIES[p.writingStyle ?? 'inherit']}
+                </p>
+                <p className="mt-1 text-xs font-medium text-on-surface-variant">
+                  {WRITING_STYLE_CATEGORIES[p.writingStyle ?? 'inherit']}
+                </p>
+              </div>
+              <p className="text-xs text-on-surface-variant">
+                Fine-tune this profile below. Each control cycles Inherit → On → Off.
+              </p>
               <div className="grid grid-cols-2 gap-1.5">
                 <button
                   type="button"
@@ -263,18 +309,18 @@ function AppProfilesEditor({ profiles, onChange }: {
                 <button
                   type="button"
                   onClick={() => cycleSmartFormatting(p.bundleId)}
-                  aria-label={`Smart formatting for ${p.label || p.bundleId}: ${chipLabel('Smart', p.smartFormattingOverride)}`}
+                  aria-label={`Prose formatting for ${p.label || p.bundleId}: ${chipLabel('Prose', p.smartFormattingOverride)}`}
                   className={`px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.smartFormattingOverride)}`}
                 >
-                  {chipLabel('Smart', p.smartFormattingOverride)}
+                  {chipLabel('Prose', p.smartFormattingOverride)}
                 </button>
                 <button
                   type="button"
                   onClick={() => cycleCliFormatting(p.bundleId)}
-                  aria-label={`CLI formatting for ${p.label || p.bundleId}: ${chipLabel('CLI', p.cliFormattingOverride)}`}
+                  aria-label={`Command formatting for ${p.label || p.bundleId}: ${chipLabel('Commands', p.cliFormattingOverride)}`}
                   className={`px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cliFormattingOverride)}`}
                 >
-                  {chipLabel('CLI', p.cliFormattingOverride)}
+                  {chipLabel('Commands', p.cliFormattingOverride)}
                 </button>
               </div>
             </li>

--- a/app/src/lib/dictation.test.ts
+++ b/app/src/lib/dictation.test.ts
@@ -16,6 +16,7 @@ describe('buildConfigureOptions', () => {
           cleanupOverride: null,
           smartFormattingOverride: false,
           cliFormattingOverride: true,
+          writingStyle: 'code_technical',
         },
       ],
     });
@@ -23,5 +24,6 @@ describe('buildConfigureOptions', () => {
     expect(options.smartFormattingEnabled).toBe(true);
     expect(options.smartPunctuation).toBe(false);
     expect(options.appProfiles?.[0].smartFormattingOverride).toBe(false);
+    expect(options.appProfiles?.[0].writingStyle).toBe('code_technical');
   });
 });

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -81,7 +81,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'smartFormattingEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch((err) => {
@@ -104,6 +104,7 @@ export function useSettings() {
               voiceCommandsEnabled: previousSettings.voiceCommandsEnabled,
               voiceCommands: previousSettings.voiceCommands,
               cleanupEnabled: previousSettings.cleanupEnabled,
+              smartFormattingEnabled: previousSettings.smartFormattingEnabled,
               cleanupRemoveFiller: previousSettings.cleanupRemoveFiller,
               cleanupCapitalize: previousSettings.cleanupCapitalize,
               codeVocabEnabled: previousSettings.codeVocabEnabled,

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -41,6 +41,7 @@ describe('loadSettings', () => {
           cleanupOverride: false,
           smartFormattingOverride: true,
           cliFormattingOverride: true,
+          writingStyle: 'polished',
         },
         {
           bundleId: 'com.apple.mail',
@@ -49,6 +50,7 @@ describe('loadSettings', () => {
           cleanupOverride: null,
           smartFormattingOverride: 'yes',
           cliFormattingOverride: 'yes',
+          writingStyle: 'automatic',
         },
         {
           bundleId: 'com.apple.TextEdit',
@@ -62,10 +64,13 @@ describe('loadSettings', () => {
     const [terminal, mail, legacy] = loadSettings().appProfiles;
     expect(terminal.smartFormattingOverride).toBe(true);
     expect(terminal.cliFormattingOverride).toBe(true);
+    expect(terminal.writingStyle).toBe('polished');
     expect(mail.smartFormattingOverride).toBeNull();
     expect(mail.cliFormattingOverride).toBeNull();
+    expect(mail.writingStyle).toBeNull();
     expect(legacy.smartFormattingOverride).toBeNull();
     expect(legacy.cliFormattingOverride).toBeNull();
+    expect(legacy.writingStyle).toBeNull();
   });
 
   it('keeps smart formatting opt-in across settings migrations', () => {

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -2,6 +2,24 @@ export type RecordingMode = 'hold_down' | 'double_tap' | 'both';
 
 export type DoubleTapKey = 'shift_l' | 'alt_l' | 'ctrl_r';
 
+export type WritingStyle =
+  | 'conversational'
+  | 'polished'
+  | 'code_technical'
+  | 'verbatim'
+  | 'notes';
+
+export type WritingStyleChoice = WritingStyle | 'inherit';
+
+export const WRITING_STYLE_OPTIONS: { value: WritingStyleChoice; label: string }[] = [
+  { value: 'inherit', label: 'Inherit current settings' },
+  { value: 'conversational', label: 'Conversational' },
+  { value: 'polished', label: 'Polished prose' },
+  { value: 'code_technical', label: 'Code / technical' },
+  { value: 'verbatim', label: 'Verbatim' },
+  { value: 'notes', label: 'Notes' },
+];
+
 /**
  * Per-app dictation profile. When the frontmost macOS app's bundle id matches
  * `bundleId`, each `*Override` (when non-null) replaces the corresponding global
@@ -14,6 +32,8 @@ export interface AppProfile {
   cleanupOverride: boolean | null;
   smartFormattingOverride: boolean | null;
   cliFormattingOverride: boolean | null;
+  /** Explicit deterministic writing policy. `null` preserves current behavior. */
+  writingStyle: WritingStyle | null;
 }
 
 /**
@@ -356,6 +376,11 @@ export function loadSettings(): Settings {
               typeof p.smartFormattingOverride === 'boolean' ? p.smartFormattingOverride : null,
             cliFormattingOverride:
               typeof p.cliFormattingOverride === 'boolean' ? p.cliFormattingOverride : null,
+            writingStyle:
+              typeof p.writingStyle === 'string' &&
+              ['conversational', 'polished', 'code_technical', 'verbatim', 'notes'].includes(p.writingStyle)
+                ? p.writingStyle as WritingStyle
+                : null,
           }));
       }
 

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -7,12 +7,26 @@ Murmur resolves one immutable `DictationContextSnapshot` for every live recordin
 `dictation_context::resolve` is the only profile resolver. It applies values in this order:
 
 1. Global dictation settings
-2. Matching per-app profile overrides
-3. One-session overrides
+2. The matching profile's explicit writing style
+3. Matching per-app fine-tuning overrides
+4. One-session overrides
 
 One-session overrides are an explicit, typed resolver input but no trigger supplies them yet. This keeps the precedence contract ready for future commands without adding a second app-detection or settings path.
 
-Profiles currently override `autoPaste`, transcript cleanup, Smart Formatting, and CLI formatting. Existing stored profile objects remain valid; missing or `null` overrides still mean "use the global/automatic value." Smart Formatting is a separate opt-in prose stage, so CLI/code/verbatim profiles can explicitly leave it off without changing CLI canonicalization. CLI defaults to conservative automatic detection; On enables command-shaped unknown tools for that profile, while Off disables implicit detection but preserves the explicit spoken `command` trigger. The settings UI prevents duplicates, but persisted or programmatic configuration can contain them. To preserve legacy behavior exactly, each field uses the first matching profile that provides that field; a `null` override falls through to the next duplicate.
+Profiles select an optional `writingStyle` and can fine-tune `autoPaste`, transcript cleanup, Smart Formatting, and CLI formatting. A style is always an explicit user choice; Murmur never infers one from an app name or bundle identifier.
+
+| Writing style | Local deterministic behavior |
+|---|---|
+| Inherit | Preserves the current global/profile behavior byte-for-byte. |
+| Conversational | Removes filler and repeated words, tidies capitalization, keeps wording, and disables automatic command formatting. |
+| Polished prose | Applies conversational cleanup, deterministic vocabulary correction, and explicitly cued prose structure. |
+| Code / technical | Preserves technical surface text, enables deterministic vocabulary correction, and enables reviewed command formatting. |
+| Verbatim | Bypasses cleanup, spoken commands, correction, prose formatting, and command formatting. |
+| Notes | Removes filler without forcing sentence capitalization, applies deterministic correction, and formats explicitly cued lists, paragraphs, lines, and symbols. |
+
+These policies use only Murmur's existing reviewed local formatting APIs. They do not call a cloud service or perform open-ended rewriting. The per-profile Clean, Prose, and Commands controls apply after the preset, so users can visibly fine-tune a category. One-session overrides remain highest precedence.
+
+Existing stored profile objects remain valid; missing, `null`, or malformed styles and overrides mean Inherit. CLI defaults to conservative automatic detection; Commands On enables command-shaped unknown tools for that profile, while Off disables implicit detection but preserves the explicit spoken `command` trigger. Verbatim bypasses the command stage entirely unless a later explicit profile/session CLI override fine-tunes it. The settings UI prevents duplicates, but persisted or programmatic configuration can contain them. To preserve legacy behavior exactly, each field uses the first matching profile that provides that field; a `null` value falls through to the next duplicate.
 
 ## Snapshot contents and lifetime
 
@@ -23,6 +37,7 @@ The snapshot contains only typed values used by the live pipeline:
 - Vocabulary source plus a monotonic configuration version
 - The resolved prompt and immutable correction matcher
 - Enabled command groups
+- Stable resolved writing-style enum
 - Context-capture permissions
 
 `AppState` stores the snapshot with its `recording_id`. Stop and processing paths can retrieve only the matching generation. Cleanup also checks the generation, so a stale pipeline cannot read or clear a newer recording's snapshot. Focus changes and settings changes after recording starts affect only later recordings.
@@ -36,6 +51,8 @@ Context capture is deny-by-default. The current snapshot never grants reading:
 - Clipboard contents as transcription context
 
 This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. A future context feature must add an explicit user setting/profile override and grant the corresponding capture permission in the resolver before any new read path is introduced.
+
+Writing styles also do not change the ASR model, language, vocabulary inputs, prompt, file-saving behavior, clipboard write, auto-paste timing, or destination. Style telemetry contains only the stable resolved enum plus the existing matched-profile boolean; bundle identifiers, labels, setting values, and transcript content are never logged.
 
 ## Extension points
 

--- a/docs/features/smart-formatting.md
+++ b/docs/features/smart-formatting.md
@@ -4,7 +4,7 @@ Smart Formatting is an opt-in, local post-recognition stage for live dictation. 
 
 ## Enablement and context
 
-The global **Smart Formatting** switch is off by default. Per-app profiles can independently inherit, enable, or disable it. Murmur resolves that value once at recording start, so focus and setting changes apply only to the next recording.
+The global **Smart Formatting** switch is off by default. Per-app writing styles can select it as part of a transparent local policy, and the profile's Prose control can independently inherit, enable, or disable it. Murmur resolves that value once at recording start, so focus and setting changes apply only to the next recording.
 
 The stage is skipped for imported-file transcription. CLI/code/verbatim contexts can bypass it through the per-app Smart Formatting override, and any utterance activated by the authoritative CLI grammar bypasses prose rules automatically. CLI canonicalization still runs after Smart Formatting.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -83,13 +83,13 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 
 ## Per-App Profiles
 
-`appProfiles` is an array of `{ bundleId, label, autoPasteOverride, cleanupOverride, smartFormattingOverride, cliFormattingOverride }`. Boolean overrides replace the corresponding global/automatic value for a matching frontmost bundle identifier; `null` means "use global/automatic." Existing persisted entries are migrated by filling missing override fields with `null`.
+`appProfiles` is an array of `{ bundleId, label, writingStyle, autoPasteOverride, cleanupOverride, smartFormattingOverride, cliFormattingOverride }`. `writingStyle` is `null` (Inherit), `conversational`, `polished`, `code_technical`, `verbatim`, or `notes`. It is an explicit user choice; bundle identifiers and labels never classify apps automatically. Boolean overrides fine-tune the resolved style/global value for a matching frontmost bundle identifier; `null` means "inherit." Existing, missing, and malformed persisted style/override fields migrate to `null`.
 
 `smartFormattingEnabled` is a separate boolean setting, off by default. It enables deterministic list, explicit structured-token, and bounded same-utterance correction rules for live prose. Missing or malformed persisted values migrate safely to `false`; it is independent of `smartPunctuation`. `smartFormattingOverride` gives profiles the same Default/On/Off choice.
 
 `cliFormattingOverride` uses the immutable recording-start context. `true` enables profile-mode CLI recognition, `false` disables implicit CLI formatting for that app, and `null` keeps conservative automatic recognition. An explicit spoken `command` trigger remains available in every mode.
 
-At recording start, the backend resolves one immutable context using global settings → matching profile → one-session overrides. Settings or focus changes during recording apply only to the next session. See [Per-App Dictation Context](../features/per-app-profiles.md).
+At recording start, the backend resolves one immutable context using global settings → matching style → matching profile fine-tuning → one-session overrides. Settings or focus changes during recording apply only to the next session. See [Per-App Dictation Context](../features/per-app-profiles.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit Inherit, Conversational, Polished prose, Code / technical, Verbatim, and Notes choices to each per-app profile
- resolve each style into typed local transformation policy in the immutable recording-start context, with existing per-field profile overrides and session overrides retaining precedence
- keep #252 Smart Formatting before the final #256 CLI stage and preserve existing clipboard, auto-paste, file, model, language, and privacy behavior
- expose plain-language transformation categories in Settings and log only the stable resolved style enum/code plus matched-profile state

## Privacy and compatibility
- no bundle-id or app-name style inference
- no selected-text, screen-text, screenshot, or clipboard reads
- no cloud rewrite or open-ended paraphrasing
- missing, malformed, and legacy style values migrate to Inherit
- duplicate profiles retain first-supplied per-field fallthrough semantics

## Validation
- `cargo check`
- `cargo test -- --test-threads=1` — 338 passed, enabled Whisper integration passed, optional Core ML fixture test ignored by design
- `npx tsc --noEmit`
- `npm test -- --run` — 110 passed
- native debug `Murmur.app` built and exercised: created a profile, inspected all presets and category summaries, selected Polished prose, and confirmed persistence after restart
- macOS reports output speakers only and no audio input device, so microphone recording and paste were not claimed or tested; delivery semantics remain covered by the unchanged full Rust suite
- updater signing was not attempted locally because no private signing key is available

Closes #250