### PR TITLE
fix: exclude one-time shared backend init from per-model load timing

### DIFF
--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -14,6 +14,11 @@ use tauri::Emitter;
 
 const PARAKEET_CPU_MODEL: &str = "parakeet-tdt-0.6b-v2-fp16";
 
+/// Whisper model names ordered smallest-to-largest. Used to pick the
+/// cheapest selected whisper model for the untimed shared-init warm-up.
+const WHISPER_SIZE_ORDER: &[&str] =
+    &["tiny.en", "base.en", "small.en", "medium.en", "large-v3-turbo"];
+
 struct Fixture {
     id: &'static str,
     label: &'static str,
@@ -127,6 +132,10 @@ pub struct ModelResult {
     pub warm_p95_ms: Option<f64>,
     pub realtime_factor: Option<f64>,
     pub word_error_rate: Option<f64>,
+    /// Process-RSS delta measured around this model's run. Models are
+    /// benchmarked sequentially in one process, so allocator retention from
+    /// an earlier model can inflate a later model's baseline; treat this as
+    /// a rough signal, not an isolated per-model measurement.
     pub memory_delta_mb: u64,
     pub fixtures: Vec<FixtureResult>,
     pub error: Option<String>,
@@ -148,6 +157,13 @@ pub struct BenchmarkReport {
     pub platform: String,
     pub preset: BenchmarkPreset,
     pub iterations: usize,
+    /// Duration of the untimed warm-up pass run once before any per-model
+    /// timing, in milliseconds. This absorbs one-time shared backend init
+    /// (Metal shader compilation, ANE compile cache, etc.) that would
+    /// otherwise be misattributed to whichever model happens to load first.
+    /// It IS representative of real first-launch latency, just not a
+    /// per-model attribute.
+    pub shared_init_ms: f64,
     pub results: Vec<ModelResult>,
     pub recommendations: Recommendations,
 }
@@ -460,6 +476,34 @@ fn prepare_fixtures(
         .collect()
 }
 
+/// Decide which model(s) to load-and-drop during the untimed shared-init
+/// warm-up pass. Picks the smallest selected whisper model (whisper models
+/// share one Metal/shader init cost, so only one needs warming) plus one
+/// entry per non-whisper backend family that is selected, since each of
+/// those (Core ML ANE compile cache, sherpa-onnx) has its own separate
+/// shared init cost. Returns an empty plan when nothing is selected.
+fn warmup_plan(selected: &[BenchmarkModel]) -> Vec<String> {
+    let mut plan = Vec::new();
+
+    let whisper_pick = WHISPER_SIZE_ORDER.iter().find_map(|candidate| {
+        selected
+            .iter()
+            .find(|model| model.model_name == *candidate)
+            .map(|model| model.model_name.clone())
+    });
+    if let Some(model_name) = whisper_pick {
+        plan.push(model_name);
+    }
+
+    for model_name in [COREML_MODEL_NAME, PARAKEET_CPU_MODEL] {
+        if selected.iter().any(|model| model.model_name == model_name) {
+            plan.push(model_name.to_string());
+        }
+    }
+
+    plan
+}
+
 fn recommendations(results: &[ModelResult]) -> Recommendations {
     let successful = results
         .iter()
@@ -529,9 +573,35 @@ pub fn run(
     let fixtures = prepare_fixtures(request.preset.fixtures(), 0.5)?;
     let iterations = request.preset.iterations();
     let steps_per_model = 1 + fixtures.len() * (1 + iterations);
-    let total_steps = selected.len() * steps_per_model;
+    let warmup_targets = warmup_plan(&selected);
+    let total_steps = selected.len() * steps_per_model + warmup_targets.len();
     let mut completed = 0;
     let mut results = Vec::with_capacity(selected.len());
+
+    // Untimed warm-up pass: absorb one-time shared backend init (Metal
+    // shader compilation, ANE compile cache, ...) before any per-model
+    // timing starts, so it isn't misattributed to whichever model happens
+    // to load first. See BenchmarkReport::shared_init_ms.
+    let mut shared_init_ms = 0.0;
+    for target in &warmup_targets {
+        if coordinator.is_cancelled() {
+            return Err("Benchmark cancelled".to_string());
+        }
+        if let Some(model) = selected
+            .iter()
+            .find(|candidate| candidate.model_name == *target)
+        {
+            emit_progress(app, completed, total_steps, model, None, "priming");
+        }
+        if let Ok(mut backend) = backend_for(target) {
+            let warmup_started = Instant::now();
+            if backend.load_model(target).is_ok() {
+                shared_init_ms += warmup_started.elapsed().as_secs_f64() * 1000.0;
+            }
+            backend.reset();
+        }
+        completed += 1;
+    }
 
     for model in selected {
         let model_start = completed;
@@ -709,6 +779,7 @@ pub fn run(
         platform: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
         preset: request.preset,
         iterations,
+        shared_init_ms,
         results,
         recommendations,
     })
@@ -763,6 +834,48 @@ mod tests {
         assert!(!coordinator.try_start_shared_backend_change());
         coordinator.finish();
         assert!(coordinator.try_start_shared_backend_change());
+    }
+
+    fn model(name: &'static str) -> BenchmarkModel {
+        benchmark_models()
+            .into_iter()
+            .find(|model| model.model_name == name)
+            .unwrap_or_else(|| panic!("{name} missing from benchmark catalog"))
+    }
+
+    #[test]
+    fn warmup_plan_is_empty_when_nothing_is_selected() {
+        assert!(warmup_plan(&[]).is_empty());
+    }
+
+    #[test]
+    fn warmup_plan_picks_the_smallest_selected_whisper_model() {
+        let selected = [model("medium.en"), model("tiny.en"), model("base.en")];
+        assert_eq!(warmup_plan(&selected), vec!["tiny.en".to_string()]);
+    }
+
+    #[test]
+    fn warmup_plan_skips_whisper_when_no_whisper_model_is_selected() {
+        let selected = [model(PARAKEET_CPU_MODEL)];
+        assert_eq!(warmup_plan(&selected), vec![PARAKEET_CPU_MODEL.to_string()]);
+    }
+
+    #[test]
+    fn warmup_plan_warms_each_selected_backend_family_once() {
+        let selected = [
+            model("base.en"),
+            model("large-v3-turbo"),
+            model(PARAKEET_CPU_MODEL),
+            model(COREML_MODEL_NAME),
+        ];
+        assert_eq!(
+            warmup_plan(&selected),
+            vec![
+                "base.en".to_string(),
+                COREML_MODEL_NAME.to_string(),
+                PARAKEET_CPU_MODEL.to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -415,6 +415,12 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
               <p className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400">
                 {report.platform} / Murmur v{report.appVersion} / {report.preset}
               </p>
+              <p
+                className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400"
+                title="One-time shared backend init (Metal shader compilation, ANE compile cache, etc.) measured once before per-model timing, so it doesn't skew any single model's cold-load number."
+              >
+                Shared init (one-time): {milliseconds(report.sharedInitMs)}
+              </p>
             </div>
             <button
               type="button"
@@ -525,7 +531,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-stone-500 dark:text-stone-400">
                     <span>Cold load</span><span className="text-right tabular-nums">{milliseconds(result.modelLoadMs)}</span>
                     <span>First inference</span><span className="text-right tabular-nums">{milliseconds(result.firstInferenceMs)}</span>
-                    <span>Memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB</span>
+                    <span title="Process RSS delta. Models run sequentially in one process, so allocator retention from an earlier model can inflate a later model's baseline — treat as a rough signal, not an isolated measurement.">Memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB</span>
                   </div>
                   {result.fixtures.map((fixture) => (
                     <div key={fixture.fixtureId} className="text-[11px] leading-relaxed">

--- a/app/src/lib/benchmark.test.ts
+++ b/app/src/lib/benchmark.test.ts
@@ -15,6 +15,7 @@ function report(createdAt: string): BenchmarkReport {
     platform: 'macos aarch64',
     preset: 'quick',
     iterations: 3,
+    sharedInitMs: 1200,
     results: [],
     recommendations: { fastest: null, mostAccurate: null, balanced: null },
   };

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -18,7 +18,7 @@ export interface BenchmarkProgress {
   modelName: string;
   modelLabel: string;
   fixture: string | null;
-  phase: 'loading' | 'warming' | 'measuring' | 'complete';
+  phase: 'priming' | 'loading' | 'warming' | 'measuring' | 'complete';
 }
 
 export interface BenchmarkActivity {
@@ -51,6 +51,10 @@ export interface BenchmarkModelResult {
   warmP95Ms: number | null;
   realtimeFactor: number | null;
   wordErrorRate: number | null;
+  /** Process-RSS delta for this model's run. Models are benchmarked
+   * sequentially in one process, so allocator retention from an earlier
+   * model can inflate a later model's baseline — treat as a rough signal,
+   * not an isolated per-model measurement. */
   memoryDeltaMb: number;
   fixtures: BenchmarkFixtureResult[];
   error: string | null;
@@ -62,6 +66,11 @@ export interface BenchmarkReport {
   platform: string;
   preset: BenchmarkPreset;
   iterations: number;
+  /** Duration (ms) of the untimed warm-up pass run once before any
+   * per-model timing, absorbing one-time shared backend init (Metal shader
+   * compilation, ANE compile cache, etc). Represents real first-launch
+   * latency but is not a per-model attribute. */
+  sharedInitMs: number;
   results: BenchmarkModelResult[];
   recommendations: {
     fastest: string | null;
@@ -131,6 +140,7 @@ function isBenchmarkReport(value: unknown): value is BenchmarkReport {
     && typeof value.platform === 'string'
     && (value.preset === 'quick' || value.preset === 'standard' || value.preset === 'thorough')
     && isNumber(value.iterations)
+    && isNumber(value.sharedInitMs)
     && Array.isArray(value.results)
     && value.results.every(isModelResult)
     && isNullableString(value.recommendations.fastest)


### PR DESCRIPTION
## Problem

Cold benchmark runs charged one-time shared backend init (Metal shader
compilation, Core ML ANE compile cache) to whichever model happened to
load first, e.g. `tiny.en` `modelLoadMs = 12,586ms` while the 2x-larger
`base.en` loaded in `69ms` in the same run (warm `tiny.en` = `84ms`).
That makes per-model load numbers misleading and unstable across
machines and first runs.

## Fix

- Add an untimed warm-up pass before the timed per-model benchmark
  loop: load-and-drop a backend context for the smallest selected
  whisper model (whisper models share one Metal init cost), plus one
  entry per selected non-whisper backend family (Core ML, sherpa-onnx
  Parakeet), each of which has its own separate shared init.
- Report the measured duration once as a new `BenchmarkReport.sharedInitMs`
  field instead of folding it into any single model's `modelLoadMs`.
  It's real first-launch latency, just not a per-model attribute.
- Emit a `"priming"` progress step for the warm-up pass so the UI
  progress/step count (`steps_per_model` math) stays truthful.
- Factored the warm-up target selection into a plain, unit-tested
  `warmup_plan()` function (handles: no whisper models selected,
  picking the smallest whisper model among several selected, warming
  each selected non-whisper backend family once).
- Documented (without re-architecting) that `memoryDeltaMb` is a
  sequential-process RSS delta that can be skewed by allocator
  retention from earlier models in the same run — added a doc comment
  on the Rust field, the mirroring TS field, and a UI tooltip.
- Mirrored the new `sharedInitMs` field and `"priming"` phase in the
  frontend `benchmark.ts` types/validator and surfaced it in the
  Performance Lab dashboard header.

## Test evidence (run on macbook via SSH worktree)

```
cd app/src-tauri && cargo check                    # clean
cargo test -- --test-threads=1                      # 371 passed; 0 failed; 0 ignored
cargo test benchmark:: -- --test-threads=1           # 10 passed (incl. 4 new warmup_plan tests)
```

```
cd app && npm ci && npx tsc --noEmit                 # no errors
npx vitest run src/lib/benchmark.test.ts             # 4 passed
```

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Shared init (one-time)” metric to benchmark reports.
  * Added a priming phase to benchmark progress tracking.
  * Improved benchmark warm-up handling for more consistent model comparisons.
* **Documentation**
  * Added explanations for shared initialization time and memory increase measurements.
* **Bug Fixes**
  * Updated report validation and storage handling to support the new benchmark metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->