### PR TITLE
feat: score benchmark delivered text through the production pipeline (#271)

### DIFF
--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -901,18 +901,18 @@ mod tests {
         // Realtime factors within 10% of each other are a tie; the model
         // with lower memory delta should win regardless of pooled timing
         // noise or input order.
-        let recommendations = recommendations(&[
+        let first_order = recommendations(&[
             full_result("heavy", 100.0, 1.00, 0.05, 3000),
             full_result("light", 100.0, 1.05, 0.05, 200),
         ]);
-        assert_eq!(recommendations.fastest.as_deref(), Some("light"));
+        assert_eq!(first_order.fastest.as_deref(), Some("light"));
 
         // Order should not matter.
-        let recommendations = recommendations(&[
+        let second_order = recommendations(&[
             full_result("light", 100.0, 1.05, 0.05, 200),
             full_result("heavy", 100.0, 1.00, 0.05, 3000),
         ]);
-        assert_eq!(recommendations.fastest.as_deref(), Some("light"));
+        assert_eq!(second_order.fastest.as_deref(), Some("light"));
     }
 
     #[test]

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -14,6 +14,11 @@ use tauri::Emitter;
 
 const PARAKEET_CPU_MODEL: &str = "parakeet-tdt-0.6b-v2-fp16";
 
+/// Whisper model names ordered smallest-to-largest. Used to pick the
+/// cheapest selected whisper model for the untimed shared-init warm-up.
+const WHISPER_SIZE_ORDER: &[&str] =
+    &["tiny.en", "base.en", "small.en", "medium.en", "large-v3-turbo"];
+
 struct Fixture {
     id: &'static str,
     label: &'static str,
@@ -127,6 +132,10 @@ pub struct ModelResult {
     pub warm_p95_ms: Option<f64>,
     pub realtime_factor: Option<f64>,
     pub word_error_rate: Option<f64>,
+    /// Process-RSS delta measured around this model's run. Models are
+    /// benchmarked sequentially in one process, so allocator retention from
+    /// an earlier model can inflate a later model's baseline; treat this as
+    /// a rough signal, not an isolated per-model measurement.
     pub memory_delta_mb: u64,
     pub fixtures: Vec<FixtureResult>,
     pub error: Option<String>,
@@ -148,6 +157,13 @@ pub struct BenchmarkReport {
     pub platform: String,
     pub preset: BenchmarkPreset,
     pub iterations: usize,
+    /// Duration of the untimed warm-up pass run once before any per-model
+    /// timing, in milliseconds. This absorbs one-time shared backend init
+    /// (Metal shader compilation, ANE compile cache, etc.) that would
+    /// otherwise be misattributed to whichever model happens to load first.
+    /// It IS representative of real first-launch latency, just not a
+    /// per-model attribute.
+    pub shared_init_ms: f64,
     pub results: Vec<ModelResult>,
     pub recommendations: Recommendations,
 }
@@ -460,6 +476,34 @@ fn prepare_fixtures(
         .collect()
 }
 
+/// Decide which model(s) to load-and-drop during the untimed shared-init
+/// warm-up pass. Picks the smallest selected whisper model (whisper models
+/// share one Metal/shader init cost, so only one needs warming) plus one
+/// entry per non-whisper backend family that is selected, since each of
+/// those (Core ML ANE compile cache, sherpa-onnx) has its own separate
+/// shared init cost. Returns an empty plan when nothing is selected.
+fn warmup_plan(selected: &[BenchmarkModel]) -> Vec<String> {
+    let mut plan = Vec::new();
+
+    let whisper_pick = WHISPER_SIZE_ORDER.iter().find_map(|candidate| {
+        selected
+            .iter()
+            .find(|model| model.model_name == *candidate)
+            .map(|model| model.model_name.clone())
+    });
+    if let Some(model_name) = whisper_pick {
+        plan.push(model_name);
+    }
+
+    for model_name in [COREML_MODEL_NAME, PARAKEET_CPU_MODEL] {
+        if selected.iter().any(|model| model.model_name == model_name) {
+            plan.push(model_name.to_string());
+        }
+    }
+
+    plan
+}
+
 fn recommendations(results: &[ModelResult]) -> Recommendations {
     let successful = results
         .iter()
@@ -529,9 +573,35 @@ pub fn run(
     let fixtures = prepare_fixtures(request.preset.fixtures(), 0.5)?;
     let iterations = request.preset.iterations();
     let steps_per_model = 1 + fixtures.len() * (1 + iterations);
-    let total_steps = selected.len() * steps_per_model;
+    let warmup_targets = warmup_plan(&selected);
+    let total_steps = selected.len() * steps_per_model + warmup_targets.len();
     let mut completed = 0;
     let mut results = Vec::with_capacity(selected.len());
+
+    // Untimed warm-up pass: absorb one-time shared backend init (Metal
+    // shader compilation, ANE compile cache, ...) before any per-model
+    // timing starts, so it isn't misattributed to whichever model happens
+    // to load first. See BenchmarkReport::shared_init_ms.
+    let mut shared_init_ms = 0.0;
+    for target in &warmup_targets {
+        if coordinator.is_cancelled() {
+            return Err("Benchmark cancelled".to_string());
+        }
+        if let Some(model) = selected
+            .iter()
+            .find(|candidate| candidate.model_name == *target)
+        {
+            emit_progress(app, completed, total_steps, model, None, "priming");
+        }
+        if let Ok(mut backend) = backend_for(target) {
+            let warmup_started = Instant::now();
+            if backend.load_model(target).is_ok() {
+                shared_init_ms += warmup_started.elapsed().as_secs_f64() * 1000.0;
+            }
+            backend.reset();
+        }
+        completed += 1;
+    }
 
     for model in selected {
         let model_start = completed;
@@ -709,6 +779,7 @@ pub fn run(
         platform: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
         preset: request.preset,
         iterations,
+        shared_init_ms,
         results,
         recommendations,
     })
@@ -763,6 +834,48 @@ mod tests {
         assert!(!coordinator.try_start_shared_backend_change());
         coordinator.finish();
         assert!(coordinator.try_start_shared_backend_change());
+    }
+
+    fn model(name: &'static str) -> BenchmarkModel {
+        benchmark_models()
+            .into_iter()
+            .find(|model| model.model_name == name)
+            .unwrap_or_else(|| panic!("{name} missing from benchmark catalog"))
+    }
+
+    #[test]
+    fn warmup_plan_is_empty_when_nothing_is_selected() {
+        assert!(warmup_plan(&[]).is_empty());
+    }
+
+    #[test]
+    fn warmup_plan_picks_the_smallest_selected_whisper_model() {
+        let selected = [model("medium.en"), model("tiny.en"), model("base.en")];
+        assert_eq!(warmup_plan(&selected), vec!["tiny.en".to_string()]);
+    }
+
+    #[test]
+    fn warmup_plan_skips_whisper_when_no_whisper_model_is_selected() {
+        let selected = [model(PARAKEET_CPU_MODEL)];
+        assert_eq!(warmup_plan(&selected), vec![PARAKEET_CPU_MODEL.to_string()]);
+    }
+
+    #[test]
+    fn warmup_plan_warms_each_selected_backend_family_once() {
+        let selected = [
+            model("base.en"),
+            model("large-v3-turbo"),
+            model(PARAKEET_CPU_MODEL),
+            model(COREML_MODEL_NAME),
+        ];
+        assert_eq!(
+            warmup_plan(&selected),
+            vec![
+                "base.en".to_string(),
+                COREML_MODEL_NAME.to_string(),
+                PARAKEET_CPU_MODEL.to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -1,14 +1,19 @@
 use crate::commands::models::check_specific_model_exists;
+use crate::correction::CorrectionMatcher;
 use crate::resource_monitor::get_process_rss_mb;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::transcriber::CoreMlBackend;
 use crate::transcriber::{
     ParakeetBackend, TranscriptionBackend, WhisperBackend, COREML_MODEL_NAME, WHISPER_SAMPLE_RATE,
 };
+use crate::transcript_transform::{
+    transform_transcript, TranscriptContext, TranscriptSource, TranscriptStageConfig,
+    TranscriptTransformResources,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::Emitter;
 
@@ -120,6 +125,19 @@ pub struct FixtureResult {
     pub normalized_reference_words: usize,
     pub reference: String,
     pub transcript: String,
+    /// Text after the production transcript-transform pipeline ran on
+    /// `transcript` (issue #271). This is what actually lands on the clipboard,
+    /// so the delivered_* WER fields below score it against `reference`. Raw
+    /// `word_error_rate` scores decoder output; `delivered_*` scores post-pipeline
+    /// output; both raw and normalized variants are kept for symmetry.
+    pub delivered_transcript: String,
+    pub delivered_word_error_rate: f64,
+    pub delivered_word_errors: usize,
+    pub delivered_normalized_word_error_rate: f64,
+    pub delivered_normalized_word_errors: usize,
+    /// True when the transform pipeline errored and delivered_* fell back to
+    /// scoring the untransformed `transcript` (issue #271 point 4).
+    pub delivered_transform_failed: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -136,6 +154,11 @@ pub struct ModelResult {
     pub realtime_factor: Option<f64>,
     pub word_error_rate: Option<f64>,
     pub normalized_word_error_rate: Option<f64>,
+    /// Corpus WER of the delivered text (post transcript-transform pipeline),
+    /// raw and normalized. This is the metric that reflects clipboard output
+    /// rather than raw decoder output. See issue #271.
+    pub delivered_word_error_rate: Option<f64>,
+    pub delivered_normalized_word_error_rate: Option<f64>,
     /// Process-RSS delta measured around this model's run. Models are
     /// benchmarked sequentially in one process, so allocator retention from
     /// an earlier model can inflate a later model's baseline; treat this as
@@ -679,9 +702,132 @@ fn error_result(model: &BenchmarkModel, error: String) -> ModelResult {
         realtime_factor: None,
         word_error_rate: None,
         normalized_word_error_rate: None,
+        delivered_word_error_rate: None,
+        delivered_normalized_word_error_rate: None,
         memory_delta_mb: 0,
         fixtures: Vec::new(),
         error: Some(error),
+    }
+}
+
+// --- Delivered-text path (issue #271) --------------------------------------
+//
+// The benchmark must score what lands on the clipboard, not raw decoder output.
+// Two production levers are mirrored here:
+//   1. Whisper models receive the built-in developer-vocabulary initial prompt,
+//      matching production's capability of biasing decoding toward domain terms.
+//      Parakeet / Core ML ignore an initial prompt (parakeet.rs, coreml.rs), so
+//      they get None.
+//   2. Each transcript is run through the production transcript-transform
+//      pipeline configured as a default out-of-the-box install (no per-app
+//      profile). The same built-in developer dictionary that seeds the whisper
+//      prompt also seeds the correction matcher, so SmartCorrectionStage repairs
+//      domain proper nouns exactly as production does when that dictionary is
+//      active. Changing which of these are shipped ON by default is out of scope
+//      (issue #271 point 3); this only measures the capability.
+
+/// Whisper backends bias decoding toward a supplied initial prompt. Feed them
+/// the built-in developer dictionary; return None for backends that ignore the
+/// prompt. See issue #271.
+fn whisper_initial_prompt(model_name: &str) -> Option<String> {
+    matches!(
+        model_name,
+        "tiny.en" | "base.en" | "small.en" | "medium.en" | "large-v3-turbo"
+    )
+    .then(crate::vocab::builtin_terms_prompt)
+}
+
+/// Build the transcript-transform context a default out-of-the-box install
+/// resolves to: global default settings, no per-app profile. Derived from the
+/// production resolver (`dictation_context::resolve`) so the delivered text is
+/// produced by the same stage selection real users get. See issue #271.
+fn default_delivery_context() -> TranscriptContext {
+    let global = crate::state::DictationState::default();
+    let snapshot = crate::dictation_context::resolve(crate::dictation_context::ResolverInputs {
+        bundle_id: None,
+        global: &global,
+        prompt: None,
+        correction_matcher: None,
+        ide_context_index: None,
+        vocabulary_version: 0,
+        session_overrides: crate::dictation_context::SessionOverrides::default(),
+    });
+    TranscriptContext {
+        session_id: 0,
+        source: TranscriptSource::Live,
+        context_handle: None,
+        cli_formatting_mode: snapshot.transformations.cli_formatting_mode,
+        stages: TranscriptStageConfig {
+            cleanup_enabled: snapshot.transformations.cleanup_enabled,
+            cleanup_remove_filler: snapshot.transformations.cleanup_remove_filler,
+            cleanup_capitalize: snapshot.transformations.cleanup_capitalize,
+            voice_commands_enabled: snapshot.enabled_command_groups.built_in_voice_commands,
+            smart_correction_enabled: snapshot.transformations.correction_enabled,
+            smart_formatting_enabled: snapshot.transformations.smart_formatting_enabled,
+            ide_context_enabled: snapshot.transformations.ide_context_enabled,
+            cli_command_enabled: snapshot.transformations.cli_formatting_enabled,
+        },
+    }
+}
+
+/// Correction matcher for the delivered path, seeded with the built-in developer
+/// dictionary (the same terms fed to the whisper prompt) plus the built-in
+/// abbreviations, mirroring `commands::recording::rebuild_correction_matcher`
+/// with the dev dictionary active. `None` when the resulting matcher is empty.
+/// See issue #271.
+fn default_delivery_correction_matcher() -> Option<Arc<CorrectionMatcher>> {
+    let terms: Vec<String> = crate::vocab::builtin_terms_prompt()
+        .split_whitespace()
+        .map(ToString::to_string)
+        .collect();
+    let matcher = CorrectionMatcher::build(
+        &terms,
+        &[],
+        crate::state::DictationState::default().correction_fuzzy,
+        true,
+    );
+    (!matcher.is_empty()).then(|| Arc::new(matcher))
+}
+
+struct DeliveredScore {
+    transcript: String,
+    word_errors: usize,
+    normalized_word_errors: usize,
+    transform_failed: bool,
+}
+
+/// Run one transcript through `transform` (the delivered-text pipeline) and
+/// score the result on both raw and normalized WER. On transform failure the
+/// untransformed transcript is scored instead and `transform_failed` is set, so
+/// a broken stage degrades one fixture's delivered numbers rather than aborting
+/// the whole run (issue #271 point 4). `transform` is injected so the plumbing
+/// is testable with a stub and no models.
+fn score_delivered(
+    reference: &str,
+    transcript: &str,
+    transform: impl FnOnce(&str) -> Result<String, String>,
+) -> DeliveredScore {
+    match transform(transcript) {
+        Ok(text) => {
+            let (raw_errors, _) = word_errors(reference, &text);
+            let (normalized_errors, _) = normalized_word_errors(reference, &text);
+            DeliveredScore {
+                transcript: text,
+                word_errors: raw_errors,
+                normalized_word_errors: normalized_errors,
+                transform_failed: false,
+            }
+        }
+        Err(_) => {
+            let (raw_errors, _) = word_errors(reference, transcript);
+            let (normalized_errors, _) = normalized_word_errors(reference, transcript);
+            DeliveredScore {
+                transcript: transcript.to_string(),
+                word_errors: raw_errors,
+                normalized_word_errors: normalized_errors,
+                transform_failed: true,
+            }
+        }
     }
 }
 
@@ -893,6 +1039,11 @@ pub fn run(
     let mut completed = 0;
     let mut results = Vec::with_capacity(selected.len());
 
+    // Delivered-text pipeline configuration is identical across models and
+    // fixtures, so build it once. See issue #271.
+    let delivery_context = default_delivery_context();
+    let delivery_matcher = default_delivery_correction_matcher();
+
     // Untimed warm-up pass: absorb one-time shared backend init (Metal
     // shader compilation, ANE compile cache, ...) before any per-model
     // timing starts, so it isn't misattributed to whichever model happens
@@ -951,9 +1102,16 @@ pub fn run(
         let mut total_reference_words = 0;
         let mut total_normalized_errors = 0;
         let mut total_normalized_reference_words = 0;
+        let mut total_delivered_errors = 0;
+        let mut total_delivered_normalized_errors = 0;
         let mut corpus_warm_seconds = 0.0;
         let mut corpus_audio_seconds = 0.0;
         let mut failed = None;
+
+        // Whisper backends decode with the built-in dev-vocab prompt; Parakeet /
+        // Core ML ignore it and receive None. See issue #271.
+        let initial_prompt = whisper_initial_prompt(&model.model_name);
+        let prompt_ref = initial_prompt.as_deref();
 
         for prepared in &fixtures {
             let fixture = prepared.fixture;
@@ -972,7 +1130,7 @@ pub fn run(
                 "warming",
             );
             let warmup_started = Instant::now();
-            match backend.transcribe(samples, "en", None, true) {
+            match backend.transcribe(samples, "en", prompt_ref, true) {
                 Ok(_) => {}
                 Err(error) => {
                     failed = Some(error);
@@ -1001,7 +1159,7 @@ pub fn run(
                     "measuring",
                 );
                 let started = Instant::now();
-                match backend.transcribe(samples, "en", None, true) {
+                match backend.transcribe(samples, "en", prompt_ref, true) {
                     Ok(output) => transcripts.push(output),
                     Err(error) => {
                         failed = Some(error);
@@ -1055,6 +1213,24 @@ pub fn run(
             total_reference_words += reference_words;
             total_normalized_errors += normalized_errors;
             total_normalized_reference_words += normalized_reference_words;
+            // Run the reported median transcript through the production
+            // transcript-transform pipeline and score the delivered text (what
+            // reaches the clipboard). The transform is deterministic, so scoring
+            // the median transcript is stable. See issue #271.
+            let delivered = score_delivered(fixture.reference, &transcript, |input| {
+                transform_transcript(
+                    input.to_string(),
+                    &delivery_context,
+                    TranscriptTransformResources {
+                        correction_matcher: delivery_matcher.clone(),
+                        ..TranscriptTransformResources::empty()
+                    },
+                )
+                .map(|output| output.text)
+                .map_err(|error| error.to_string())
+            });
+            total_delivered_errors += delivered.word_errors;
+            total_delivered_normalized_errors += delivered.normalized_word_errors;
             fixture_results.push(FixtureResult {
                 fixture_id: fixture.id.to_string(),
                 label: fixture.label.to_string(),
@@ -1071,6 +1247,13 @@ pub fn run(
                 normalized_reference_words,
                 reference: fixture.reference.trim().to_string(),
                 transcript,
+                delivered_word_error_rate: delivered.word_errors as f64 / reference_words as f64,
+                delivered_word_errors: delivered.word_errors,
+                delivered_normalized_word_error_rate: delivered.normalized_word_errors as f64
+                    / normalized_reference_words as f64,
+                delivered_normalized_word_errors: delivered.normalized_word_errors,
+                delivered_transform_failed: delivered.transform_failed,
+                delivered_transcript: delivered.transcript,
             });
         }
 
@@ -1094,6 +1277,12 @@ pub fn run(
             word_error_rate: Some(total_errors as f64 / total_reference_words as f64),
             normalized_word_error_rate: Some(
                 total_normalized_errors as f64 / total_normalized_reference_words as f64,
+            ),
+            delivered_word_error_rate: Some(
+                total_delivered_errors as f64 / total_reference_words as f64,
+            ),
+            delivered_normalized_word_error_rate: Some(
+                total_delivered_normalized_errors as f64 / total_normalized_reference_words as f64,
             ),
             memory_delta_mb: peak_rss.saturating_sub(baseline_rss),
             fixtures: fixture_results,
@@ -1277,6 +1466,8 @@ mod tests {
             realtime_factor: Some(latency / 1000.0),
             word_error_rate: Some(wer),
             normalized_word_error_rate: Some(wer),
+            delivered_word_error_rate: Some(wer),
+            delivered_normalized_word_error_rate: Some(wer),
             memory_delta_mb: 0,
             fixtures: Vec::new(),
             error: None,
@@ -1310,6 +1501,8 @@ mod tests {
             realtime_factor: Some(realtime_factor),
             word_error_rate: Some(wer),
             normalized_word_error_rate: Some(wer),
+            delivered_word_error_rate: Some(wer),
+            delivered_normalized_word_error_rate: Some(wer),
             memory_delta_mb,
             fixtures: Vec::new(),
             error: None,
@@ -1392,5 +1585,159 @@ mod tests {
             full_result("inaccurate-but-fast", 10.0, 0.01, 0.20, 50),
         ]);
         assert_eq!(recommendations.balanced.as_deref(), Some("accurate"));
+    }
+
+    // --- Delivered-text path (issue #271) -----------------------------------
+
+    #[test]
+    fn whisper_models_get_the_dev_prompt_and_others_do_not() {
+        for whisper in ["tiny.en", "base.en", "small.en", "medium.en", "large-v3-turbo"] {
+            let prompt = whisper_initial_prompt(whisper)
+                .unwrap_or_else(|| panic!("{whisper} should receive an initial prompt"));
+            assert!(
+                prompt.contains("Tauri"),
+                "the built-in dev dictionary should include Tauri"
+            );
+        }
+        // Parakeet / Core ML ignore an initial prompt, so none is supplied.
+        assert!(whisper_initial_prompt(PARAKEET_CPU_MODEL).is_none());
+        assert!(whisper_initial_prompt(COREML_MODEL_NAME).is_none());
+    }
+
+    #[test]
+    fn default_delivery_context_matches_out_of_the_box_settings() {
+        let context = default_delivery_context();
+        assert_eq!(context.source, TranscriptSource::Live);
+        assert_eq!(
+            context.cli_formatting_mode,
+            crate::cli_command::CliFormattingMode::Auto
+        );
+        let stages = context.stages;
+        // Mirrors DictationState::default(): cleanup gate off (filler/capitalize
+        // remain configured but unused until cleanup is enabled), voice commands
+        // off, correction on, smart formatting off, IDE off, CLI stage on (Auto).
+        assert!(!stages.cleanup_enabled);
+        assert!(stages.cleanup_remove_filler);
+        assert!(stages.cleanup_capitalize);
+        assert!(!stages.voice_commands_enabled);
+        assert!(stages.smart_correction_enabled);
+        assert!(!stages.smart_formatting_enabled);
+        assert!(!stages.ide_context_enabled);
+        assert!(stages.cli_command_enabled);
+    }
+
+    #[test]
+    fn score_delivered_scores_transformed_output_on_success() {
+        // Stub transform "corrects" tori -> Tauri, removing the only error.
+        let score = score_delivered("we ship Tauri today", "we ship tori today", |input| {
+            Ok(input.replace("tori", "Tauri"))
+        });
+        assert!(!score.transform_failed);
+        assert_eq!(score.transcript, "we ship Tauri today");
+        assert_eq!(score.word_errors, 0);
+        assert_eq!(score.normalized_word_errors, 0);
+    }
+
+    #[test]
+    fn score_delivered_falls_back_to_raw_transcript_when_transform_fails() {
+        let score = score_delivered("we ship Tauri today", "we ship tori today", |_input| {
+            Err("stage exploded".to_string())
+        });
+        assert!(score.transform_failed);
+        // Scored against the untransformed transcript: "tori" != "Tauri" is one
+        // error, and the delivered transcript is the untransformed text.
+        assert_eq!(score.transcript, "we ship tori today");
+        assert_eq!(score.word_errors, 1);
+    }
+
+    #[test]
+    fn default_delivery_pipeline_runs_the_correction_stage() {
+        // "standard error" is a built-in abbreviation the correction matcher
+        // rewrites to "stderr"; cleanup/voice-commands/smart-formatting are all
+        // no-ops on this prose under default settings, and the CLI stage leaves
+        // non-command prose untouched. So the delivered text equals the
+        // correction-only output, proving the stage is wired and scored.
+        let input = "we deploy with standard error logging";
+        let context = default_delivery_context();
+        let matcher = default_delivery_correction_matcher();
+        let expected = matcher
+            .as_ref()
+            .expect("built-in dictionary yields a non-empty matcher")
+            .apply(input);
+        assert_ne!(expected, input, "correction stage should change the text");
+
+        let score = score_delivered(&expected, input, |transcript| {
+            transform_transcript(
+                transcript.to_string(),
+                &context,
+                TranscriptTransformResources {
+                    correction_matcher: matcher.clone(),
+                    ..TranscriptTransformResources::empty()
+                },
+            )
+            .map(|output| output.text)
+            .map_err(|error| error.to_string())
+        });
+        assert!(!score.transform_failed);
+        assert_eq!(score.transcript, expected);
+        assert_eq!(score.word_errors, 0);
+    }
+
+    #[test]
+    #[ignore = "requires tiny.en + Silero VAD; run on macOS with --ignored"]
+    fn delivered_path_smoke_tiny_en_end_to_end() {
+        // The vocab prompt is passed to whisper and carries the dev dictionary.
+        let prompt =
+            whisper_initial_prompt("tiny.en").expect("whisper models get an initial prompt");
+        assert!(prompt.contains("Tauri"));
+
+        let prepared = prepare_fixtures(&FIXTURES[..1], 0.5).expect("prepare the short fixture");
+        let fixture = &prepared[0];
+
+        let mut backend = backend_for("tiny.en").expect("tiny.en backend");
+        backend.load_model("tiny.en").expect("load tiny.en");
+        let transcript = backend
+            .transcribe(&fixture.samples, "en", Some(prompt.as_str()), true)
+            .expect("transcribe the short fixture");
+        backend.reset();
+        assert!(
+            !transcript.trim().is_empty(),
+            "raw transcript should be non-empty"
+        );
+
+        let context = default_delivery_context();
+        let matcher = default_delivery_correction_matcher();
+        let delivered = score_delivered(fixture.fixture.reference, &transcript, |input| {
+            transform_transcript(
+                input.to_string(),
+                &context,
+                TranscriptTransformResources {
+                    correction_matcher: matcher.clone(),
+                    ..TranscriptTransformResources::empty()
+                },
+            )
+            .map(|output| output.text)
+            .map_err(|error| error.to_string())
+        });
+
+        assert!(!delivered.transform_failed, "default transform must not fail");
+        assert!(
+            !delivered.transcript.trim().is_empty(),
+            "delivered transcript should be populated"
+        );
+        let (raw_errors, reference_words) = word_errors(fixture.fixture.reference, &transcript);
+        assert!(reference_words > 0);
+
+        println!("--- delivered path smoke (tiny.en) ---");
+        println!(
+            "initial_prompt[..60]: {}",
+            prompt.chars().take(60).collect::<String>()
+        );
+        println!("RAW       : {transcript}");
+        println!("DELIVERED : {}", delivered.transcript);
+        println!(
+            "raw WER errors={raw_errors} delivered WER errors={} ref_words={reference_words}",
+            delivered.word_errors
+        );
     }
 }

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -472,7 +472,10 @@ fn within_tie_band(a: f64, b: f64) -> bool {
     if base <= 0.0 {
         return (a - b).abs() <= f64::EPSILON;
     }
-    (a - b).abs() / base <= REALTIME_FACTOR_TIE_BAND
+    // A tiny epsilon keeps the boundary inclusive of an intended-exact 10%
+    // delta despite binary floating-point representation error (e.g.
+    // 1.10 - 1.00 != 0.10 bit-for-bit).
+    (a - b).abs() / base <= REALTIME_FACTOR_TIE_BAND + 1e-9
 }
 
 /// Picks the model with the lowest `metric` value, then deterministically

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -110,6 +110,9 @@ pub struct FixtureResult {
     pub word_error_rate: f64,
     pub word_errors: usize,
     pub reference_words: usize,
+    pub normalized_word_error_rate: f64,
+    pub normalized_word_errors: usize,
+    pub normalized_reference_words: usize,
     pub reference: String,
     pub transcript: String,
 }
@@ -127,6 +130,7 @@ pub struct ModelResult {
     pub warm_p95_ms: Option<f64>,
     pub realtime_factor: Option<f64>,
     pub word_error_rate: Option<f64>,
+    pub normalized_word_error_rate: Option<f64>,
     pub memory_delta_mb: u64,
     pub fixtures: Vec<FixtureResult>,
     pub error: Option<String>,
@@ -358,9 +362,233 @@ fn words(text: &str) -> Vec<String> {
         .collect()
 }
 
-fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
-    let reference = words(reference);
-    let hypothesis = words(hypothesis);
+// --- Text normalization for WER scoring -------------------------------------
+//
+// Raw WER punishes formatting and inverse-text-normalization (ITN) differences
+// that are not recognition errors: "16 kHz" vs "sixteen kilohertz", "Mac OS" vs
+// "macOS", "front end" vs "frontend". `normalized_words` maps both the reference
+// and the hypothesis to a common canonical token stream (on top of the existing
+// lowercase + punctuation-split behaviour) so those differences stop counting.
+//
+// The normalization is intentionally conservative: every rule maps genuinely
+// equivalent spellings of the SAME thing to one token. It never collapses two
+// different spoken words, so real misrecognitions (e.g. "Tauri" -> "Tori") still
+// score as errors. The compound-word and unit tables below are small, curated,
+// and hand-maintained for exactly this reason.
+
+/// Curated technical compounds frequently written as either one word or two.
+/// Both spellings collapse to the joined single-word form. Adding an entry that
+/// joins two genuinely distinct words would hide real errors, so keep this list
+/// limited to true one-word/two-word spelling variants.
+const COMPOUND_JOINS: &[(&str, &str)] = &[
+    ("front", "end"),
+    ("back", "end"),
+    ("mac", "os"),
+    ("web", "site"),
+    ("data", "base"),
+    ("run", "time"),
+    ("code", "base"),
+    ("name", "space"),
+    ("white", "space"),
+    ("life", "cycle"),
+    ("key", "board"),
+    ("check", "box"),
+    ("drop", "down"),
+    ("time", "stamp"),
+];
+
+/// Canonicalize a common unit token. Both the abbreviation and the spelled-out
+/// form map to the same canonical abbreviation. Curated; only true synonyms.
+fn normalize_unit(word: &str) -> Option<&'static str> {
+    Some(match word {
+        "hz" | "hertz" => "hz",
+        "khz" | "kilohertz" => "khz",
+        "mhz" | "megahertz" => "mhz",
+        "ghz" | "gigahertz" => "ghz",
+        "kb" | "kilobyte" | "kilobytes" => "kb",
+        "mb" | "megabyte" | "megabytes" => "mb",
+        "gb" | "gigabyte" | "gigabytes" => "gb",
+        "tb" | "terabyte" | "terabytes" => "tb",
+        "ms" | "millisecond" | "milliseconds" => "ms",
+        _ => return None,
+    })
+}
+
+fn cardinal_small(word: &str) -> Option<u32> {
+    Some(match word {
+        "zero" => 0,
+        "one" => 1,
+        "two" => 2,
+        "three" => 3,
+        "four" => 4,
+        "five" => 5,
+        "six" => 6,
+        "seven" => 7,
+        "eight" => 8,
+        "nine" => 9,
+        "ten" => 10,
+        "eleven" => 11,
+        "twelve" => 12,
+        "thirteen" => 13,
+        "fourteen" => 14,
+        "fifteen" => 15,
+        "sixteen" => 16,
+        "seventeen" => 17,
+        "eighteen" => 18,
+        "nineteen" => 19,
+        _ => return None,
+    })
+}
+
+fn tens_word(word: &str) -> Option<u32> {
+    Some(match word {
+        "twenty" => 20,
+        "thirty" => 30,
+        "forty" => 40,
+        "fifty" => 50,
+        "sixty" => 60,
+        "seventy" => 70,
+        "eighty" => 80,
+        "ninety" => 90,
+        _ => return None,
+    })
+}
+
+fn ones_word(word: &str) -> Option<u32> {
+    cardinal_small(word).filter(|value| (1..=9).contains(value))
+}
+
+fn ordinal_word(word: &str) -> Option<u32> {
+    Some(match word {
+        "first" => 1,
+        "second" => 2,
+        "third" => 3,
+        "fourth" => 4,
+        "fifth" => 5,
+        "sixth" => 6,
+        "seventh" => 7,
+        "eighth" => 8,
+        "ninth" => 9,
+        "tenth" => 10,
+        "eleventh" => 11,
+        "twelfth" => 12,
+        "thirteenth" => 13,
+        "fourteenth" => 14,
+        "fifteenth" => 15,
+        "sixteenth" => 16,
+        "seventeenth" => 17,
+        "eighteenth" => 18,
+        "nineteenth" => 19,
+        "twentieth" => 20,
+        "thirtieth" => 30,
+        "fortieth" => 40,
+        "fiftieth" => 50,
+        "sixtieth" => 60,
+        "seventieth" => 70,
+        "eightieth" => 80,
+        "ninetieth" => 90,
+        _ => return None,
+    })
+}
+
+/// Parse a digit ordinal such as "1st", "2nd", "16th" into its numeric value.
+fn digit_ordinal(word: &str) -> Option<u32> {
+    for suffix in ["st", "nd", "rd", "th"] {
+        if let Some(digits) = word.strip_suffix(suffix) {
+            if !digits.is_empty() && digits.chars().all(|character| character.is_ascii_digit()) {
+                return digits.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+/// Collapse number words to digits so "sixteen" and "16" score identically.
+/// Cardinals and ordinals map to distinct canonical tokens ("16" vs "16ord") so
+/// a cardinal/ordinal mismatch is still counted. Handles 0-100, common ordinals,
+/// two-word tens ("twenty one" -> "21"), and "hundred".
+fn fold_numbers(tokens: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(tokens.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = tokens[index].as_str();
+
+        if let Some(value) = digit_ordinal(token).or_else(|| ordinal_word(token)) {
+            out.push(format!("{value}ord"));
+            index += 1;
+            continue;
+        }
+
+        if let Some(tens) = tens_word(token) {
+            if let Some(ones) = tokens.get(index + 1).and_then(|word| ones_word(word)) {
+                out.push((tens + ones).to_string());
+                index += 2;
+                continue;
+            }
+            out.push(tens.to_string());
+            index += 1;
+            continue;
+        }
+
+        if token == "hundred" {
+            if let Some(previous) = out.last().and_then(|word| word.parse::<u32>().ok()) {
+                if (1..=9).contains(&previous) {
+                    *out.last_mut().expect("previous digit present") = (previous * 100).to_string();
+                    index += 1;
+                    continue;
+                }
+            }
+            out.push("100".to_string());
+            index += 1;
+            continue;
+        }
+
+        if let Some(value) = cardinal_small(token) {
+            out.push(value.to_string());
+            index += 1;
+            continue;
+        }
+
+        out.push(tokens[index].clone());
+        index += 1;
+    }
+    out
+}
+
+/// Join curated two-word technical compounds into their single-word form.
+fn join_compounds(tokens: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(tokens.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        if let Some(next) = tokens.get(index + 1) {
+            let matches = COMPOUND_JOINS
+                .iter()
+                .any(|(left, right)| *left == tokens[index] && *right == next);
+            if matches {
+                out.push(format!("{}{}", tokens[index], next));
+                index += 2;
+                continue;
+            }
+        }
+        out.push(tokens[index].clone());
+        index += 1;
+    }
+    out
+}
+
+/// Whisper-`EnglishTextNormalizer`-style canonicalization on top of `words`:
+/// digit/word number equivalence, common unit abbreviations, and curated tech
+/// compounds. Deterministic and local. Applied to both reference and hypothesis
+/// before the edit-distance pass.
+fn normalized_words(text: &str) -> Vec<String> {
+    let joined = join_compounds(fold_numbers(words(text)));
+    joined
+        .into_iter()
+        .map(|word| normalize_unit(&word).map(str::to_string).unwrap_or(word))
+        .collect()
+}
+
+fn edit_distance(reference: &[String], hypothesis: &[String]) -> usize {
     let mut previous: Vec<usize> = (0..=hypothesis.len()).collect();
     for (row, reference_word) in reference.iter().enumerate() {
         let mut current = vec![row + 1; hypothesis.len() + 1];
@@ -371,7 +599,22 @@ fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
         }
         previous = current;
     }
-    (previous[hypothesis.len()], reference.len())
+    previous[hypothesis.len()]
+}
+
+/// Raw WER: lowercase + punctuation split only. Returns (errors, reference words).
+fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
+    let reference = words(reference);
+    let hypothesis = words(hypothesis);
+    (edit_distance(&reference, &hypothesis), reference.len())
+}
+
+/// Normalized WER: applies `normalized_words` before scoring so formatting/ITN
+/// differences do not count. Returns (errors, normalized reference words).
+fn normalized_word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
+    let reference = normalized_words(reference);
+    let hypothesis = normalized_words(hypothesis);
+    (edit_distance(&reference, &hypothesis), reference.len())
 }
 
 fn percentile(values: &[f64], percentile: f64) -> Option<f64> {
@@ -419,6 +662,7 @@ fn error_result(model: &BenchmarkModel, error: String) -> ModelResult {
         warm_p95_ms: None,
         realtime_factor: None,
         word_error_rate: None,
+        normalized_word_error_rate: None,
         memory_delta_mb: 0,
         fixtures: Vec::new(),
         error: Some(error),
@@ -470,19 +714,25 @@ fn recommendations(results: &[ModelResult]) -> Recommendations {
         .filter_map(|result| result.warm_median_ms.map(|value| (*result, value)))
         .min_by(|left, right| left.1.total_cmp(&right.1))
         .map(|(result, _)| result.model_name.clone());
+    // Accuracy recommendations rank on the normalized WER so formatting/ITN
+    // differences do not distort the ranking (see `normalized_words`).
     let most_accurate = successful
         .iter()
-        .filter_map(|result| result.word_error_rate.map(|value| (*result, value)))
+        .filter_map(|result| result.normalized_word_error_rate.map(|value| (*result, value)))
         .min_by(|left, right| left.1.total_cmp(&right.1))
         .map(|(result, _)| result.model_name.clone());
     let best_wer = successful
         .iter()
-        .filter_map(|result| result.word_error_rate)
+        .filter_map(|result| result.normalized_word_error_rate)
         .min_by(f64::total_cmp);
     let balanced = best_wer.and_then(|best| {
         successful
             .iter()
-            .filter(|result| result.word_error_rate.is_some_and(|wer| wer <= best + 0.02))
+            .filter(|result| {
+                result
+                    .normalized_word_error_rate
+                    .is_some_and(|wer| wer <= best + 0.02)
+            })
             .filter_map(|result| result.warm_median_ms.map(|value| (*result, value)))
             .min_by(|left, right| left.1.total_cmp(&right.1))
             .map(|(result, _)| result.model_name.clone())
@@ -564,6 +814,8 @@ pub fn run(
         let mut fixture_results = Vec::with_capacity(fixtures.len());
         let mut total_errors = 0;
         let mut total_reference_words = 0;
+        let mut total_normalized_errors = 0;
+        let mut total_normalized_reference_words = 0;
         let mut corpus_warm_seconds = 0.0;
         let mut corpus_audio_seconds = 0.0;
         let mut failed = None;
@@ -634,20 +886,40 @@ pub fn run(
             all_warm.extend_from_slice(&warm);
             corpus_warm_seconds += warm_median_ms / 1000.0;
             corpus_audio_seconds += audio_seconds;
+            // Score each transcript on both raw and normalized WER. Pick the
+            // median transcript by normalized errors (the reported ranking
+            // metric), breaking ties by raw errors for determinism.
             let mut scored_transcripts = transcripts
                 .into_iter()
                 .map(|transcript| {
                     let (errors, reference_words) = word_errors(fixture.reference, &transcript);
-                    (errors, reference_words, transcript)
+                    let (normalized_errors, normalized_reference_words) =
+                        normalized_word_errors(fixture.reference, &transcript);
+                    (
+                        normalized_errors,
+                        errors,
+                        reference_words,
+                        normalized_reference_words,
+                        transcript,
+                    )
                 })
                 .collect::<Vec<_>>();
-            scored_transcripts.sort_by_key(|(errors, _, _)| *errors);
-            let (errors, reference_words, transcript) = scored_transcripts
+            scored_transcripts
+                .sort_by_key(|(normalized_errors, errors, ..)| (*normalized_errors, *errors));
+            let (
+                normalized_errors,
+                errors,
+                reference_words,
+                normalized_reference_words,
+                transcript,
+            ) = scored_transcripts
                 .into_iter()
                 .nth((iterations - 1) / 2)
                 .expect("benchmark presets include measured iterations");
             total_errors += errors;
             total_reference_words += reference_words;
+            total_normalized_errors += normalized_errors;
+            total_normalized_reference_words += normalized_reference_words;
             fixture_results.push(FixtureResult {
                 fixture_id: fixture.id.to_string(),
                 label: fixture.label.to_string(),
@@ -658,6 +930,10 @@ pub fn run(
                 word_error_rate: errors as f64 / reference_words as f64,
                 word_errors: errors,
                 reference_words,
+                normalized_word_error_rate: normalized_errors as f64
+                    / normalized_reference_words as f64,
+                normalized_word_errors: normalized_errors,
+                normalized_reference_words,
                 reference: fixture.reference.trim().to_string(),
                 transcript,
             });
@@ -681,6 +957,9 @@ pub fn run(
             warm_p95_ms: percentile(&all_warm, 0.95),
             realtime_factor: Some(corpus_warm_seconds / corpus_audio_seconds),
             word_error_rate: Some(total_errors as f64 / total_reference_words as f64),
+            normalized_word_error_rate: Some(
+                total_normalized_errors as f64 / total_normalized_reference_words as f64,
+            ),
             memory_delta_mb: peak_rss.saturating_sub(baseline_rss),
             fixtures: fixture_results,
             error: None,
@@ -723,6 +1002,47 @@ mod tests {
         assert_eq!(word_errors("one two three", "one four three"), (1, 3));
         assert_eq!(word_errors("one two three", "one two three four"), (1, 3));
         assert_eq!(word_errors("one two three", "one three"), (1, 3));
+    }
+
+    #[test]
+    fn normalizer_collapses_formatting_and_itn_differences() {
+        // The concrete pairs from the issue must normalize to identical tokens.
+        assert_eq!(normalized_words("16 kHz"), normalized_words("sixteen kilohertz"));
+        assert_eq!(normalized_words("Mac OS"), normalized_words("macOS"));
+        assert_eq!(normalized_words("front end"), normalized_words("frontend"));
+        // A few more equivalences the tables promise.
+        assert_eq!(normalized_words("500 MB"), normalized_words("five hundred megabytes"));
+        assert_eq!(normalized_words("2 ms"), normalized_words("two milliseconds"));
+        assert_eq!(normalized_words("twenty one"), normalized_words("21"));
+        assert_eq!(normalized_words("the 1st run"), normalized_words("the first run"));
+    }
+
+    #[test]
+    fn normalized_word_errors_ignores_formatting_but_keeps_recognition_errors() {
+        // Formatting/ITN differences score zero under normalization.
+        assert_eq!(normalized_word_errors("16 kHz", "sixteen kilohertz"), (0, 2));
+        assert_eq!(normalized_word_errors("front end", "frontend"), (0, 1));
+        assert_eq!(normalized_word_errors("Mac OS", "macOS"), (0, 1));
+
+        // Real misrecognitions still count (this is #271's territory, not ours).
+        assert!(normalized_word_errors("Tauri", "Tori").0 > 0);
+        assert!(word_errors("Tauri", "Tori").0 > 0);
+
+        // Different numbers/units must not collapse to the same token.
+        assert_eq!(normalized_word_errors("16 kHz", "32 kHz"), (1, 2));
+        assert_eq!(normalized_word_errors("500 MB", "500 GB"), (1, 2));
+        // Cardinal vs ordinal is a genuine difference and is preserved.
+        assert!(normalized_word_errors("one", "first").0 > 0);
+    }
+
+    #[test]
+    fn normalization_shrinks_a_known_raw_wer_delta() {
+        // Same sentence, formatted two ways: raw scoring counts several errors,
+        // normalized scoring counts none. Locks the raw-vs-normalized delta.
+        let reference = "The front end uses 16 kHz audio";
+        let hypothesis = "The frontend uses sixteen kilohertz audio";
+        assert_eq!(word_errors(reference, hypothesis), (4, 7));
+        assert_eq!(normalized_word_errors(reference, hypothesis), (0, 6));
     }
 
     #[test]
@@ -778,6 +1098,7 @@ mod tests {
             warm_p95_ms: Some(latency),
             realtime_factor: Some(latency / 1000.0),
             word_error_rate: Some(wer),
+            normalized_word_error_rate: Some(wer),
             memory_delta_mb: 0,
             fixtures: Vec::new(),
             error: None,

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -1309,6 +1309,7 @@ mod tests {
             warm_p95_ms: Some(warm_median_ms),
             realtime_factor: Some(realtime_factor),
             word_error_rate: Some(wer),
+            normalized_word_error_rate: Some(wer),
             memory_delta_mb,
             fixtures: Vec::new(),
             error: None,

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -460,33 +460,95 @@ fn prepare_fixtures(
         .collect()
 }
 
+/// Realtime-factor deltas below this fraction are treated as statistical
+/// noise rather than a genuine performance difference, so run-to-run jitter
+/// never flips which model looks "fastest" or "balanced". See issue #272.
+const REALTIME_FACTOR_TIE_BAND: f64 = 0.10;
+
+/// True when `a` and `b` are within `REALTIME_FACTOR_TIE_BAND` of the smaller
+/// of the two, i.e. indistinguishable for recommendation purposes.
+fn within_tie_band(a: f64, b: f64) -> bool {
+    let base = a.min(b);
+    if base <= 0.0 {
+        return (a - b).abs() <= f64::EPSILON;
+    }
+    (a - b).abs() / base <= REALTIME_FACTOR_TIE_BAND
+}
+
+/// Picks the model with the lowest `metric` value, then deterministically
+/// breaks ties among every candidate within `REALTIME_FACTOR_TIE_BAND` of the
+/// best value: lower peak memory delta wins, then alphabetical model name as
+/// a final stable tie-break. Used for both "fastest" and "balanced" so noise
+/// in the underlying metric is never presented as signal.
+fn pick_by_metric_with_tiebreak<'a>(
+    candidates: &[(&'a ModelResult, f64)],
+) -> Option<&'a ModelResult> {
+    let best = candidates
+        .iter()
+        .map(|(_, value)| *value)
+        .min_by(f64::total_cmp)?;
+    candidates
+        .iter()
+        .filter(|(_, value)| within_tie_band(*value, best))
+        .map(|(result, _)| *result)
+        .min_by(|left, right| {
+            left.memory_delta_mb
+                .cmp(&right.memory_delta_mb)
+                .then_with(|| left.model_name.cmp(&right.model_name))
+        })
+}
+
 fn recommendations(results: &[ModelResult]) -> Recommendations {
     let successful = results
         .iter()
         .filter(|result| result.error.is_none())
         .collect::<Vec<_>>();
-    let fastest = successful
+
+    // "Fastest" ranks by realtime_factor (compute-seconds per audio-second),
+    // not warm_median_ms. warm_median_ms on ModelResult is a percentile
+    // pooled across every fixture's warm samples -- short and long audio in
+    // one distribution -- so its rank position jitters between fixture-length
+    // strata across otherwise-identical runs. realtime_factor is a
+    // corpus-weighted ratio computed per fixture then combined, so it stays
+    // stable and comparable across different fixture mixes. warm_median_ms is
+    // left untouched elsewhere in the report; only this ranking input
+    // changes. See issue #272.
+    let fastest_candidates = successful
         .iter()
-        .filter_map(|result| result.warm_median_ms.map(|value| (*result, value)))
-        .min_by(|left, right| left.1.total_cmp(&right.1))
-        .map(|(result, _)| result.model_name.clone());
+        .filter_map(|result| result.realtime_factor.map(|value| (*result, value)))
+        .collect::<Vec<_>>();
+    let fastest =
+        pick_by_metric_with_tiebreak(&fastest_candidates).map(|result| result.model_name.clone());
+
     let most_accurate = successful
         .iter()
         .filter_map(|result| result.word_error_rate.map(|value| (*result, value)))
         .min_by(|left, right| left.1.total_cmp(&right.1))
         .map(|(result, _)| result.model_name.clone());
+
     let best_wer = successful
         .iter()
         .filter_map(|result| result.word_error_rate)
         .min_by(f64::total_cmp);
+
+    // "Balanced" first narrows to models within 2 accuracy points of the best
+    // WER, then within that accuracy window ranks by realtime_factor (same
+    // stability fix as "fastest") and, among models whose realtime_factor is
+    // tied within the 10% noise band, prefers lower peak memory delta. This
+    // is the rule that stops a model like Parakeet v2 (~2.9GB RSS delta) from
+    // winning over alternatives at 46-545MB purely because pooled timing
+    // noise nudged it ahead when their speed is otherwise indistinguishable.
+    // See issue #272.
     let balanced = best_wer.and_then(|best| {
-        successful
+        let balanced_candidates = successful
             .iter()
             .filter(|result| result.word_error_rate.is_some_and(|wer| wer <= best + 0.02))
-            .filter_map(|result| result.warm_median_ms.map(|value| (*result, value)))
-            .min_by(|left, right| left.1.total_cmp(&right.1))
-            .map(|(result, _)| result.model_name.clone())
+            .filter_map(|result| result.realtime_factor.map(|value| (*result, value)))
+            .collect::<Vec<_>>();
+        pick_by_metric_with_tiebreak(&balanced_candidates)
+            .map(|result| result.model_name.clone())
     });
+
     Recommendations {
         fastest,
         most_accurate,
@@ -790,5 +852,107 @@ mod tests {
         assert_eq!(recommendations.fastest.as_deref(), Some("fast"));
         assert_eq!(recommendations.most_accurate.as_deref(), Some("accurate"));
         assert_eq!(recommendations.balanced.as_deref(), Some("balanced"));
+    }
+
+    fn full_result(
+        name: &str,
+        warm_median_ms: f64,
+        realtime_factor: f64,
+        wer: f64,
+        memory_delta_mb: u64,
+    ) -> ModelResult {
+        ModelResult {
+            model_name: name.to_string(),
+            label: name.to_string(),
+            backend: String::new(),
+            accelerator: String::new(),
+            model_load_ms: Some(1.0),
+            first_inference_ms: Some(1.0),
+            warm_median_ms: Some(warm_median_ms),
+            warm_p95_ms: Some(warm_median_ms),
+            realtime_factor: Some(realtime_factor),
+            word_error_rate: Some(wer),
+            memory_delta_mb,
+            fixtures: Vec::new(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn fastest_ignores_pooled_median_flip_and_follows_stable_realtime_factor() {
+        // Reproduces the issue #272 scenario: two runs of the same models
+        // where the pooled warm_median_ms straddles and flips which model
+        // looks faster, but realtime_factor (computed per-fixture, stable
+        // across fixture mixes) consistently favors the same model.
+        let run_a = recommendations(&[
+            full_result("tiny.en", 108.6, 0.09, 0.04, 75),
+            full_result("parakeet-v3", 95.0, 0.05, 0.03, 470),
+        ]);
+        let run_b = recommendations(&[
+            full_result("tiny.en", 70.0, 0.09, 0.04, 75),
+            full_result("parakeet-v3", 77.5, 0.05, 0.03, 470),
+        ]);
+        assert_eq!(run_a.fastest.as_deref(), Some("parakeet-v3"));
+        assert_eq!(run_b.fastest.as_deref(), Some("parakeet-v3"));
+    }
+
+    #[test]
+    fn fastest_breaks_ties_within_ten_percent_by_lower_memory_then_name() {
+        // Realtime factors within 10% of each other are a tie; the model
+        // with lower memory delta should win regardless of pooled timing
+        // noise or input order.
+        let recommendations = recommendations(&[
+            full_result("heavy", 100.0, 1.00, 0.05, 3000),
+            full_result("light", 100.0, 1.05, 0.05, 200),
+        ]);
+        assert_eq!(recommendations.fastest.as_deref(), Some("light"));
+
+        // Order should not matter.
+        let recommendations = recommendations(&[
+            full_result("light", 100.0, 1.05, 0.05, 200),
+            full_result("heavy", 100.0, 1.00, 0.05, 3000),
+        ]);
+        assert_eq!(recommendations.fastest.as_deref(), Some("light"));
+    }
+
+    #[test]
+    fn fastest_tie_band_boundary_is_exactly_ten_percent() {
+        // At exactly 10% relative delta the two models are still tied, so
+        // the lower-memory model wins even though it is nominally slower.
+        let at_boundary = recommendations(&[
+            full_result("slower-lighter", 100.0, 1.10, 0.05, 100),
+            full_result("faster-heavier", 100.0, 1.00, 0.05, 3000),
+        ]);
+        assert_eq!(at_boundary.fastest.as_deref(), Some("slower-lighter"));
+
+        // Just past 10% the delta is a real difference, so the faster model
+        // wins outright regardless of memory.
+        let past_boundary = recommendations(&[
+            full_result("slower-lighter", 100.0, 1.1001, 0.05, 100),
+            full_result("faster-heavier", 100.0, 1.00, 0.05, 3000),
+        ]);
+        assert_eq!(past_boundary.fastest.as_deref(), Some("faster-heavier"));
+    }
+
+    #[test]
+    fn balanced_breaks_ties_within_accuracy_window_by_lower_memory() {
+        // Both models are within the 2-point accuracy window and their
+        // realtime factors are tied within 10%, so the lower-memory model
+        // (matching the Parakeet v2 ~2.9GB-vs-alternatives scenario from the
+        // issue) should be recommended as "balanced".
+        let recommendations = recommendations(&[
+            full_result("parakeet-v2", 100.0, 1.00, 0.05, 2925),
+            full_result("small.en", 100.0, 1.03, 0.06, 500),
+        ]);
+        assert_eq!(recommendations.balanced.as_deref(), Some("small.en"));
+    }
+
+    #[test]
+    fn balanced_excludes_models_outside_the_accuracy_window() {
+        let recommendations = recommendations(&[
+            full_result("accurate", 300.0, 0.30, 0.05, 500),
+            full_result("inaccurate-but-fast", 10.0, 0.01, 0.20, 50),
+        ]);
+        assert_eq!(recommendations.balanced.as_deref(), Some("accurate"));
     }
 }

--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -11,6 +11,29 @@ static INIT_LOGGING: Once = Once::new();
 /// Relative path under the platform data directory for app models.
 const APP_MODELS_REL: &[&str] = &["local-dictation", "models"];
 
+/// Above this many samples, whisper.cpp's `single_segment` mode is unsafe:
+/// small models can emit an early end-of-text token roughly 24s into a 28s
+/// window, and `single_segment` force-skips the *entire* 30s decode window
+/// on early EOT (discarding the unread tail) instead of resuming decode from
+/// the last emitted timestamp. 12s gives comfortable headroom under the
+/// ~24s failure point observed in production while covering every
+/// streaming window (10s) with margin to spare.
+///
+/// Streaming's incremental windows ([`super::chunking::WINDOW_SAMPLES`], 10s)
+/// stay under this threshold and keep `single_segment = true`, which is
+/// correct and desired there: each window is short enough that early EOT
+/// isn't observed in practice, and single-segment output avoids spurious
+/// segment splits within a short utterance. Longer batch/file transcriptions
+/// cross the threshold and get multi-segment decoding so the tail isn't
+/// silently dropped.
+const SINGLE_SEGMENT_MAX_SECONDS: usize = 12;
+
+/// Decide whether whisper should be constrained to a single output segment
+/// for a given sample count. See [`SINGLE_SEGMENT_MAX_SECONDS`] for why.
+fn should_use_single_segment(sample_count: usize) -> bool {
+    sample_count <= SINGLE_SEGMENT_MAX_SECONDS * super::WHISPER_SAMPLE_RATE as usize
+}
+
 /// Suppress whisper.cpp verbose logging by installing a trampoline that routes to Rust's log crate
 /// (which we don't configure, so logs go nowhere).
 fn suppress_whisper_logs() {
@@ -164,7 +187,7 @@ impl TranscriptionBackend for WhisperBackend {
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
         params.set_suppress_blank(true);
-        params.set_single_segment(true);
+        params.set_single_segment(should_use_single_segment(samples.len()));
         if let Some(prompt) = initial_prompt {
             params.set_initial_prompt(prompt);
         }
@@ -184,7 +207,7 @@ impl TranscriptionBackend for WhisperBackend {
             let segment_text = segment
                 .to_str()
                 .map_err(|e| format!("Failed to get text for segment {}: {}", i, e))?;
-            text.push_str(segment_text);
+            append_segment(&mut text, segment_text);
         }
 
         let trimmed = text.trim().to_string();
@@ -240,6 +263,24 @@ fn whisper_language_param(language: &str) -> Option<&str> {
     }
 }
 
+/// Append a whisper segment's text to the accumulated transcript, inserting a
+/// separating space only when neither side already has whitespace at the
+/// join. Whisper.cpp segments *usually* carry their own leading space (it's
+/// part of the BPE token), which is why the single-segment path historically
+/// got away with a bare `push_str`. Multi-segment decoding (see
+/// [`should_use_single_segment`]) makes the join point observable more often,
+/// so this guards against words gluing together across a segment boundary
+/// (e.g. "...dictating" + "The next..." => "...dictatingThe next...").
+fn append_segment(text: &mut String, segment_text: &str) {
+    let needs_space = !text.is_empty()
+        && !text.ends_with(char::is_whitespace)
+        && !segment_text.starts_with(char::is_whitespace);
+    if needs_space {
+        text.push(' ');
+    }
+    text.push_str(segment_text);
+}
+
 fn strip_punctuation(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut result = String::with_capacity(input.len());
@@ -277,7 +318,10 @@ fn strip_punctuation(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{strip_punctuation, whisper_language_param};
+    use super::{
+        append_segment, get_model_path, should_use_single_segment, specific_model_exists,
+        strip_punctuation, whisper_language_param, TranscriptionBackend, WhisperBackend,
+    };
 
     #[test]
     fn language_auto_maps_to_none() {
@@ -331,5 +375,223 @@ mod tests {
     #[test]
     fn strip_preserves_french_contraction() {
         assert_eq!(strip_punctuation("c'est la vie!"), "c'est la vie");
+    }
+
+    // --- should_use_single_segment ---------------------------------------
+
+    #[test]
+    fn streaming_windows_stay_single_segment() {
+        // Streaming's incremental decode window (see transcriber::chunking::
+        // WINDOW_SAMPLES) is 10s of 16kHz audio. That must remain
+        // single-segment: streaming behavior is correct today and this issue
+        // must not change it.
+        let window_samples = 10 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(window_samples));
+    }
+
+    #[test]
+    fn streaming_step_size_stays_single_segment() {
+        // STEP_SAMPLES (8s) is smaller than WINDOW_SAMPLES but exercise it
+        // too since some call sites may transcribe partial windows.
+        let step_samples = 8 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(step_samples));
+    }
+
+    #[test]
+    fn xlong_batch_audio_disables_single_segment() {
+        // The production repro: a 28s batch/file transcription must not be
+        // constrained to a single segment, or whisper.cpp's early-EOT
+        // force-skip silently drops the tail.
+        let xlong_samples = 28 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(!should_use_single_segment(xlong_samples));
+    }
+
+    #[test]
+    fn boundary_exactly_at_threshold_is_single_segment() {
+        let boundary = 12 * super::super::WHISPER_SAMPLE_RATE as usize;
+        assert!(should_use_single_segment(boundary));
+    }
+
+    #[test]
+    fn boundary_one_sample_over_threshold_is_multi_segment() {
+        let boundary = 12 * super::super::WHISPER_SAMPLE_RATE as usize + 1;
+        assert!(!should_use_single_segment(boundary));
+    }
+
+    #[test]
+    fn zero_samples_is_single_segment() {
+        assert!(should_use_single_segment(0));
+    }
+
+    // --- append_segment ----------------------------------------------------
+
+    #[test]
+    fn append_segment_first_segment_starts_text() {
+        let mut text = String::new();
+        append_segment(&mut text, " Hello");
+        assert_eq!(text, " Hello");
+    }
+
+    #[test]
+    fn append_segment_preserves_existing_leading_space() {
+        // Mirrors whisper.cpp's normal behavior: each segment's text already
+        // carries its own leading space as part of the BPE token, so no
+        // extra separator should be inserted.
+        let mut text = String::new();
+        append_segment(&mut text, " Hello");
+        append_segment(&mut text, " world.");
+        assert_eq!(text.trim(), "Hello world.");
+    }
+
+    #[test]
+    fn append_segment_inserts_space_when_both_sides_lack_one() {
+        // Defensive case: if a segment boundary ever lacks whitespace on
+        // both sides, words must not glue together.
+        let mut text = String::new();
+        append_segment(&mut text, "Hello");
+        append_segment(&mut text, "world");
+        assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn append_segment_does_not_double_space() {
+        let mut text = String::new();
+        append_segment(&mut text, "Hello ");
+        append_segment(&mut text, " world");
+        assert_eq!(text, "Hello  world");
+    }
+
+    // --- model-backed repro + fix proof (require installed .en models) ----
+    //
+    // Run on a machine with the models installed:
+    //   cargo test -- --ignored --nocapture --test-threads=1 xlong
+
+    /// Reproduces the bug directly: same model, same audio, only the
+    /// `single_segment` flag flipped. `single_segment = true` must truncate
+    /// the 28s xlong fixture (fewer words recovered) relative to
+    /// `single_segment = false`, matching the production repro in issue #269.
+    #[test]
+    #[ignore]
+    fn xlong_truncation_repro_single_segment() {
+        use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+        let wav = include_bytes!("../../../../bench/audio/xlong.wav");
+        let samples =
+            crate::transcriber::parse_wav_to_samples(wav).expect("decode xlong fixture");
+
+        let mut ran_any = false;
+        for model_name in ["tiny.en", "base.en"] {
+            let model_path = match get_model_path(model_name) {
+                Ok(path) => path,
+                Err(_) => {
+                    eprintln!("skipping {model_name}: model not installed");
+                    continue;
+                }
+            };
+            ran_any = true;
+            let path_str = model_path.to_str().expect("model path is valid UTF-8");
+
+            let run = |single_segment: bool| -> String {
+                let ctx = WhisperContext::new_with_params(
+                    path_str,
+                    WhisperContextParameters::default(),
+                )
+                .expect("load whisper model");
+                let mut state = ctx.create_state().expect("create whisper state");
+                let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+                params.set_language(Some("en"));
+                params.set_print_special(false);
+                params.set_print_progress(false);
+                params.set_print_realtime(false);
+                params.set_print_timestamps(false);
+                params.set_suppress_blank(true);
+                params.set_single_segment(single_segment);
+                state.full(params, &samples).expect("transcribe xlong fixture");
+
+                let mut text = String::new();
+                for i in 0..state.full_n_segments() {
+                    let segment = state.get_segment(i).expect("segment");
+                    let segment_text = segment.to_str().expect("segment text");
+                    append_segment(&mut text, segment_text);
+                }
+                text.trim().to_string()
+            };
+
+            let truncated = run(true);
+            let complete = run(false);
+            let truncated_words = truncated.split_whitespace().count();
+            let complete_words = complete.split_whitespace().count();
+
+            eprintln!(
+                "{model_name}: single_segment=true -> {truncated_words} words: {truncated:?}"
+            );
+            eprintln!(
+                "{model_name}: single_segment=false -> {complete_words} words: {complete:?}"
+            );
+
+            assert!(
+                complete_words > truncated_words,
+                "{model_name}: expected single_segment=false to recover more words than \
+                 single_segment=true (got {complete_words} vs {truncated_words}); this was \
+                 supposed to reproduce the issue #269 truncation"
+            );
+        }
+
+        if !ran_any {
+            panic!(
+                "no whisper .en models installed to run this repro (need at least one of \
+                 tiny.en, base.en)"
+            );
+        }
+    }
+
+    /// Proves the fix: the normal, public `transcribe()` path (which now
+    /// picks `single_segment` via [`should_use_single_segment`]) recovers the
+    /// xlong fixture's final clause ("...throughout the day") instead of
+    /// truncating at "...for dictating" as it did before this issue's fix.
+    #[test]
+    #[ignore]
+    fn xlong_batch_transcription_recovers_full_tail_after_fix() {
+        let wav = include_bytes!("../../../../bench/audio/xlong.wav");
+        let samples =
+            crate::transcriber::parse_wav_to_samples(wav).expect("decode xlong fixture");
+
+        let mut ran_any = false;
+        for model_name in ["tiny.en", "base.en"] {
+            if !specific_model_exists(model_name) {
+                eprintln!("skipping {model_name}: model not installed");
+                continue;
+            }
+            ran_any = true;
+
+            let mut backend = WhisperBackend::new();
+            backend.load_model(model_name).expect("load model");
+            let text = backend
+                .transcribe(&samples, "en", None, true)
+                .expect("transcribe xlong fixture");
+
+            eprintln!(
+                "{model_name}: {} words: {text:?}",
+                text.split_whitespace().count()
+            );
+
+            let lower = text.to_lowercase();
+            assert!(
+                lower.contains("throughout the day"),
+                "{model_name}: expected the fixed batch transcribe() to recover the fixture's \
+                 final clause ('...throughout the day'), but truncated output was: {text:?}"
+            );
+            assert!(
+                !lower.trim_end().ends_with("for dictating"),
+                "{model_name}: transcribe() still truncates at 'for dictating', got: {text:?}"
+            );
+        }
+
+        if !ran_any {
+            panic!(
+                "no whisper .en models installed to run this fix proof (need at least one of \
+                 tiny.en, base.en)"
+            );
+        }
     }
 }

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -479,9 +479,10 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
             <h4 className="mb-1 text-xs font-semibold text-stone-700 dark:text-stone-300">Metrics</h4>
             <table className="w-full table-fixed text-[11px]">
               <colgroup>
-                <col className="w-[34%]" />
-                <col className="w-[18%]" />
-                <col className="w-[16%]" />
+                <col className="w-[28%]" />
+                <col className="w-[14%]" />
+                <col className="w-[13%]" />
+                <col className="w-[13%]" />
                 <col className="w-[16%]" />
                 <col className="w-[16%]" />
               </colgroup>
@@ -491,7 +492,8 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   <th className="px-2 py-2 font-medium text-right">Median</th>
                   <th className="px-2 py-2 font-medium text-right">P95</th>
                   <th className="px-2 py-2 font-medium text-right">Speed</th>
-                  <th className="pl-2 py-2 font-medium text-right">WER norm (raw)</th>
+                  <th className="px-2 py-2 font-medium text-right">WER norm (raw)</th>
+                  <th className="pl-2 py-2 font-medium text-right">Delivered (raw)</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-stone-200 dark:divide-stone-700 text-stone-700 dark:text-stone-300">
@@ -502,15 +504,19 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                       <span className="block text-[10px] text-stone-400">{result.accelerator}</span>
                     </td>
                     {result.error ? (
-                      <td colSpan={4} className="px-2 py-2.5 text-red-600 dark:text-red-400">{result.error}</td>
+                      <td colSpan={5} className="px-2 py-2.5 text-red-600 dark:text-red-400">{result.error}</td>
                     ) : (
                       <>
                         <td className="px-2 py-2.5 text-right tabular-nums">{milliseconds(result.warmMedianMs)}</td>
                         <td className="px-2 py-2.5 text-right tabular-nums">{milliseconds(result.warmP95Ms)}</td>
                         <td className="px-2 py-2.5 text-right tabular-nums">{speed(result.realtimeFactor)}</td>
-                        <td className="pl-2 py-2.5 text-right tabular-nums">
+                        <td className="px-2 py-2.5 text-right tabular-nums">
                           {percentage(result.normalizedWordErrorRate)}
                           <span className="text-stone-400 dark:text-stone-500"> ({percentage(result.wordErrorRate)})</span>
+                        </td>
+                        <td className="pl-2 py-2.5 text-right tabular-nums">
+                          {percentage(result.deliveredNormalizedWordErrorRate)}
+                          <span className="text-stone-400 dark:text-stone-500"> ({percentage(result.deliveredWordErrorRate)})</span>
                         </td>
                       </>
                     )}
@@ -521,7 +527,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
           </div>
 
           <p className="text-[11px] leading-relaxed text-stone-500 dark:text-stone-400">
-            WER counts changed, missing, and extra words against the known transcript. Normalized WER first ignores formatting and number/unit spelling (16 kHz = sixteen kilohertz, front end = frontend) so it reflects recognition, not formatting; raw WER is shown in parentheses. Accuracy ranking and the Accurate/Balanced picks use the normalized number. Balanced means the fastest model within 2 accuracy points of the best result.
+            WER counts changed, missing, and extra words against the known transcript. Normalized WER first ignores formatting and number/unit spelling (16 kHz = sixteen kilohertz, front end = frontend) so it reflects recognition, not formatting; raw WER is shown in parentheses. Delivered WER scores the text after the production transform pipeline (dev-vocab prompt for Whisper, then cleanup / correction / formatting) — what actually reaches the clipboard — again shown normalized with raw in parentheses. Accuracy ranking and the Accurate/Balanced picks use the normalized recognition number. Balanced means the fastest model within 2 accuracy points of the best result.
           </p>
 
           <div className="space-y-2">
@@ -548,6 +554,13 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                       <div className="mt-1 grid gap-1 text-stone-500 dark:text-stone-400">
                         <p><span className="font-medium">Reference:</span> {fixture.reference}</p>
                         <p><span className="font-medium">Output:</span> {fixture.transcript || '(empty)'}</p>
+                        <p>
+                          <span className="font-medium">Delivered:</span> {fixture.deliveredTranscript || '(empty)'}
+                          <span className="text-stone-400 dark:text-stone-500"> — {fixture.deliveredNormalizedWordErrors}/{fixture.normalizedReferenceWords} errors ({fixture.deliveredWordErrors}/{fixture.referenceWords} raw)</span>
+                          {fixture.deliveredTransformFailed && (
+                            <span className="text-amber-600 dark:text-amber-400"> — transform failed, showing raw</span>
+                          )}
+                        </p>
                       </div>
                     </div>
                   ))}

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -47,7 +47,7 @@ function modelLabel(report: BenchmarkReport, modelName: string | null): string {
 }
 
 type LatencyResult = BenchmarkModelResult & { warmMedianMs: number; warmP95Ms: number };
-type AccuracyResult = BenchmarkModelResult & { wordErrorRate: number };
+type AccuracyResult = BenchmarkModelResult & { normalizedWordErrorRate: number };
 
 function latencyResults(report: BenchmarkReport): LatencyResult[] {
   return report.results.filter((result): result is LatencyResult => (
@@ -57,7 +57,7 @@ function latencyResults(report: BenchmarkReport): LatencyResult[] {
 
 function accuracyResults(report: BenchmarkReport): AccuracyResult[] {
   return report.results.filter((result): result is AccuracyResult => (
-    !result.error && result.wordErrorRate !== null
+    !result.error && result.normalizedWordErrorRate !== null
   ));
 }
 
@@ -103,11 +103,11 @@ function AccuracyChart({ report }: { report: BenchmarkReport }) {
     <div>
       <div className="mb-2 flex items-center justify-between gap-3">
         <h4 className="text-xs font-semibold text-stone-700 dark:text-stone-300">Word accuracy</h4>
-        <span className="text-[10px] text-stone-400 dark:text-stone-500">Higher is better</span>
+        <span className="text-[10px] text-stone-400 dark:text-stone-500">Normalized / higher is better</span>
       </div>
       <div className="space-y-2">
         {results.map((result) => {
-          const accuracy = Math.max(0, 1 - result.wordErrorRate);
+          const accuracy = Math.max(0, 1 - result.normalizedWordErrorRate);
           return (
             <div key={result.modelName} className="grid grid-cols-[6.5rem_1fr_3rem] items-center gap-2">
               <span className="truncate text-[11px] font-medium text-stone-600 dark:text-stone-300" title={result.label}>{result.label}</span>
@@ -485,7 +485,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   <th className="px-2 py-2 font-medium text-right">Median</th>
                   <th className="px-2 py-2 font-medium text-right">P95</th>
                   <th className="px-2 py-2 font-medium text-right">Speed</th>
-                  <th className="pl-2 py-2 font-medium text-right">WER</th>
+                  <th className="pl-2 py-2 font-medium text-right">WER norm (raw)</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-stone-200 dark:divide-stone-700 text-stone-700 dark:text-stone-300">
@@ -502,7 +502,10 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                         <td className="px-2 py-2.5 text-right tabular-nums">{milliseconds(result.warmMedianMs)}</td>
                         <td className="px-2 py-2.5 text-right tabular-nums">{milliseconds(result.warmP95Ms)}</td>
                         <td className="px-2 py-2.5 text-right tabular-nums">{speed(result.realtimeFactor)}</td>
-                        <td className="pl-2 py-2.5 text-right tabular-nums">{percentage(result.wordErrorRate)}</td>
+                        <td className="pl-2 py-2.5 text-right tabular-nums">
+                          {percentage(result.normalizedWordErrorRate)}
+                          <span className="text-stone-400 dark:text-stone-500"> ({percentage(result.wordErrorRate)})</span>
+                        </td>
                       </>
                     )}
                   </tr>
@@ -512,7 +515,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
           </div>
 
           <p className="text-[11px] leading-relaxed text-stone-500 dark:text-stone-400">
-            WER counts changed, missing, and extra words against the known transcript. Balanced means the fastest model within 2 accuracy points of the best result.
+            WER counts changed, missing, and extra words against the known transcript. Normalized WER first ignores formatting and number/unit spelling (16 kHz = sixteen kilohertz, front end = frontend) so it reflects recognition, not formatting; raw WER is shown in parentheses. Accuracy ranking and the Accurate/Balanced picks use the normalized number. Balanced means the fastest model within 2 accuracy points of the best result.
           </p>
 
           <div className="space-y-2">
@@ -531,7 +534,10 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                     <div key={fixture.fixtureId} className="text-[11px] leading-relaxed">
                       <div className="flex justify-between gap-3 font-medium text-stone-700 dark:text-stone-300">
                         <span>{fixture.label} / {fixture.audioSeconds.toFixed(1)}s</span>
-                        <span>{fixture.wordErrors}/{fixture.referenceWords} errors</span>
+                        <span>
+                          {fixture.normalizedWordErrors}/{fixture.normalizedReferenceWords} errors
+                          <span className="text-stone-400 dark:text-stone-500"> ({fixture.wordErrors}/{fixture.referenceWords} raw)</span>
+                        </span>
                       </div>
                       <div className="mt-1 grid gap-1 text-stone-500 dark:text-stone-400">
                         <p><span className="font-medium">Reference:</span> {fixture.reference}</p>

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -415,6 +415,12 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
               <p className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400">
                 {report.platform} / Murmur v{report.appVersion} / {report.preset}
               </p>
+              <p
+                className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400"
+                title="One-time shared backend init (Metal shader compilation, ANE compile cache, etc.) measured once before per-model timing, so it doesn't skew any single model's cold-load number."
+              >
+                Shared init (one-time): {milliseconds(report.sharedInitMs)}
+              </p>
             </div>
             <button
               type="button"
@@ -525,7 +531,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-stone-500 dark:text-stone-400">
                     <span>Cold load</span><span className="text-right tabular-nums">{milliseconds(result.modelLoadMs)}</span>
                     <span>First inference</span><span className="text-right tabular-nums">{milliseconds(result.firstInferenceMs)}</span>
-                    <span>Memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB</span>
+                    <span title="Process RSS delta. Models run sequentially in one process, so allocator retention from an earlier model can inflate a later model's baseline — treat as a rough signal, not an isolated measurement.">Memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB</span>
                   </div>
                   {result.fixtures.map((fixture) => (
                     <div key={fixture.fixtureId} className="text-[11px] leading-relaxed">

--- a/app/src/lib/benchmark.test.ts
+++ b/app/src/lib/benchmark.test.ts
@@ -15,6 +15,7 @@ function report(createdAt: string): BenchmarkReport {
     platform: 'macos aarch64',
     preset: 'quick',
     iterations: 3,
+    sharedInitMs: 1200,
     results: [],
     recommendations: { fastest: null, mostAccurate: null, balanced: null },
   };

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -18,7 +18,7 @@ export interface BenchmarkProgress {
   modelName: string;
   modelLabel: string;
   fixture: string | null;
-  phase: 'loading' | 'warming' | 'measuring' | 'complete';
+  phase: 'priming' | 'loading' | 'warming' | 'measuring' | 'complete';
 }
 
 export interface BenchmarkActivity {
@@ -51,6 +51,10 @@ export interface BenchmarkModelResult {
   warmP95Ms: number | null;
   realtimeFactor: number | null;
   wordErrorRate: number | null;
+  /** Process-RSS delta for this model's run. Models are benchmarked
+   * sequentially in one process, so allocator retention from an earlier
+   * model can inflate a later model's baseline — treat as a rough signal,
+   * not an isolated per-model measurement. */
   memoryDeltaMb: number;
   fixtures: BenchmarkFixtureResult[];
   error: string | null;
@@ -62,6 +66,11 @@ export interface BenchmarkReport {
   platform: string;
   preset: BenchmarkPreset;
   iterations: number;
+  /** Duration (ms) of the untimed warm-up pass run once before any
+   * per-model timing, absorbing one-time shared backend init (Metal shader
+   * compilation, ANE compile cache, etc). Represents real first-launch
+   * latency but is not a per-model attribute. */
+  sharedInitMs: number;
   results: BenchmarkModelResult[];
   recommendations: {
     fastest: string | null;
@@ -131,6 +140,7 @@ function isBenchmarkReport(value: unknown): value is BenchmarkReport {
     && typeof value.platform === 'string'
     && (value.preset === 'quick' || value.preset === 'standard' || value.preset === 'thorough')
     && isNumber(value.iterations)
+    && isNumber(value.sharedInitMs)
     && Array.isArray(value.results)
     && value.results.every(isModelResult)
     && isNullableString(value.recommendations.fastest)

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -36,6 +36,9 @@ export interface BenchmarkFixtureResult {
   wordErrorRate: number;
   wordErrors: number;
   referenceWords: number;
+  normalizedWordErrorRate: number;
+  normalizedWordErrors: number;
+  normalizedReferenceWords: number;
   reference: string;
   transcript: string;
 }
@@ -51,6 +54,7 @@ export interface BenchmarkModelResult {
   warmP95Ms: number | null;
   realtimeFactor: number | null;
   wordErrorRate: number | null;
+  normalizedWordErrorRate: number | null;
   memoryDeltaMb: number;
   fixtures: BenchmarkFixtureResult[];
   error: string | null;
@@ -101,6 +105,9 @@ function isFixtureResult(value: unknown): value is BenchmarkFixtureResult {
     && isNumber(value.wordErrorRate)
     && isNumber(value.wordErrors)
     && isNumber(value.referenceWords)
+    && isNumber(value.normalizedWordErrorRate)
+    && isNumber(value.normalizedWordErrors)
+    && isNumber(value.normalizedReferenceWords)
     && typeof value.reference === 'string'
     && typeof value.transcript === 'string';
 }
@@ -117,6 +124,7 @@ function isModelResult(value: unknown): value is BenchmarkModelResult {
     && isNullableNumber(value.warmP95Ms)
     && isNullableNumber(value.realtimeFactor)
     && isNullableNumber(value.wordErrorRate)
+    && isNullableNumber(value.normalizedWordErrorRate)
     && isNumber(value.memoryDeltaMb)
     && Array.isArray(value.fixtures)
     && value.fixtures.every(isFixtureResult)

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -41,6 +41,18 @@ export interface BenchmarkFixtureResult {
   normalizedReferenceWords: number;
   reference: string;
   transcript: string;
+  /** Text after the production transcript-transform pipeline ran on
+   * `transcript` — what actually reaches the clipboard. The delivered* WER
+   * fields score this against `reference`; raw/normalized above score the
+   * decoder output. See issue #271. */
+  deliveredTranscript: string;
+  deliveredWordErrorRate: number;
+  deliveredWordErrors: number;
+  deliveredNormalizedWordErrorRate: number;
+  deliveredNormalizedWordErrors: number;
+  /** True when the transform errored and delivered* fell back to scoring the
+   * untransformed `transcript`. */
+  deliveredTransformFailed: boolean;
 }
 
 export interface BenchmarkModelResult {
@@ -55,6 +67,11 @@ export interface BenchmarkModelResult {
   realtimeFactor: number | null;
   wordErrorRate: number | null;
   normalizedWordErrorRate: number | null;
+  /** Corpus WER of the delivered text (post transcript-transform pipeline),
+   * raw and normalized — the metric reflecting clipboard output rather than
+   * raw decoder output. See issue #271. */
+  deliveredWordErrorRate: number | null;
+  deliveredNormalizedWordErrorRate: number | null;
   /** Process-RSS delta for this model's run. Models are benchmarked
    * sequentially in one process, so allocator retention from an earlier
    * model can inflate a later model's baseline — treat as a rough signal,
@@ -118,7 +135,13 @@ function isFixtureResult(value: unknown): value is BenchmarkFixtureResult {
     && isNumber(value.normalizedWordErrors)
     && isNumber(value.normalizedReferenceWords)
     && typeof value.reference === 'string'
-    && typeof value.transcript === 'string';
+    && typeof value.transcript === 'string'
+    && typeof value.deliveredTranscript === 'string'
+    && isNumber(value.deliveredWordErrorRate)
+    && isNumber(value.deliveredWordErrors)
+    && isNumber(value.deliveredNormalizedWordErrorRate)
+    && isNumber(value.deliveredNormalizedWordErrors)
+    && typeof value.deliveredTransformFailed === 'boolean';
 }
 
 function isModelResult(value: unknown): value is BenchmarkModelResult {
@@ -134,6 +157,8 @@ function isModelResult(value: unknown): value is BenchmarkModelResult {
     && isNullableNumber(value.realtimeFactor)
     && isNullableNumber(value.wordErrorRate)
     && isNullableNumber(value.normalizedWordErrorRate)
+    && isNullableNumber(value.deliveredWordErrorRate)
+    && isNullableNumber(value.deliveredNormalizedWordErrorRate)
     && isNumber(value.memoryDeltaMb)
     && Array.isArray(value.fixtures)
     && value.fixtures.every(isFixtureResult)

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -50,6 +50,7 @@ The active backend is stored as `Mutex<Box<dyn TranscriptionBackend>>` in `AppSt
 - If the user changes models in settings, the context is dropped and re-created on next transcription
 - Model files are single `.bin` files (e.g., `ggml-base.en.bin`)
 - Model search paths are documented in `docs/onboarding.md`
+- `single_segment` decoding is duration-conditional (`should_use_single_segment`, 12s threshold): short chunks (streaming's 10s windows) stay single-segment, but longer batch/file transcriptions use multi-segment decoding so an early end-of-text token from the model can't force-skip the rest of a long window and silently truncate the tail
 
 ### Incremental Whisper path (`streaming.rs`, `transcriber/chunking.rs`)
 


### PR DESCRIPTION
## Problem

`benchmark.rs` called `backend.transcribe(samples, "en", None, true)` — no initial prompt — and scored **raw decoder output**, skipping the entire `transcript_transform` pipeline (cleanup, voice commands, SmartCorrectionStage Tier-1/2, smart formatting). That is not what lands on the clipboard. Every model was penalized for the same proper-noun mangling ("Tauri"→"Tori", "Murmur"→"Mermer") that post-ASR correction repairs — and since Parakeet/Core ML ignore `initial_prompt` entirely (parakeet.rs), correction is the *only* accuracy lever for the recommended fastest backend, yet it was never measured. Fixes #271 (points 1 & 2).

## Approach

1. **Whisper initial prompt** — whisper models decode with the built-in dev-vocab prompt (`vocab::builtin_terms_prompt()`, includes Tauri / whisper-rs / macOS), matching production capability. Parakeet / Core ML get `None` (they ignore it).
2. **Delivered text** — each reported median transcript is run through the production `transcript_transform` pipeline configured as a **default out-of-the-box install**: the stage config is derived from `dictation_context::resolve(DictationState::default())` with no per-app profile, and the same built-in dev dictionary that seeds the whisper prompt seeds the correction matcher (mirroring `rebuild_correction_matcher`). The delivered text is scored with the **same** raw+normalized scorer machinery and added as a third metric tier — `delivered*` / normalized-`delivered*` WER per fixture and per model — with `deliveredTranscript` kept for inspection.
3. **Failure isolation** (point 4) — on transform error the untransformed transcript is scored and the fixture is flagged (`deliveredTransformFailed`) instead of aborting the run. The `transform` closure is injected into `score_delivered` so the plumbing is unit-tested with a stub and no models.
4. **Frontend** — `benchmark.ts` mirrors the new fields + runtime guards; `PerformanceLab.tsx` adds a Delivered (raw) column and a per-fixture delivered line, following the #270 normalized-with-raw-in-parens pattern.

### Interpretation note
Point 1 ("pass the builtin vocab prompt") treats the app's shipped dev dictionary as an active capability; the delivered path applies it consistently to both the whisper prompt and the correction matcher so the third tier is meaningful. **Changing which levers ship ON by default (e.g. making code-vocab a default) is out of scope — issue #271 point 3.** Recommendation: enabling the dev dictionary + a small proper-noun lexicon by default is what moves the recommended Parakeet backend's delivered WER toward 0; worth a follow-up.

## Test evidence (macbook, Apple Silicon)

- `cargo check` — clean.
- `cargo test -- --test-threads=1` — **394 passed; 0 failed; 3 ignored**. New unit tests: default-context construction, delivered-scoring success + fallback plumbing (stubbed transform), whisper-prompt selection, real default pipeline runs the correction stage.
- `npm ci && npx tsc --noEmit` — clean (exit 0).
- Ignored end-to-end smoke (`--ignored --nocapture`, tiny.en, one fixture):

```
--- delivered path smoke (tiny.en) ---
initial_prompt[..60]: useEffect useState useRef useCallback useMemo useContext Typ
RAW       : Please commit these changes to the main branch
DELIVERED : Please commit these changes to the main branch
raw WER errors=0 delivered WER errors=0 ref_words=8
test result: ok. 1 passed; 0 failed
```

The prompt is passed (dev-vocab visible) and delivered fields are populated end-to-end; tiny.en happened to score this fixture perfectly, so raw == delivered here.

Stacked on #281 #282 #283 #284 via bench/integration — diff vs main includes those until they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)