### PR TITLE
Fix reliable frontmost-app profile detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 - Post-recognition cleanup, voice commands, and Smart Correction now run through one ordered, backend-neutral transformation pipeline with privacy-safe per-stage timing/change telemetry and explicit failure policy (#244).
 
+### Fixed
+- Per-app profile matching now uses the native macOS frontmost-application query with bounded retries and a timeout-bounded compatibility fallback, while preserving one immutable recording-start snapshot and privacy-safe detection telemetry (#265).
+
 ## [0.17.2] - 2026-07-19
 
 ### Added

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -1,44 +1,303 @@
 //! Frontmost-app detection used by per-app dictation profiles.
 //!
-//! Reuses the osascript approach from `injector.rs` to ask System Events for
-//! the bundle identifier of whatever app currently owns the keyboard focus.
-//! Detection is best-effort: any failure (osascript missing, permission denied,
-//! empty result) returns `None` so callers fall back to global behaviour.
+//! The primary query uses `NSWorkspace` directly. Transient unavailable/empty
+//! results are retried briefly before the existing System Events AppleScript is
+//! used once as a bounded compatibility fallback. The first successful sample
+//! is returned to the caller and becomes part of its immutable recording
+//! context; failures remain global-only and deny app-specific context reads.
 
-/// Return the bundle identifier of the frontmost macOS app, e.g.
-/// `"com.apple.Terminal"`. Returns `None` on any failure so the caller can fall
-/// back to a global-only dictation context.
-#[cfg(target_os = "macos")]
-pub fn frontmost_bundle_id() -> Option<String> {
-    let output = match crate::injector::run_osascript_with_timeout(
-        r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#,
-    ) {
-        Ok(output) => output,
-        Err(_) => {
-            tracing::warn!(target: "pipeline", "frontmost app query failed");
-            return None;
+#[cfg(any(target_os = "macos", test))]
+use std::time::Duration;
+
+#[cfg(any(target_os = "macos", test))]
+const MAX_NATIVE_ATTEMPTS: usize = 3;
+#[cfg(any(target_os = "macos", test))]
+const NATIVE_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+#[cfg(any(target_os = "macos", test))]
+type QueryResult = Result<Option<String>, ()>;
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetectionSource {
+    None,
+    Native,
+    Osascript,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl DetectionSource {
+    const fn code(self) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::Native => 1,
+            Self::Osascript => 2,
         }
-    };
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct DetectionResult {
+    bundle_id: Option<String>,
+    source: DetectionSource,
+    retry_count: usize,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl DetectionResult {
+    fn outcome_code(&self) -> u64 {
+        u64::from(self.bundle_id.is_some())
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn normalized_bundle_id(result: QueryResult) -> Option<String> {
+    result.ok().flatten().and_then(|bundle_id| {
+        let bundle_id = bundle_id.trim();
+        (!bundle_id.is_empty()).then(|| bundle_id.to_string())
+    })
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn detect_with<N, F, S>(mut native: N, mut fallback: F, mut sleep: S) -> DetectionResult
+where
+    N: FnMut() -> QueryResult,
+    F: FnMut() -> QueryResult,
+    S: FnMut(Duration),
+{
+    for attempt in 0..MAX_NATIVE_ATTEMPTS {
+        if let Some(bundle_id) = normalized_bundle_id(native()) {
+            return DetectionResult {
+                bundle_id: Some(bundle_id),
+                source: DetectionSource::Native,
+                retry_count: attempt,
+            };
+        }
+
+        if attempt + 1 < MAX_NATIVE_ATTEMPTS {
+            sleep(NATIVE_RETRY_DELAY);
+        }
+    }
+
+    let retry_count = MAX_NATIVE_ATTEMPTS.saturating_sub(1);
+    if let Some(bundle_id) = normalized_bundle_id(fallback()) {
+        DetectionResult {
+            bundle_id: Some(bundle_id),
+            source: DetectionSource::Osascript,
+            retry_count,
+        }
+    } else {
+        DetectionResult {
+            bundle_id: None,
+            source: DetectionSource::None,
+            retry_count,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn native_frontmost_bundle_id() -> QueryResult {
+    use objc2_app_kit::NSWorkspace;
+
+    let app = NSWorkspace::sharedWorkspace()
+        .frontmostApplication()
+        .ok_or(())?;
+    Ok(app.bundleIdentifier().map(|value| value.to_string()))
+}
+
+#[cfg(target_os = "macos")]
+fn osascript_frontmost_bundle_id() -> QueryResult {
+    let output = crate::injector::run_osascript_with_timeout(
+        r#"tell application "System Events" to get bundle identifier of first process whose frontmost is true"#,
+    )
+    .map_err(|_| ())?;
 
     if !output.status.success() {
-        tracing::warn!(
-            target: "pipeline",
-            exit_code = output.status.code(),
-            "frontmost app query returned an error"
-        );
-        return None;
+        return Err(());
     }
 
-    let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if bundle_id.is_empty() {
-        None
-    } else {
-        Some(bundle_id)
-    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()))
+}
+
+/// Return the bundle identifier of the first frontmost macOS app observed by
+/// the bounded detector. Returns `None` on total failure so the caller resolves
+/// a global-only dictation context.
+#[cfg(target_os = "macos")]
+pub fn frontmost_bundle_id() -> Option<String> {
+    let started = std::time::Instant::now();
+    let result = detect_with(
+        native_frontmost_bundle_id,
+        osascript_frontmost_bundle_id,
+        std::thread::sleep,
+    );
+    tracing::info!(
+        target: "pipeline",
+        outcome_code = result.outcome_code(),
+        retry_count = result.retry_count as u64,
+        source_code = result.source.code(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "frontmost app detection completed"
+    );
+    result.bundle_id
 }
 
 /// Non-macOS platforms have no frontmost-app concept here; profiles are a no-op.
 #[cfg(not(target_os = "macos"))]
 pub fn frontmost_bundle_id() -> Option<String> {
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn immediate_native_success_skips_retry_and_fallback() {
+        let native_calls = Cell::new(0);
+        let fallback_calls = Cell::new(0);
+        let sleep_calls = Cell::new(0);
+
+        let result = detect_with(
+            || {
+                native_calls.set(native_calls.get() + 1);
+                Ok(Some(" com.apple.Terminal ".to_string()))
+            },
+            || {
+                fallback_calls.set(fallback_calls.get() + 1);
+                Ok(Some("fallback".to_string()))
+            },
+            |_| sleep_calls.set(sleep_calls.get() + 1),
+        );
+
+        assert_eq!(result.bundle_id.as_deref(), Some("com.apple.Terminal"));
+        assert_eq!(result.source, DetectionSource::Native);
+        assert_eq!(result.retry_count, 0);
+        assert_eq!(native_calls.get(), 1);
+        assert_eq!(fallback_calls.get(), 0);
+        assert_eq!(sleep_calls.get(), 0);
+    }
+
+    #[test]
+    fn transient_native_failures_retry_until_success() {
+        let mut native_results = VecDeque::from([
+            Err(()),
+            Ok(Some("  ".to_string())),
+            Ok(Some("com.todesktop.cursor".to_string())),
+        ]);
+        let fallback_calls = Cell::new(0);
+        let sleep_calls = Cell::new(0);
+
+        let result = detect_with(
+            || native_results.pop_front().expect("bounded native attempt"),
+            || {
+                fallback_calls.set(fallback_calls.get() + 1);
+                Err(())
+            },
+            |delay| {
+                assert_eq!(delay, NATIVE_RETRY_DELAY);
+                sleep_calls.set(sleep_calls.get() + 1);
+            },
+        );
+
+        assert_eq!(result.bundle_id.as_deref(), Some("com.todesktop.cursor"));
+        assert_eq!(result.source, DetectionSource::Native);
+        assert_eq!(result.retry_count, 2);
+        assert_eq!(fallback_calls.get(), 0);
+        assert_eq!(sleep_calls.get(), 2);
+    }
+
+    #[test]
+    fn fallback_succeeds_after_native_attempts_are_exhausted() {
+        let native_calls = Cell::new(0);
+        let fallback_calls = Cell::new(0);
+
+        let result = detect_with(
+            || {
+                native_calls.set(native_calls.get() + 1);
+                Err(())
+            },
+            || {
+                fallback_calls.set(fallback_calls.get() + 1);
+                Ok(Some("com.apple.Safari".to_string()))
+            },
+            |_| {},
+        );
+
+        assert_eq!(result.bundle_id.as_deref(), Some("com.apple.Safari"));
+        assert_eq!(result.source, DetectionSource::Osascript);
+        assert_eq!(result.retry_count, 2);
+        assert_eq!(native_calls.get(), MAX_NATIVE_ATTEMPTS);
+        assert_eq!(fallback_calls.get(), 1);
+    }
+
+    #[test]
+    fn total_failure_is_bounded_and_deny_by_default() {
+        let native_calls = Cell::new(0);
+        let fallback_calls = Cell::new(0);
+        let sleep_calls = Cell::new(0);
+
+        let result = detect_with(
+            || {
+                native_calls.set(native_calls.get() + 1);
+                Err(())
+            },
+            || {
+                fallback_calls.set(fallback_calls.get() + 1);
+                Ok(Some(String::new()))
+            },
+            |_| sleep_calls.set(sleep_calls.get() + 1),
+        );
+
+        assert_eq!(result.bundle_id, None);
+        assert_eq!(result.source, DetectionSource::None);
+        assert_eq!(result.outcome_code(), 0);
+        assert_eq!(result.retry_count, 2);
+        assert_eq!(native_calls.get(), MAX_NATIVE_ATTEMPTS);
+        assert_eq!(fallback_calls.get(), 1);
+        assert_eq!(sleep_calls.get(), MAX_NATIVE_ATTEMPTS - 1);
+    }
+
+    #[test]
+    fn app_change_during_retry_uses_first_successful_sample() {
+        let mut native_results = VecDeque::from([
+            Err(()),
+            Ok(Some("com.apple.Terminal".to_string())),
+            Ok(Some("com.apple.Safari".to_string())),
+        ]);
+
+        let result = detect_with(
+            || native_results.pop_front().expect("bounded native attempt"),
+            || Err(()),
+            |_| {},
+        );
+
+        assert_eq!(result.bundle_id.as_deref(), Some("com.apple.Terminal"));
+        assert_eq!(result.retry_count, 1);
+        assert_eq!(
+            native_results.len(),
+            1,
+            "later focus changes are not sampled"
+        );
+    }
+
+    #[test]
+    fn first_success_is_immutable_even_if_the_app_would_change() {
+        let mut native_results = VecDeque::from([
+            Ok(Some("com.apple.Terminal".to_string())),
+            Ok(Some("com.apple.Safari".to_string())),
+        ]);
+
+        let result = detect_with(
+            || native_results.pop_front().expect("bounded native attempt"),
+            || Err(()),
+            |_| {},
+        );
+
+        assert_eq!(result.bundle_id.as_deref(), Some("com.apple.Terminal"));
+        assert_eq!(result.retry_count, 0);
+        assert_eq!(native_results.len(), 1, "detector must not re-read focus");
+    }
 }

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -43,6 +43,12 @@ The snapshot contains only typed values used by the live pipeline:
 
 `AppState` stores the snapshot with its `recording_id`. Stop and processing paths can retrieve only the matching generation. Cleanup also checks the generation, so a stale pipeline cannot read or clear a newer recording's snapshot. Focus changes and settings changes after recording starts affect only later recordings.
 
+### Frontmost-app sampling
+
+At recording start, Murmur queries the native macOS `NSWorkspace` frontmost application first. An unavailable or empty native result is retried twice at 10 ms intervals, then the timeout-bounded System Events query is attempted once as a compatibility fallback. The nominal worst-case query budget is 270 ms: 20 ms of retry delay plus the fallback's 250 ms timeout.
+
+The first successful sample wins and is resolved into the immutable snapshot exactly once. If focus changes after a successful native sample, the original app remains active for that recording. If an early native sample is unavailable while the user switches apps, the first later successful native or fallback sample becomes active for the recording. If every query fails, Murmur resolves an unmatched global-only context; app-specific IDE/context reads remain disabled.
+
 ## Privacy boundary
 
 Context capture is deny-by-default. A profile may explicitly grant only its bounded local project index. The snapshot never grants reading:
@@ -54,6 +60,8 @@ Context capture is deny-by-default. A profile may explicitly grant only its boun
 This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. IDE project context does not change those denials: it reads only user-selected roots through the bounded local index described in [Local IDE Symbols and `@file` Context](ide-context.md). Unmatched profiles and app names that merely look like IDEs remain no-ops.
 
 Writing styles also do not change the ASR model, language, vocabulary inputs, prompt, file-saving behavior, clipboard write, auto-paste timing, or destination. Style telemetry contains only the stable resolved enum plus the existing matched-profile boolean; bundle identifiers, labels, setting values, and transcript content are never logged.
+
+Frontmost-app detection telemetry likewise contains only a numeric outcome code, retry count, numeric source code, and elapsed milliseconds. It never contains the detected bundle identifier, application name, profile label, project roots, or user content.
 
 ## Extension points
 


### PR DESCRIPTION
## Summary
- query the frontmost macOS application through native `NSWorkspace` first, with two short retries and one timeout-bounded System Events fallback
- preserve first-success recording-start snapshot semantics and deny app-specific context on total failure
- emit only numeric privacy-safe detection telemetry and document rapid-switch behavior

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` (356 unit tests + Whisper integration passed; optional Core ML fixture test ignored)
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] native debug app build and launch
- [x] 20/20 unconfigured-app recording starts detected natively and remained unmatched
- [x] 20/20 Cursor recording starts detected natively and matched the configured Cursor profile
- [x] 20/20 Terminal frontmost queries detected Terminal through the production native detector path
- [x] matching Terminal snapshot changed synthetic IDE and profile-only CLI fixtures; wrong-app and unconfigured snapshots preserved both inputs and denied IDE reads
- [x] detection telemetry contained exactly `elapsed_ms`, `outcome_code`, `retry_count`, and `source_code`

## Additional native acceptance evidence

An ephemeral ignored-test harness activated Terminal, waited until macOS reported it frontmost, then exercised the same bounded detector used at recording start twenty consecutive times. All 20 samples returned `outcome_code=1`, `source_code=1` (native), `retry_count=0`; measured detector latency was 1–54 μs. The harness printed no bundle identifiers, profile labels, paths, or transcript content.

A second ephemeral harness exercised the production immutable `dictation_context::resolve` snapshot and `transcript_transform::transform_transcript` path with a bounded synthetic in-memory IDE index:

```text
matched_profile=true
ide_changed=true
cli_profile_changed=true
wrong_app_ide_skipped=true
wrong_app_cli_unchanged=true
unconfigured_ide_skipped=true
unconfigured_cli_unchanged=true
context_reads_terminal=true
context_reads_wrong=false
```

Both harnesses passed and were removed. The branch remains clean at commit `951c57f`.

## Host limitation

Actual microphone capture still reaches this host's existing CoreAudio blocker and recovers to Ready:

`Failed to get input config: A backend-specific error has occurred: An unknown error unknown to the coreaudio-rs API occurred`

No microphone/final-paste coverage is claimed. The missing frontmost-app, immutable snapshot, IDE-stage, and profile-only CLI-stage acceptance paths were covered synthetically through production code despite that hardware limitation.

Closes #265