### PR TITLE
fix: make whisper single_segment decoding duration-conditional

### DIFF
--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -11,6 +11,29 @@ static INIT_LOGGING: Once = Once::new();
 /// Relative path under the platform data directory for app models.
 const APP_MODELS_REL: &[&str] = &["local-dictation", "models"];
 
+/// Above this many samples, whisper.cpp's `single_segment` mode is unsafe:
+/// small models can emit an early end-of-text token roughly 24s into a 28s
+/// window, and `single_segment` force-skips the *entire* 30s decode window
+/// on early EOT (discarding the unread tail) instead of resuming decode from
+/// the last emitted timestamp. 12s gives comfortable headroom under the
+/// ~24s failure point observed in production while covering every
+/// streaming window (10s) with margin to spare.
+///
+/// Streaming's incremental windows ([`super::chunking::WINDOW_SAMPLES`], 10s)
+/// stay under this threshold and keep `single_segment = true`, which is
+/// correct and desired there: each window is short enough that early EOT
+/// isn't observed in practice, and single-segment output avoids spurious
+/// segment splits within a short utterance. Longer batch/file transcriptions
+/// cross the threshold and get multi-segment decoding so the tail isn't
+/// silently dropped.
+const SINGLE_SEGMENT_MAX_SECONDS: usize = 12;
+
+/// Decide whether whisper should be constrained to a single output segment
+/// for a given sample count. See [`SINGLE_SEGMENT_MAX_SECONDS`] for why.
+fn should_use_single_segment(sample_count: usize) -> bool {
+    sample_count <= SINGLE_SEGMENT_MAX_SECONDS * super::WHISPER_SAMPLE_RATE as usize
+}
+
 /// Suppress whisper.cpp verbose logging by installing a trampoline that routes to Rust's log crate
 /// (which we don't configure, so logs go nowhere).
 fn suppress_whisper_logs() {
@@ -164,7 +187,7 @@ impl TranscriptionBackend for WhisperBackend {
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
         params.set_suppress_blank(true);
-        params.set_single_segment(true);
+        params.set_single_segment(should_use_single_segment(samples.len()));
         if let Some(prompt) = initial_prompt {
             params.set_initial_prompt(prompt);
         }
@@ -184,7 +207,7 @@ impl TranscriptionBackend for WhisperBackend {
             let segment_text = segment
                 .to_str()
                 .map_err(|e| format!("Failed to get text for segment {}: {}", i, e))?;
-            text.push_str(segment_text);
+            append_segment(&mut text, segment_text);
         }
 
         let trimmed = text.trim().to_string();
@@ -240,6 +263,24 @@ fn whisper_language_param(language: &str) -> Option<&str> {
     }
 }
 
+/// Append a whisper segment's text to the accumulated transcript, inserting a
+/// separating space only when neither side already has whitespace at the
+/// join. Whisper.cpp segments *usually* carry their own leading space (it's
+/// part of the BPE token), which is why the single-segment path historically
+/// got away with a bare `push_str`. Multi-segment decoding (see
+/// [`should_use_single_segment`]) makes the join point observable more often,
+/// so this guards against words gluing together across a segment boundary
+/// (e.g. "...dictating" + "The next..." => "...dictatingThe next...").
+fn append_segment(text: &mut String, segment_text: &str) {
+    let needs_space = !text.is_empty()
+        && !text.ends_with(char::is_whitespace)
+        && !segment_text.starts_with(char::is_whitespace);
+    if needs_space {
+        text.push(' ');
+    }
+    text.push_str(segment_text);
+}
+
 fn strip_punctuation(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut result = String::with_capacity(input.len());
@@ -277,7 +318,10 @@ fn strip_punctuation(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{strip_punctuation, whisper_language_param};
+    use super::{
+        append_segment, get_model_path, should_use_single_segment, specific_model_exists,
+        strip_punctuation, whisper_language_param, TranscriptionBackend, WhisperBackend,
+    };
 
     #[test]
     fn language_auto_maps_to_none() {
@@ -331,5 +375,223 @@ mod tests {
     #[test]
     fn strip_preserves_french_contraction() {
         assert_eq!(strip_punctuation("c'est la vie!"), "c'est la vie");
+    }
+
+    // --- should_use_single_segment ---------------------------------------
+
+    #[test]
+    fn streaming_windows_stay_single_segment() {
+        // Streaming's incremental decode window (see transcriber::chunking::
+        // WINDOW_SAMPLES) is 10s of 16kHz audio. That must remain
+        // single-segment: streaming behavior is correct today and this issue
+        // must not change it.
+        let window_samples = 10 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(window_samples));
+    }
+
+    #[test]
+    fn streaming_step_size_stays_single_segment() {
+        // STEP_SAMPLES (8s) is smaller than WINDOW_SAMPLES but exercise it
+        // too since some call sites may transcribe partial windows.
+        let step_samples = 8 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(step_samples));
+    }
+
+    #[test]
+    fn xlong_batch_audio_disables_single_segment() {
+        // The production repro: a 28s batch/file transcription must not be
+        // constrained to a single segment, or whisper.cpp's early-EOT
+        // force-skip silently drops the tail.
+        let xlong_samples = 28 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(!should_use_single_segment(xlong_samples));
+    }
+
+    #[test]
+    fn boundary_exactly_at_threshold_is_single_segment() {
+        let boundary = 12 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(boundary));
+    }
+
+    #[test]
+    fn boundary_one_sample_over_threshold_is_multi_segment() {
+        let boundary = 12 * super::super::WHISPER_SAMPLE_RATE as usize + 1;
+        assert!(!should_use_single_segment(boundary));
+    }
+
+    #[test]
+    fn zero_samples_is_single_segment() {
+        assert!(should_use_single_segment(0));
+    }
+
+    // --- append_segment ----------------------------------------------------
+
+    #[test]
+    fn append_segment_first_segment_starts_text() {
+        let mut text = String::new();
+        append_segment(&mut text, " Hello");
+        assert_eq!(text, " Hello");
+    }
+
+    #[test]
+    fn append_segment_preserves_existing_leading_space() {
+        // Mirrors whisper.cpp's normal behavior: each segment's text already
+        // carries its own leading space as part of the BPE token, so no
+        // extra separator should be inserted.
+        let mut text = String::new();
+        append_segment(&mut text, " Hello");
+        append_segment(&mut text, " world.");
+        assert_eq!(text.trim(), "Hello world.");
+    }
+
+    #[test]
+    fn append_segment_inserts_space_when_both_sides_lack_one() {
+        // Defensive case: if a segment boundary ever lacks whitespace on
+        // both sides, words must not glue together.
+        let mut text = String::new();
+        append_segment(&mut text, "Hello");
+        append_segment(&mut text, "world");
+        assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn append_segment_does_not_double_space() {
+        let mut text = String::new();
+        append_segment(&mut text, "Hello ");
+        append_segment(&mut text, " world");
+        assert_eq!(text, "Hello  world");
+    }
+
+    // --- model-backed repro + fix proof (require installed .en models) ----
+    //
+    // Run on a machine with the models installed:
+    //   cargo test -- --ignored --nocapture --test-threads=1 xlong
+
+    /// Reproduces the bug directly: same model, same audio, only the
+    /// `single_segment` flag flipped. `single_segment = true` must truncate
+    /// the 28s xlong fixture (fewer words recovered) relative to
+    /// `single_segment = false`, matching the production repro in issue #269.
+    #[test]
+    #[ignore]
+    fn xlong_truncation_repro_single_segment() {
+        use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+        let wav = include_bytes!("../../../../bench/audio/xlong.wav");
+        let samples =
+            crate::transcriber::parse_wav_to_samples(wav).expect("decode xlong fixture");
+
+        let mut ran_any = false;
+        for model_name in ["tiny.en", "base.en"] {
+            let model_path = match get_model_path(model_name) {
+                Ok(path) => path,
+                Err(_) => {
+                    eprintln!("skipping {model_name}: model not installed");
+                    continue;
+                }
+            };
+            ran_any = true;
+            let path_str = model_path.to_str().expect("model path is valid UTF-8");
+
+            let run = |single_segment: bool| -> String {
+                let ctx = WhisperContext::new_with_params(
+                    path_str,
+                    WhisperContextParameters::default(),
+                )
+                .expect("load whisper model");
+                let mut state = ctx.create_state().expect("create whisper state");
+                let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+                params.set_language(Some("en"));
+                params.set_print_special(false);
+                params.set_print_progress(false);
+                params.set_print_realtime(false);
+                params.set_print_timestamps(false);
+                params.set_suppress_blank(true);
+                params.set_single_segment(single_segment);
+                state.full(params, &samples).expect("transcribe xlong fixture");
+
+                let mut text = String::new();
+                for i in 0..state.full_n_segments() {
+                    let segment = state.get_segment(i).expect("segment");
+                    let segment_text = segment.to_str().expect("segment text");
+                    append_segment(&mut text, segment_text);
+                }
+                text.trim().to_string()
+            };
+
+            let truncated = run(true);
+            let complete = run(false);
+            let truncated_words = truncated.split_whitespace().count();
+            let complete_words = complete.split_whitespace().count();
+
+            eprintln!(
+                "{model_name}: single_segment=true -> {truncated_words} words: {truncated:?}"
+            );
+            eprintln!(
+                "{model_name}: single_segment=false -> {complete_words} words: {complete:?}"
+            );
+
+            assert!(
+                complete_words > truncated_words,
+                "{model_name}: expected single_segment=false to recover more words than \
+                 single_segment=true (got {complete_words} vs {truncated_words}); this was \
+                 supposed to reproduce the issue #269 truncation"
+            );
+        }
+
+        if !ran_any {
+            panic!(
+                "no whisper .en models installed to run this repro (need at least one of \
+                 tiny.en, base.en)"
+            );
+        }
+    }
+
+    /// Proves the fix: the normal, public `transcribe()` path (which now
+    /// picks `single_segment` via [`should_use_single_segment`]) recovers the
+    /// xlong fixture's final clause ("...throughout the day") instead of
+    /// truncating at "...for dictating" as it did before this issue's fix.
+    #[test]
+    #[ignore]
+    fn xlong_batch_transcription_recovers_full_tail_after_fix() {
+        let wav = include_bytes!("../../../../bench/audio/xlong.wav");
+        let samples =
+            crate::transcriber::parse_wav_to_samples(wav).expect("decode xlong fixture");
+
+        let mut ran_any = false;
+        for model_name in ["tiny.en", "base.en"] {
+            if !specific_model_exists(model_name) {
+                eprintln!("skipping {model_name}: model not installed");
+                continue;
+            }
+            ran_any = true;
+
+            let mut backend = WhisperBackend::new();
+            backend.load_model(model_name).expect("load model");
+            let text = backend
+                .transcribe(&samples, "en", None, true)
+                .expect("transcribe xlong fixture");
+
+            eprintln!(
+                "{model_name}: {} words: {text:?}",
+                text.split_whitespace().count()
+            );
+
+            let lower = text.to_lowercase();
+            assert!(
+                lower.contains("throughout the day"),
+                "{model_name}: expected the fixed batch transcribe() to recover the fixture's \
+                 final clause ('...throughout the day'), but truncated output was: {text:?}"
+            );
+            assert!(
+                !lower.trim_end().ends_with("for dictating"),
+                "{model_name}: transcribe() still truncates at 'for dictating', got: {text:?}"
+            );
+        }
+
+        if !ran_any {
+            panic!(
+                "no whisper .en models installed to run this fix proof (need at least one of \
+                 tiny.en, base.en)"
+            );
+        }
     }
 }

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -50,6 +50,7 @@ The active backend is stored as `Mutex<Box<dyn TranscriptionBackend>>` in `AppSt
 - If the user changes models in settings, the context is dropped and re-created on next transcription
 - Model files are single `.bin` files (e.g., `ggml-base.en.bin`)
 - Model search paths are documented in `docs/onboarding.md`
+- `single_segment` decoding is duration-conditional (`should_use_single_segment`, 12s threshold): short chunks (streaming's 10s windows) stay single-segment, but longer batch/file transcriptions use multi-segment decoding so an early end-of-text token from the model can't force-skip the rest of a long window and silently truncate the tail
 
 ### Incremental Whisper path (`streaming.rs`, `transcriber/chunking.rs`)
 


### PR DESCRIPTION
## Problem

`app/src-tauri/src/transcriber/whisper.rs:167` set `params.set_single_segment(true)` for every batch transcribe call. In vendored whisper.cpp, `single_segment` mode force-skips the *entire* 30s decode window the moment the model emits an early end-of-text token — and small models (tiny.en, base.en) do this ~24s into a 28s window. The result is silent data loss: the unread tail of long audio gets discarded with no error.

Production benchmark runs (v0.17.2) showed tiny.en and base.en truncating the 28s `xlong` benchmark fixture at the same point ("…for dictating"), losing the final clause ("code comments and chat messages throughout the day").

This transcribe path serves the batch fallback in `run_transcription_pipeline`, `transcribe_file`, and the benchmark itself. The incremental streaming path (10s windows) is unaffected and intentionally left unchanged — short windows don't hit the early-EOT failure mode in practice, and single-segment output is correct/desired there.

## Fix

- Extracted a pure, unit-testable `should_use_single_segment(sample_count) -> bool` (12s threshold — comfortably under the ~24s failure point, comfortably above streaming's 10s windows). `transcribe()` now calls `params.set_single_segment(should_use_single_segment(samples.len()))` instead of hardcoding `true`.
- Hardened segment-text concatenation (`append_segment`) so multi-segment output can't glue words together at a segment boundary that happens to lack whisper's usual leading-space token — inserts a single space only when neither side of the join already has whitespace.
- Added plain unit tests (no models required) for the boundary: streaming's 10s/8s windows stay single-segment; 28s batch audio does not; exact-boundary and off-by-one cases; `append_segment` join behavior.
- Added two `#[ignore]` model-backed tests against the `bench/audio/xlong.wav` fixture (28s):
  - `xlong_truncation_repro_single_segment` — reproduces the bug directly (same model/audio, only the flag flipped) to prove `single_segment=true` truncates relative to `single_segment=false`.
  - `xlong_batch_transcription_recovers_full_tail_after_fix` — proves the *fixed* public `transcribe()` path now recovers the fixture's final clause for both tiny.en and base.en.

## Docs

Added a line to `docs/features/transcription.md` documenting the duration-conditional `single_segment` behavior under the Whisper Backend section.

## Test evidence (run on macOS, models installed)

Full suite, `cargo check` + `cargo test -- --test-threads=1`: **377 passed, 0 failed, 2 ignored** (the two new ignored tests below).

Targeted unit tests (`cargo test --lib transcriber::whisper`): 20 passed, 0 failed, 2 ignored, all boundary/append_segment/language/strip_punctuation cases green.

Model-backed ignored tests (`cargo test --lib transcriber::whisper -- --ignored --nocapture --test-threads=1`):

```
test transcriber::whisper::tests::xlong_batch_transcription_recovers_full_tail_after_fix ...
tiny.en: 82 words: "Murmur is a privacy-first Mac OS voice-to-text application built with Tori, combining a rust back end with the React front and for a fast-end lightweight experience. Local transcription runs entirely on device using either the Parakeet Transducer model through Sherpa Onks or the Whisper Backend accelerated with metal on Apple Silicon. So no audio ever leaves the machine. The recording pipeline supports both a hold-down mode and a double tap mode for dictating and code comments and chat messages throughout the day."
base.en: 80 words: "Mermer is a privacy-first Mac OS voice to text application built with Tori, combining a rust back-end with the React front-end for a fast-end lightweight experience. Local transcription runs entirely on device using either the Parakeet Transducer model through Sherpa Onyx or the Whisper back-end accelerated with metal on Apple Silicon, so no audio ever leaves the machine. The recording pipeline supports both a hold-down mode and a double-tap mode for dictating code comments and chat messages throughout the day."
ok

test transcriber::whisper::tests::xlong_truncation_repro_single_segment ...
tiny.en: single_segment=true  -> 73 words, ends "...for dictating"
tiny.en: single_segment=false -> 82 words, complete (recovers "...and code comments and chat messages throughout the day.")
base.en: single_segment=true  -> 72 words, ends "...for dictating"
base.en: single_segment=false -> 80 words, complete (recovers "...code comments and chat messages throughout the day")
ok

test result: ok. 2 passed; 0 failed; 0 measured; 377 filtered out; finished in 2.60s
```

Word counts match the issue's reported bug pattern almost exactly (issue quoted tiny.en 71→79, base.en 72→80; this run got tiny.en 73→82, base.en 72→80 — small variance is expected since VAD/trim wasn't applied identically, but the truncation-at-"for dictating" signature and the fix recovering the tail are exact matches).

Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)