### PR TITLE
feat: add local IDE symbol and @file context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Read these before working on a feature:
 - **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
 - **[docs/features/models.md](docs/features/models.md)** — Model management and download
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
+- **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 
 ## File Map
 
@@ -47,6 +48,7 @@ Read these before working on a feature:
 | `audio.rs` | cpal capture, mono conversion, 16kHz resampling |
 | `transcriber/` | whisper-rs model loading and inference |
 | `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
+| `ide_context.rs` | Memory-only bounded IDE symbol and root-relative file index |
 | `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
 | `state.rs` | `DictationState`, `AppState` with mutex-wrapped state |
 | `telemetry.rs` | Structured event system: TauriEmitterLayer, ring buffer, JSONL, privacy stripping |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Opt-in per-app **Local IDE symbols and `@file` context** builds a bounded memory-only index from user-selected roots, corrects unique project symbols, and canonicalizes explicitly triggered file mentions to root-relative text. It never reads screen, selection, or clipboard context; ambiguous or stale references stay unchanged, and reviewed CLI formatting remains authoritative (#253).
 - Per-app **Writing Styles** add explicit Inherit, Conversational, Polished prose, Code / technical, Verbatim, and Notes policies using only local deterministic transforms. Styles resolve once in the immutable recording context, never infer app type or capture app content, and preserve existing delivery behavior (#250).
 - Long Whisper recordings now show a session-scoped provisional transcript in the notch overlay after each reliable incremental chunk. The privacy-safe preview can be disabled in Settings; final clipboard and auto-paste delivery remain unchanged and occur exactly once after stop (#243).
 - **Spoken CLI command formatting** — likely npm/npx, Git, Cargo, Docker, kubectl, and other developer commands now receive deterministic local formatting for versions, flags, paths, operators, quotes, and small canonical aliases. Detection is prefix/trigger/profile bounded, project `package.json` names extend the local lexicon, and ordinary prose remains unchanged (#256).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Read these before working on a feature:
 - **[docs/features/auto-updater.md](docs/features/auto-updater.md)** — Auto-update system
 - **[docs/features/models.md](docs/features/models.md)** — Model management and download
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
+- **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 - **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map
@@ -49,6 +50,7 @@ Read these before working on a feature:
 | `audio.rs` | cpal capture, mono conversion, 16kHz resampling |
 | `transcriber/` | whisper-rs model loading and inference |
 | `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
+| `ide_context.rs` | Memory-only bounded IDE symbol and root-relative file index |
 | `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
 | `state.rs` | `DictationState`, `AppState` with mutex-wrapped state |
 | `telemetry.rs` | Structured event system: TauriEmitterLayer, ring buffer, JSONL, privacy stripping |

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -5826,6 +5826,7 @@ dependencies = [
  "fluidaudio-rs",
  "futures-util",
  "hound",
+ "libc",
  "memory-stats",
  "objc2",
  "objc2-app-kit",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "fmt"]
 tracing-appender = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 aho-corasick = "1"
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["metal"] }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1620,11 +1620,16 @@ fn schedule_ide_scan(
     tauri::async_runtime::spawn(async move {
         let generation = request.generation;
         let roots = request.roots.clone();
+        let cancellation = request.cancellation.clone();
         let result = tokio::task::spawn_blocking(move || {
-            crate::ide_context::build_index(generation, &roots)
+            crate::ide_context::build_index_with_cancellation(
+                generation,
+                &roots,
+                cancellation.as_ref(),
+            )
         })
         .await
-        .unwrap_or(Err("scan_task_failed"));
+        .unwrap_or_else(|_| Err(crate::ide_context::IdeIndexBuildFailure::task_failed()));
 
         let (files, symbols, bytes, capped, ms, outcome_code) = match &result {
             Ok(build) => (
@@ -1635,7 +1640,14 @@ fn schedule_ide_scan(
                 build.stats.ms,
                 1u64,
             ),
-            Err(_) => (0, 0, 0, false, 0, 2u64),
+            Err(failure) => (
+                failure.stats.files as u64,
+                failure.stats.symbols as u64,
+                failure.stats.bytes,
+                failure.stats.capped,
+                failure.stats.ms,
+                failure.outcome_code,
+            ),
         };
         let state = app_handle.state::<State>();
         let adopted = state

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -157,12 +157,26 @@ fn resolve_live_context(
         let sanitized = dictation.custom_vocabulary.replace('\0', "");
         let prompt = combine_prompts(&sanitized, &code_vocab);
         let correction_matcher = app_state.correction_matcher.lock_or_recover().clone();
+        let ide_context_index = bundle_id.and_then(|bundle_id| {
+            dictation
+                .app_profiles
+                .iter()
+                .find(|profile| profile.bundle_id == bundle_id)
+                .filter(|profile| profile.ide_context_enabled)
+                .and_then(|profile| {
+                    app_state
+                        .ide_context
+                        .lock_or_recover()
+                        .snapshot(bundle_id, &profile.ide_project_roots)
+                })
+        });
         let vocabulary_version = app_state.settings_revision.load(Ordering::SeqCst);
         return Arc::new(dictation_context::resolve(ResolverInputs {
             bundle_id,
             global: &dictation,
             prompt,
             correction_matcher,
+            ide_context_index,
             vocabulary_version,
             session_overrides: SessionOverrides::default(),
         }));
@@ -698,6 +712,7 @@ async fn run_transcription_pipeline(
                 .built_in_voice_commands,
             smart_correction_enabled: transformations.correction_enabled,
             smart_formatting_enabled: transformations.smart_formatting_enabled,
+            ide_context_enabled: transformations.ide_context_enabled,
             cli_command_enabled: transformations.cli_formatting_enabled,
         },
     };
@@ -709,6 +724,7 @@ async fn run_transcription_pipeline(
         custom_commands,
         correction_matcher: transformations.correction_matcher.clone(),
         cli_lexicon,
+        ide_context_index: transformations.ide_context_index.clone(),
     };
     let transformed = crate::transcript_transform::transform_transcript(
         text,
@@ -1115,6 +1131,24 @@ pub async fn configure_dictation(
                     .get("smartFormattingOverride")
                     .and_then(|v| v.as_bool());
                 let writing_style = parse_writing_style(p.get("writingStyle"));
+                let ide_context_enabled = p
+                    .get("ideContextEnabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let ide_project_roots = p
+                    .get("ideProjectRoots")
+                    .and_then(|value| value.as_array())
+                    .map(|roots| {
+                        let roots = roots
+                            .iter()
+                            .filter_map(|root| root.as_str())
+                            .map(str::trim)
+                            .filter(|root| !root.is_empty())
+                            .map(str::to_string)
+                            .collect::<Vec<_>>();
+                        crate::ide_context::normalize_config_roots(&roots)
+                    })
+                    .unwrap_or_default();
                 Some(crate::state::AppProfile {
                     bundle_id,
                     label,
@@ -1123,9 +1157,19 @@ pub async fn configure_dictation(
                     cli_formatting_override,
                     smart_formatting_override,
                     writing_style,
+                    ide_context_enabled,
+                    ide_project_roots,
                 })
             })
             .collect();
+        let requests = state
+            .app_state
+            .ide_context
+            .lock_or_recover()
+            .reconcile_profiles(&dictation.app_profiles);
+        for request in requests {
+            schedule_ide_scan(app_handle.clone(), request);
+        }
     }
 
     if let Some(cleanup_enabled) = options.get("cleanupEnabled").and_then(|v| v.as_bool()) {
@@ -1560,6 +1604,153 @@ pub async fn scan_code_vocab(
     Ok(summary)
 }
 
+/// Run a memory-only IDE project scan off the async runtime. Completion adopts
+/// only the still-current generation; root/profile changes and Clear invalidate
+/// the request before it can publish stale symbols.
+fn schedule_ide_scan(
+    app_handle: tauri::AppHandle,
+    request: crate::ide_context::IdeScanRequest,
+) {
+    tracing::info!(
+        target: "pipeline",
+        generation = request.generation,
+        roots = request.roots.len(),
+        "ide_context_scan: start"
+    );
+    tauri::async_runtime::spawn(async move {
+        let generation = request.generation;
+        let roots = request.roots.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            crate::ide_context::build_index(generation, &roots)
+        })
+        .await
+        .unwrap_or(Err("scan_task_failed"));
+
+        let (files, symbols, bytes, capped, ms, outcome_code) = match &result {
+            Ok(build) => (
+                build.stats.files as u64,
+                build.stats.symbols as u64,
+                build.stats.bytes,
+                build.stats.capped,
+                build.stats.ms,
+                1u64,
+            ),
+            Err(_) => (0, 0, 0, false, 0, 2u64),
+        };
+        let state = app_handle.state::<State>();
+        let adopted = state
+            .app_state
+            .ide_context
+            .lock_or_recover()
+            .complete(&request, result);
+        if adopted {
+            state.app_state.bump_settings_revision();
+        }
+        tracing::info!(
+            target: "pipeline",
+            generation,
+            roots = request.roots.len(),
+            files,
+            symbols,
+            bytes,
+            capped,
+            ms,
+            adopted,
+            outcome_code,
+            "ide_context_scan: complete"
+        );
+    });
+}
+
+fn enabled_ide_profile_roots(app_state: &AppState, bundle_id: &str) -> Option<Vec<String>> {
+    app_state
+        .dictation
+        .lock_or_recover()
+        .app_profiles
+        .iter()
+        .find(|profile| profile.bundle_id == bundle_id)
+        .filter(|profile| profile.ide_context_enabled)
+        .map(|profile| profile.ide_project_roots.clone())
+}
+
+fn refresh_expired_ide_context(
+    app_handle: &tauri::AppHandle,
+    app_state: &AppState,
+    bundle_id: Option<&str>,
+) {
+    let Some(bundle_id) = bundle_id else {
+        return;
+    };
+    let Some(roots) = enabled_ide_profile_roots(app_state, bundle_id) else {
+        return;
+    };
+    let request = app_state
+        .ide_context
+        .lock_or_recover()
+        .refresh_if_expired(bundle_id, &roots);
+    if let Some(request) = request {
+        app_state.bump_settings_revision();
+        schedule_ide_scan(app_handle.clone(), request);
+    }
+}
+
+#[tauri::command]
+pub fn get_ide_context_status(
+    state: tauri::State<'_, State>,
+    bundle_id: String,
+) -> crate::ide_context::IdeContextStatus {
+    state
+        .app_state
+        .ide_context
+        .lock_or_recover()
+        .status(bundle_id.trim())
+}
+
+#[tauri::command]
+pub fn refresh_ide_context(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, State>,
+    bundle_id: String,
+) -> Result<crate::ide_context::IdeContextStatus, String> {
+    let bundle_id = bundle_id.trim();
+    let roots = enabled_ide_profile_roots(&state.app_state, bundle_id)
+        .ok_or_else(|| "Enable local project context on this app profile first.".to_string())?;
+    let request = state
+        .app_state
+        .ide_context
+        .lock_or_recover()
+        .begin_refresh(bundle_id, &roots)
+        .ok_or_else(|| "Add at least one project root first.".to_string())?;
+    state.app_state.bump_settings_revision();
+    schedule_ide_scan(app_handle, request);
+    Ok(state
+        .app_state
+        .ide_context
+        .lock_or_recover()
+        .status(bundle_id))
+}
+
+#[tauri::command]
+pub fn clear_ide_context(
+    state: tauri::State<'_, State>,
+    bundle_id: String,
+) -> Result<crate::ide_context::IdeContextStatus, String> {
+    let bundle_id = bundle_id.trim();
+    let roots = enabled_ide_profile_roots(&state.app_state, bundle_id)
+        .ok_or_else(|| "Enable local project context on this app profile first.".to_string())?;
+    state
+        .app_state
+        .ide_context
+        .lock_or_recover()
+        .clear(bundle_id, &roots);
+    state.app_state.bump_settings_revision();
+    Ok(state
+        .app_state
+        .ide_context
+        .lock_or_recover()
+        .status(bundle_id))
+}
+
 #[tauri::command]
 pub async fn start_native_recording(
     app_handle: tauri::AppHandle,
@@ -1618,6 +1809,7 @@ pub async fn start_native_recording(
         }
     };
     let bundle_id = crate::frontmost::frontmost_bundle_id();
+    refresh_expired_ide_context(&app_handle, &state.app_state, bundle_id.as_deref());
     let context = resolve_live_context(&state.app_state, bundle_id.as_deref());
     state.app_state.set_active_context(rid, Arc::clone(&context));
     tracing::info!(
@@ -1630,7 +1822,8 @@ pub async fn start_native_recording(
         vocabulary_version = context.vocabulary.version,
         context_reads_enabled = context.context_capture.selected_text
             || context.context_capture.surrounding_screen_text
-            || context.context_capture.clipboard,
+            || context.context_capture.clipboard
+            || context.context_capture.local_project_index,
         "dictation context resolved"
     );
     tracing::info!(target: "pipeline", "start_native_recording: device={} recording_id={}", device_name.as_deref().unwrap_or("system_default"), rid);

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -7,6 +7,7 @@
 
 use crate::cli_command::CliFormattingMode;
 use crate::correction::CorrectionMatcher;
+use crate::ide_context::IdeContextIndex;
 use crate::state::{AppProfile, DictationState, VoiceCommand, WritingStyle};
 use std::sync::Arc;
 
@@ -24,6 +25,7 @@ pub struct MatchedAppProfile {
     pub cli_formatting_override: Option<bool>,
     pub smart_formatting_override: Option<bool>,
     pub writing_style: Option<WritingStyle>,
+    pub ide_context_enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,6 +59,9 @@ pub struct ContextCapturePermissions {
     pub selected_text: bool,
     pub surrounding_screen_text: bool,
     pub clipboard: bool,
+    /// Permission to use the configured local project roots. This never grants
+    /// screen, selection, or clipboard reads.
+    pub local_project_index: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -79,6 +84,8 @@ pub struct TransformationSettings {
     pub cli_formatting_mode: CliFormattingMode,
     pub cli_formatting_enabled: bool,
     pub smart_formatting_enabled: bool,
+    pub ide_context_enabled: bool,
+    pub ide_context_index: Option<Arc<IdeContextIndex>>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +126,7 @@ pub struct ResolverInputs<'a> {
     pub global: &'a DictationState,
     pub prompt: Option<String>,
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
+    pub ide_context_index: Option<Arc<IdeContextIndex>>,
     pub vocabulary_version: u64,
     pub session_overrides: SessionOverrides,
 }
@@ -130,6 +138,13 @@ pub struct ResolverInputs<'a> {
 /// matching entry with `None` falls through to the next duplicate entry.
 pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
     let global = inputs.global;
+    let explicit_profile = inputs.bundle_id.and_then(|bundle_id| {
+        global
+            .app_profiles
+            .iter()
+            .find(|profile| profile.bundle_id == bundle_id)
+    });
+    let ide_context_enabled = explicit_profile.is_some_and(|profile| profile.ide_context_enabled);
     let writing_style =
         resolve_profile_optional(inputs.bundle_id, &global.app_profiles, |profile| {
             profile
@@ -165,7 +180,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         None => style.cli_formatting_mode.unwrap_or(CliFormattingMode::Auto),
     };
     let cli_formatting_enabled = cli_override.is_some() || style.cli_formatting_enabled;
-    let smart_formatting_enabled = inputs
+    let resolved_smart_formatting = inputs
         .session_overrides
         .smart_formatting_enabled
         .unwrap_or_else(|| {
@@ -178,6 +193,10 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
                 |profile| profile.smart_formatting_override,
             )
         });
+    // The explicit local-project opt-in defines a code context. Deterministic
+    // prose rewriting is always bypassed there, even if another style or
+    // fine-tuning override would otherwise enable it.
+    let smart_formatting_enabled = !ide_context_enabled && resolved_smart_formatting;
     let matched_profile = inputs.bundle_id.and_then(|bundle_id| {
         global
             .app_profiles
@@ -191,6 +210,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
                 cli_formatting_override: profile.cli_formatting_override,
                 smart_formatting_override: profile.smart_formatting_override,
                 writing_style: profile.writing_style,
+                ide_context_enabled: profile.ide_context_enabled,
             })
     });
     let custom_vocab = !global.custom_vocabulary.trim().is_empty();
@@ -233,6 +253,12 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
             cli_formatting_mode,
             cli_formatting_enabled,
             smart_formatting_enabled,
+            ide_context_enabled,
+            ide_context_index: if ide_context_enabled {
+                inputs.ide_context_index
+            } else {
+                None
+            },
         },
         delivery: DeliverySettings {
             auto_paste,
@@ -249,9 +275,12 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
             built_in_voice_commands: voice_commands,
             custom_voice_commands: voice_commands && !global.voice_command_pairs.is_empty(),
         },
-        // No selected-text, screen-text, or clipboard reads exist. Future
-        // features must add an explicit setting/profile override here first.
-        context_capture: ContextCapturePermissions::default(),
+        // No selected-text, screen-text, or clipboard reads exist. The project
+        // index permission is a separate explicit per-profile opt-in.
+        context_capture: ContextCapturePermissions {
+            local_project_index: ide_context_enabled,
+            ..ContextCapturePermissions::default()
+        },
         writing_style,
     }
 }
@@ -374,6 +403,7 @@ mod tests {
                 voice_commands_enabled: snapshot.enabled_command_groups.built_in_voice_commands,
                 smart_correction_enabled: snapshot.transformations.correction_enabled,
                 smart_formatting_enabled: snapshot.transformations.smart_formatting_enabled,
+                ide_context_enabled: snapshot.transformations.ide_context_enabled,
                 cli_command_enabled: snapshot.transformations.cli_formatting_enabled,
             },
         };
@@ -399,6 +429,8 @@ mod tests {
             cli_formatting_override: None,
             smart_formatting_override: None,
             writing_style: None,
+            ide_context_enabled: false,
+            ide_project_roots: Vec::new(),
         }
     }
 
@@ -412,6 +444,7 @@ mod tests {
             global,
             prompt: None,
             correction_matcher: None,
+            ide_context_index: None,
             vocabulary_version: 7,
             session_overrides,
         })
@@ -626,6 +659,42 @@ mod tests {
             ContextCapturePermissions::default()
         );
         assert!(snapshot.delivery.auto_paste);
+    }
+
+    #[test]
+    fn ide_context_requires_explicit_matching_profile_and_bypasses_prose() {
+        let mut global = DictationState {
+            smart_formatting_enabled: true,
+            ..DictationState::default()
+        };
+        let mut editor = profile("com.example.Editor", None, None);
+        editor.ide_context_enabled = true;
+        editor.ide_project_roots = vec!["/explicit/project".to_string()];
+        global.app_profiles = vec![editor];
+
+        let opted_in = resolve_test(
+            &global,
+            Some("com.example.Editor"),
+            SessionOverrides::default(),
+        );
+        assert!(opted_in.transformations.ide_context_enabled);
+        assert!(!opted_in.transformations.smart_formatting_enabled);
+        assert!(opted_in.context_capture.local_project_index);
+        assert!(!opted_in.context_capture.surrounding_screen_text);
+        assert!(!opted_in.context_capture.selected_text);
+        assert!(!opted_in.context_capture.clipboard);
+
+        let ide_named_but_unconfigured = resolve_test(
+            &global,
+            Some("com.apple.dt.Xcode"),
+            SessionOverrides::default(),
+        );
+        assert!(!ide_named_but_unconfigured.transformations.ide_context_enabled);
+        assert!(ide_named_but_unconfigured.transformations.smart_formatting_enabled);
+        assert_eq!(
+            ide_named_but_unconfigured.context_capture,
+            ContextCapturePermissions::default()
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -197,21 +197,15 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
     // prose rewriting is always bypassed there, even if another style or
     // fine-tuning override would otherwise enable it.
     let smart_formatting_enabled = !ide_context_enabled && resolved_smart_formatting;
-    let matched_profile = inputs.bundle_id.and_then(|bundle_id| {
-        global
-            .app_profiles
-            .iter()
-            .find(|profile| profile.bundle_id == bundle_id)
-            .map(|profile| MatchedAppProfile {
-                bundle_id: profile.bundle_id.clone(),
-                label: profile.label.clone(),
-                auto_paste_override: profile.auto_paste_override,
-                cleanup_override: profile.cleanup_override,
-                cli_formatting_override: profile.cli_formatting_override,
-                smart_formatting_override: profile.smart_formatting_override,
-                writing_style: profile.writing_style,
-                ide_context_enabled: profile.ide_context_enabled,
-            })
+    let matched_profile = explicit_profile.map(|profile| MatchedAppProfile {
+        bundle_id: profile.bundle_id.clone(),
+        label: profile.label.clone(),
+        auto_paste_override: profile.auto_paste_override,
+        cleanup_override: profile.cleanup_override,
+        cli_formatting_override: profile.cli_formatting_override,
+        smart_formatting_override: profile.smart_formatting_override,
+        writing_style: profile.writing_style,
+        ide_context_enabled: profile.ide_context_enabled,
     });
     let custom_vocab = !global.custom_vocabulary.trim().is_empty();
     let code_vocab = global.code_vocab_enabled;

--- a/app/src-tauri/src/ide_context.rs
+++ b/app/src-tauri/src/ide_context.rs
@@ -1,0 +1,1008 @@
+//! Explicit, local IDE project context.
+//!
+//! Users opt a per-app profile into one or more local project roots. Murmur
+//! builds a short-lived, memory-only index of source identifiers and
+//! root-relative filenames. No source text, symbol, filename, or absolute path
+//! from this index is serialized or logged.
+
+use crate::correction::{derive_spoken_form, CorrectionMatcher};
+use crate::state::AppProfile;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+pub(crate) const MAX_IDE_ROOTS: usize = 4;
+pub(crate) const MAX_IDE_FILES: usize = 1_000;
+pub(crate) const MAX_IDE_TOTAL_BYTES: u64 = 32 * 1024 * 1024;
+pub(crate) const MAX_IDE_FILE_BYTES: u64 = 512 * 1024;
+pub(crate) const MAX_IDE_SYMBOLS: usize = 500;
+const MAX_IDE_CANDIDATE_SYMBOLS: usize = 10_000;
+const MAX_RELATIVE_PATH_BYTES: usize = 512;
+const MAX_FORMAT_INPUT_BYTES: usize = 16 * 1024;
+const INDEX_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileAlias {
+    tokens: Vec<String>,
+    relative: String,
+}
+
+/// Immutable resources captured by one recording-start context snapshot.
+pub(crate) struct IdeContextIndex {
+    symbol_matcher: Arc<CorrectionMatcher>,
+    file_aliases: Arc<Vec<FileAlias>>,
+    built_at: Instant,
+    valid: AtomicBool,
+}
+
+impl IdeContextIndex {
+    fn is_fresh(&self) -> bool {
+        self.built_at.elapsed() < INDEX_TTL
+    }
+
+    fn is_usable(&self) -> bool {
+        self.valid.load(Ordering::Acquire) && self.is_fresh()
+    }
+
+    fn invalidate(&self) {
+        self.valid.store(false, Ordering::Release);
+    }
+
+    /// Canonicalize explicit file mentions, then apply the unique project-symbol
+    /// matcher. Both operations are deterministic and bounded.
+    pub(crate) fn apply(&self, input: &str) -> String {
+        if !self.is_usable() || input.is_empty() || input.len() > MAX_FORMAT_INPUT_BYTES {
+            return input.to_string();
+        }
+        let with_files = apply_file_mentions(input, &self.file_aliases);
+        let transformed = if self.symbol_matcher.is_empty() {
+            with_files
+        } else {
+            self.symbol_matcher.apply(&with_files)
+        };
+        if self.is_usable() {
+            transformed
+        } else {
+            input.to_string()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct IdeIndexStats {
+    pub roots: usize,
+    pub files: usize,
+    pub symbols: usize,
+    pub bytes: u64,
+    pub capped: bool,
+    pub ms: u64,
+}
+
+pub(crate) struct IdeIndexBuild {
+    pub index: Arc<IdeContextIndex>,
+    pub stats: IdeIndexStats,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryState {
+    Disabled,
+    Empty,
+    Scanning,
+    Ready,
+    Cleared,
+    Error,
+}
+
+impl EntryState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Empty => "empty",
+            Self::Scanning => "scanning",
+            Self::Ready => "ready",
+            Self::Cleared => "cleared",
+            Self::Error => "error",
+        }
+    }
+}
+
+struct ProfileIndexEntry {
+    enabled: bool,
+    roots: Vec<String>,
+    generation: u64,
+    state: EntryState,
+    index: Option<Arc<IdeContextIndex>>,
+    stats: IdeIndexStats,
+}
+
+impl ProfileIndexEntry {
+    fn disabled(generation: u64) -> Self {
+        Self {
+            enabled: false,
+            roots: Vec::new(),
+            generation,
+            state: EntryState::Disabled,
+            index: None,
+            stats: IdeIndexStats::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IdeScanRequest {
+    pub bundle_id: String,
+    pub roots: Vec<String>,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IdeContextStatus {
+    pub state: String,
+    pub generation: u64,
+    pub roots: usize,
+    pub files: usize,
+    pub symbols: usize,
+    pub bytes: u64,
+    pub capped: bool,
+    pub ms: u64,
+}
+
+/// Memory-only store keyed by the explicitly configured profile bundle id.
+#[derive(Default)]
+pub(crate) struct IdeContextStore {
+    next_generation: u64,
+    entries: HashMap<String, ProfileIndexEntry>,
+}
+
+impl IdeContextStore {
+    fn next_generation(&mut self) -> u64 {
+        self.next_generation = self.next_generation.saturating_add(1);
+        self.next_generation
+    }
+
+    fn invalidate_current(&self, bundle_id: &str) {
+        if let Some(index) = self
+            .entries
+            .get(bundle_id)
+            .and_then(|entry| entry.index.as_ref())
+        {
+            index.invalidate();
+        }
+    }
+
+    /// Reconcile the store with the first profile for each bundle id. A root or
+    /// opt-in change invalidates the previous index immediately and returns a
+    /// fresh scan request. Unchanged cleared/error states remain explicit until
+    /// the user refreshes or changes configuration.
+    pub(crate) fn reconcile_profiles(&mut self, profiles: &[AppProfile]) -> Vec<IdeScanRequest> {
+        let mut configs: HashMap<String, (bool, Vec<String>)> = HashMap::new();
+        for profile in profiles {
+            configs.entry(profile.bundle_id.clone()).or_insert_with(|| {
+                (
+                    profile.ide_context_enabled,
+                    normalize_config_roots(&profile.ide_project_roots),
+                )
+            });
+        }
+
+        let existing_ids = self.entries.keys().cloned().collect::<Vec<_>>();
+        for bundle_id in existing_ids {
+            if !configs.contains_key(&bundle_id) {
+                self.invalidate_current(&bundle_id);
+                let generation = self.next_generation();
+                self.entries
+                    .insert(bundle_id, ProfileIndexEntry::disabled(generation));
+            }
+        }
+
+        let mut requests = Vec::new();
+        for (bundle_id, (enabled, roots)) in configs {
+            let changed = self
+                .entries
+                .get(&bundle_id)
+                .is_none_or(|entry| entry.enabled != enabled || entry.roots != roots);
+            if !changed {
+                continue;
+            }
+            self.invalidate_current(&bundle_id);
+            let generation = self.next_generation();
+            let state = if !enabled {
+                EntryState::Disabled
+            } else if roots.is_empty() {
+                EntryState::Empty
+            } else {
+                EntryState::Scanning
+            };
+            self.entries.insert(
+                bundle_id.clone(),
+                ProfileIndexEntry {
+                    enabled,
+                    roots: roots.clone(),
+                    generation,
+                    state,
+                    index: None,
+                    stats: IdeIndexStats {
+                        roots: roots.len(),
+                        ..IdeIndexStats::default()
+                    },
+                },
+            );
+            if state == EntryState::Scanning {
+                requests.push(IdeScanRequest {
+                    bundle_id,
+                    roots,
+                    generation,
+                });
+            }
+        }
+        requests
+    }
+
+    pub(crate) fn begin_refresh(
+        &mut self,
+        bundle_id: &str,
+        roots: &[String],
+    ) -> Option<IdeScanRequest> {
+        let roots = normalize_config_roots(roots);
+        self.invalidate_current(bundle_id);
+        if roots.is_empty() {
+            let generation = self.next_generation();
+            self.entries.insert(
+                bundle_id.to_string(),
+                ProfileIndexEntry {
+                    enabled: true,
+                    roots,
+                    generation,
+                    state: EntryState::Empty,
+                    index: None,
+                    stats: IdeIndexStats::default(),
+                },
+            );
+            return None;
+        }
+        let generation = self.next_generation();
+        self.entries.insert(
+            bundle_id.to_string(),
+            ProfileIndexEntry {
+                enabled: true,
+                roots: roots.clone(),
+                generation,
+                state: EntryState::Scanning,
+                index: None,
+                stats: IdeIndexStats {
+                    roots: roots.len(),
+                    ..IdeIndexStats::default()
+                },
+            },
+        );
+        Some(IdeScanRequest {
+            bundle_id: bundle_id.to_string(),
+            roots,
+            generation,
+        })
+    }
+
+    /// Start a refresh only when a ready index has expired. The expired index is
+    /// revoked before the request is returned, so no recording can use stale
+    /// symbols, including one that already captured the previous generation.
+    pub(crate) fn refresh_if_expired(
+        &mut self,
+        bundle_id: &str,
+        roots: &[String],
+    ) -> Option<IdeScanRequest> {
+        let expired = self
+            .entries
+            .get(bundle_id)
+            .and_then(|entry| entry.index.as_ref())
+            .is_some_and(|index| !index.is_usable());
+        expired
+            .then(|| self.begin_refresh(bundle_id, roots))
+            .flatten()
+    }
+
+    pub(crate) fn clear(&mut self, bundle_id: &str, roots: &[String]) -> u64 {
+        self.invalidate_current(bundle_id);
+        let generation = self.next_generation();
+        let roots = normalize_config_roots(roots);
+        self.entries.insert(
+            bundle_id.to_string(),
+            ProfileIndexEntry {
+                enabled: true,
+                roots: roots.clone(),
+                generation,
+                state: EntryState::Cleared,
+                index: None,
+                stats: IdeIndexStats {
+                    roots: roots.len(),
+                    ..IdeIndexStats::default()
+                },
+            },
+        );
+        generation
+    }
+
+    pub(crate) fn complete(
+        &mut self,
+        request: &IdeScanRequest,
+        result: Result<IdeIndexBuild, &'static str>,
+    ) -> bool {
+        let Some(entry) = self.entries.get_mut(&request.bundle_id) else {
+            return false;
+        };
+        if entry.generation != request.generation
+            || !entry.enabled
+            || entry.roots != request.roots
+            || entry.state != EntryState::Scanning
+        {
+            return false;
+        }
+        match result {
+            Ok(build) => {
+                entry.stats = build.stats;
+                entry.index = Some(build.index);
+                entry.state = EntryState::Ready;
+            }
+            Err(_) => {
+                entry.index = None;
+                entry.state = EntryState::Error;
+            }
+        }
+        true
+    }
+
+    pub(crate) fn snapshot(
+        &self,
+        bundle_id: &str,
+        roots: &[String],
+    ) -> Option<Arc<IdeContextIndex>> {
+        let entry = self.entries.get(bundle_id)?;
+        if !entry.enabled
+            || entry.roots != normalize_config_roots(roots)
+            || entry.state != EntryState::Ready
+        {
+            return None;
+        }
+        entry
+            .index
+            .as_ref()
+            .filter(|index| index.is_usable())
+            .cloned()
+    }
+
+    pub(crate) fn status(&self, bundle_id: &str) -> IdeContextStatus {
+        let Some(entry) = self.entries.get(bundle_id) else {
+            return IdeContextStatus {
+                state: EntryState::Disabled.as_str().to_string(),
+                generation: 0,
+                roots: 0,
+                files: 0,
+                symbols: 0,
+                bytes: 0,
+                capped: false,
+                ms: 0,
+            };
+        };
+        let expired = entry.index.as_ref().is_some_and(|index| !index.is_usable());
+        IdeContextStatus {
+            state: if expired {
+                "stale".to_string()
+            } else {
+                entry.state.as_str().to_string()
+            },
+            generation: entry.generation,
+            roots: entry.stats.roots,
+            files: entry.stats.files,
+            symbols: entry.stats.symbols,
+            bytes: entry.stats.bytes,
+            capped: entry.stats.capped,
+            ms: entry.stats.ms,
+        }
+    }
+}
+
+pub(crate) fn normalize_config_roots(roots: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    roots
+        .iter()
+        .map(|root| root.trim())
+        .filter(|root| !root.is_empty())
+        .filter(|root| seen.insert((*root).to_string()))
+        .take(MAX_IDE_ROOTS)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Build one generation. Roots are canonicalized exactly once, then the walk
+/// uses lexical descendants returned by `read_dir` and refuses all symlinks and
+/// non-regular files before reading.
+pub(crate) fn build_index(
+    _generation: u64,
+    configured_roots: &[String],
+) -> Result<IdeIndexBuild, &'static str> {
+    let started = Instant::now();
+    let mut canonical_roots = Vec::new();
+    let mut seen = HashSet::new();
+    for configured in normalize_config_roots(configured_roots) {
+        let path = Path::new(&configured);
+        if !path.is_absolute() {
+            continue;
+        }
+        let Ok(canonical) = std::fs::canonicalize(path) else {
+            continue;
+        };
+        let Ok(metadata) = std::fs::symlink_metadata(&canonical) else {
+            continue;
+        };
+        if !metadata.file_type().is_dir() || !seen.insert(canonical.clone()) {
+            continue;
+        }
+        canonical_roots.push(canonical);
+    }
+    if canonical_roots.is_empty() {
+        return Err("no_valid_roots");
+    }
+    canonical_roots.sort();
+
+    let mut queue: VecDeque<(usize, PathBuf)> = canonical_roots
+        .iter()
+        .enumerate()
+        .map(|(index, root)| (index, root.clone()))
+        .collect();
+    let mut vocab = crate::vocab::VocabAccumulator::new();
+    let mut indexed_files = Vec::new();
+    let mut files = 0usize;
+    let mut bytes = 0u64;
+    let mut capped = false;
+
+    'walk: while let Some((root_index, dir)) = queue.pop_front() {
+        if files >= MAX_IDE_FILES || bytes >= MAX_IDE_TOTAL_BYTES {
+            capped = true;
+            break;
+        }
+        let root = &canonical_roots[root_index];
+        if !dir.starts_with(root) {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        let mut entries = entries.flatten().collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let name = entry.file_name();
+            let name_lossy = name.to_string_lossy();
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                if name_lossy.starts_with('.') || crate::vocab::is_skipped_dir(&name_lossy) {
+                    continue;
+                }
+                if path.starts_with(root) {
+                    queue.push_back((root_index, path));
+                }
+                continue;
+            }
+            if !file_type.is_file()
+                || name_lossy.starts_with('.')
+                || (!crate::vocab::is_source_file(&path)
+                    && !crate::vocab::is_package_manifest(&path))
+            {
+                continue;
+            }
+            if files >= MAX_IDE_FILES || bytes >= MAX_IDE_TOTAL_BYTES {
+                capped = true;
+                break 'walk;
+            }
+            let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if !metadata.file_type().is_file()
+                || metadata.file_type().is_symlink()
+                || metadata.len() > MAX_IDE_FILE_BYTES
+                || bytes.saturating_add(metadata.len()) > MAX_IDE_TOTAL_BYTES
+            {
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(root) else {
+                continue;
+            };
+            let Some(relative) = relative_path_text(relative) else {
+                continue;
+            };
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            files += 1;
+            bytes = bytes.saturating_add(contents.len() as u64);
+            indexed_files.push(relative);
+            let symbol_cap_reached = if crate::vocab::is_package_manifest(&path) {
+                let mut reached = false;
+                for term in crate::vocab::extract_package_json_terms(&contents) {
+                    if vocab.add_written_term_bounded(&term, MAX_IDE_CANDIDATE_SYMBOLS) {
+                        reached = true;
+                        break;
+                    }
+                }
+                reached
+            } else {
+                vocab.add_source_bounded(&contents, MAX_IDE_CANDIDATE_SYMBOLS)
+            };
+            if symbol_cap_reached {
+                capped = true;
+                break 'walk;
+            }
+        }
+    }
+
+    // Resolve spoken-form ambiguity across the complete bounded scan before
+    // selecting the top terms. Otherwise a lower-ranked collision just beyond
+    // the output cap could make a top-ranked symbol look falsely unique.
+    let ranked = vocab.ranked(usize::MAX);
+    let unique_symbols = unique_spoken_symbols(&ranked)
+        .into_iter()
+        .take(MAX_IDE_SYMBOLS)
+        .collect::<Vec<_>>();
+    let symbol_matcher = Arc::new(CorrectionMatcher::build(&unique_symbols, &[], false, false));
+    let file_aliases = Arc::new(build_file_aliases(&indexed_files));
+    let stats = IdeIndexStats {
+        roots: canonical_roots.len(),
+        files,
+        symbols: unique_symbols.len(),
+        bytes,
+        capped,
+        ms: started.elapsed().as_millis() as u64,
+    };
+    Ok(IdeIndexBuild {
+        index: Arc::new(IdeContextIndex {
+            symbol_matcher,
+            file_aliases,
+            built_at: Instant::now(),
+            valid: AtomicBool::new(true),
+        }),
+        stats,
+    })
+}
+
+fn relative_path_text(path: &Path) -> Option<String> {
+    let text = path.to_str()?.replace(std::path::MAIN_SEPARATOR, "/");
+    if text.is_empty()
+        || text.len() > MAX_RELATIVE_PATH_BYTES
+        || text.starts_with('/')
+        || text
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn unique_spoken_symbols(ranked: &[crate::vocab::RankedTerm]) -> Vec<String> {
+    let mut by_spoken: HashMap<String, Vec<String>> = HashMap::new();
+    for term in ranked {
+        let spoken = derive_spoken_form(&term.term);
+        let values = by_spoken.entry(spoken).or_default();
+        if !values
+            .iter()
+            .any(|value| value.eq_ignore_ascii_case(&term.term))
+        {
+            values.push(term.term.clone());
+        }
+    }
+    ranked
+        .iter()
+        .filter(|term| {
+            let spoken = derive_spoken_form(&term.term);
+            by_spoken
+                .get(&spoken)
+                .is_some_and(|values| values.len() == 1)
+        })
+        .map(|term| term.term.clone())
+        .collect()
+}
+
+fn build_file_aliases(files: &[String]) -> Vec<FileAlias> {
+    let mut candidates: HashMap<Vec<String>, Vec<(usize, String)>> = HashMap::new();
+    for (file_id, relative) in files.iter().enumerate() {
+        let basename = relative.rsplit('/').next().unwrap_or(relative);
+        for tokens in [
+            vec![relative.to_ascii_lowercase()],
+            file_spoken_tokens(relative),
+            vec![basename.to_ascii_lowercase()],
+            file_spoken_tokens(basename),
+        ] {
+            if tokens.is_empty() {
+                continue;
+            }
+            let entries = candidates.entry(tokens).or_default();
+            if !entries.iter().any(|(id, _)| *id == file_id) {
+                entries.push((file_id, relative.clone()));
+            }
+        }
+    }
+    let mut aliases = candidates
+        .into_iter()
+        .filter_map(|(tokens, candidates)| {
+            (candidates.len() == 1).then(|| FileAlias {
+                tokens,
+                relative: candidates[0].1.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    aliases.sort_by(|left, right| {
+        right.tokens.len().cmp(&left.tokens.len()).then_with(|| {
+            right
+                .tokens
+                .join(" ")
+                .len()
+                .cmp(&left.tokens.join(" ").len())
+        })
+    });
+    aliases
+}
+
+fn file_spoken_tokens(relative: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for (component_index, component) in relative.split('/').enumerate() {
+        if component_index > 0 {
+            tokens.push("slash".to_string());
+        }
+        for (part_index, part) in component.split('.').enumerate() {
+            if part_index > 0 {
+                tokens.push("dot".to_string());
+            }
+            tokens.extend(
+                derive_spoken_form(part)
+                    .split_whitespace()
+                    .map(str::to_string),
+            );
+        }
+    }
+    tokens
+}
+
+#[derive(Debug)]
+struct InputToken {
+    lower: String,
+    start: usize,
+    end: usize,
+}
+
+fn tokenize_reference_input(input: &str) -> Vec<InputToken> {
+    let bytes = input.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        let is_token = |byte: u8| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/' | b'@')
+        };
+        if !is_token(bytes[index]) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        while index < bytes.len() && is_token(bytes[index]) {
+            index += 1;
+        }
+        tokens.push(InputToken {
+            lower: input[start..index].to_ascii_lowercase(),
+            start,
+            end: index,
+        });
+    }
+    tokens
+}
+
+fn apply_file_mentions(input: &str, aliases: &[FileAlias]) -> String {
+    let tokens = tokenize_reference_input(input);
+    let mut replacements = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index].lower != "mention" {
+            index += 1;
+            continue;
+        }
+        let candidate_start = index + 1;
+        let matched = aliases.iter().find(|alias| {
+            let end = candidate_start + alias.tokens.len();
+            if end > tokens.len() {
+                return false;
+            }
+            if input[tokens[index].end..tokens[end - 1].start]
+                .bytes()
+                .any(|byte| matches!(byte, b'\n' | b'\r'))
+            {
+                return false;
+            }
+            tokens[candidate_start..end]
+                .iter()
+                .map(|token| token.lower.as_str())
+                .eq(alias.tokens.iter().map(String::as_str))
+        });
+        if let Some(alias) = matched {
+            let end_index = candidate_start + alias.tokens.len() - 1;
+            replacements.push((
+                tokens[index].start,
+                tokens[end_index].end,
+                format!("@{}", alias.relative),
+            ));
+            index = end_index + 1;
+        } else {
+            index += 1;
+        }
+    }
+    if replacements.is_empty() {
+        return input.to_string();
+    }
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    for (start, end, replacement) in replacements {
+        output.push_str(&input[cursor..start]);
+        output.push_str(&replacement);
+        cursor = end;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-ide-context-{tag}-{}-{}",
+            std::process::id(),
+            Instant::now().elapsed().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn profile(bundle_id: &str, enabled: bool, roots: Vec<String>) -> AppProfile {
+        AppProfile {
+            bundle_id: bundle_id.to_string(),
+            label: String::new(),
+            auto_paste_override: None,
+            cleanup_override: None,
+            cli_formatting_override: None,
+            smart_formatting_override: None,
+            writing_style: None,
+            ide_context_enabled: enabled,
+            ide_project_roots: roots,
+        }
+    }
+
+    #[test]
+    fn builds_memory_index_and_formats_symbols_and_unique_files() {
+        let root = scratch_dir("basic");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/recording.rs"),
+            "fn useRecordingState() { useRecordingState(); }",
+        )
+        .unwrap();
+        let build = build_index(7, &[root.to_string_lossy().to_string()]).unwrap();
+        assert_eq!(
+            build.index.apply("use recording state"),
+            "useRecordingState"
+        );
+        assert_eq!(
+            build.index.apply("mention recording dot rs"),
+            "@src/recording.rs"
+        );
+        assert_eq!(
+            build.index.apply("mention src slash recording dot rs"),
+            "@src/recording.rs"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn duplicate_basenames_and_relative_paths_never_guess() {
+        let first = scratch_dir("ambiguous-a");
+        let second = scratch_dir("ambiguous-b");
+        std::fs::create_dir_all(first.join("src")).unwrap();
+        std::fs::create_dir_all(second.join("src")).unwrap();
+        std::fs::write(first.join("src/main.rs"), "fn firstSymbol() {}").unwrap();
+        std::fs::write(second.join("src/main.rs"), "fn secondSymbol() {}").unwrap();
+        let build = build_index(
+            1,
+            &[
+                first.to_string_lossy().to_string(),
+                second.to_string_lossy().to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            build.index.apply("mention main dot rs"),
+            "mention main dot rs"
+        );
+        assert_eq!(
+            build.index.apply("mention src slash main dot rs"),
+            "mention src slash main dot rs"
+        );
+        let _ = std::fs::remove_dir_all(first);
+        let _ = std::fs::remove_dir_all(second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_refuses_symlinked_files_and_directories_outside_root() {
+        use std::os::unix::fs::symlink;
+        let root = scratch_dir("symlink-root");
+        let outside = scratch_dir("symlink-outside");
+        std::fs::write(outside.join("secret.rs"), "fn leakedSecretSymbol() {}").unwrap();
+        symlink(outside.join("secret.rs"), root.join("linked.rs")).unwrap();
+        symlink(&outside, root.join("linked-dir")).unwrap();
+        std::fs::write(root.join("local.rs"), "fn localProjectSymbol() {}").unwrap();
+        let build = build_index(1, &[root.to_string_lossy().to_string()]).unwrap();
+        assert_eq!(build.stats.files, 1);
+        assert_eq!(
+            build.index.apply("leaked secret symbol"),
+            "leaked secret symbol"
+        );
+        assert_eq!(
+            build.index.apply("mention linked dot rs"),
+            "mention linked dot rs"
+        );
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(outside);
+    }
+
+    #[test]
+    fn walk_excludes_hidden_dependency_build_cache_and_disallowed_files() {
+        let root = scratch_dir("excluded");
+        for directory in [
+            ".hidden",
+            "node_modules",
+            "vendor",
+            "target",
+            "build",
+            "cache",
+        ] {
+            std::fs::create_dir_all(root.join(directory)).unwrap();
+            std::fs::write(
+                root.join(directory).join("secret.rs"),
+                "fn excludedProjectSecret() {}",
+            )
+            .unwrap();
+        }
+        std::fs::write(root.join("notes.txt"), "fn textFileSecret() {}").unwrap();
+        std::fs::write(root.join("visible.rs"), "fn visibleProjectSymbol() {}").unwrap();
+        #[cfg(unix)]
+        let _socket = std::os::unix::net::UnixListener::bind(root.join("device.rs")).unwrap();
+
+        let build = build_index(1, &[root.to_string_lossy().to_string()]).unwrap();
+        assert_eq!(build.stats.files, 1);
+        assert_eq!(
+            build.index.apply("excluded project secret"),
+            "excluded project secret"
+        );
+        assert_eq!(build.index.apply("text file secret"), "text file secret");
+        assert_eq!(
+            build.index.apply("visible project symbol"),
+            "visibleProjectSymbol"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn file_formatting_is_explicit_false_positive_safe_and_idempotent() {
+        let aliases = build_file_aliases(&["src/recording.rs".to_string()]);
+        assert_eq!(
+            apply_file_mentions("recording dot rs is useful", &aliases),
+            "recording dot rs is useful"
+        );
+        assert_eq!(
+            apply_file_mentions("please mention recording dot rs, thanks", &aliases),
+            "please @src/recording.rs, thanks"
+        );
+        assert_eq!(
+            apply_file_mentions("@src/recording.rs", &aliases),
+            "@src/recording.rs"
+        );
+        assert_eq!(
+            apply_file_mentions("mention recording\ndot rs", &aliases),
+            "mention recording\ndot rs"
+        );
+    }
+
+    #[test]
+    fn symbol_ambiguity_is_resolved_before_the_output_cap() {
+        let mut ranked = vec![crate::vocab::RankedTerm {
+            term: "fooBar".to_string(),
+            freq: 100,
+        }];
+        ranked.extend((0..MAX_IDE_SYMBOLS).map(|index| crate::vocab::RankedTerm {
+            term: format!("uniqueSymbol{index}"),
+            freq: 1,
+        }));
+        ranked.push(crate::vocab::RankedTerm {
+            term: "foo_bar".to_string(),
+            freq: 1,
+        });
+
+        let selected = unique_spoken_symbols(&ranked)
+            .into_iter()
+            .take(MAX_IDE_SYMBOLS)
+            .collect::<Vec<_>>();
+        assert!(!selected.iter().any(|term| term == "fooBar"));
+        assert!(!selected.iter().any(|term| term == "foo_bar"));
+    }
+
+    #[test]
+    fn root_change_clear_and_expiry_invalidate_generations() {
+        let root = scratch_dir("generation");
+        std::fs::write(root.join("main.rs"), "fn currentSymbol() {}").unwrap();
+        let roots = vec![root.to_string_lossy().to_string()];
+        let mut store = IdeContextStore::default();
+        let request = store
+            .reconcile_profiles(&[profile("com.example.Editor", true, roots.clone())])
+            .remove(0);
+        let build = build_index(request.generation, &request.roots).unwrap();
+        assert!(store.complete(&request, Ok(build)));
+        let captured = store.snapshot("com.example.Editor", &roots).unwrap();
+        assert_eq!(captured.apply("current symbol"), "currentSymbol");
+
+        store.clear("com.example.Editor", &roots);
+        assert!(store.snapshot("com.example.Editor", &roots).is_none());
+        assert_eq!(captured.apply("current symbol"), "current symbol");
+        assert!(!store.complete(&request, build_index(request.generation, &request.roots)));
+
+        let refreshed = store.begin_refresh("com.example.Editor", &roots).unwrap();
+        let build = build_index(refreshed.generation, &refreshed.roots).unwrap();
+        assert!(store.complete(&refreshed, Ok(build)));
+        store
+            .entries
+            .get_mut("com.example.Editor")
+            .unwrap()
+            .index
+            .as_mut()
+            .unwrap();
+        let entry = store.entries.get_mut("com.example.Editor").unwrap();
+        let index = Arc::get_mut(entry.index.as_mut().unwrap()).unwrap();
+        index.built_at = Instant::now() - INDEX_TTL - Duration::from_secs(1);
+        assert!(store.snapshot("com.example.Editor", &roots).is_none());
+        assert!(store
+            .refresh_if_expired("com.example.Editor", &roots)
+            .is_some());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resource_limits_are_explicit_and_bounded() {
+        assert_eq!(MAX_IDE_ROOTS, 4);
+        assert_eq!(MAX_IDE_FILES, 1_000);
+        assert_eq!(MAX_IDE_TOTAL_BYTES, 32 * 1024 * 1024);
+        assert_eq!(MAX_IDE_FILE_BYTES, 512 * 1024);
+        assert_eq!(MAX_IDE_SYMBOLS, 500);
+        assert_eq!(MAX_IDE_CANDIDATE_SYMBOLS, 10_000);
+        assert_eq!(MAX_RELATIVE_PATH_BYTES, 512);
+        assert_eq!(MAX_FORMAT_INPUT_BYTES, 16 * 1024);
+        let mut bounded_vocab = crate::vocab::VocabAccumulator::new();
+        assert!(bounded_vocab.add_source_bounded("firstSymbol secondSymbol thirdSymbol", 2));
+        assert_eq!(bounded_vocab.len(), 2);
+        assert_eq!(
+            normalize_config_roots(&[
+                " /a ".to_string(),
+                "/a".to_string(),
+                "/b".to_string(),
+                "/c".to_string(),
+                "/d".to_string(),
+                "/e".to_string(),
+            ]),
+            vec!["/a", "/b", "/c", "/d"]
+        );
+    }
+}

--- a/app/src-tauri/src/ide_context.rs
+++ b/app/src-tauri/src/ide_context.rs
@@ -8,6 +8,8 @@
 use crate::correction::{derive_spoken_form, CorrectionMatcher};
 use crate::state::AppProfile;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs::OpenOptions;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -20,8 +22,17 @@ pub(crate) const MAX_IDE_FILE_BYTES: u64 = 512 * 1024;
 pub(crate) const MAX_IDE_SYMBOLS: usize = 500;
 const MAX_IDE_CANDIDATE_SYMBOLS: usize = 10_000;
 const MAX_RELATIVE_PATH_BYTES: usize = 512;
+const MAX_CONFIG_ROOT_BYTES: usize = 4_096;
 const MAX_FORMAT_INPUT_BYTES: usize = 16 * 1024;
+const MAX_IDE_SCAN_ENTRIES: usize = 20_000;
+const MAX_IDE_SCAN_DURATION: Duration = Duration::from_secs(10);
 const INDEX_TTL: Duration = Duration::from_secs(60);
+
+const SCAN_OUTCOME_NO_VALID_ROOTS: u64 = 2;
+const SCAN_OUTCOME_TRUNCATED: u64 = 3;
+const SCAN_OUTCOME_CANCELLED: u64 = 4;
+const SCAN_OUTCOME_DEADLINE: u64 = 5;
+const SCAN_OUTCOME_TASK_FAILED: u64 = 6;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FileAlias {
@@ -85,6 +96,21 @@ pub(crate) struct IdeIndexBuild {
     pub stats: IdeIndexStats,
 }
 
+#[derive(Debug)]
+pub(crate) struct IdeIndexBuildFailure {
+    pub stats: IdeIndexStats,
+    pub outcome_code: u64,
+}
+
+impl IdeIndexBuildFailure {
+    pub(crate) fn task_failed() -> Self {
+        Self {
+            stats: IdeIndexStats::default(),
+            outcome_code: SCAN_OUTCOME_TASK_FAILED,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EntryState {
     Disabled,
@@ -114,6 +140,7 @@ struct ProfileIndexEntry {
     generation: u64,
     state: EntryState,
     index: Option<Arc<IdeContextIndex>>,
+    scan_cancel: Option<Arc<AtomicBool>>,
     stats: IdeIndexStats,
 }
 
@@ -125,6 +152,7 @@ impl ProfileIndexEntry {
             generation,
             state: EntryState::Disabled,
             index: None,
+            scan_cancel: None,
             stats: IdeIndexStats::default(),
         }
     }
@@ -135,6 +163,7 @@ pub(crate) struct IdeScanRequest {
     pub bundle_id: String,
     pub roots: Vec<String>,
     pub generation: u64,
+    pub cancellation: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -164,12 +193,13 @@ impl IdeContextStore {
     }
 
     fn invalidate_current(&self, bundle_id: &str) {
-        if let Some(index) = self
-            .entries
-            .get(bundle_id)
-            .and_then(|entry| entry.index.as_ref())
-        {
-            index.invalidate();
+        if let Some(entry) = self.entries.get(bundle_id) {
+            if let Some(index) = entry.index.as_ref() {
+                index.invalidate();
+            }
+            if let Some(cancellation) = entry.scan_cancel.as_ref() {
+                cancellation.store(true, Ordering::Release);
+            }
         }
     }
 
@@ -216,6 +246,8 @@ impl IdeContextStore {
             } else {
                 EntryState::Scanning
             };
+            let cancellation =
+                (state == EntryState::Scanning).then(|| Arc::new(AtomicBool::new(false)));
             self.entries.insert(
                 bundle_id.clone(),
                 ProfileIndexEntry {
@@ -224,6 +256,7 @@ impl IdeContextStore {
                     generation,
                     state,
                     index: None,
+                    scan_cancel: cancellation.clone(),
                     stats: IdeIndexStats {
                         roots: roots.len(),
                         ..IdeIndexStats::default()
@@ -235,6 +268,7 @@ impl IdeContextStore {
                     bundle_id,
                     roots,
                     generation,
+                    cancellation: cancellation.expect("scanning requests have cancellation"),
                 });
             }
         }
@@ -258,12 +292,14 @@ impl IdeContextStore {
                     generation,
                     state: EntryState::Empty,
                     index: None,
+                    scan_cancel: None,
                     stats: IdeIndexStats::default(),
                 },
             );
             return None;
         }
         let generation = self.next_generation();
+        let cancellation = Arc::new(AtomicBool::new(false));
         self.entries.insert(
             bundle_id.to_string(),
             ProfileIndexEntry {
@@ -272,6 +308,7 @@ impl IdeContextStore {
                 generation,
                 state: EntryState::Scanning,
                 index: None,
+                scan_cancel: Some(cancellation.clone()),
                 stats: IdeIndexStats {
                     roots: roots.len(),
                     ..IdeIndexStats::default()
@@ -282,6 +319,7 @@ impl IdeContextStore {
             bundle_id: bundle_id.to_string(),
             roots,
             generation,
+            cancellation,
         })
     }
 
@@ -315,6 +353,7 @@ impl IdeContextStore {
                 generation,
                 state: EntryState::Cleared,
                 index: None,
+                scan_cancel: None,
                 stats: IdeIndexStats {
                     roots: roots.len(),
                     ..IdeIndexStats::default()
@@ -327,7 +366,7 @@ impl IdeContextStore {
     pub(crate) fn complete(
         &mut self,
         request: &IdeScanRequest,
-        result: Result<IdeIndexBuild, &'static str>,
+        result: Result<IdeIndexBuild, IdeIndexBuildFailure>,
     ) -> bool {
         let Some(entry) = self.entries.get_mut(&request.bundle_id) else {
             return false;
@@ -343,14 +382,18 @@ impl IdeContextStore {
             Ok(build) => {
                 entry.stats = build.stats;
                 entry.index = Some(build.index);
+                entry.scan_cancel = None;
                 entry.state = EntryState::Ready;
+                true
             }
-            Err(_) => {
+            Err(failure) => {
+                entry.stats = failure.stats;
                 entry.index = None;
+                entry.scan_cancel = None;
                 entry.state = EntryState::Error;
+                false
             }
         }
-        true
     }
 
     pub(crate) fn snapshot(
@@ -409,6 +452,7 @@ pub(crate) fn normalize_config_roots(roots: &[String]) -> Vec<String> {
         .iter()
         .map(|root| root.trim())
         .filter(|root| !root.is_empty())
+        .filter(|root| root.len() <= MAX_CONFIG_ROOT_BYTES)
         .filter(|root| seen.insert((*root).to_string()))
         .take(MAX_IDE_ROOTS)
         .map(str::to_string)
@@ -418,10 +462,39 @@ pub(crate) fn normalize_config_roots(roots: &[String]) -> Vec<String> {
 /// Build one generation. Roots are canonicalized exactly once, then the walk
 /// uses lexical descendants returned by `read_dir` and refuses all symlinks and
 /// non-regular files before reading.
+#[cfg(test)]
 pub(crate) fn build_index(
+    generation: u64,
+    configured_roots: &[String],
+) -> Result<IdeIndexBuild, IdeIndexBuildFailure> {
+    let cancellation = AtomicBool::new(false);
+    build_index_controlled(
+        generation,
+        configured_roots,
+        &cancellation,
+        MAX_IDE_SCAN_DURATION,
+    )
+}
+
+pub(crate) fn build_index_with_cancellation(
+    generation: u64,
+    configured_roots: &[String],
+    cancellation: &AtomicBool,
+) -> Result<IdeIndexBuild, IdeIndexBuildFailure> {
+    build_index_controlled(
+        generation,
+        configured_roots,
+        cancellation,
+        MAX_IDE_SCAN_DURATION,
+    )
+}
+
+fn build_index_controlled(
     _generation: u64,
     configured_roots: &[String],
-) -> Result<IdeIndexBuild, &'static str> {
+    cancellation: &AtomicBool,
+    max_duration: Duration,
+) -> Result<IdeIndexBuild, IdeIndexBuildFailure> {
     let started = Instant::now();
     let mut canonical_roots = Vec::new();
     let mut seen = HashSet::new();
@@ -442,7 +515,15 @@ pub(crate) fn build_index(
         canonical_roots.push(canonical);
     }
     if canonical_roots.is_empty() {
-        return Err("no_valid_roots");
+        return Err(scan_failure(
+            &started,
+            0,
+            0,
+            0,
+            0,
+            false,
+            SCAN_OUTCOME_NO_VALID_ROOTS,
+        ));
     }
     canonical_roots.sort();
 
@@ -455,23 +536,104 @@ pub(crate) fn build_index(
     let mut indexed_files = Vec::new();
     let mut files = 0usize;
     let mut bytes = 0u64;
-    let mut capped = false;
+    let mut scanned_entries = 0usize;
 
-    'walk: while let Some((root_index, dir)) = queue.pop_front() {
+    while let Some((root_index, dir)) = queue.pop_front() {
+        if cancellation.load(Ordering::Acquire) {
+            return Err(scan_failure(
+                &started,
+                canonical_roots.len(),
+                files,
+                vocab.len(),
+                bytes,
+                false,
+                SCAN_OUTCOME_CANCELLED,
+            ));
+        }
+        if started.elapsed() >= max_duration {
+            return Err(scan_failure(
+                &started,
+                canonical_roots.len(),
+                files,
+                vocab.len(),
+                bytes,
+                true,
+                SCAN_OUTCOME_DEADLINE,
+            ));
+        }
         if files >= MAX_IDE_FILES || bytes >= MAX_IDE_TOTAL_BYTES {
-            capped = true;
-            break;
+            return Err(scan_failure(
+                &started,
+                canonical_roots.len(),
+                files,
+                vocab.len(),
+                bytes,
+                true,
+                SCAN_OUTCOME_TRUNCATED,
+            ));
         }
         let root = &canonical_roots[root_index];
         if !dir.starts_with(root) {
             continue;
         }
+        let Ok(canonical_dir) = std::fs::canonicalize(&dir) else {
+            continue;
+        };
+        let Ok(dir_metadata) = std::fs::symlink_metadata(&dir) else {
+            continue;
+        };
+        if canonical_dir != dir
+            || !canonical_dir.starts_with(root)
+            || !dir_metadata.file_type().is_dir()
+            || dir_metadata.file_type().is_symlink()
+        {
+            continue;
+        }
         let Ok(entries) = std::fs::read_dir(&dir) else {
             continue;
         };
-        let mut entries = entries.flatten().collect::<Vec<_>>();
-        entries.sort_by_key(|entry| entry.file_name());
+        let mut sorted_entries = Vec::new();
         for entry in entries {
+            scanned_entries = scanned_entries.saturating_add(1);
+            if scanned_entries > MAX_IDE_SCAN_ENTRIES {
+                return Err(scan_failure(
+                    &started,
+                    canonical_roots.len(),
+                    files,
+                    vocab.len(),
+                    bytes,
+                    true,
+                    SCAN_OUTCOME_TRUNCATED,
+                ));
+            }
+            if let Ok(entry) = entry {
+                sorted_entries.push(entry);
+            }
+        }
+        sorted_entries.sort_by_key(|entry| entry.file_name());
+        for entry in sorted_entries {
+            if cancellation.load(Ordering::Acquire) {
+                return Err(scan_failure(
+                    &started,
+                    canonical_roots.len(),
+                    files,
+                    vocab.len(),
+                    bytes,
+                    false,
+                    SCAN_OUTCOME_CANCELLED,
+                ));
+            }
+            if started.elapsed() >= max_duration {
+                return Err(scan_failure(
+                    &started,
+                    canonical_roots.len(),
+                    files,
+                    vocab.len(),
+                    bytes,
+                    true,
+                    SCAN_OUTCOME_DEADLINE,
+                ));
+            }
             let name = entry.file_name();
             let name_lossy = name.to_string_lossy();
             let path = entry.path();
@@ -498,8 +660,15 @@ pub(crate) fn build_index(
                 continue;
             }
             if files >= MAX_IDE_FILES || bytes >= MAX_IDE_TOTAL_BYTES {
-                capped = true;
-                break 'walk;
+                return Err(scan_failure(
+                    &started,
+                    canonical_roots.len(),
+                    files,
+                    vocab.len(),
+                    bytes,
+                    true,
+                    SCAN_OUTCOME_TRUNCATED,
+                ));
             }
             let Ok(metadata) = std::fs::symlink_metadata(&path) else {
                 continue;
@@ -517,8 +686,21 @@ pub(crate) fn build_index(
             let Some(relative) = relative_path_text(relative) else {
                 continue;
             };
-            let Ok(contents) = std::fs::read_to_string(&path) else {
-                continue;
+            let remaining = MAX_IDE_TOTAL_BYTES.saturating_sub(bytes);
+            let contents = match read_source_file(&path, root, remaining) {
+                SourceRead::Contents(contents) => contents,
+                SourceRead::Skip => continue,
+                SourceRead::TotalCap => {
+                    return Err(scan_failure(
+                        &started,
+                        canonical_roots.len(),
+                        files,
+                        vocab.len(),
+                        bytes,
+                        true,
+                        SCAN_OUTCOME_TRUNCATED,
+                    ));
+                }
             };
             files += 1;
             bytes = bytes.saturating_add(contents.len() as u64);
@@ -536,8 +718,15 @@ pub(crate) fn build_index(
                 vocab.add_source_bounded(&contents, MAX_IDE_CANDIDATE_SYMBOLS)
             };
             if symbol_cap_reached {
-                capped = true;
-                break 'walk;
+                return Err(scan_failure(
+                    &started,
+                    canonical_roots.len(),
+                    files,
+                    vocab.len(),
+                    bytes,
+                    true,
+                    SCAN_OUTCOME_TRUNCATED,
+                ));
             }
         }
     }
@@ -557,7 +746,7 @@ pub(crate) fn build_index(
         files,
         symbols: unique_symbols.len(),
         bytes,
-        capped,
+        capped: false,
         ms: started.elapsed().as_millis() as u64,
     };
     Ok(IdeIndexBuild {
@@ -569,6 +758,93 @@ pub(crate) fn build_index(
         }),
         stats,
     })
+}
+
+fn scan_failure(
+    started: &Instant,
+    roots: usize,
+    files: usize,
+    symbols: usize,
+    bytes: u64,
+    capped: bool,
+    outcome_code: u64,
+) -> IdeIndexBuildFailure {
+    IdeIndexBuildFailure {
+        stats: IdeIndexStats {
+            roots,
+            files,
+            symbols: symbols.min(MAX_IDE_SYMBOLS),
+            bytes,
+            capped,
+            ms: started.elapsed().as_millis() as u64,
+        },
+        outcome_code,
+    }
+}
+
+enum SourceRead {
+    Contents(String),
+    Skip,
+    TotalCap,
+}
+
+fn read_source_file(path: &Path, root: &Path, remaining: u64) -> SourceRead {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    let Ok(file) = options.open(path) else {
+        return SourceRead::Skip;
+    };
+    let Ok(opened_metadata) = file.metadata() else {
+        return SourceRead::Skip;
+    };
+    if !opened_metadata.file_type().is_file() || opened_metadata.len() > MAX_IDE_FILE_BYTES {
+        return SourceRead::Skip;
+    }
+    let Ok(canonical) = std::fs::canonicalize(path) else {
+        return SourceRead::Skip;
+    };
+    if canonical != path || !canonical.starts_with(root) {
+        return SourceRead::Skip;
+    }
+    let Ok(path_metadata) = std::fs::metadata(&canonical) else {
+        return SourceRead::Skip;
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if opened_metadata.dev() != path_metadata.dev()
+            || opened_metadata.ino() != path_metadata.ino()
+        {
+            return SourceRead::Skip;
+        }
+    }
+    if opened_metadata.len() > remaining {
+        return SourceRead::TotalCap;
+    }
+    let read_limit = MAX_IDE_FILE_BYTES.min(remaining);
+    let mut bytes = Vec::with_capacity(opened_metadata.len() as usize);
+    if file
+        .take(read_limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        return SourceRead::Skip;
+    }
+    if bytes.len() as u64 > MAX_IDE_FILE_BYTES {
+        return SourceRead::Skip;
+    }
+    if bytes.len() as u64 > remaining {
+        return SourceRead::TotalCap;
+    }
+    match String::from_utf8(bytes) {
+        Ok(contents) => SourceRead::Contents(contents),
+        Err(_) => SourceRead::Skip,
+    }
 }
 
 fn relative_path_text(path: &Path) -> Option<String> {
@@ -919,6 +1195,33 @@ mod tests {
     }
 
     #[test]
+    fn symbols_preserve_unicode_line_boundaries_and_are_idempotent() {
+        let root = scratch_dir("symbol-boundaries");
+        std::fs::write(
+            root.join("main.rs"),
+            "fn localProjectSymbol() { localProjectSymbol(); }",
+        )
+        .unwrap();
+        let index = build_index(1, &[root.to_string_lossy().to_string()])
+            .unwrap()
+            .index;
+        assert_eq!(
+            index.apply("café local project symbol naïve"),
+            "café localProjectSymbol naïve"
+        );
+        assert_eq!(
+            index.apply("local project\nsymbol"),
+            "local project\nsymbol"
+        );
+        assert_eq!(index.apply("localProjectSymbol"), "localProjectSymbol");
+        assert_eq!(
+            index.apply(&index.apply("local project symbol")),
+            "localProjectSymbol"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn symbol_ambiguity_is_resolved_before_the_output_cap() {
         let mut ranked = vec![crate::vocab::RankedTerm {
             term: "fooBar".to_string(),
@@ -989,6 +1292,9 @@ mod tests {
         assert_eq!(MAX_IDE_SYMBOLS, 500);
         assert_eq!(MAX_IDE_CANDIDATE_SYMBOLS, 10_000);
         assert_eq!(MAX_RELATIVE_PATH_BYTES, 512);
+        assert_eq!(MAX_CONFIG_ROOT_BYTES, 4_096);
+        assert_eq!(MAX_IDE_SCAN_ENTRIES, 20_000);
+        assert_eq!(MAX_IDE_SCAN_DURATION, Duration::from_secs(10));
         assert_eq!(MAX_FORMAT_INPUT_BYTES, 16 * 1024);
         let mut bounded_vocab = crate::vocab::VocabAccumulator::new();
         assert!(bounded_vocab.add_source_bounded("firstSymbol secondSymbol thirdSymbol", 2));
@@ -1004,5 +1310,50 @@ mod tests {
             ]),
             vec!["/a", "/b", "/c", "/d"]
         );
+        assert!(
+            normalize_config_roots(&[format!("/{}", "a".repeat(MAX_CONFIG_ROOT_BYTES))]).is_empty()
+        );
+    }
+
+    #[test]
+    fn cancelled_deadline_and_truncated_scans_publish_no_generation() {
+        let root = scratch_dir("fail-closed");
+        std::fs::write(root.join("main.rs"), "fn currentProjectSymbol() {}").unwrap();
+        let roots = vec![root.to_string_lossy().to_string()];
+
+        let cancelled = AtomicBool::new(true);
+        let failure = build_index_controlled(1, &roots, &cancelled, MAX_IDE_SCAN_DURATION)
+            .err()
+            .unwrap();
+        assert_eq!(failure.outcome_code, SCAN_OUTCOME_CANCELLED);
+        assert!(!failure.stats.capped);
+
+        let active = AtomicBool::new(false);
+        let failure = build_index_controlled(2, &roots, &active, Duration::ZERO)
+            .err()
+            .unwrap();
+        assert_eq!(failure.outcome_code, SCAN_OUTCOME_DEADLINE);
+        assert!(failure.stats.capped);
+
+        for index in 0..=MAX_IDE_FILES {
+            std::fs::write(
+                root.join(format!("cap-{index:04}.rs")),
+                format!("fn cappedProjectSymbol{index}() {{}}"),
+            )
+            .unwrap();
+        }
+        let mut store = IdeContextStore::default();
+        let request = store
+            .reconcile_profiles(&[profile("com.example.Editor", true, roots.clone())])
+            .remove(0);
+        let failure = build_index(request.generation, &request.roots)
+            .err()
+            .unwrap();
+        assert_eq!(failure.outcome_code, SCAN_OUTCOME_TRUNCATED);
+        assert!(failure.stats.capped);
+        assert!(!store.complete(&request, Err(failure)));
+        assert_eq!(store.status("com.example.Editor").state, "error");
+        assert!(store.snapshot("com.example.Editor", &roots).is_none());
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod dictation_context;
 mod file_output;
 mod frontmost;
 mod injector;
+mod ide_context;
 mod keyboard;
 mod partial_transcript;
 mod platform;
@@ -141,6 +142,9 @@ pub fn run() {
             commands::recording::transcribe_file,
             commands::recording::scan_code_vocab,
             commands::recording::cancel_code_vocab_scan,
+            commands::recording::get_ide_context_status,
+            commands::recording::refresh_ide_context,
+            commands::recording::clear_ide_context,
             commands::permissions::open_system_preferences,
             commands::permissions::check_accessibility_permission,
             commands::permissions::request_accessibility_permission,

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -83,6 +83,14 @@ pub struct AppProfile {
     /// pre-style resolver path byte-for-byte.
     #[serde(default)]
     pub writing_style: Option<WritingStyle>,
+    /// Explicit opt-in to the memory-only local project index for this profile.
+    /// Murmur never infers this from the app label or bundle identifier.
+    #[serde(default)]
+    pub ide_context_enabled: bool,
+    /// User-selected project roots. Only this configuration persists; index
+    /// contents remain memory-only and are rebuilt locally.
+    #[serde(default)]
+    pub ide_project_roots: Vec<String>,
 }
 
 /// A user-defined voice command: when `phrase` is spoken (matched
@@ -218,6 +226,9 @@ pub struct AppState {
     /// `configure_dictation`. Lives outside `DictationState` because the compiled
     /// Aho-Corasick automaton isn't serializable.
     pub correction_matcher: Mutex<Option<std::sync::Arc<crate::correction::CorrectionMatcher>>>,
+    /// Short-lived local project indexes for explicitly opted-in app profiles.
+    /// Contents (symbols and root-relative filenames) are never serialized.
+    pub ide_context: Mutex<crate::ide_context::IdeContextStore>,
     /// At most one bounded incremental Whisper worker is attached to the active
     /// recording. The handle owns no audio; it snapshots one fixed-size window
     /// at a time and stores only reconciled text and timing counters.
@@ -301,6 +312,7 @@ impl Default for AppState {
             cancelled_id: AtomicU64::new(0),
             file_transcribing: AtomicBool::new(false),
             correction_matcher: Mutex::new(None),
+            ide_context: Mutex::new(crate::ide_context::IdeContextStore::default()),
             streaming_session: tokio::sync::Mutex::new(None),
         }
     }
@@ -321,6 +333,7 @@ mod tests {
             global: &settings,
             prompt: None,
             correction_matcher: None,
+            ide_context_index: None,
             vocabulary_version: 0,
             session_overrides: SessionOverrides::default(),
         }))

--- a/app/src-tauri/src/transcript_transform.rs
+++ b/app/src-tauri/src/transcript_transform.rs
@@ -11,11 +11,13 @@ use std::time::Instant;
 use crate::cleanup::CleanupOptions;
 use crate::cli_command::{canonicalize_cli, is_cli_utterance, CliFormattingMode, CliLexicon};
 use crate::correction::CorrectionMatcher;
+use crate::ide_context::IdeContextIndex;
 
 pub(crate) const CLEANUP_STAGE: &str = "cleanup";
 pub(crate) const VOICE_COMMANDS_STAGE: &str = "voice_commands";
 pub(crate) const SMART_CORRECTION_STAGE: &str = "smart_correction";
 pub(crate) const SMART_FORMATTING_STAGE: &str = "smart_formatting";
+pub(crate) const IDE_CONTEXT_STAGE: &str = "ide_context";
 pub(crate) const CLI_COMMAND_STAGE: &str = "cli_command";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +48,7 @@ pub(crate) struct TranscriptStageConfig {
     pub voice_commands_enabled: bool,
     pub smart_correction_enabled: bool,
     pub smart_formatting_enabled: bool,
+    pub ide_context_enabled: bool,
     pub cli_command_enabled: bool,
 }
 
@@ -58,6 +61,7 @@ impl TranscriptStageConfig {
             voice_commands_enabled: false,
             smart_correction_enabled: false,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: false,
         }
     }
@@ -207,6 +211,7 @@ impl TranscriptPipeline {
             custom_commands,
             correction_matcher,
             cli_lexicon,
+            ide_context_index,
         } = resources;
         Self::new(vec![
             Box::new(CleanupStage),
@@ -216,6 +221,9 @@ impl TranscriptPipeline {
             }),
             Box::new(SmartFormattingStage {
                 cli_lexicon: cli_lexicon.clone(),
+            }),
+            Box::new(IdeContextStage {
+                index: ide_context_index,
             }),
             Box::new(CliCommandStage {
                 lexicon: cli_lexicon,
@@ -321,6 +329,7 @@ pub(crate) struct TranscriptTransformResources {
     pub custom_commands: Vec<(String, String)>,
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
     pub cli_lexicon: CliLexicon,
+    pub ide_context_index: Option<Arc<IdeContextIndex>>,
 }
 
 impl TranscriptTransformResources {
@@ -329,6 +338,7 @@ impl TranscriptTransformResources {
             custom_commands: Vec::new(),
             correction_matcher: None,
             cli_lexicon: CliLexicon::from_context(None, &[]),
+            ide_context_index: None,
         }
     }
 }
@@ -407,6 +417,33 @@ struct CliCommandStage {
 
 struct SmartFormattingStage {
     cli_lexicon: CliLexicon,
+}
+
+struct IdeContextStage {
+    index: Option<Arc<IdeContextIndex>>,
+}
+
+impl TranscriptTransform for IdeContextStage {
+    fn name(&self) -> &'static str {
+        IDE_CONTEXT_STAGE
+    }
+
+    fn failure_policy(&self) -> StageFailurePolicy {
+        StageFailurePolicy::Required
+    }
+
+    fn enabled(&self, context: &TranscriptContext) -> bool {
+        context.source == TranscriptSource::Live
+            && context.stages.ide_context_enabled
+            && self.index.is_some()
+    }
+
+    fn transform(&self, text: &str, _context: &TranscriptContext) -> Result<String, StageError> {
+        Ok(self
+            .index
+            .as_ref()
+            .map_or_else(|| text.to_string(), |index| index.apply(text)))
+    }
 }
 
 impl TranscriptTransform for SmartFormattingStage {
@@ -502,6 +539,7 @@ mod tests {
             voice_commands_enabled: true,
             smart_correction_enabled: true,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: true,
         }
     }
@@ -520,6 +558,7 @@ mod tests {
             custom_commands: vec![("my email".to_string(), "test@example.com".to_string())],
             correction_matcher: with_matcher.then(correction_matcher),
             cli_lexicon: CliLexicon::from_context(None, &[]),
+            ide_context_index: None,
         }
     }
 
@@ -617,9 +656,64 @@ mod tests {
                 VOICE_COMMANDS_STAGE,
                 SMART_CORRECTION_STAGE,
                 SMART_FORMATTING_STAGE,
+                IDE_CONTEXT_STAGE,
                 CLI_COMMAND_STAGE,
             ]
         );
+    }
+
+    #[test]
+    fn ide_context_runs_after_generic_resources_and_before_authoritative_cli() {
+        let root = std::env::temp_dir().join(format!(
+            "murmur-transform-ide-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/recording.rs"),
+            "fn localProjectSymbol() { localProjectSymbol(); }",
+        )
+        .unwrap();
+        let ide_index = crate::ide_context::build_index(
+            1,
+            &[root.to_string_lossy().to_string()],
+        )
+        .unwrap()
+        .index;
+        let stages = TranscriptStageConfig {
+            cleanup_enabled: false,
+            cleanup_remove_filler: false,
+            cleanup_capitalize: false,
+            voice_commands_enabled: false,
+            smart_correction_enabled: true,
+            smart_formatting_enabled: false,
+            ide_context_enabled: true,
+            cli_command_enabled: true,
+        };
+        let output = transform_transcript(
+            "use effect mention recording dot rs and local project symbol".to_string(),
+            &live_context(stages),
+            TranscriptTransformResources {
+                correction_matcher: Some(correction_matcher()),
+                ide_context_index: Some(ide_index),
+                ..TranscriptTransformResources::empty()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.text,
+            "useEffect @src/recording.rs and localProjectSymbol"
+        );
+        assert!(output.stages[2].changed);
+        assert_eq!(output.stages[3].outcome, StageOutcome::Skipped);
+        assert!(output.stages[4].changed);
+        assert_eq!(output.stages[5].stage, CLI_COMMAND_STAGE);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -631,6 +725,7 @@ mod tests {
             voice_commands_enabled: false,
             smart_correction_enabled: false,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: false,
         };
         let output = transform_transcript(
@@ -651,6 +746,7 @@ mod tests {
             voice_commands_enabled: true,
             smart_correction_enabled: false,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: false,
         };
         let output = transform_transcript(
@@ -671,6 +767,7 @@ mod tests {
             voice_commands_enabled: false,
             smart_correction_enabled: true,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: false,
         };
         let output = transform_transcript(
@@ -695,7 +792,7 @@ mod tests {
         let output = transform_transcript(raw.to_string(), &context, resources(true)).unwrap();
         assert_eq!(output.text.as_bytes(), raw.as_bytes());
         assert_eq!(output.original_text.as_bytes(), raw.as_bytes());
-        assert_eq!(output.stages.len(), 5);
+        assert_eq!(output.stages.len(), 6);
         assert!(output
             .stages
             .iter()
@@ -711,6 +808,7 @@ mod tests {
             voice_commands_enabled: false,
             smart_correction_enabled: true,
             smart_formatting_enabled: false,
+            ide_context_enabled: false,
             cli_command_enabled: true,
         };
         let raw = "NPM run Tauri dev";
@@ -724,7 +822,8 @@ mod tests {
         assert_eq!(output.text, "npm run tauri dev");
         assert_eq!(output.stages[2].stage, SMART_CORRECTION_STAGE);
         assert_eq!(output.stages[3].stage, SMART_FORMATTING_STAGE);
-        assert_eq!(output.stages[4].stage, CLI_COMMAND_STAGE);
+        assert_eq!(output.stages[4].stage, IDE_CONTEXT_STAGE);
+        assert_eq!(output.stages[5].stage, CLI_COMMAND_STAGE);
     }
 
     #[test]
@@ -736,6 +835,7 @@ mod tests {
             voice_commands_enabled: false,
             smart_correction_enabled: false,
             smart_formatting_enabled: true,
+            ide_context_enabled: false,
             cli_command_enabled: true,
         };
         let prose = transform_transcript(
@@ -747,7 +847,8 @@ mod tests {
         assert_eq!(prose.text, "The tasks are:\n1. Review\n2. Ship");
         assert!(prose.stages[3].changed);
         assert_eq!(prose.stages[3].stage, SMART_FORMATTING_STAGE);
-        assert_eq!(prose.stages[4].stage, CLI_COMMAND_STAGE);
+        assert_eq!(prose.stages[4].stage, IDE_CONTEXT_STAGE);
+        assert_eq!(prose.stages[5].stage, CLI_COMMAND_STAGE);
 
         let command = transform_transcript(
             "command echo open quote first second close quote".to_string(),

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -90,7 +90,7 @@ pub fn is_source_file(path: &Path) -> bool {
 
 /// Project manifests are scanned only for their local package/script names.
 /// Their dependency bodies are not treated as source text.
-fn is_package_manifest(path: &Path) -> bool {
+pub fn is_package_manifest(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.eq_ignore_ascii_case("package.json"))
@@ -140,12 +140,14 @@ fn push_manifest_term(terms: &mut Vec<String>, term: &str) {
 const SKIP_DIRS: &[&str] = &[
     "node_modules", "target", ".git", "dist", "build", ".next", "vendor",
     "__pycache__", ".venv", "venv", ".svn", ".hg", "Pods", "DerivedData",
-    ".cargo", ".idea", ".vscode", "coverage", "out",
+    ".cargo", ".idea", ".vscode", "coverage", "out", "cache", "caches",
 ];
 
 /// Return true if a directory with this name should not be descended into.
 pub fn is_skipped_dir(name: &str) -> bool {
-    SKIP_DIRS.contains(&name)
+    SKIP_DIRS
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(name))
 }
 
 /// Language keywords and ultra-common English/programming words to exclude from
@@ -314,8 +316,33 @@ impl VocabAccumulator {
         }
     }
 
+    /// Fold identifiers until `max_unique` distinct terms have been retained.
+    /// Returns true when a new term was refused at the cap. Existing terms may
+    /// still increment their frequency without growing memory.
+    pub fn add_source_bounded(&mut self, source: &str, max_unique: usize) -> bool {
+        for ident in extract_identifiers(source) {
+            if self.add_identifier_bounded(&ident, max_unique) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn add_written_term(&mut self, term: &str) {
         self.add_identifier(term);
+    }
+
+    pub fn add_written_term_bounded(&mut self, term: &str, max_unique: usize) -> bool {
+        self.add_identifier_bounded(term, max_unique)
+    }
+
+    fn add_identifier_bounded(&mut self, ident: &str, max_unique: usize) -> bool {
+        let key = ident.to_ascii_lowercase();
+        if !self.freq.contains_key(&key) && self.freq.len() >= max_unique {
+            return true;
+        }
+        self.add_identifier(ident);
+        false
     }
 
     /// Fold a single already-extracted identifier into the tallies.

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -152,6 +152,30 @@ const WRITING_STYLE_CATEGORIES: Record<WritingStyleChoice, string> = {
   notes: 'Cleanup on · Vocabulary corrections on · Prose structure on · Automatic command formatting off',
 };
 
+interface IdeContextStatus {
+  state: 'disabled' | 'empty' | 'scanning' | 'ready' | 'stale' | 'cleared' | 'error';
+  generation: number;
+  roots: number;
+  files: number;
+  symbols: number;
+  bytes: number;
+  capped: boolean;
+  ms: number;
+}
+
+function ideStatusText(status: IdeContextStatus | undefined, roots: number): string {
+  if (!status) return roots > 0 ? 'Checking the memory-only index…' : 'Add a project root to build an index.';
+  switch (status.state) {
+    case 'scanning': return `Indexing locally… generation ${status.generation}`;
+    case 'ready': return `Ready · ${status.files} files · ${status.symbols} symbols${status.capped ? ' · capped' : ''}`;
+    case 'stale': return 'Expired safely · refresh to use project symbols again.';
+    case 'cleared': return 'Index cleared from memory. Configured roots are still available.';
+    case 'error': return 'Index unavailable. Check the configured roots and refresh.';
+    case 'empty': return 'Add a project root to build an index.';
+    default: return 'Local project context is off.';
+  }
+}
+
 // Per-app profiles map a macOS bundle id to an explicit writing style plus
 // independent delivery/transformation overrides.
 function AppProfilesEditor({ profiles, onChange }: {
@@ -160,6 +184,30 @@ function AppProfilesEditor({ profiles, onChange }: {
 }) {
   const [bundleId, setBundleId] = useState('');
   const [label, setLabel] = useState('');
+  const [ideStatuses, setIdeStatuses] = useState<Record<string, IdeContextStatus>>({});
+
+  const pollIdeStatuses = useCallback(async () => {
+    const enabled = profiles.filter((profile) => profile.ideContextEnabled);
+    if (enabled.length === 0) return;
+    const pairs = await Promise.all(enabled.map(async (profile) => {
+      try {
+        const status = await invoke<IdeContextStatus>('get_ide_context_status', { bundleId: profile.bundleId });
+        return [profile.bundleId, status] as const;
+      } catch {
+        return null;
+      }
+    }));
+    setIdeStatuses((current) => ({
+      ...current,
+      ...Object.fromEntries(pairs.filter((pair): pair is readonly [string, IdeContextStatus] => pair !== null)),
+    }));
+  }, [profiles]);
+
+  useEffect(() => {
+    void pollIdeStatuses();
+    const timer = window.setInterval(() => void pollIdeStatuses(), 1000);
+    return () => window.clearInterval(timer);
+  }, [pollIdeStatuses]);
 
   const handleAdd = () => {
     const trimmedId = bundleId.trim();
@@ -180,6 +228,8 @@ function AppProfilesEditor({ profiles, onChange }: {
         smartFormattingOverride: null,
         cliFormattingOverride: null,
         writingStyle: null,
+        ideContextEnabled: false,
+        ideProjectRoots: [],
       },
     ]);
     setBundleId('');
@@ -219,6 +269,51 @@ function AppProfilesEditor({ profiles, onChange }: {
       p.bundleId === id
         ? { ...p, writingStyle: choice === 'inherit' ? null : choice as WritingStyle }
         : p));
+  };
+
+  const toggleIdeContext = (id: string) => {
+    onChange(profiles.map((profile) => profile.bundleId === id
+      ? { ...profile, ideContextEnabled: !profile.ideContextEnabled }
+      : profile));
+  };
+
+  const addIdeRoot = async (id: string) => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (typeof selected !== 'string') return;
+      onChange(profiles.map((profile) => {
+        if (profile.bundleId !== id || profile.ideProjectRoots.includes(selected) || profile.ideProjectRoots.length >= 4) {
+          return profile;
+        }
+        return { ...profile, ideProjectRoots: [...profile.ideProjectRoots, selected] };
+      }));
+    } catch {
+      // Dialog cancelled or unavailable — keep the configured roots.
+    }
+  };
+
+  const removeIdeRoot = (id: string, root: string) => {
+    onChange(profiles.map((profile) => profile.bundleId === id
+      ? { ...profile, ideProjectRoots: profile.ideProjectRoots.filter((candidate) => candidate !== root) }
+      : profile));
+  };
+
+  const refreshIdeIndex = async (id: string) => {
+    try {
+      const status = await invoke<IdeContextStatus>('refresh_ide_context', { bundleId: id });
+      setIdeStatuses((current) => ({ ...current, [id]: status }));
+    } catch {
+      // Backend status polling will surface the stable failure state.
+    }
+  };
+
+  const clearIdeIndex = async (id: string) => {
+    try {
+      const status = await invoke<IdeContextStatus>('clear_ide_context', { bundleId: id });
+      setIdeStatuses((current) => ({ ...current, [id]: status }));
+    } catch {
+      // Keep configured roots intact even if the command is unavailable.
+    }
   };
 
   const chipLabel = (kind: string, value: boolean | null) =>
@@ -322,6 +417,80 @@ function AppProfilesEditor({ profiles, onChange }: {
                 >
                   {chipLabel('Commands', p.cliFormattingOverride)}
                 </button>
+              </div>
+              <div className="rounded-lg border border-outline-variant/30 bg-surface-container-lowest p-2.5">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-xs font-medium text-on-surface">Local IDE project context</div>
+                    <p className="mt-1 text-xs text-on-surface-variant">
+                      Explicitly index selected source roots in memory for symbols and <span className="font-mono">@file</span> mentions. Murmur never reads editor text, selections, or the clipboard.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={p.ideContextEnabled}
+                    aria-label={`Local IDE project context for ${p.label || p.bundleId}`}
+                    onClick={() => toggleIdeContext(p.bundleId)}
+                    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary ${p.ideContextEnabled ? 'bg-primary' : 'bg-surface-container-highest'}`}
+                  >
+                    <span className={`inline-block h-4 w-4 rounded-full bg-on-primary shadow transition-transform ${p.ideContextEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                  </button>
+                </div>
+                {p.ideContextEnabled && (
+                  <div className="mt-2.5 space-y-2">
+                    {p.ideProjectRoots.length > 0 ? (
+                      <ul className="space-y-1">
+                        {p.ideProjectRoots.map((root) => (
+                          <li key={root} className="flex items-center gap-2 rounded-md bg-surface-container px-2 py-1.5">
+                            <span className="min-w-0 flex-1 break-all font-mono text-xs text-on-surface">{root}</span>
+                            <button
+                              type="button"
+                              onClick={() => removeIdeRoot(p.bundleId, root)}
+                              className="shrink-0 text-xs text-on-surface-variant underline hover:text-error"
+                            >
+                              Remove root
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-xs text-on-surface-variant">No project roots configured.</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => void addIdeRoot(p.bundleId)}
+                        disabled={p.ideProjectRoots.length >= 4}
+                        className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50"
+                      >
+                        Add project root
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void refreshIdeIndex(p.bundleId)}
+                        disabled={p.ideProjectRoots.length === 0 || ideStatuses[p.bundleId]?.state === 'scanning'}
+                        className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50"
+                      >
+                        Refresh index
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void clearIdeIndex(p.bundleId)}
+                        disabled={p.ideProjectRoots.length === 0}
+                        className="text-xs font-medium text-on-surface-variant underline hover:text-error disabled:opacity-50"
+                      >
+                        Clear index
+                      </button>
+                    </div>
+                    <p className="text-xs text-on-surface-variant" role="status">
+                      {ideStatusText(ideStatuses[p.bundleId], p.ideProjectRoots.length)}
+                    </p>
+                    <p className="text-xs text-on-surface-variant">
+                      Clear index removes only memory contents; Remove root changes the persisted profile configuration. Paths are shown only here and never written to logs.
+                    </p>
+                  </div>
+                )}
               </div>
             </li>
           ))}

--- a/app/src/lib/dictation.test.ts
+++ b/app/src/lib/dictation.test.ts
@@ -17,6 +17,8 @@ describe('buildConfigureOptions', () => {
           smartFormattingOverride: false,
           cliFormattingOverride: true,
           writingStyle: 'code_technical',
+          ideContextEnabled: false,
+          ideProjectRoots: [],
         },
       ],
     });

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -73,6 +73,55 @@ describe('loadSettings', () => {
     expect(legacy.writingStyle).toBeNull();
   });
 
+  it('migrates IDE context as explicit opt-in with bounded persisted roots only', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      appProfiles: [
+        {
+          bundleId: 'com.example.Editor',
+          label: 'Editor',
+          ideContextEnabled: true,
+          ideProjectRoots: [
+            ' /project/one ',
+            '/project/one',
+            '/project/two',
+            '/project/three',
+            '/project/four',
+            '/project/five',
+            42,
+          ],
+          persistedSymbols: ['must-not-survive'],
+          scanResults: { filename: 'must-not-survive.rs' },
+        },
+        {
+          bundleId: 'com.example.Legacy',
+          label: 'Legacy',
+        },
+        {
+          bundleId: 'com.example.Malformed',
+          label: 'Malformed',
+          ideContextEnabled: 'yes',
+          ideProjectRoots: '/project/not-an-array',
+        },
+      ],
+    }));
+
+    const [editor, legacy, malformed] = loadSettings().appProfiles;
+    expect(editor.ideContextEnabled).toBe(true);
+    expect(editor.ideProjectRoots).toEqual([
+      '/project/one',
+      '/project/two',
+      '/project/three',
+      '/project/four',
+    ]);
+    expect(editor).not.toHaveProperty('persistedSymbols');
+    expect(editor).not.toHaveProperty('scanResults');
+    expect(legacy.ideContextEnabled).toBe(false);
+    expect(legacy.ideProjectRoots).toEqual([]);
+    expect(malformed.ideContextEnabled).toBe(false);
+    expect(malformed.ideProjectRoots).toEqual([]);
+  });
+
   it('keeps smart formatting opt-in across settings migrations', () => {
     localStorage.setItem('dictation-settings', JSON.stringify({
       ...DEFAULT_SETTINGS,

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -84,6 +84,7 @@ describe('loadSettings', () => {
           ideProjectRoots: [
             ' /project/one ',
             '/project/one',
+            `/${'x'.repeat(4096)}`,
             '/project/two',
             '/project/three',
             '/project/four',

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -34,6 +34,10 @@ export interface AppProfile {
   cliFormattingOverride: boolean | null;
   /** Explicit deterministic writing policy. `null` preserves current behavior. */
   writingStyle: WritingStyle | null;
+  /** Explicit opt-in to a memory-only local project index for this profile. */
+  ideContextEnabled: boolean;
+  /** User-selected local roots. Index contents are never persisted. */
+  ideProjectRoots: string[];
 }
 
 /**
@@ -381,6 +385,14 @@ export function loadSettings(): Settings {
               ['conversational', 'polished', 'code_technical', 'verbatim', 'notes'].includes(p.writingStyle)
                 ? p.writingStyle as WritingStyle
                 : null,
+            ideContextEnabled: typeof p.ideContextEnabled === 'boolean' ? p.ideContextEnabled : false,
+            ideProjectRoots: Array.isArray(p.ideProjectRoots)
+              ? p.ideProjectRoots
+                  .filter((root): root is string => typeof root === 'string' && root.trim().length > 0)
+                  .map((root) => root.trim())
+                  .filter((root, index, roots) => roots.indexOf(root) === index)
+                  .slice(0, 4)
+              : [],
           }));
       }
 

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -40,6 +40,8 @@ export interface AppProfile {
   ideProjectRoots: string[];
 }
 
+const MAX_IDE_PROJECT_ROOT_BYTES = 4096;
+
 /**
  * A user-defined voice command. When `phrase` is spoken it is replaced by
  * `replacement` (case-insensitive, word-boundary). Applied after the built-in
@@ -390,6 +392,7 @@ export function loadSettings(): Settings {
               ? p.ideProjectRoots
                   .filter((root): root is string => typeof root === 'string' && root.trim().length > 0)
                   .map((root) => root.trim())
+                  .filter((root) => root.length <= MAX_IDE_PROJECT_ROOT_BYTES)
                   .filter((root, index, roots) => roots.indexOf(root) === index)
                   .slice(0, 4)
               : [],

--- a/docs/features/ide-context.md
+++ b/docs/features/ide-context.md
@@ -1,0 +1,51 @@
+# Local IDE Symbols and `@file` Context
+
+Murmur can use an explicitly selected local project root to correct project symbols and canonicalize spoken file references for one configured app profile. The feature is off by default and fully local. Murmur never classifies an app as an IDE from its name or bundle identifier.
+
+## Opt-in and profile scope
+
+In Settings → Application Profiles, enable **Local IDE symbols & @file** on a specific profile and add up to four project roots with the folder picker. The frontmost application's bundle identifier must exactly match that configured profile at recording start. Unsupported, unmatched, disabled, or rootless profiles do not run this stage and preserve the preceding text byte-for-byte.
+
+The selected root paths are visible locally in Settings and are persisted as profile configuration. As with every persisted setting, they remain present in the transparent `dictation-settings` JSON if it is inspected or backed up. Filenames, symbols, source snippets, and scan results are never persisted.
+
+## Index boundary
+
+Each configured root is canonicalized once per scan. Murmur then performs a bounded, read-only walk under that canonical root:
+
+- At most 4 roots, 1,000 files, 32 MiB total, 512 KiB per file, 10,000 candidate symbols with 500 retained, 512 bytes per root-relative path, and 16 KiB per transformed transcript
+- Only allowlisted source files and `package.json` manifests
+- No symlinks, sockets, devices, hidden files/directories, version-control directories, dependency/vendor directories, build output, or cache directories
+- No path that cannot be represented as a clean descendant of its canonical root
+
+The source text exists only while its file is being parsed. The finished index contains only the bounded correction matcher and relative-file aliases in process memory. A ready generation expires after 60 seconds. Root/profile changes, manual refresh, manual clear, cancellation, or expiry invalidate the prior generation before a new scan can be adopted.
+
+Indexing telemetry contains only generation IDs, counts, capped sizes, elapsed time, and outcomes. It never includes roots, basenames, relative or absolute paths, symbols, or source content.
+
+## Deterministic formatting
+
+Project symbols reuse the exact, ambiguity-safe local correction matcher. A spoken form is eligible only when it maps to one unique written symbol in the active generation.
+
+File canonicalization requires the explicit word `mention`:
+
+```text
+mention recording dot rs → @src/recording.rs
+mention src slash recording dot rs → @src/recording.rs
+```
+
+Output is always the canonical root-relative text beginning with `@`; absolute paths are never emitted. If two roots contain the same basename or the same relative candidate, that reference remains unchanged. A longer relative qualification is used only when it resolves uniquely. Existing canonical `@file` text is idempotent, and a filename without the explicit trigger is not rewritten.
+
+## Pipeline and delivery
+
+The live pipeline order is:
+
+```text
+cleanup → voice commands → Smart Correction → Smart Formatting → IDE context → CLI formatting
+```
+
+Explicit IDE opt-in disables Smart Formatting for that recording so prose structure cannot interfere with code-oriented text. Generic correction resources still run first, and the reviewed CLI stage remains final and authoritative. Imported-file transcription never runs the IDE stage.
+
+The immutable recording-start snapshot may capture only the ready memory index for the exact matching opted-in profile. It does not grant selected-text, screen-text, or clipboard reads. Delivery remains unchanged and final-only: one final string reaches optional file output, clipboard, paste, history, and stats.
+
+## Clear versus remove
+
+**Clear index** immediately discards the current memory generation while keeping the selected roots and opt-in. **Remove** beside a root changes persisted configuration and removes that root from future scans. **Refresh index** invalidates the old generation first and builds a new one from the still-configured roots.

--- a/docs/features/ide-context.md
+++ b/docs/features/ide-context.md
@@ -12,12 +12,12 @@ The selected root paths are visible locally in Settings and are persisted as pro
 
 Each configured root is canonicalized once per scan. Murmur then performs a bounded, read-only walk under that canonical root:
 
-- At most 4 roots, 1,000 files, 32 MiB total, 512 KiB per file, 10,000 candidate symbols with 500 retained, 512 bytes per root-relative path, and 16 KiB per transformed transcript
+- At most 4 roots (4,096 bytes per configured root), 1,000 files, 32 MiB total, 512 KiB per file, 10,000 candidate symbols with 500 retained, 20,000 visited directory entries, 512 bytes per root-relative path, 10 seconds per scan, and 16 KiB per transformed transcript
 - Only allowlisted source files and `package.json` manifests
 - No symlinks, sockets, devices, hidden files/directories, version-control directories, dependency/vendor directories, build output, or cache directories
 - No path that cannot be represented as a clean descendant of its canonical root
 
-The source text exists only while its file is being parsed. The finished index contains only the bounded correction matcher and relative-file aliases in process memory. A ready generation expires after 60 seconds. Root/profile changes, manual refresh, manual clear, cancellation, or expiry invalidate the prior generation before a new scan can be adopted.
+The source text exists only while its file is being parsed. Files are opened without following symlinks and revalidated against the canonical root before parsing. The finished index contains only the bounded correction matcher and relative-file aliases in process memory. A ready generation expires after 60 seconds. Root/profile changes, manual refresh, manual clear, cancellation, or expiry invalidate the prior generation before a new scan can be adopted. A cancelled, timed-out, or cap-truncated scan publishes no partial index.
 
 Indexing telemetry contains only generation IDs, counts, capped sizes, elapsed time, and outcomes. It never includes roots, basenames, relative or absolute paths, symbols, or source content.
 

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -13,7 +13,7 @@ Murmur resolves one immutable `DictationContextSnapshot` for every live recordin
 
 One-session overrides are an explicit, typed resolver input but no trigger supplies them yet. This keeps the precedence contract ready for future commands without adding a second app-detection or settings path.
 
-Profiles select an optional `writingStyle` and can fine-tune `autoPaste`, transcript cleanup, Smart Formatting, and CLI formatting. A style is always an explicit user choice; Murmur never infers one from an app name or bundle identifier.
+Profiles select an optional `writingStyle` and can fine-tune `autoPaste`, transcript cleanup, Smart Formatting, CLI formatting, and local IDE project context. A style and IDE-context opt-in are always explicit user choices; Murmur never infers either one from an app name or bundle identifier.
 
 | Writing style | Local deterministic behavior |
 |---|---|
@@ -39,18 +39,19 @@ The snapshot contains only typed values used by the live pipeline:
 - Enabled command groups
 - Stable resolved writing-style enum
 - Context-capture permissions
+- An optional ready, memory-only IDE index for the exact matching opted-in profile
 
 `AppState` stores the snapshot with its `recording_id`. Stop and processing paths can retrieve only the matching generation. Cleanup also checks the generation, so a stale pipeline cannot read or clear a newer recording's snapshot. Focus changes and settings changes after recording starts affect only later recordings.
 
 ## Privacy boundary
 
-Context capture is deny-by-default. The current snapshot never grants reading:
+Context capture is deny-by-default. A profile may explicitly grant only its bounded local project index. The snapshot never grants reading:
 
 - Selected text
 - Nearby or surrounding screen text
 - Clipboard contents as transcription context
 
-This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. A future context feature must add an explicit user setting/profile override and grant the corresponding capture permission in the resolver before any new read path is introduced.
+This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. IDE project context does not change those denials: it reads only user-selected roots through the bounded local index described in [Local IDE Symbols and `@file` Context](ide-context.md). Unmatched profiles and app names that merely look like IDEs remain no-ops.
 
 Writing styles also do not change the ASR model, language, vocabulary inputs, prompt, file-saving behavior, clipboard write, auto-paste timing, or destination. Style telemetry contains only the stable resolved enum plus the existing matched-profile boolean; bundle identifiers, labels, setting values, and transcript content are never logged.
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -96,12 +96,12 @@ Uses `IdleGuard` (RAII) to reset status on any early return or error — prevent
 `transform_transcript()` is the authoritative post-recognition entry point for both live and imported-file transcription. It owns a fixed internal sequence:
 
 ```text
-raw transcript → cleanup → voice commands → Smart Correction → Smart Formatting → CLI formatting → final text
+raw transcript → cleanup → voice commands → Smart Correction → Smart Formatting → IDE context → CLI formatting → final text
 ```
 
 Each stage receives immutable session/source metadata plus privacy-safe enablement flags and produces privacy-safe execution metadata (`duration_us`, changed/not-changed, outcome, and required/optional failure policy). Structured stage logs never include transcript text, model/language settings, app/profile values, custom replacement values, correction vocabulary, package/script names, or project paths.
 
-Cleanup, voice commands, Smart Formatting, and CLI formatting are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. Smart Formatting is live-only and opt-in, fails closed outside its bounded prose grammar, and skips any utterance owned by the CLI grammar. The final CLI stage uses conservative prefix/trigger/profile activation and returns non-command prose byte-for-byte unchanged. Imported-file transcription invokes the same entry point with every stage disabled so its existing raw-ASR output remains unchanged.
+Cleanup, voice commands, Smart Formatting, IDE context, and CLI formatting are required deterministic stages when enabled. Smart Correction is optional-fallback: a future recoverable correction failure leaves the preceding text intact. Smart Formatting is live-only and opt-in, fails closed outside its bounded prose grammar, and skips any utterance owned by the CLI grammar. Explicit IDE opt-in bypasses Smart Formatting, then applies only the matching profile's fresh memory-only project index. The final CLI stage remains authoritative, uses conservative prefix/trigger/profile activation, and returns non-command prose byte-for-byte unchanged. Imported-file transcription invokes the same entry point with every stage disabled so its existing raw-ASR output remains unchanged.
 
 The pipeline result can compare its original and final strings in memory for tests and diagnostics, but only privacy-safe stage metadata is logged. Only the final string reaches optional file output, clipboard/paste, history, and stats; delivery remains final-only and happens once.
 
@@ -110,6 +110,7 @@ File persistence, clipboard/paste, history, and stats are intentionally outside 
 See [Per-App Dictation Context](per-app-profiles.md) for resolver precedence, duplicate-profile compatibility, lifetime, and privacy boundaries.
 See [Spoken CLI Command Formatting](cli-command-formatting.md) for activation, grammar, local lexicon layering, and safety guarantees.
 See [Smart Formatting and Same-Utterance Backtracking](smart-formatting.md) for its explicit prose grammar, bounds, bypass rules, and privacy contract.
+See [Local IDE Symbols and `@file` Context](ide-context.md) for opt-in, scan boundaries, ambiguity, expiry, and privacy guarantees.
 
 ## Model Downloads (`commands/models.rs`)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -83,13 +83,15 @@ Both the Rust-side `DictationState::default()` and the frontend default use `bas
 
 ## Per-App Profiles
 
-`appProfiles` is an array of `{ bundleId, label, writingStyle, autoPasteOverride, cleanupOverride, smartFormattingOverride, cliFormattingOverride }`. `writingStyle` is `null` (Inherit), `conversational`, `polished`, `code_technical`, `verbatim`, or `notes`. It is an explicit user choice; bundle identifiers and labels never classify apps automatically. Boolean overrides fine-tune the resolved style/global value for a matching frontmost bundle identifier; `null` means "inherit." Existing, missing, and malformed persisted style/override fields migrate to `null`.
+`appProfiles` is an array of `{ bundleId, label, writingStyle, autoPasteOverride, cleanupOverride, smartFormattingOverride, cliFormattingOverride, ideContextEnabled, ideProjectRoots }`. `writingStyle` is `null` (Inherit), `conversational`, `polished`, `code_technical`, `verbatim`, or `notes`. It is an explicit user choice; bundle identifiers and labels never classify apps automatically. Boolean overrides fine-tune the resolved style/global value for a matching frontmost bundle identifier; `null` means "inherit." Existing, missing, and malformed persisted style/override fields migrate to `null`.
+
+`ideContextEnabled` defaults to `false` and must be enabled on the exact matching profile. `ideProjectRoots` persists only the explicit user-selected root strings, trimmed, deduplicated, and capped at four. Filenames, symbols, source snippets, and scan results are memory-only and are not settings fields. The roots therefore remain visible in Settings and in any direct inspection or backup of the existing settings JSON; there is no hidden export path.
 
 `smartFormattingEnabled` is a separate boolean setting, off by default. It enables deterministic list, explicit structured-token, and bounded same-utterance correction rules for live prose. Missing or malformed persisted values migrate safely to `false`; it is independent of `smartPunctuation`. `smartFormattingOverride` gives profiles the same Default/On/Off choice.
 
 `cliFormattingOverride` uses the immutable recording-start context. `true` enables profile-mode CLI recognition, `false` disables implicit CLI formatting for that app, and `null` keeps conservative automatic recognition. An explicit spoken `command` trigger remains available in every mode.
 
-At recording start, the backend resolves one immutable context using global settings → matching style → matching profile fine-tuning → one-session overrides. Settings or focus changes during recording apply only to the next session. See [Per-App Dictation Context](../features/per-app-profiles.md).
+At recording start, the backend resolves one immutable context using global settings → matching style → matching profile fine-tuning → one-session overrides. Settings or focus changes during recording apply only to the next session. Explicit IDE opt-in also disables Smart Formatting for that recording and can capture only the matching profile's fresh local index. See [Per-App Dictation Context](../features/per-app-profiles.md) and [Local IDE Symbols and `@file` Context](../features/ide-context.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- add an explicit per-app opt-in for short-lived local project symbol and root-relative file context
- scan only bounded allowlisted source and manifest files under canonical user-selected roots, with symlink, hidden, dependency, build, cache, device, and path-boundary exclusions
- canonicalize uniquely resolved spoken file mentions to root-relative @file text and leave ambiguity unchanged
- place the IDE stage after generic correction and Smart Formatting but before authoritative CLI formatting; opted-in code profiles bypass Smart Formatting
- add clear-versus-remove UI, migration coverage, privacy documentation, and immediate generation revocation

## Privacy and bounds
- index contents are memory-only; only explicit profile roots and opt-in persist
- no screen, selection, or clipboard reads; no command execution or network upload
- logs contain generation IDs, counts, capped sizes, timings, and outcomes only
- limits: 4 roots, 1000 files, 32 MiB total, 512 KiB per file, 10000 symbol candidates with 500 retained, 512-byte relative paths, 16 KiB transform input, 60-second generations

## Validation
- cargo check
- cargo test -- --test-threads=1: 348 unit tests passed, Whisper integration passed, optional Core ML fixture test correctly ignored
- npx tsc --noEmit
- npm test -- --run: 111 tests passed
- debug app bundle produced from src-tauri/tauri.dev.conf.json; command reached only the expected missing TAURI_SIGNING_PRIVATE_KEY condition after producing the app and updater archive
- exact Local Dictation Dev.app native Computer Use QA: launch to Murmur Ready, explicit toggle and no-root state, disabled refresh/clear, directory picker open/cancel, and restored profile state
- local Playwright surface was unavailable because this host has no Chrome distribution; native exact-bundle visual verification completed instead

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-app Local IDE Context using selected project folders.
  * Recognizes unique project symbols and converts explicit file mentions to root-relative `@file` references.
  * Added controls to configure roots, monitor index status, refresh, and clear the in-memory index.
  * Added bounded, privacy-focused indexing with no persisted source content, symbols, or scan results.

* **Documentation**
  * Added setup, privacy, behavior, and settings guidance for Local IDE Context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->