### PR TITLE
Unify Settings UX and qualify Performance Lab results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Unified Settings and trustworthy Performance Lab state** reorganizes Settings into six task-oriented pages, adds a bounded memory-only running-app picker with manual bundle-ID fallback, and records privacy-safe environment/corpus/execution metadata in versioned benchmark reports while retaining legacy saved runs (#258).
 - **Correct and Teach** lets users edit the newest local history entry, review one bounded high-confidence replacement, and explicitly save it as global, app, or unambiguous project-scoped knowledge. Learned rules persist locally, run deterministically through Smart Correction, and remain inspectable, editable, disableable, exportable, and deletable in Knowledge; ambiguous edits and Voice Command conflicts fail closed (#251).
 - A single transcription model catalog and runtime manager now expose backend capabilities, platform/install state, serialized load/warm/readiness/unload lifecycle, and privacy-safe generation-ordered status events for all seven shipped models (#247).
 - **Voice Commands 2.0** upgrades legacy phrase replacements into typed, persistent local commands with multiline snippets, deterministic date/time variables, explicitly permitted clipboard insertion, global/per-app scopes, conflict validation, and a no-paste preview/test UI. Existing pairs migrate idempotently and retain built-in-first literal behavior (#248).
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- Settings now uses one model selector, presents clipboard-first delivery and file-output suppression explicitly without overwriting the stored auto-paste preference, and uses semantic surface tokens throughout Performance Lab. The strict Fastest and Balanced recommendation contract is unchanged (#258).
 - Onboarding, Settings, recording preparation, model downloads, and Performance Lab now consume the shared catalog/runtime contract. Unknown model identifiers fail closed, and model failures never trigger automatic cross-model fallback (#247).
 - All supported backends now use one final-after-stop transcription path. The Whisper-only incremental worker, provisional overlay preview, preview setting, lifecycle events, reconciliation code, and incremental telemetry were removed; final clipboard, paste, file output, history, and stats delivery remains exactly once (#279).
 - Post-recognition cleanup, voice commands, and Smart Correction now run through one ordered, backend-neutral transformation pipeline with privacy-safe per-stage timing/change telemetry and explicit failure policy (#244).

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use tauri::Emitter;
 
 const BALANCED_ACCURACY_WINDOW: f64 = 0.02;
+const BENCHMARK_REPORT_VERSION: u32 = 2;
 
 /// Whisper model names ordered smallest-to-largest. Used to pick the
 /// cheapest selected whisper model for the untimed shared-init warm-up.
@@ -206,6 +207,9 @@ pub struct ModelResult {
     pub label: String,
     pub backend: String,
     pub accelerator: String,
+    /// Catalog download size. This is deliberately separate from the rough
+    /// process-RSS delta measured below.
+    pub download_size: String,
     pub model_load_ms: Option<f64>,
     pub first_inference_ms: Option<f64>,
     pub warm_median_ms: Option<f64>,
@@ -237,7 +241,41 @@ pub struct Recommendations {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct BenchmarkEnvironment {
+    pub os: String,
+    pub os_version: Option<String>,
+    pub architecture: String,
+    pub hardware_model: Option<String>,
+    pub chip: Option<String>,
+    pub memory_mb: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BenchmarkCorpus {
+    pub language: &'static str,
+    pub fixture_ids: Vec<String>,
+    pub fixture_count: usize,
+    pub reference_words: usize,
+    pub provenance: &'static str,
+    pub limitation: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BenchmarkConfiguration {
+    pub vad_threshold: f32,
+    pub execution_path: &'static str,
+    pub transcript_transform_profile: &'static str,
+    pub percentile_method: &'static str,
+    pub model_run_order: Vec<String>,
+    pub shared_init_order: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BenchmarkReport {
+    pub report_version: u32,
     pub created_at: String,
     pub app_version: String,
     pub platform: String,
@@ -250,6 +288,9 @@ pub struct BenchmarkReport {
     /// It IS representative of real first-launch latency, just not a
     /// per-model attribute.
     pub shared_init_ms: f64,
+    pub environment: BenchmarkEnvironment,
+    pub corpus: BenchmarkCorpus,
+    pub configuration: BenchmarkConfiguration,
     pub results: Vec<ModelResult>,
     pub recommendations: Recommendations,
 }
@@ -680,6 +721,7 @@ fn error_result(model: &BenchmarkModel, error: String) -> ModelResult {
         label: model.label.clone(),
         backend: model.backend.clone(),
         accelerator: model.accelerator.clone(),
+        download_size: model.size.clone(),
         model_load_ms: None,
         first_inference_ms: None,
         warm_median_ms: None,
@@ -692,6 +734,74 @@ fn error_result(model: &BenchmarkModel, error: String) -> ModelResult {
         memory_delta_mb: 0,
         fixtures: Vec::new(),
         error: Some(error),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn benchmark_environment() -> BenchmarkEnvironment {
+    #[cfg(target_os = "macos")]
+    {
+        let memory_mb = command_output("/usr/sbin/sysctl", &["-n", "hw.memsize"])
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(|bytes| bytes / 1024 / 1024);
+        BenchmarkEnvironment {
+            os: "macOS".to_string(),
+            os_version: command_output("/usr/bin/sw_vers", &["-productVersion"]),
+            architecture: std::env::consts::ARCH.to_string(),
+            hardware_model: command_output("/usr/sbin/sysctl", &["-n", "hw.model"]),
+            chip: command_output("/usr/sbin/sysctl", &["-n", "machdep.cpu.brand_string"]),
+            memory_mb,
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        BenchmarkEnvironment {
+            os: std::env::consts::OS.to_string(),
+            os_version: None,
+            architecture: std::env::consts::ARCH.to_string(),
+            hardware_model: None,
+            chip: None,
+            memory_mb: None,
+        }
+    }
+}
+
+fn benchmark_corpus(preset: BenchmarkPreset) -> BenchmarkCorpus {
+    let fixtures = preset.fixtures();
+    BenchmarkCorpus {
+        language: "en",
+        fixture_ids: fixtures.iter().map(|fixture| fixture.id.to_string()).collect(),
+        fixture_count: fixtures.len(),
+        reference_words: fixtures.iter().map(|fixture| words(fixture.reference).len()).sum(),
+        provenance: "Bundled macOS Samantha TTS fixtures",
+        limitation: "Directional local comparison only; clean synthetic speech is not representative of natural speakers, accents, microphones, or environments.",
+    }
+}
+
+fn benchmark_configuration(
+    model_run_order: Vec<String>,
+    shared_init_order: Vec<String>,
+) -> BenchmarkConfiguration {
+    BenchmarkConfiguration {
+        vad_threshold: 0.5,
+        execution_path: "full-buffer final transcription after recording stops",
+        transcript_transform_profile: "default local delivery pipeline",
+        percentile_method: "nearest-rank over measured warm iterations",
+        model_run_order,
+        shared_init_order,
     }
 }
 
@@ -1024,6 +1134,11 @@ pub fn run<R: tauri::Runtime>(
     let iterations = request.preset.iterations();
     let steps_per_model = 1 + fixtures.len() * (1 + iterations);
     let warmup_targets = warmup_plan(&selected);
+    let model_run_order = selected
+        .iter()
+        .map(|model| model.model_name.clone())
+        .collect();
+    let shared_init_order = warmup_targets.clone();
     let total_steps = selected.len() * steps_per_model + warmup_targets.len();
     let mut completed = 0;
     let mut results = Vec::with_capacity(selected.len());
@@ -1258,6 +1373,7 @@ pub fn run<R: tauri::Runtime>(
             label: model.label,
             backend: model.backend,
             accelerator: model.accelerator,
+            download_size: model.size,
             model_load_ms: Some(model_load_ms),
             first_inference_ms,
             warm_median_ms: percentile(&all_warm, 0.5),
@@ -1296,12 +1412,16 @@ pub fn run<R: tauri::Runtime>(
     );
     let recommendations = recommendations(&results);
     Ok(BenchmarkReport {
+        report_version: BENCHMARK_REPORT_VERSION,
         created_at: chrono::Utc::now().to_rfc3339(),
         app_version: env!("CARGO_PKG_VERSION").to_string(),
         platform: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
         preset: request.preset,
         iterations,
         shared_init_ms,
+        environment: benchmark_environment(),
+        corpus: benchmark_corpus(request.preset),
+        configuration: benchmark_configuration(model_run_order, shared_init_order),
         results,
         recommendations,
     })
@@ -1323,6 +1443,7 @@ mod tests {
             label: name.to_string(),
             backend: String::new(),
             accelerator: String::new(),
+            download_size: String::new(),
             model_load_ms: Some(1.0),
             first_inference_ms: Some(1.0),
             warm_median_ms: Some(warm_median_ms),
@@ -1343,6 +1464,30 @@ mod tests {
         assert_eq!(word_errors("one two three", "one four three"), (1, 3));
         assert_eq!(word_errors("one two three", "one two three four"), (1, 3));
         assert_eq!(word_errors("one two three", "one three"), (1, 3));
+    }
+
+    #[test]
+    fn report_metadata_describes_the_exact_corpus_and_final_only_path() {
+        let quick = benchmark_corpus(BenchmarkPreset::Quick);
+        let standard = benchmark_corpus(BenchmarkPreset::Standard);
+        let thorough = benchmark_corpus(BenchmarkPreset::Thorough);
+        assert_eq!(BENCHMARK_REPORT_VERSION, 2);
+        assert_eq!((quick.fixture_count, quick.reference_words), (2, 29));
+        assert_eq!((standard.fixture_count, standard.reference_words), (7, 248));
+        assert_eq!((thorough.fixture_count, thorough.reference_words), (9, 514));
+        assert!(thorough.limitation.contains("synthetic speech"));
+
+        let configuration = benchmark_configuration(
+            vec!["tiny.en".to_string(), "base.en".to_string()],
+            vec!["tiny.en".to_string()],
+        );
+        assert_eq!(configuration.vad_threshold, 0.5);
+        assert_eq!(
+            configuration.execution_path,
+            "full-buffer final transcription after recording stops"
+        );
+        assert_eq!(configuration.model_run_order, ["tiny.en", "base.en"]);
+        assert_eq!(configuration.shared_init_order, ["tiny.en"]);
     }
 
     #[test]

--- a/app/src-tauri/src/frontmost.rs
+++ b/app/src-tauri/src/frontmost.rs
@@ -6,6 +6,97 @@
 //! is returned to the caller and becomes part of its immutable recording
 //! context; failures remain global-only and deny app-specific context reads.
 
+use serde::Serialize;
+
+const MAX_RUNNING_APPLICATIONS: usize = 64;
+
+/// Privacy-bounded data exposed to the Settings picker. Process identifiers,
+/// paths, launch arguments, window titles, and document state never cross the
+/// command boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunningApplication {
+    pub bundle_id: String,
+    pub name: String,
+}
+
+#[derive(Debug)]
+struct RunningApplicationCandidate {
+    bundle_id: Option<String>,
+    name: Option<String>,
+    regular: bool,
+    current_process: bool,
+}
+
+fn bounded_running_applications(
+    candidates: impl IntoIterator<Item = RunningApplicationCandidate>,
+) -> Vec<RunningApplication> {
+    let mut applications = candidates
+        .into_iter()
+        .filter(|candidate| candidate.regular && !candidate.current_process)
+        .filter_map(|candidate| {
+            let bundle_id = candidate.bundle_id?.trim().to_string();
+            if bundle_id.is_empty() {
+                return None;
+            }
+            let name = candidate.name.unwrap_or_default().trim().to_string();
+            Some(RunningApplication {
+                name: if name.is_empty() {
+                    bundle_id.clone()
+                } else {
+                    name
+                },
+                bundle_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    applications.sort_by(|left, right| {
+        left.name
+            .to_lowercase()
+            .cmp(&right.name.to_lowercase())
+            .then_with(|| {
+                left.bundle_id
+                    .to_lowercase()
+                    .cmp(&right.bundle_id.to_lowercase())
+            })
+    });
+    let mut seen = std::collections::HashSet::new();
+    applications.retain(|application| seen.insert(application.bundle_id.to_lowercase()));
+    applications.truncate(MAX_RUNNING_APPLICATIONS);
+    applications
+}
+
+/// Return a bounded, ephemeral list for Settings. The caller owns the only
+/// copy; this module does not cache or log app names or bundle identifiers.
+#[tauri::command]
+#[cfg(target_os = "macos")]
+pub fn list_running_applications() -> Vec<RunningApplication> {
+    use objc2_app_kit::{NSApplicationActivationPolicy, NSWorkspace};
+
+    let current_pid = std::process::id() as i32;
+    let candidates = NSWorkspace::sharedWorkspace()
+        .runningApplications()
+        .iter()
+        .map(|application| RunningApplicationCandidate {
+            bundle_id: application
+                .bundleIdentifier()
+                .map(|value| value.to_string()),
+            name: application.localizedName().map(|value| value.to_string()),
+            regular: application.activationPolicy() == NSApplicationActivationPolicy::Regular,
+            current_process: application.processIdentifier() == current_pid,
+        })
+        .collect::<Vec<_>>();
+    bounded_running_applications(candidates)
+}
+
+/// Linux and other non-macOS builds retain the same command surface without
+/// probing platform process state.
+#[tauri::command]
+#[cfg(not(target_os = "macos"))]
+pub fn list_running_applications() -> Vec<RunningApplication> {
+    Vec::new()
+}
+
 #[cfg(any(target_os = "macos", test))]
 use std::time::Duration;
 
@@ -153,6 +244,84 @@ mod tests {
     use super::*;
     use std::cell::Cell;
     use std::collections::VecDeque;
+
+    fn candidate(id: &str, name: &str) -> RunningApplicationCandidate {
+        RunningApplicationCandidate {
+            bundle_id: Some(id.to_string()),
+            name: Some(name.to_string()),
+            regular: true,
+            current_process: false,
+        }
+    }
+
+    #[test]
+    fn running_app_picker_is_sorted_deduplicated_and_private_by_default() {
+        let mut candidates = vec![
+            candidate("com.example.zulu", "Zulu"),
+            candidate("com.example.alpha", "Alpha"),
+        ];
+        candidates.push(candidate("COM.EXAMPLE.03", "Duplicate"));
+        candidates.push(candidate("com.example.03", "Elsewhere in sort order"));
+        candidates.push(RunningApplicationCandidate {
+            bundle_id: Some("com.example.menu".into()),
+            name: Some("Menu helper".into()),
+            regular: false,
+            current_process: false,
+        });
+        candidates.push(RunningApplicationCandidate {
+            bundle_id: Some("com.example.murmur".into()),
+            name: Some("Murmur".into()),
+            regular: true,
+            current_process: true,
+        });
+
+        let applications = bounded_running_applications(candidates);
+
+        assert_eq!(applications.len(), 3);
+        assert_eq!(applications[0].name, "Alpha");
+        assert_eq!(
+            applications
+                .iter()
+                .filter(|app| app.bundle_id.eq_ignore_ascii_case("com.example.03"))
+                .count(),
+            1
+        );
+        assert!(applications
+            .iter()
+            .all(|app| app.bundle_id != "com.example.menu"));
+        assert!(applications
+            .iter()
+            .all(|app| app.bundle_id != "com.example.murmur"));
+    }
+
+    #[test]
+    fn running_app_picker_is_bounded() {
+        let candidates = (0..80)
+            .map(|index| {
+                candidate(
+                    &format!("com.example.{index:02}"),
+                    &format!("App {index:02}"),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bounded_running_applications(candidates).len(),
+            MAX_RUNNING_APPLICATIONS
+        );
+    }
+
+    #[test]
+    fn running_app_payload_contains_only_picker_fields() {
+        let payload = serde_json::to_value(RunningApplication {
+            bundle_id: "com.apple.Terminal".into(),
+            name: "Terminal".into(),
+        })
+        .expect("serialize picker payload");
+
+        assert_eq!(payload.as_object().expect("object").len(), 2);
+        assert_eq!(payload["bundleId"], "com.apple.Terminal");
+        assert_eq!(payload["name"], "Terminal");
+    }
 
     #[test]
     fn immediate_native_success_skips_retry_and_fallback() {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -196,6 +196,7 @@ pub fn run() {
             commands::models::get_model_runtime_catalog,
             commands::models::get_model_runtime_status,
             commands::models::download_model,
+            frontmost::list_running_applications,
             commands::benchmark::get_benchmark_models,
             commands::benchmark::get_benchmark_activity,
             commands::benchmark::run_benchmark,

--- a/app/src/components/settings/AppOverridesEditor.test.tsx
+++ b/app/src/components/settings/AppOverridesEditor.test.tsx
@@ -1,0 +1,86 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppProfile } from '../../lib/settings';
+import { AppOverridesEditor, overrideChoice, overrideValue } from './AppOverridesEditor';
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+
+const TERMINAL: AppProfile = {
+  bundleId: 'com.apple.Terminal',
+  label: 'Terminal',
+  autoPasteOverride: null,
+  cleanupOverride: null,
+  smartFormattingOverride: null,
+  cliFormattingOverride: null,
+  writingStyle: null,
+  ideContextEnabled: false,
+  ideProjectRoots: [],
+};
+
+describe('AppOverridesEditor', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue([
+      { name: 'Terminal', bundleId: 'com.apple.Terminal' },
+      { name: 'Safari', bundleId: 'com.apple.Safari' },
+    ]);
+    onChange.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('maps explicit override choices without changing stored tri-state semantics', () => {
+    expect([null, true, false].map(overrideChoice)).toEqual(['inherit', 'always', 'never']);
+    expect(['inherit', 'always', 'never'].map((choice) => overrideValue(choice as 'inherit' | 'always' | 'never'))).toEqual([null, true, false]);
+  });
+
+  it('adds a running app from the memory-only picker', async () => {
+    await act(async () => root.render(<AppOverridesEditor profiles={[]} onChange={onChange} />));
+    await act(async () => { await Promise.resolve(); });
+    const picker = container.querySelector('[aria-label="Running app"]') as HTMLSelectElement;
+    await act(async () => {
+      picker.value = 'com.apple.Terminal';
+      picker.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    const add = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Add app') as HTMLButtonElement;
+    await act(async () => add.click());
+    expect(onChange).toHaveBeenCalledWith([TERMINAL]);
+    expect(container.textContent).toContain('list stays in memory');
+  });
+
+  it('keeps manual bundle ID entry and reports duplicates visibly', async () => {
+    await act(async () => root.render(<AppOverridesEditor profiles={[TERMINAL]} onChange={onChange} />));
+    const bundle = container.querySelector('input[placeholder="com.apple.Terminal"]') as HTMLInputElement;
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(bundle, 'COM.APPLE.TERMINAL');
+      bundle.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const add = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Add') as HTMLButtonElement;
+    await act(async () => add.click());
+    expect(onChange).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('already exists');
+  });
+
+  it('writes explicit Always and Never values from labeled selects', async () => {
+    await act(async () => root.render(<AppOverridesEditor profiles={[TERMINAL]} onChange={onChange} />));
+    const select = container.querySelector('[aria-label="Transcript cleanup for Terminal"]') as HTMLSelectElement;
+    await act(async () => {
+      select.value = 'never';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith([{ ...TERMINAL, cleanupOverride: false }]);
+  });
+});

--- a/app/src/components/settings/AppOverridesEditor.tsx
+++ b/app/src/components/settings/AppOverridesEditor.tsx
@@ -1,0 +1,382 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
+import {
+  type AppProfile,
+  type WritingStyle,
+  type WritingStyleChoice,
+  WRITING_STYLE_OPTIONS,
+} from '../../lib/settings';
+import { Select } from '../ui/Select';
+
+export interface RunningApplication {
+  bundleId: string;
+  name: string;
+}
+
+type OverrideChoice = 'inherit' | 'always' | 'never';
+
+interface IdeContextStatus {
+  state: 'disabled' | 'empty' | 'scanning' | 'ready' | 'stale' | 'cleared' | 'error';
+  generation: number;
+  roots: number;
+  files: number;
+  symbols: number;
+  bytes: number;
+  capped: boolean;
+  ms: number;
+}
+
+const OVERRIDE_OPTIONS: { value: OverrideChoice; label: string }[] = [
+  { value: 'inherit', label: 'Use global setting' },
+  { value: 'always', label: 'Always' },
+  { value: 'never', label: 'Never' },
+];
+
+const WRITING_STYLE_SUMMARIES: Record<WritingStyleChoice, string> = {
+  inherit: 'Uses your global behavior and the explicit overrides below.',
+  conversational: 'Removes filler and repeated words, tidies capitalization, and keeps your wording.',
+  polished: 'Cleans speech and applies explicitly spoken lists, punctuation, symbols, and corrections.',
+  code_technical: 'Preserves technical wording and enables deterministic command formatting.',
+  verbatim: 'Leaves recognized text unchanged, including filler, spacing, and spoken command words.',
+  notes: 'Removes filler, keeps note-like capitalization, and turns explicit list, paragraph, and line cues into structure.',
+};
+
+const WRITING_STYLE_CATEGORIES: Record<WritingStyleChoice, string> = {
+  inherit: 'Cleanup, corrections, structured writing, and command formatting all inherit.',
+  conversational: 'Cleanup on · Structured writing off · Automatic command formatting off',
+  polished: 'Cleanup on · Preferred spellings on · Structured writing on · Automatic command formatting off',
+  code_technical: 'Cleanup off · Preferred spellings on · Structured writing off · Command formatting on',
+  verbatim: 'Cleanup, corrections, structured writing, and command formatting all off',
+  notes: 'Cleanup on · Preferred spellings on · Structured writing on · Automatic command formatting off',
+};
+
+export function overrideChoice(value: boolean | null): OverrideChoice {
+  return value === null ? 'inherit' : value ? 'always' : 'never';
+}
+
+export function overrideValue(choice: OverrideChoice): boolean | null {
+  return choice === 'inherit' ? null : choice === 'always';
+}
+
+function ideStatusText(status: IdeContextStatus | undefined, roots: number): string {
+  if (!status) return roots > 0 ? 'Checking the memory-only index…' : 'Add a project root to build an index.';
+  switch (status.state) {
+    case 'scanning': return `Indexing locally… generation ${status.generation}`;
+    case 'ready': return `Ready · ${status.files} files · ${status.symbols} symbols${status.capped ? ' · capped' : ''}`;
+    case 'stale': return 'Expired safely · refresh to use project symbols again.';
+    case 'cleared': return 'Index cleared from memory. Configured roots are still available.';
+    case 'error': return 'Index unavailable. Check the configured roots and refresh.';
+    case 'empty': return 'Add a project root to build an index.';
+    default: return 'Local project context is off.';
+  }
+}
+
+function newProfile(bundleId: string, label: string): AppProfile {
+  return {
+    bundleId,
+    label,
+    autoPasteOverride: null,
+    cleanupOverride: null,
+    smartFormattingOverride: null,
+    cliFormattingOverride: null,
+    writingStyle: null,
+    ideContextEnabled: false,
+    ideProjectRoots: [],
+  };
+}
+
+function OverrideSelect({
+  label,
+  appLabel,
+  value,
+  onChange,
+}: {
+  label: string;
+  appLabel: string;
+  value: boolean | null;
+  onChange: (next: boolean | null) => void;
+}) {
+  return (
+    <label className="block text-xs font-medium text-on-surface">
+      {label}
+      <select
+        aria-label={`${label} for ${appLabel}`}
+        value={overrideChoice(value)}
+        onChange={(event) => onChange(overrideValue(event.target.value as OverrideChoice))}
+        className="mt-1 w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-2.5 py-2 text-xs text-on-surface outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+      >
+        {OVERRIDE_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>{option.label}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export function AppOverridesEditor({ profiles, onChange }: {
+  profiles: AppProfile[];
+  onChange: (next: AppProfile[]) => void;
+}) {
+  const [runningApps, setRunningApps] = useState<RunningApplication[]>([]);
+  const [selectedApp, setSelectedApp] = useState('');
+  const [bundleId, setBundleId] = useState('');
+  const [label, setLabel] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [ideStatuses, setIdeStatuses] = useState<Record<string, IdeContextStatus>>({});
+
+  useEffect(() => {
+    let disposed = false;
+    invoke<RunningApplication[]>('list_running_applications')
+      .then((apps) => { if (!disposed) setRunningApps(apps); })
+      .catch(() => { if (!disposed) setRunningApps([]); });
+    return () => { disposed = true; };
+  }, []);
+
+  const availableApps = useMemo(() => {
+    const configured = new Set(profiles.map((profile) => profile.bundleId.toLocaleLowerCase()));
+    return runningApps.filter((app) => !configured.has(app.bundleId.toLocaleLowerCase()));
+  }, [profiles, runningApps]);
+
+  useEffect(() => {
+    if (selectedApp && !availableApps.some((app) => app.bundleId === selectedApp)) {
+      setSelectedApp('');
+    }
+  }, [availableApps, selectedApp]);
+
+  const pollIdeStatuses = useCallback(async () => {
+    const enabled = profiles.filter((profile) => profile.ideContextEnabled);
+    if (enabled.length === 0) return;
+    const pairs = await Promise.all(enabled.map(async (profile) => {
+      try {
+        const status = await invoke<IdeContextStatus>('get_ide_context_status', { bundleId: profile.bundleId });
+        return [profile.bundleId, status] as const;
+      } catch {
+        return null;
+      }
+    }));
+    setIdeStatuses((current) => ({
+      ...current,
+      ...Object.fromEntries(pairs.filter((pair): pair is readonly [string, IdeContextStatus] => pair !== null)),
+    }));
+  }, [profiles]);
+
+  useEffect(() => {
+    void pollIdeStatuses();
+    const timer = window.setInterval(() => void pollIdeStatuses(), 1000);
+    return () => window.clearInterval(timer);
+  }, [pollIdeStatuses]);
+
+  const addProfile = (nextBundleId: string, nextLabel: string) => {
+    const trimmedId = nextBundleId.trim();
+    if (!trimmedId) return;
+    if (profiles.some((profile) => profile.bundleId.toLocaleLowerCase() === trimmedId.toLocaleLowerCase())) {
+      setError(`An override already exists for ${trimmedId}.`);
+      return;
+    }
+    onChange([...profiles, newProfile(trimmedId, nextLabel.trim())]);
+    setSelectedApp('');
+    setBundleId('');
+    setLabel('');
+    setError(null);
+  };
+
+  const updateProfile = (id: string, update: Partial<AppProfile>) => {
+    onChange(profiles.map((profile) => profile.bundleId === id ? { ...profile, ...update } : profile));
+  };
+
+  const addIdeRoot = async (id: string) => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (typeof selected !== 'string') return;
+      onChange(profiles.map((profile) => {
+        if (profile.bundleId !== id || profile.ideProjectRoots.includes(selected) || profile.ideProjectRoots.length >= 4) return profile;
+        return { ...profile, ideProjectRoots: [...profile.ideProjectRoots, selected] };
+      }));
+    } catch {
+      // Dialog cancelled or unavailable — keep the configured roots.
+    }
+  };
+
+  const refreshIdeIndex = async (id: string) => {
+    try {
+      const status = await invoke<IdeContextStatus>('refresh_ide_context', { bundleId: id });
+      setIdeStatuses((current) => ({ ...current, [id]: status }));
+    } catch {
+      // Polling will surface the stable failure state.
+    }
+  };
+
+  const clearIdeIndex = async (id: string) => {
+    try {
+      const status = await invoke<IdeContextStatus>('clear_ide_context', { bundleId: id });
+      setIdeStatuses((current) => ({ ...current, [id]: status }));
+    } catch {
+      // Keep configured roots intact if the command is unavailable.
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-3">
+        <h2 className="text-sm font-medium text-on-surface">Add an app</h2>
+        <p className="mt-1 text-xs text-on-surface-variant">
+          Murmur reads only the names and bundle IDs of currently running apps for this picker. The list stays in memory, is never logged, and is not saved unless you choose an app.
+        </p>
+        {availableApps.length > 0 ? (
+          <div className="mt-3 flex gap-2">
+            <select
+              aria-label="Running app"
+              value={selectedApp}
+              onChange={(event) => setSelectedApp(event.target.value)}
+              className="min-w-0 flex-1 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+            >
+              <option value="">Choose a running app…</option>
+              {availableApps.map((app) => (
+                <option key={app.bundleId} value={app.bundleId}>{app.name} — {app.bundleId}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              disabled={!selectedApp}
+              onClick={() => {
+                const app = availableApps.find((candidate) => candidate.bundleId === selectedApp);
+                if (app) addProfile(app.bundleId, app.name);
+              }}
+              className="shrink-0 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-on-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Add app
+            </button>
+          </div>
+        ) : (
+          <p className="mt-3 text-xs text-on-surface-variant">No unconfigured running apps are available. Use the advanced entry below.</p>
+        )}
+
+        <details className="mt-3">
+          <summary className="cursor-pointer text-xs font-medium text-on-surface-variant hover:text-primary">Advanced: enter a bundle ID</summary>
+          <div className="mt-2 space-y-2">
+            <input
+              type="text"
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="App name (optional)"
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={bundleId}
+                onChange={(event) => setBundleId(event.target.value)}
+                onKeyDown={(event) => { if (event.key === 'Enter') addProfile(bundleId, label); }}
+                placeholder="com.apple.Terminal"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                className="min-w-0 flex-1 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 font-mono text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <button
+                type="button"
+                onClick={() => addProfile(bundleId, label)}
+                disabled={!bundleId.trim()}
+                className="shrink-0 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant hover:bg-surface-container hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        </details>
+        {error && <p role="alert" className="mt-2 text-xs text-error">{error}</p>}
+      </div>
+
+      {profiles.length === 0 ? (
+        <p className="text-xs text-on-surface-variant">No app overrides configured. Global settings apply everywhere.</p>
+      ) : (
+        <ul className="space-y-3">
+          {profiles.map((profile) => {
+            const appLabel = profile.label || profile.bundleId;
+            return (
+              <li key={profile.bundleId} className="space-y-3 rounded-xl border border-outline-variant/25 bg-surface-container-lowest p-3 shadow-sm">
+                <div className="flex items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate text-sm font-medium text-on-surface">{appLabel}</h3>
+                    <p className="truncate font-mono text-[11px] text-on-surface-variant">{profile.bundleId}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onChange(profiles.filter((candidate) => candidate.bundleId !== profile.bundleId))}
+                    aria-label={`Remove override for ${appLabel}`}
+                    className="rounded-md px-2 py-1 text-xs text-on-surface-variant hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    Remove
+                  </button>
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-on-surface">Writing style</label>
+                  <Select
+                    value={profile.writingStyle ?? 'inherit'}
+                    onChange={(choice) => updateProfile(profile.bundleId, { writingStyle: choice === 'inherit' ? null : choice as WritingStyle })}
+                    items={WRITING_STYLE_OPTIONS}
+                    aria-label={`Writing style for ${appLabel}`}
+                  />
+                  <p className="mt-1 text-xs text-on-surface-variant">{WRITING_STYLE_SUMMARIES[profile.writingStyle ?? 'inherit']}</p>
+                  <p className="mt-1 text-xs font-medium text-on-surface-variant">{WRITING_STYLE_CATEGORIES[profile.writingStyle ?? 'inherit']}</p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2">
+                  <OverrideSelect label="Auto-paste" appLabel={appLabel} value={profile.autoPasteOverride} onChange={(value) => updateProfile(profile.bundleId, { autoPasteOverride: value })} />
+                  <OverrideSelect label="Transcript cleanup" appLabel={appLabel} value={profile.cleanupOverride} onChange={(value) => updateProfile(profile.bundleId, { cleanupOverride: value })} />
+                  <OverrideSelect label="Structured writing" appLabel={appLabel} value={profile.smartFormattingOverride} onChange={(value) => updateProfile(profile.bundleId, { smartFormattingOverride: value })} />
+                  <OverrideSelect label="Command formatting" appLabel={appLabel} value={profile.cliFormattingOverride} onChange={(value) => updateProfile(profile.bundleId, { cliFormattingOverride: value })} />
+                </div>
+
+                <div className="rounded-lg border border-outline-variant/30 bg-surface-container-low p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h4 className="text-xs font-medium text-on-surface">Local IDE project context</h4>
+                      <p className="mt-1 text-xs text-on-surface-variant">Index only selected roots in memory for symbols and <span className="font-mono">@file</span> mentions. Murmur never reads editor text, selections, or the clipboard.</p>
+                    </div>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={profile.ideContextEnabled}
+                      aria-label={`Local IDE project context for ${appLabel}`}
+                      onClick={() => updateProfile(profile.bundleId, { ideContextEnabled: !profile.ideContextEnabled })}
+                      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary ${profile.ideContextEnabled ? 'bg-primary' : 'bg-surface-container-highest'}`}
+                    >
+                      <span className={`inline-block h-4 w-4 rounded-full bg-on-primary shadow transition-transform ${profile.ideContextEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                    </button>
+                  </div>
+                  {profile.ideContextEnabled && (
+                    <div className="mt-3 space-y-2">
+                      {profile.ideProjectRoots.length > 0 ? (
+                        <ul className="space-y-1">
+                          {profile.ideProjectRoots.map((root) => (
+                            <li key={root} className="flex items-center gap-2 rounded-md bg-surface-container-lowest px-2 py-1.5">
+                              <span className="min-w-0 flex-1 break-all font-mono text-xs text-on-surface">{root}</span>
+                              <button type="button" onClick={() => updateProfile(profile.bundleId, { ideProjectRoots: profile.ideProjectRoots.filter((candidate) => candidate !== root) })} className="shrink-0 text-xs text-on-surface-variant underline hover:text-error">Remove root</button>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : <p className="text-xs text-on-surface-variant">No project roots configured.</p>}
+                      <div className="flex flex-wrap gap-3">
+                        <button type="button" onClick={() => void addIdeRoot(profile.bundleId)} disabled={profile.ideProjectRoots.length >= 4} className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50">Add project root</button>
+                        <button type="button" onClick={() => void refreshIdeIndex(profile.bundleId)} disabled={profile.ideProjectRoots.length === 0 || ideStatuses[profile.bundleId]?.state === 'scanning'} className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50">Refresh index</button>
+                        <button type="button" onClick={() => void clearIdeIndex(profile.bundleId)} disabled={profile.ideProjectRoots.length === 0} className="text-xs font-medium text-on-surface-variant underline hover:text-error disabled:opacity-50">Clear index</button>
+                      </div>
+                      <p role="status" className="text-xs text-on-surface-variant">{ideStatusText(ideStatuses[profile.bundleId], profile.ideProjectRoots.length)}</p>
+                      <p className="text-xs text-on-surface-variant">Clear index removes only memory contents; Remove root changes the persisted override. Paths are never written to logs.</p>
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -67,19 +67,19 @@ function LatencyChart({ report }: { report: BenchmarkReport }) {
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-3">
-        <h4 className="text-xs font-semibold text-stone-700 dark:text-stone-300">Inference latency</h4>
-        <div className="flex gap-3 text-[10px] text-stone-400 dark:text-stone-500">
+        <h4 className="text-xs font-semibold text-on-surface dark:text-on-surface-variant">Inference latency</h4>
+        <div className="flex gap-3 text-[10px] text-on-surface-variant dark:text-on-surface-variant">
           <span><i className="inline-block h-1.5 w-3 rounded-sm bg-emerald-500 mr-1" />Median</span>
-          <span><i className="inline-block h-1.5 w-3 rounded-sm bg-stone-300 dark:bg-stone-600 mr-1" />P95</span>
+          <span><i className="inline-block h-1.5 w-3 rounded-sm bg-surface-container-high dark:bg-surface-container-high mr-1" />P95</span>
         </div>
       </div>
       <div className="space-y-2">
         {results.map((result) => (
           <div key={result.modelName} className="grid grid-cols-[6.5rem_1fr_4.5rem] items-center gap-2">
-            <span className="truncate text-[11px] font-medium text-stone-600 dark:text-stone-300" title={result.label}>{result.label}</span>
-            <div className="relative h-4 rounded-sm bg-stone-100 dark:bg-stone-800 overflow-hidden">
+            <span className="truncate text-[11px] font-medium text-on-surface dark:text-on-surface-variant" title={result.label}>{result.label}</span>
+            <div className="relative h-4 rounded-sm bg-surface-container-low dark:bg-surface-container-high overflow-hidden">
               <div
-                className="absolute inset-y-0 left-0 bg-stone-300 dark:bg-stone-600"
+                className="absolute inset-y-0 left-0 bg-surface-container-high dark:bg-surface-container-high"
                 style={{ width: `${(result.warmP95Ms / maximum) * 100}%` }}
               />
               <div
@@ -87,7 +87,7 @@ function LatencyChart({ report }: { report: BenchmarkReport }) {
                 style={{ width: `${(result.warmMedianMs / maximum) * 100}%` }}
               />
             </div>
-            <span className="text-right text-[10px] tabular-nums text-stone-500 dark:text-stone-400">
+            <span className="text-right text-[10px] tabular-nums text-on-surface-variant dark:text-on-surface-variant">
               {Math.round(result.warmMedianMs)} / {Math.round(result.warmP95Ms)}
             </span>
           </div>
@@ -102,19 +102,19 @@ function AccuracyChart({ report }: { report: BenchmarkReport }) {
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-3">
-        <h4 className="text-xs font-semibold text-stone-700 dark:text-stone-300">Word accuracy</h4>
-        <span className="text-[10px] text-stone-400 dark:text-stone-500">Normalized / higher is better</span>
+        <h4 className="text-xs font-semibold text-on-surface dark:text-on-surface-variant">Word accuracy</h4>
+        <span className="text-[10px] text-on-surface-variant dark:text-on-surface-variant">Normalized / higher is better</span>
       </div>
       <div className="space-y-2">
         {results.map((result) => {
           const accuracy = Math.max(0, 1 - result.normalizedWordErrorRate);
           return (
             <div key={result.modelName} className="grid grid-cols-[6.5rem_1fr_3rem] items-center gap-2">
-              <span className="truncate text-[11px] font-medium text-stone-600 dark:text-stone-300" title={result.label}>{result.label}</span>
-              <div className="h-2.5 rounded-sm bg-stone-100 dark:bg-stone-800 overflow-hidden">
+              <span className="truncate text-[11px] font-medium text-on-surface dark:text-on-surface-variant" title={result.label}>{result.label}</span>
+              <div className="h-2.5 rounded-sm bg-surface-container-low dark:bg-surface-container-high overflow-hidden">
                 <div className="h-full bg-amber-400 dark:bg-amber-500" style={{ width: `${accuracy * 100}%` }} />
               </div>
-              <span className="text-right text-[10px] tabular-nums text-stone-500 dark:text-stone-400">
+              <span className="text-right text-[10px] tabular-nums text-on-surface-variant dark:text-on-surface-variant">
                 {(accuracy * 100).toFixed(1)}%
               </span>
             </div>
@@ -283,11 +283,15 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
 
   return (
     <div className="space-y-6">
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-on-surface-variant">
+        <p className="font-medium text-on-surface">Directional results, not a universal model ranking</p>
+        <p className="mt-1">This lab compares installed models on this Mac with a small, clean synthetic English corpus. It does not represent your voice, microphone, accent, room, or every dictation workload.</p>
+      </div>
       <section>
         <div className="flex items-end justify-between gap-4 mb-3">
           <div>
-            <h3 className="text-sm font-semibold text-stone-800 dark:text-stone-200">Configurations</h3>
-            <p className="mt-0.5 text-xs text-stone-500 dark:text-stone-400">
+            <h3 className="text-sm font-semibold text-on-surface">Models</h3>
+            <p className="mt-0.5 text-xs text-on-surface-variant dark:text-on-surface-variant">
               {installedCount} installed. All tests run locally.
             </p>
           </div>
@@ -296,14 +300,14 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
               type="button"
               disabled={running}
               onClick={() => setSelected(models.filter((model) => model.installed).map((model) => model.modelName))}
-              className="text-xs text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white disabled:opacity-50"
+              className="text-xs text-on-surface dark:text-on-surface-variant hover:text-on-surface dark:hover:text-white disabled:opacity-50"
             >
               Select installed
             </button>
           )}
         </div>
 
-        <div className="border-y border-stone-200 dark:border-stone-700 divide-y divide-stone-200 dark:divide-stone-700">
+        <div className="border-y border-outline-variant/30 dark:border-outline-variant/30 divide-y divide-outline-variant/30 dark:divide-outline-variant/30">
           {models.filter((model) => model.supported).map((model) => (
             <div key={model.modelName} className="min-h-14 flex items-center gap-3 py-2.5">
               <input
@@ -312,14 +316,14 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                 checked={selectedSet.has(model.modelName)}
                 disabled={!model.installed || running}
                 onChange={() => toggleModel(model.modelName)}
-                className="h-4 w-4 accent-stone-800 dark:accent-stone-200"
+                className="h-4 w-4 accent-primary dark:accent-primary"
               />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-stone-800 dark:text-stone-200">{model.label}</span>
-                  <span className="text-[11px] text-stone-400 dark:text-stone-500">{model.size}</span>
+                  <span className="text-sm font-medium text-on-surface dark:text-on-surface">{model.label}</span>
+                  <span className="text-[11px] text-on-surface-variant dark:text-on-surface-variant">{model.size}</span>
                 </div>
-                <p className="text-xs text-stone-500 dark:text-stone-400 truncate">
+                <p className="text-xs text-on-surface-variant dark:text-on-surface-variant truncate">
                   {model.backend} / {model.accelerator}
                 </p>
               </div>
@@ -328,7 +332,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   type="button"
                   disabled={downloading !== null || running}
                   onClick={() => handleDownload(model.modelName)}
-                  className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-stone-300 dark:border-stone-600 rounded-md text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700 disabled:opacity-50"
+                  className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface dark:text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80 disabled:opacity-50"
                 >
                   {downloading === model.modelName
                     ? downloadProgress === null
@@ -345,8 +349,8 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
       </section>
 
       <section>
-        <h3 className="mb-2 text-sm font-semibold text-stone-800 dark:text-stone-200">Workload</h3>
-        <div className="grid grid-cols-3 gap-1 p-1 bg-stone-100 dark:bg-stone-800 rounded-lg">
+        <h3 className="mb-2 text-sm font-semibold text-on-surface">Test Length</h3>
+        <div className="grid grid-cols-3 gap-1 p-1 bg-surface-container-low dark:bg-surface-container-high rounded-lg">
           {PRESETS.map((option) => (
             <button
               type="button"
@@ -355,8 +359,8 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
               onClick={() => setPreset(option.id)}
               className={`min-w-0 px-2 py-2 rounded-md transition-colors disabled:opacity-50 ${
                 preset === option.id
-                  ? 'bg-white dark:bg-stone-700 shadow-sm text-stone-900 dark:text-stone-100'
-                  : 'text-stone-500 dark:text-stone-400 hover:text-stone-800 dark:hover:text-stone-200'
+                  ? 'bg-surface-container-lowest dark:bg-surface-container-high shadow-sm text-on-surface dark:text-on-surface'
+                  : 'text-on-surface-variant hover:text-on-surface'
               }`}
             >
               <span className="block text-xs font-semibold">{option.label}</span>
@@ -370,18 +374,18 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
         {running ? (
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-3 text-xs">
-              <span className="min-w-0 truncate text-stone-700 dark:text-stone-300">
+              <span className="min-w-0 truncate text-on-surface dark:text-on-surface-variant">
                 {progress ? `${progress.modelLabel}${progress.fixture ? ` / ${progress.fixture}` : ''} / ${progress.phase}` : 'Starting benchmark'}
               </span>
-              <span className="shrink-0 tabular-nums text-stone-500">{progressPercent}%</span>
+              <span className="shrink-0 tabular-nums text-on-surface-variant">{progressPercent}%</span>
             </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-stone-200 dark:bg-stone-700">
+            <div className="h-1.5 overflow-hidden rounded-full bg-surface-container-high dark:bg-surface-container-high">
               <div className="h-full bg-emerald-500 transition-all duration-200" style={{ width: `${progressPercent}%` }} />
             </div>
             <button
               type="button"
               onClick={handleCancel}
-              className="w-full px-3 py-2 text-xs font-medium border border-stone-300 dark:border-stone-600 rounded-lg text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-800"
+              className="w-full rounded-lg border border-outline-variant/30 px-3 py-2 text-xs font-medium text-on-surface hover:bg-surface-container-low"
             >
               Cancel
             </button>
@@ -391,7 +395,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
             type="button"
             onClick={handleRun}
             disabled={!canRun}
-            className="w-full px-4 py-2.5 text-sm font-semibold rounded-lg bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 hover:bg-stone-700 dark:hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className="w-full px-4 py-2.5 text-sm font-semibold rounded-lg bg-primary dark:bg-surface-container-low text-white dark:text-on-surface hover:bg-primary/80 dark:hover:bg-surface-container-lowest disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Run Benchmark
           </button>
@@ -408,15 +412,18 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
       </section>
 
       {report && !running && (
-        <section className="space-y-4 border-t border-stone-200 dark:border-stone-700 pt-5">
+        <section className="space-y-4 border-t border-outline-variant/30 dark:border-outline-variant/30 pt-5">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <h3 className="text-sm font-semibold text-stone-800 dark:text-stone-200">Benchmark Dashboard</h3>
-              <p className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400">
-                {report.platform} / Murmur v{report.appVersion} / {report.preset}
+              <h3 className="text-sm font-semibold text-on-surface">Results</h3>
+              <p className="mt-0.5 text-[11px] text-on-surface-variant dark:text-on-surface-variant">
+                {report.environment
+                  ? `${report.environment.os}${report.environment.osVersion ? ` ${report.environment.osVersion}` : ''} / ${report.environment.chip ?? report.environment.hardwareModel ?? report.environment.architecture}${report.environment.memoryMb ? ` / ${Math.round(report.environment.memoryMb / 1024)} GB RAM` : ''}`
+                  : report.platform}
+                {' / '}Murmur v{report.appVersion} / {report.preset}
               </p>
               <p
-                className="mt-0.5 text-[11px] text-stone-500 dark:text-stone-400"
+                className="mt-0.5 text-[11px] text-on-surface-variant dark:text-on-surface-variant"
                 title="One-time shared backend init (Metal shader compilation, ANE compile cache, etc.) measured once before per-model timing, so it doesn't skew any single model's cold-load number."
               >
                 Shared init (one-time): {milliseconds(report.sharedInitMs)}
@@ -425,19 +432,31 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
             <button
               type="button"
               onClick={copyReport}
-              className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-stone-300 dark:border-stone-600 rounded-md text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700"
+              className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface dark:text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80"
             >
               {copied ? 'Copied' : 'Copy JSON'}
             </button>
           </div>
 
+          <div className="rounded-lg border border-outline-variant/30 bg-surface-container-low p-3 text-[11px] leading-relaxed text-on-surface-variant">
+            <p className="font-medium text-on-surface">What this run measured</p>
+            <p className="mt-1">
+              {report.corpus
+                ? `${report.corpus.fixtureCount} ${report.corpus.language.toUpperCase()} synthetic clips / ${report.corpus.referenceWords} reference words / ${report.iterations} measured runs per clip.`
+                : `${report.results.find((result) => !result.error)?.fixtures.length ?? 0} synthetic clips / ${report.iterations} measured runs per clip (legacy saved report).`}
+            </p>
+            <p className="mt-1">{report.configuration?.executionPath ?? 'Full-buffer final transcription after recording stops'}; VAD threshold {report.configuration?.vadThreshold ?? 0.5}; {report.configuration?.transcriptTransformProfile ?? 'default local delivery pipeline'}.</p>
+            {report.configuration && <p className="mt-1">Model run order: {report.configuration.modelRunOrder.join(' → ') || 'none'}. Shared-init order: {report.configuration.sharedInitOrder.join(' → ') || 'none'}.</p>}
+            <p className="mt-1">{report.corpus?.limitation ?? 'Directional local comparison only; the synthetic corpus is not representative of natural speakers or recording environments.'}</p>
+          </div>
+
           <div className="flex items-center gap-2">
-            <label htmlFor="benchmark-run" className="shrink-0 text-[11px] text-stone-500 dark:text-stone-400">Saved run</label>
+            <label htmlFor="benchmark-run" className="shrink-0 text-[11px] text-on-surface-variant dark:text-on-surface-variant">Saved run</label>
             <select
               id="benchmark-run"
               value={dashboard.selectedAt ?? ''}
               onChange={(event) => setDashboard((current) => ({ ...current, selectedAt: event.target.value }))}
-              className="min-w-0 flex-1 px-2 py-1.5 text-xs rounded-md border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 text-stone-700 dark:text-stone-300 focus:outline-none focus:ring-2 focus:ring-stone-500"
+              className="min-w-0 flex-1 px-2 py-1.5 text-xs rounded-md border border-outline-variant/30 dark:border-outline-variant/30 bg-surface-container-lowest dark:bg-surface-container-high text-on-surface dark:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
             >
               {dashboard.reports.map((item) => (
                 <option key={item.createdAt} value={item.createdAt}>
@@ -451,32 +470,32 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                 clearBenchmarkReports();
                 setDashboard({ reports: [], selectedAt: null });
               }}
-              className="shrink-0 px-2 py-1.5 text-xs text-stone-500 dark:text-stone-400 hover:text-red-600 dark:hover:text-red-400"
+              className="shrink-0 px-2 py-1.5 text-xs text-on-surface-variant dark:text-on-surface-variant hover:text-red-600 dark:hover:text-red-400"
             >
               Clear
             </button>
           </div>
 
-          <div className="grid grid-cols-3 border-y border-stone-200 dark:border-stone-700 divide-x divide-stone-200 dark:divide-stone-700">
+          <div className="grid grid-cols-3 border-y border-outline-variant/30 dark:border-outline-variant/30 divide-x divide-outline-variant/30 dark:divide-outline-variant/30">
             {[
               ['Fastest', modelLabel(report, report.recommendations.fastest)],
               ['Accurate', modelLabel(report, report.recommendations.mostAccurate)],
               ['Balanced', modelLabel(report, report.recommendations.balanced)],
             ].map(([label, value]) => (
               <div key={label} className="min-w-0 px-2 py-2.5 text-center">
-                <div className="text-[10px] uppercase text-stone-400 dark:text-stone-500">{label}</div>
-                <div className="mt-1 text-xs font-semibold text-stone-800 dark:text-stone-200 truncate" title={value}>{value}</div>
+                <div className="text-[10px] uppercase text-on-surface-variant dark:text-on-surface-variant">{label}</div>
+                <div className="mt-1 text-xs font-semibold text-on-surface dark:text-on-surface truncate" title={value}>{value}</div>
               </div>
             ))}
           </div>
 
-          <div className="space-y-4 border-b border-stone-200 dark:border-stone-700 pb-4">
+          <div className="space-y-4 border-b border-outline-variant/30 dark:border-outline-variant/30 pb-4">
             <LatencyChart report={report} />
             <AccuracyChart report={report} />
           </div>
 
           <div>
-            <h4 className="mb-1 text-xs font-semibold text-stone-700 dark:text-stone-300">Metrics</h4>
+            <h4 className="mb-1 text-xs font-semibold text-on-surface dark:text-on-surface-variant">Metrics</h4>
             <table className="w-full table-fixed text-[11px]">
               <colgroup>
                 <col className="w-[28%]" />
@@ -486,8 +505,8 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                 <col className="w-[16%]" />
                 <col className="w-[16%]" />
               </colgroup>
-              <thead className="text-left text-stone-400 dark:text-stone-500">
-                <tr className="border-b border-stone-200 dark:border-stone-700">
+              <thead className="text-left text-on-surface-variant dark:text-on-surface-variant">
+                <tr className="border-b border-outline-variant/30 dark:border-outline-variant/30">
                   <th className="py-2 pr-3 font-medium">Model</th>
                   <th className="px-2 py-2 font-medium text-right">Median</th>
                   <th className="px-2 py-2 font-medium text-right">P95</th>
@@ -496,12 +515,12 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                   <th className="pl-2 py-2 font-medium text-right">Delivered (raw)</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-stone-200 dark:divide-stone-700 text-stone-700 dark:text-stone-300">
+              <tbody className="divide-y divide-outline-variant/30 dark:divide-outline-variant/30 text-on-surface dark:text-on-surface-variant">
                 {report.results.map((result) => (
                   <tr key={result.modelName}>
                     <td className="py-2.5 pr-3">
-                      <span className="font-medium text-stone-900 dark:text-stone-100">{result.label}</span>
-                      <span className="block text-[10px] text-stone-400">{result.accelerator}</span>
+                      <span className="font-medium text-on-surface dark:text-on-surface">{result.label}</span>
+                      <span className="block text-[10px] text-on-surface-variant">{result.accelerator}</span>
                     </td>
                     {result.error ? (
                       <td colSpan={5} className="px-2 py-2.5 text-red-600 dark:text-red-400">{result.error}</td>
@@ -512,11 +531,11 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                         <td className="px-2 py-2.5 text-right tabular-nums">{speed(result.realtimeFactor)}</td>
                         <td className="px-2 py-2.5 text-right tabular-nums">
                           {percentage(result.normalizedWordErrorRate)}
-                          <span className="text-stone-400 dark:text-stone-500"> ({percentage(result.wordErrorRate)})</span>
+                          <span className="text-on-surface-variant dark:text-on-surface-variant"> ({percentage(result.wordErrorRate)})</span>
                         </td>
                         <td className="pl-2 py-2.5 text-right tabular-nums">
                           {percentage(result.deliveredNormalizedWordErrorRate)}
-                          <span className="text-stone-400 dark:text-stone-500"> ({percentage(result.deliveredWordErrorRate)})</span>
+                          <span className="text-on-surface-variant dark:text-on-surface-variant"> ({percentage(result.deliveredWordErrorRate)})</span>
                         </td>
                       </>
                     )}
@@ -526,25 +545,26 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
             </table>
           </div>
 
-          <p className="text-[11px] leading-relaxed text-stone-500 dark:text-stone-400">
-            WER counts changed, missing, and extra words against the known transcript. Normalized WER first ignores formatting and number/unit spelling (16 kHz = sixteen kilohertz, front end = frontend) so it reflects recognition, not formatting; raw WER is shown in parentheses. Delivered WER scores the text after the production transform pipeline (dev-vocab prompt for Whisper, then cleanup / correction / formatting) — what actually reaches the clipboard — again shown normalized with raw in parentheses. Accuracy ranking and the Accurate/Balanced picks use the normalized recognition number. Fastest is the strict minimum duration-weighted speed. Balanced favors lower memory among models within 2 accuracy points and an inclusive 10% band of the fastest eligible speed.
+          <p className="text-[11px] leading-relaxed text-on-surface-variant dark:text-on-surface-variant">
+            WER counts changed, missing, and extra words against the known transcript. Normalized WER first ignores formatting and number/unit spelling (16 kHz = sixteen kilohertz, front end = frontend) so it reflects recognition, not formatting; raw WER is shown in parentheses. Delivered WER scores the text after the production transform pipeline (dev-vocab prompt for Whisper, then cleanup / correction / formatting) — what actually reaches the clipboard — again shown normalized with raw in parentheses. P95 uses nearest-rank selection over the measured warm runs; with only 3, 5, or 10 samples it is a coarse tail-latency signal. Accuracy ranking and the Accurate/Balanced picks use the normalized recognition number. Fastest is the strict minimum duration-weighted speed. Balanced favors lower memory among models within 2 accuracy points and an inclusive 10% band of the fastest eligible speed.
           </p>
 
           <div className="space-y-2">
             {report.results.filter((result) => !result.error).map((result) => (
-              <details key={result.modelName} className="border-t border-stone-200 dark:border-stone-700 pt-2">
-                <summary className="cursor-pointer text-xs font-medium text-stone-700 dark:text-stone-300">
+              <details key={result.modelName} className="border-t border-outline-variant/30 dark:border-outline-variant/30 pt-2">
+                <summary className="cursor-pointer text-xs font-medium text-on-surface dark:text-on-surface-variant">
                   {result.label} details
                 </summary>
                 <div className="mt-2 space-y-3">
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-stone-500 dark:text-stone-400">
-                    <span>Cold load</span><span className="text-right tabular-nums">{milliseconds(result.modelLoadMs)}</span>
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-on-surface-variant dark:text-on-surface-variant">
+                    <span title="Per-model load measured after the separate one-time shared backend initialization shown above.">Model load after shared init</span><span className="text-right tabular-nums">{milliseconds(result.modelLoadMs)}</span>
                     <span>First inference</span><span className="text-right tabular-nums">{milliseconds(result.firstInferenceMs)}</span>
-                    <span title="Process RSS delta. Models run sequentially in one process, so allocator retention from an earlier model can inflate a later model's baseline — treat as a rough signal, not an isolated measurement.">Memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB</span>
+                    <span>Download size</span><span className="text-right tabular-nums">{result.downloadSize ?? 'Not recorded'}</span>
+                    <span title="Observed process RSS delta. Models run sequentially in one process, so allocator retention from an earlier model can inflate a later model's baseline. This is not download size or isolated peak memory.">Observed memory increase</span><span className="text-right tabular-nums">{result.memoryDeltaMb} MB (rough)</span>
                   </div>
                   {result.fixtures.map((fixture) => (
                     <div key={fixture.fixtureId} className="text-[11px] leading-relaxed">
-                      <div className="flex justify-between gap-3 font-medium text-stone-700 dark:text-stone-300">
+                      <div className="flex justify-between gap-3 font-medium text-on-surface dark:text-on-surface-variant">
                         <span>
                           {fixture.label} / {fixture.audioSeconds.toFixed(1)}s
                           {fixture.normalizedWordErrors === 0 && (
@@ -558,15 +578,15 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                         </span>
                         <span>
                           {fixture.normalizedWordErrors}/{fixture.normalizedReferenceWords} errors
-                          <span className="text-stone-400 dark:text-stone-500"> ({fixture.wordErrors}/{fixture.referenceWords} raw)</span>
+                          <span className="text-on-surface-variant dark:text-on-surface-variant"> ({fixture.wordErrors}/{fixture.referenceWords} raw)</span>
                         </span>
                       </div>
-                      <div className="mt-1 grid gap-1 text-stone-500 dark:text-stone-400">
+                      <div className="mt-1 grid gap-1 text-on-surface-variant dark:text-on-surface-variant">
                         <p><span className="font-medium">Reference:</span> {fixture.reference}</p>
                         <p><span className="font-medium">Output:</span> {fixture.transcript || '(empty)'}</p>
                         <p>
                           <span className="font-medium">Delivered:</span> {fixture.deliveredTranscript || '(empty)'}
-                          <span className="text-stone-400 dark:text-stone-500"> — {fixture.deliveredNormalizedWordErrors}/{fixture.normalizedReferenceWords} errors ({fixture.deliveredWordErrors}/{fixture.referenceWords} raw)</span>
+                          <span className="text-on-surface-variant dark:text-on-surface-variant"> — {fixture.deliveredNormalizedWordErrors}/{fixture.normalizedReferenceWords} errors ({fixture.deliveredWordErrors}/{fixture.referenceWords} raw)</span>
                           {fixture.deliveredTransformFailed && (
                             <span className="text-amber-600 dark:text-amber-400"> — transform failed, showing raw</span>
                           )}

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -1,0 +1,88 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../lib/settings';
+import { SETTINGS_CATEGORIES, SettingsPanel, effectiveAutoPaste } from './SettingsPanel';
+
+vi.mock('@tauri-apps/api/app', () => ({ getVersion: vi.fn(async () => '0.18.0') }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async (command: string) => command === 'list_audio_devices' ? [] : undefined) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => {}) }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('../../lib/modelRuntime', () => ({ useModelRuntimeCatalog: () => ({ models: [], byName: new Map(), error: null }) }));
+vi.mock('../../lib/hooks/useVocabScan', () => ({
+  useVocabScan: () => ({ status: 'idle', walker: null, stats: null, scan: vi.fn(), cancel: vi.fn() }),
+}));
+vi.mock('./AppOverridesEditor', () => ({ AppOverridesEditor: () => <div>App overrides editor</div> }));
+vi.mock('./KnowledgeManager', () => ({ KnowledgeManager: () => <div>Knowledge manager</div> }));
+vi.mock('./PerformanceLab', () => ({ PerformanceLab: () => <div>Performance lab</div> }));
+vi.mock('./VocabularyAliasesEditor', () => ({ VocabularyAliasesEditor: () => <div>Vocabulary editor</div> }));
+vi.mock('./VoiceCommandsManager', () => ({ VoiceCommandsManager: () => <div>Voice commands editor</div> }));
+vi.mock('./VocabScanStrip', () => ({ VocabScanStrip: () => <div>Vocabulary scan</div> }));
+
+describe('SettingsPanel information architecture', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const scrollTo = vi.fn();
+
+  beforeEach(async () => {
+    scrollTo.mockReset();
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', { value: scrollTo, configurable: true });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(
+      <SettingsPanel
+        isOpen
+        onClose={vi.fn()}
+        settings={DEFAULT_SETTINGS}
+        onUpdateSettings={vi.fn()}
+        status="idle"
+        onResetStats={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRerunSetup={vi.fn()}
+        accessibilityGranted
+        onCheckForUpdate={vi.fn(async () => {})}
+        updateStatus={{ phase: 'idle' }}
+        configureError={null}
+      />,
+    ));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('renders exactly six ordered pages with Recording selected first', () => {
+    expect(SETTINGS_CATEGORIES.map((category) => category.label)).toEqual([
+      'Recording', 'Transcription', 'Text & Vocabulary', 'Delivery', 'Performance', 'General',
+    ]);
+    const nav = container.querySelector('nav[aria-label="Settings pages"]') as HTMLElement;
+    expect(Array.from(nav.querySelectorAll('button')).slice(1).map((button) => button.textContent)).toEqual(SETTINGS_CATEGORIES.map((category) => category.label));
+    expect(nav.querySelector('[aria-current="page"]')?.textContent).toBe('Recording');
+    expect(container.textContent).toContain('Microphone');
+  });
+
+  it('moves vocabulary, app overrides, Performance, and startup into their intended pages', async () => {
+    for (const [page, expected] of [
+      ['Text & Vocabulary', 'Names & Terms'],
+      ['Delivery', 'Always copied to clipboard'],
+      ['Performance', 'Performance lab'],
+      ['General', 'Launch at Login'],
+    ] as const) {
+      const button = Array.from(container.querySelectorAll('nav button')).find((item) => item.textContent === page) as HTMLButtonElement;
+      await act(async () => button.click());
+      expect(container.textContent).toContain(expected);
+      expect(button.getAttribute('aria-current')).toBe('page');
+    }
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+});
+
+describe('effectiveAutoPaste', () => {
+  it('preserves the preference while pausing delivery for either file output', () => {
+    expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: false, saveAudio: false })).toBe(true);
+    expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: true, saveAudio: false })).toBe(false);
+    expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: false, saveAudio: true })).toBe(false);
+  });
+});

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -2,7 +2,13 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../lib/settings';
-import { SETTINGS_CATEGORIES, SettingsPanel, effectiveAutoPaste } from './SettingsPanel';
+import {
+  SETTINGS_CATEGORIES,
+  SettingsPanel,
+  autoPasteDeliveryDescription,
+  effectiveAutoPaste,
+  fileOutputDeliveryDescription,
+} from './SettingsPanel';
 
 vi.mock('@tauri-apps/api/app', () => ({ getVersion: vi.fn(async () => '0.18.0') }));
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async (command: string) => command === 'list_audio_devices' ? [] : undefined) }));
@@ -84,5 +90,17 @@ describe('effectiveAutoPaste', () => {
     expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: false, saveAudio: false })).toBe(true);
     expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: true, saveAudio: false })).toBe(false);
     expect(effectiveAutoPaste({ autoPaste: true, saveTranscript: false, saveAudio: true })).toBe(false);
+  });
+
+  it('describes paused and already-off preferences without conflating them', () => {
+    expect(autoPasteDeliveryDescription({ autoPaste: true, saveTranscript: true, saveAudio: false })).toContain('Paused');
+    expect(fileOutputDeliveryDescription({ autoPaste: true })).toContain('paused');
+
+    expect(autoPasteDeliveryDescription({ autoPaste: false, saveTranscript: false, saveAudio: true })).toBe(
+      'Unavailable while file output is on. Turn off file output to enable auto-paste.',
+    );
+    expect(fileOutputDeliveryDescription({ autoPaste: false })).toBe(
+      'Clipboard copying stays on; auto-paste remains off.',
+    );
   });
 });

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -148,6 +148,21 @@ export function effectiveAutoPaste(settings: Pick<Settings, 'autoPaste' | 'saveT
   return settings.autoPaste && !settings.saveTranscript && !settings.saveAudio;
 }
 
+export function autoPasteDeliveryDescription(settings: Pick<Settings, 'autoPaste' | 'saveTranscript' | 'saveAudio'>): string {
+  if (!settings.saveTranscript && !settings.saveAudio) {
+    return 'Paste the clipboard result into the active app (Accessibility permission required).';
+  }
+  return settings.autoPaste
+    ? 'Paused while file output is on. Your saved preference will resume when file output is off.'
+    : 'Unavailable while file output is on. Turn off file output to enable auto-paste.';
+}
+
+export function fileOutputDeliveryDescription(settings: Pick<Settings, 'autoPaste'>): string {
+  return settings.autoPaste
+    ? 'Clipboard copying stays on; only automatic paste is paused.'
+    : 'Clipboard copying stays on; auto-paste remains off.';
+}
+
 export function SettingsPanel({
   isOpen,
   onClose,
@@ -432,7 +447,7 @@ export function SettingsPanel({
               <h2 className="text-sm font-medium text-on-surface">Always copied to clipboard</h2>
               <p className="mt-1 text-xs text-on-surface-variant">Every completed transcription is copied first. Auto-paste and file output only change what happens next.</p>
             </div>
-            <SettingToggle title="Auto-Paste" label="Auto paste" description={saveToFile ? 'Paused while file output is on. Your saved preference will resume when file output is off.' : 'Paste the clipboard result into the active app (Accessibility permission required).'} checked={autoPasteOn} disabled={saveToFile} onChange={() => onUpdateSettings({ autoPaste: !settings.autoPaste })} />
+            <SettingToggle title="Auto-Paste" label="Auto paste" description={autoPasteDeliveryDescription(settings)} checked={autoPasteOn} disabled={saveToFile} onChange={() => onUpdateSettings({ autoPaste: !settings.autoPaste })} />
             {settings.autoPaste && saveToFile && <p role="status" className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">Auto-paste is paused; the stored preference remains on.</p>}
             {autoPasteOn && accessibilityGranted !== null && <div className={`flex items-center gap-2 text-xs ${accessibilityGranted ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}><span>{accessibilityGranted ? 'Accessibility permission granted' : 'Accessibility permission required'}</span>{accessibilityGranted === false && <button type="button" onClick={requestAccessibility} className="underline">Grant</button>}</div>}
             {autoPasteOn && <PasteDelaySlider value={settings.autoPasteDelayMs} onCommit={(autoPasteDelayMs) => onUpdateSettings({ autoPasteDelayMs })} />}
@@ -443,7 +458,7 @@ export function SettingsPanel({
                 <p className="mb-1 text-xs text-on-surface-variant">Output Folder</p>
                 <p className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">{settings.outputDir || 'Documents/Murmur (default)'}</p>
                 <div className="mt-2 flex gap-3"><button type="button" onClick={() => void chooseOutputFolder()} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>{settings.outputDir && <button type="button" onClick={() => onUpdateSettings({ outputDir: '' })} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Reset to default</button>}</div>
-                <p className="mt-2 text-xs text-on-surface-variant">Clipboard copying stays on; only automatic paste is paused.</p>
+                <p className="mt-2 text-xs text-on-surface-variant">{fileOutputDeliveryDescription(settings)}</p>
               </div>
             )}
             <div className="border-t border-outline-variant/20 pt-4">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -1,22 +1,21 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { open } from '@tauri-apps/plugin-dialog';
-import { getVersion } from '@tauri-apps/api/app';
 import {
-  Settings, RecordingMode, DEFAULT_SETTINGS,
-  AVAILABLE_MODEL_OPTIONS, DOUBLE_TAP_KEY_OPTIONS, RECORDING_MODE_OPTIONS,
-  IDLE_TIMEOUT_OPTIONS, LANGUAGE_OPTIONS, WRITING_STYLE_OPTIONS,
-  AppProfile, WritingStyle, WritingStyleChoice, vocabularyPrompt,
+  AVAILABLE_MODEL_OPTIONS,
+  DEFAULT_SETTINGS,
+  DOUBLE_TAP_KEY_OPTIONS,
+  IDLE_TIMEOUT_OPTIONS,
+  LANGUAGE_OPTIONS,
+  RECORDING_MODE_OPTIONS,
+  type RecordingMode,
+  type Settings,
+  vocabularyPrompt,
 } from '../../lib/settings';
-import { Select } from '../ui/Select';
-import { SettingsSection } from './SettingsSection';
-import { VocabScanStrip } from './VocabScanStrip';
-import { PerformanceLab } from './PerformanceLab';
-import { VocabularyAliasesEditor } from './VocabularyAliasesEditor';
-import { KnowledgeManager } from './KnowledgeManager';
-import { VoiceCommandsManager } from './VoiceCommandsManager';
 import { useVocabScan } from '../../lib/hooks/useVocabScan';
+import { useModelRuntimeCatalog } from '../../lib/modelRuntime';
 import {
   modelDownloadLabel,
   modelDownloadPercent,
@@ -24,21 +23,63 @@ import {
 } from '../../lib/modelDownload';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
-import { useModelRuntimeCatalog } from '../../lib/modelRuntime';
+import { Select } from '../ui/Select';
+import { AppOverridesEditor } from './AppOverridesEditor';
+import { KnowledgeManager } from './KnowledgeManager';
+import { PerformanceLab } from './PerformanceLab';
+import { SettingsSection } from './SettingsSection';
+import { VocabScanStrip } from './VocabScanStrip';
+import { VocabularyAliasesEditor } from './VocabularyAliasesEditor';
+import { VoiceCommandsManager } from './VoiceCommandsManager';
 
-function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: number) => void }) {
-  const [draft, setDraft] = useState(value);
-  useEffect(() => { setDraft(value); }, [value]);
-
+function Toggle({ label, checked, onChange, disabled = false }: {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+}) {
   return (
-    <div className="mt-3">
-      <div className="flex items-center justify-between mb-1">
-        <label className="text-xs text-on-surface-variant">
-          Paste Delay
-        </label>
-        <span className="text-xs font-medium text-on-surface">
-          {draft}ms
-        </span>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onChange}
+      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${checked ? 'bg-primary' : 'bg-surface-container-highest'}`}
+    >
+      <span className={`inline-block h-4 w-4 rounded-full bg-on-primary shadow transition-transform ${checked ? 'translate-x-6' : 'translate-x-1'}`} />
+    </button>
+  );
+}
+
+function SettingToggle({ title, description, label = title, checked, onChange, disabled = false }: {
+  title: string;
+  description: string;
+  label?: string;
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div>
+        <p className="text-sm font-medium text-on-surface">{title}</p>
+        <p className="mt-1 text-xs text-on-surface-variant">{description}</p>
+      </div>
+      <Toggle label={label} checked={checked} onChange={onChange} disabled={disabled} />
+    </div>
+  );
+}
+
+function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (value: number) => void }) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <label className="text-xs text-on-surface-variant">Paste Delay</label>
+        <span className="text-xs font-medium text-on-surface">{draft}ms</span>
       </div>
       <input
         type="range"
@@ -46,30 +87,23 @@ function PasteDelaySlider({ value, onCommit }: { value: number; onCommit: (v: nu
         max={500}
         step={10}
         value={draft}
-        onChange={(e) => setDraft(Number(e.target.value))}
+        onChange={(event) => setDraft(Number(event.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-primary"
+        className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-surface-container-highest accent-primary"
       />
-      <p className="mt-1 text-xs text-on-surface-variant">
-        Delay before paste. Increase if paste lands in the wrong window.
-      </p>
+      <p className="mt-1 text-xs text-on-surface-variant">Increase this if paste lands in the wrong window.</p>
     </div>
   );
 }
 
-function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v: number) => void }) {
+function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (value: number) => void }) {
   const [draft, setDraft] = useState(value);
-  useEffect(() => { setDraft(value); }, [value]);
-
+  useEffect(() => setDraft(value), [value]);
   return (
     <div>
-      <div className="flex items-center justify-between mb-1">
-        <label className="text-xs text-on-surface-variant">
-          Sensitivity
-        </label>
-        <span className="text-xs font-medium text-on-surface">
-          {draft}%
-        </span>
+      <div className="mb-1 flex items-center justify-between">
+        <label className="text-xs text-on-surface-variant">Sensitivity</label>
+        <span className="text-xs font-medium text-on-surface">{draft}%</span>
       </div>
       <input
         type="range"
@@ -77,415 +111,11 @@ function VadSensitivitySlider({ value, onCommit }: { value: number; onCommit: (v
         max={100}
         step={5}
         value={draft}
-        onChange={(e) => setDraft(Number(e.target.value))}
+        onChange={(event) => setDraft(Number(event.target.value))}
         onPointerUp={() => onCommit(draft)}
-        className="w-full h-1.5 bg-surface-container-highest rounded-full appearance-none cursor-pointer accent-primary"
+        className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-surface-container-highest accent-primary"
       />
-      <p className="mt-1 text-xs text-on-surface-variant">
-        Higher = keeps more audio. Lower = trims silence more aggressively.
-      </p>
-    </div>
-  );
-}
-
-const WRITING_STYLE_SUMMARIES: Record<WritingStyleChoice, string> = {
-  inherit: 'Uses your current global behavior and the fine-tuning controls below.',
-  conversational: 'Removes filler and repeated words, tidies capitalization, and keeps your wording.',
-  polished: 'Cleans speech and applies explicitly spoken lists, punctuation, symbols, and corrections.',
-  code_technical: 'Preserves technical wording and enables deterministic command formatting.',
-  verbatim: 'Leaves recognized text unchanged, including filler, spacing, and spoken command words.',
-  notes: 'Removes filler, keeps note-like capitalization, and turns explicit list, paragraph, and line cues into structure.',
-};
-
-const WRITING_STYLE_CATEGORIES: Record<WritingStyleChoice, string> = {
-  inherit: 'Cleanup, corrections, prose structure, and command formatting all inherit.',
-  conversational: 'Cleanup on · Prose structure off · Automatic command formatting off',
-  polished: 'Cleanup on · Vocabulary corrections on · Prose structure on · Automatic command formatting off',
-  code_technical: 'Cleanup off · Vocabulary corrections on · Prose structure off · Command formatting on',
-  verbatim: 'Cleanup, corrections, prose structure, and command formatting all off',
-  notes: 'Cleanup on · Vocabulary corrections on · Prose structure on · Automatic command formatting off',
-};
-
-interface IdeContextStatus {
-  state: 'disabled' | 'empty' | 'scanning' | 'ready' | 'stale' | 'cleared' | 'error';
-  generation: number;
-  roots: number;
-  files: number;
-  symbols: number;
-  bytes: number;
-  capped: boolean;
-  ms: number;
-}
-
-function ideStatusText(status: IdeContextStatus | undefined, roots: number): string {
-  if (!status) return roots > 0 ? 'Checking the memory-only index…' : 'Add a project root to build an index.';
-  switch (status.state) {
-    case 'scanning': return `Indexing locally… generation ${status.generation}`;
-    case 'ready': return `Ready · ${status.files} files · ${status.symbols} symbols${status.capped ? ' · capped' : ''}`;
-    case 'stale': return 'Expired safely · refresh to use project symbols again.';
-    case 'cleared': return 'Index cleared from memory. Configured roots are still available.';
-    case 'error': return 'Index unavailable. Check the configured roots and refresh.';
-    case 'empty': return 'Add a project root to build an index.';
-    default: return 'Local project context is off.';
-  }
-}
-
-// Per-app profiles map a macOS bundle id to an explicit writing style plus
-// independent delivery/transformation overrides.
-function AppProfilesEditor({ profiles, onChange }: {
-  profiles: AppProfile[];
-  onChange: (next: AppProfile[]) => void;
-}) {
-  const [bundleId, setBundleId] = useState('');
-  const [label, setLabel] = useState('');
-  const [ideStatuses, setIdeStatuses] = useState<Record<string, IdeContextStatus>>({});
-
-  const pollIdeStatuses = useCallback(async () => {
-    const enabled = profiles.filter((profile) => profile.ideContextEnabled);
-    if (enabled.length === 0) return;
-    const pairs = await Promise.all(enabled.map(async (profile) => {
-      try {
-        const status = await invoke<IdeContextStatus>('get_ide_context_status', { bundleId: profile.bundleId });
-        return [profile.bundleId, status] as const;
-      } catch {
-        return null;
-      }
-    }));
-    setIdeStatuses((current) => ({
-      ...current,
-      ...Object.fromEntries(pairs.filter((pair): pair is readonly [string, IdeContextStatus] => pair !== null)),
-    }));
-  }, [profiles]);
-
-  useEffect(() => {
-    void pollIdeStatuses();
-    const timer = window.setInterval(() => void pollIdeStatuses(), 1000);
-    return () => window.clearInterval(timer);
-  }, [pollIdeStatuses]);
-
-  const handleAdd = () => {
-    const trimmedId = bundleId.trim();
-    if (!trimmedId) return;
-    if (profiles.some((p) => p.bundleId === trimmedId)) {
-      // Already have a profile for this app — clear the inputs and bail.
-      setBundleId('');
-      setLabel('');
-      return;
-    }
-    onChange([
-      ...profiles,
-      {
-        bundleId: trimmedId,
-        label: label.trim(),
-        autoPasteOverride: null,
-        cleanupOverride: null,
-        smartFormattingOverride: null,
-        cliFormattingOverride: null,
-        writingStyle: null,
-        ideContextEnabled: false,
-        ideProjectRoots: [],
-      },
-    ]);
-    setBundleId('');
-    setLabel('');
-  };
-
-  const handleRemove = (id: string) => {
-    onChange(profiles.filter((p) => p.bundleId !== id));
-  };
-
-  // Cycle a tri-state override: Default (null) -> On (true) -> Off (false) -> Default.
-  const cycle = (value: boolean | null): boolean | null =>
-    value === null ? true : value === true ? false : null;
-
-  const cyclePaste = (id: string) => {
-    onChange(profiles.map((p) =>
-      p.bundleId === id ? { ...p, autoPasteOverride: cycle(p.autoPasteOverride) } : p));
-  };
-
-  const cycleCleanup = (id: string) => {
-    onChange(profiles.map((p) =>
-      p.bundleId === id ? { ...p, cleanupOverride: cycle(p.cleanupOverride) } : p));
-  };
-
-  const cycleCliFormatting = (id: string) => {
-    onChange(profiles.map((p) =>
-      p.bundleId === id ? { ...p, cliFormattingOverride: cycle(p.cliFormattingOverride) } : p));
-  };
-
-  const cycleSmartFormatting = (id: string) => {
-    onChange(profiles.map((p) =>
-      p.bundleId === id ? { ...p, smartFormattingOverride: cycle(p.smartFormattingOverride) } : p));
-  };
-
-  const changeWritingStyle = (id: string, choice: WritingStyleChoice) => {
-    onChange(profiles.map((p) =>
-      p.bundleId === id
-        ? { ...p, writingStyle: choice === 'inherit' ? null : choice as WritingStyle }
-        : p));
-  };
-
-  const toggleIdeContext = (id: string) => {
-    onChange(profiles.map((profile) => profile.bundleId === id
-      ? { ...profile, ideContextEnabled: !profile.ideContextEnabled }
-      : profile));
-  };
-
-  const addIdeRoot = async (id: string) => {
-    try {
-      const selected = await open({ directory: true, multiple: false });
-      if (typeof selected !== 'string') return;
-      onChange(profiles.map((profile) => {
-        if (profile.bundleId !== id || profile.ideProjectRoots.includes(selected) || profile.ideProjectRoots.length >= 4) {
-          return profile;
-        }
-        return { ...profile, ideProjectRoots: [...profile.ideProjectRoots, selected] };
-      }));
-    } catch {
-      // Dialog cancelled or unavailable — keep the configured roots.
-    }
-  };
-
-  const removeIdeRoot = (id: string, root: string) => {
-    onChange(profiles.map((profile) => profile.bundleId === id
-      ? { ...profile, ideProjectRoots: profile.ideProjectRoots.filter((candidate) => candidate !== root) }
-      : profile));
-  };
-
-  const refreshIdeIndex = async (id: string) => {
-    try {
-      const status = await invoke<IdeContextStatus>('refresh_ide_context', { bundleId: id });
-      setIdeStatuses((current) => ({ ...current, [id]: status }));
-    } catch {
-      // Backend status polling will surface the stable failure state.
-    }
-  };
-
-  const clearIdeIndex = async (id: string) => {
-    try {
-      const status = await invoke<IdeContextStatus>('clear_ide_context', { bundleId: id });
-      setIdeStatuses((current) => ({ ...current, [id]: status }));
-    } catch {
-      // Keep configured roots intact even if the command is unavailable.
-    }
-  };
-
-  const chipLabel = (kind: string, value: boolean | null) =>
-    value === null ? `${kind}: Default` : value ? `${kind}: On` : `${kind}: Off`;
-
-  const chipClass = (value: boolean | null) =>
-    value === null
-      ? 'border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant'
-      : value
-        ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
-        : 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400';
-
-  return (
-    <div>
-      <p className="mb-2 text-xs text-on-surface-variant">
-        Choose a local writing style and optional fine-tuning for specific apps by bundle id
-        (e.g. <span className="font-mono">com.apple.Terminal</span>). The frontmost
-        app when you start dictating selects the profile. Murmur never classifies
-        apps automatically or reads their screen, selection, or clipboard content.
-      </p>
-
-      {profiles.length > 0 && (
-        <ul className="mb-3 space-y-1.5">
-          {profiles.map((p) => (
-            <li
-              key={p.bundleId}
-              className="flex flex-col gap-2 rounded-lg bg-surface-container-lowest px-2.5 py-2 shadow-sm"
-            >
-              <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  {p.label && (
-                    <div className="text-xs font-medium text-on-surface truncate">
-                      {p.label}
-                    </div>
-                  )}
-                  <div className="text-xs font-mono text-on-surface-variant truncate">
-                    {p.bundleId}
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => handleRemove(p.bundleId)}
-                  aria-label={`Remove profile for ${p.label || p.bundleId}`}
-                  className="shrink-0 rounded-md p-1 text-on-surface-variant transition-colors hover:bg-surface-container hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-on-surface">
-                  Writing style
-                </label>
-                <Select
-                  value={p.writingStyle ?? 'inherit'}
-                  onChange={(choice) => changeWritingStyle(p.bundleId, choice)}
-                  items={WRITING_STYLE_OPTIONS}
-                  aria-label={`Writing style for ${p.label || p.bundleId}`}
-                />
-                <p className="mt-1 text-xs text-on-surface-variant">
-                  {WRITING_STYLE_SUMMARIES[p.writingStyle ?? 'inherit']}
-                </p>
-                <p className="mt-1 text-xs font-medium text-on-surface-variant">
-                  {WRITING_STYLE_CATEGORIES[p.writingStyle ?? 'inherit']}
-                </p>
-              </div>
-              <p className="text-xs text-on-surface-variant">
-                Fine-tune this profile below. Each control cycles Inherit → On → Off.
-              </p>
-              <div className="grid grid-cols-2 gap-1.5">
-                <button
-                  type="button"
-                  onClick={() => cyclePaste(p.bundleId)}
-                  aria-label={`Auto-paste for ${p.label || p.bundleId}: ${chipLabel('Paste', p.autoPasteOverride)}`}
-                  className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.autoPasteOverride)}`}
-                >
-                  {chipLabel('Paste', p.autoPasteOverride)}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => cycleCleanup(p.bundleId)}
-                  aria-label={`Cleanup for ${p.label || p.bundleId}: ${chipLabel('Clean', p.cleanupOverride)}`}
-                  className={`flex-1 px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cleanupOverride)}`}
-                >
-                  {chipLabel('Clean', p.cleanupOverride)}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => cycleSmartFormatting(p.bundleId)}
-                  aria-label={`Prose formatting for ${p.label || p.bundleId}: ${chipLabel('Prose', p.smartFormattingOverride)}`}
-                  className={`px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.smartFormattingOverride)}`}
-                >
-                  {chipLabel('Prose', p.smartFormattingOverride)}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => cycleCliFormatting(p.bundleId)}
-                  aria-label={`Command formatting for ${p.label || p.bundleId}: ${chipLabel('Commands', p.cliFormattingOverride)}`}
-                  className={`px-2 py-1 rounded-md text-xs font-medium border transition-colors ${chipClass(p.cliFormattingOverride)}`}
-                >
-                  {chipLabel('Commands', p.cliFormattingOverride)}
-                </button>
-              </div>
-              <div className="rounded-lg border border-outline-variant/30 bg-surface-container-lowest p-2.5">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="text-xs font-medium text-on-surface">Local IDE project context</div>
-                    <p className="mt-1 text-xs text-on-surface-variant">
-                      Explicitly index selected source roots in memory for symbols and <span className="font-mono">@file</span> mentions. Murmur never reads editor text, selections, or the clipboard.
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={p.ideContextEnabled}
-                    aria-label={`Local IDE project context for ${p.label || p.bundleId}`}
-                    onClick={() => toggleIdeContext(p.bundleId)}
-                    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary ${p.ideContextEnabled ? 'bg-primary' : 'bg-surface-container-highest'}`}
-                  >
-                    <span className={`inline-block h-4 w-4 rounded-full bg-on-primary shadow transition-transform ${p.ideContextEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
-                  </button>
-                </div>
-                {p.ideContextEnabled && (
-                  <div className="mt-2.5 space-y-2">
-                    {p.ideProjectRoots.length > 0 ? (
-                      <ul className="space-y-1">
-                        {p.ideProjectRoots.map((root) => (
-                          <li key={root} className="flex items-center gap-2 rounded-md bg-surface-container px-2 py-1.5">
-                            <span className="min-w-0 flex-1 break-all font-mono text-xs text-on-surface">{root}</span>
-                            <button
-                              type="button"
-                              onClick={() => removeIdeRoot(p.bundleId, root)}
-                              className="shrink-0 text-xs text-on-surface-variant underline hover:text-error"
-                            >
-                              Remove root
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-xs text-on-surface-variant">No project roots configured.</p>
-                    )}
-                    <div className="flex flex-wrap items-center gap-3">
-                      <button
-                        type="button"
-                        onClick={() => void addIdeRoot(p.bundleId)}
-                        disabled={p.ideProjectRoots.length >= 4}
-                        className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50"
-                      >
-                        Add project root
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void refreshIdeIndex(p.bundleId)}
-                        disabled={p.ideProjectRoots.length === 0 || ideStatuses[p.bundleId]?.state === 'scanning'}
-                        className="text-xs font-medium text-on-surface-variant underline hover:text-primary disabled:opacity-50"
-                      >
-                        Refresh index
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void clearIdeIndex(p.bundleId)}
-                        disabled={p.ideProjectRoots.length === 0}
-                        className="text-xs font-medium text-on-surface-variant underline hover:text-error disabled:opacity-50"
-                      >
-                        Clear index
-                      </button>
-                    </div>
-                    <p className="text-xs text-on-surface-variant" role="status">
-                      {ideStatusText(ideStatuses[p.bundleId], p.ideProjectRoots.length)}
-                    </p>
-                    <p className="text-xs text-on-surface-variant">
-                      Clear index removes only memory contents; Remove root changes the persisted profile configuration. Paths are shown only here and never written to logs.
-                    </p>
-                  </div>
-                )}
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      <div className="space-y-2">
-        <input
-          type="text"
-          value={label}
-          onChange={(e) => setLabel(e.target.value)}
-          placeholder="Label (optional, e.g. Terminal)"
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          spellCheck={false}
-          className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={bundleId}
-            onChange={(e) => setBundleId(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
-            placeholder="com.apple.Terminal"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            className="min-w-0 flex-1 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 font-mono text-xs text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary"
-          />
-          <button
-            type="button"
-            onClick={handleAdd}
-            disabled={!bundleId.trim()}
-            className="shrink-0 px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Add
-          </button>
-        </div>
-      </div>
+      <p className="mt-1 text-xs text-on-surface-variant">Higher keeps more audio; lower trims silence more aggressively.</p>
     </div>
   );
 }
@@ -498,7 +128,6 @@ interface SettingsPanelProps {
   status: DictationStatus;
   onResetStats: () => void;
   onViewLogs: () => void;
-  /** Relaunch the first-run setup assistant (permission troubleshooting). */
   onRerunSetup: () => void;
   accessibilityGranted: boolean | null;
   onCheckForUpdate: () => Promise<void>;
@@ -506,101 +135,81 @@ interface SettingsPanelProps {
   configureError: string | null;
 }
 
-const SETTINGS_CATEGORIES = [
-  { id: 'transcription', label: 'Transcription' },
+export const SETTINGS_CATEGORIES = [
   { id: 'recording', label: 'Recording' },
-  { id: 'output', label: 'Output & Paste' },
-  { id: 'profiles', label: 'Per-App Profiles' },
-  { id: 'vocab', label: 'Vocabulary' },
-  { id: 'knowledge', label: 'Knowledge' },
+  { id: 'transcription', label: 'Transcription' },
+  { id: 'text-vocabulary', label: 'Text & Vocabulary' },
+  { id: 'delivery', label: 'Delivery' },
   { id: 'performance', label: 'Performance' },
-  { id: 'about', label: 'About' },
+  { id: 'general', label: 'General' },
 ] as const;
 
-export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, status, onResetStats, onViewLogs, onRerunSetup, accessibilityGranted, onCheckForUpdate, updateStatus, configureError }: SettingsPanelProps) {
-  const { models: runtimeModels, byName: runtimeByName } = useModelRuntimeCatalog(isOpen);
-  const [confirmReset, setConfirmReset] = useState(false);
-  const [activeCat, setActiveCat] = useState<string>('transcription');
-  const [version, setVersion] = useState('');
+export function effectiveAutoPaste(settings: Pick<Settings, 'autoPaste' | 'saveTranscript' | 'saveAudio'>): boolean {
+  return settings.autoPaste && !settings.saveTranscript && !settings.saveAudio;
+}
 
-  useEffect(() => { getVersion().then(setVersion); }, []);
+export function SettingsPanel({
+  isOpen,
+  onClose,
+  settings,
+  onUpdateSettings,
+  status,
+  onResetStats,
+  onViewLogs,
+  onRerunSetup,
+  accessibilityGranted,
+  onCheckForUpdate,
+  updateStatus,
+  configureError,
+}: SettingsPanelProps) {
+  const { byName: runtimeByName } = useModelRuntimeCatalog(isOpen);
+  const [activeCat, setActiveCat] = useState<string>('recording');
+  const [version, setVersion] = useState('');
+  const [confirmReset, setConfirmReset] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
   const confirmResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleResetClick = () => {
-    if (confirmReset) {
-      if (confirmResetTimeoutRef.current) clearTimeout(confirmResetTimeoutRef.current);
-      confirmResetTimeoutRef.current = null;
-      setConfirmReset(false);
-      onResetStats();
-    } else {
-      setConfirmReset(true);
-      confirmResetTimeoutRef.current = setTimeout(() => {
-        setConfirmReset(false);
-        confirmResetTimeoutRef.current = null;
-      }, 3000);
-    }
-  };
+  useEffect(() => { void getVersion().then(setVersion); }, []);
+  useEffect(() => { contentRef.current?.scrollTo({ top: 0 }); }, [activeCat]);
+  useEffect(() => () => {
+    if (confirmResetTimeoutRef.current) clearTimeout(confirmResetTimeoutRef.current);
+  }, []);
 
-  const handleRequestPermission = () => invoke('request_accessibility_permission');
-
-  const handleChooseFolder = async () => {
+  const requestAccessibility = () => { void invoke('request_accessibility_permission'); };
+  const chooseOutputFolder = async () => {
     try {
       const selected = await open({ directory: true, multiple: false });
-      if (typeof selected === 'string') {
-        onUpdateSettings({ outputDir: selected });
-      }
+      if (typeof selected === 'string') onUpdateSettings({ outputDir: selected });
     } catch {
-      // Dialog cancelled or unavailable — keep the current folder.
+      // Cancellation leaves the stored folder untouched.
     }
   };
 
-  // Code-vocab scan: live walker + ticking counts + done-state. Seeded from the
-  // persisted last-scan summary so reopening settings shows the prior result.
   const vocabScan = useVocabScan(settings.codeVocabLastScan);
-  // useVocabScan returns a fresh object literal each render, but scan/cancel are
-  // stable useCallbacks — depend on the function, not the whole object, so
-  // runVocabScan (and the closures built from it) keep a stable identity.
   const { scan: doScan } = vocabScan;
-
-  // Run a scan against a folder and persist its summary so the done-state
-  // survives a settings reopen. Persisting via onUpdateSettings keeps the hook
-  // and localStorage in sync (the hook also resolves to the summary).
-  const runVocabScan = useCallback(
-    async (folder: string) => {
-      if (!folder) return;
-      const summary = await doScan(folder);
-      if (summary?.adopted) onUpdateSettings({ codeVocabLastScan: summary });
-      else if (summary) onUpdateSettings({ codeVocabLastScan: null });
-    },
-    [doScan, onUpdateSettings],
-  );
-
-  const handleChooseCodeVocabFolder = async () => {
+  const runVocabScan = useCallback(async (folder: string) => {
+    if (!folder) return;
+    const summary = await doScan(folder);
+    if (summary?.adopted) onUpdateSettings({ codeVocabLastScan: summary });
+    else if (summary) onUpdateSettings({ codeVocabLastScan: null });
+  }, [doScan, onUpdateSettings]);
+  const chooseCodeFolder = async () => {
     try {
       const selected = await open({ directory: true, multiple: false });
-      if (typeof selected === 'string') {
-        onUpdateSettings({ codeVocabFolder: selected, codeVocabLastScan: null });
-        // Auto-scan the freshly chosen folder.
-        void runVocabScan(selected);
-      }
+      if (typeof selected !== 'string') return;
+      onUpdateSettings({ codeVocabFolder: selected, codeVocabLastScan: null });
+      void runVocabScan(selected);
     } catch {
-      // Dialog cancelled or unavailable — keep the current folder.
+      // Cancellation leaves the stored folder untouched.
     }
   };
-
-  // Clear the folder: also drop the persisted scan and reset the strip to idle.
-  const handleClearCodeVocabFolder = () => {
+  const clearCodeFolder = () => {
     vocabScan.cancel();
     onUpdateSettings({ codeVocabFolder: '', codeVocabLastScan: null });
   };
 
-  const saveToFile = settings.saveTranscript || settings.saveAudio;
-
-  // Model availability check and inline download
   const selectedRuntime = runtimeByName.get(settings.model);
-  const modelAvailable = selectedRuntime
-    ? selectedRuntime.installState === 'installed'
-    : null;
+  const modelAvailable = selectedRuntime ? selectedRuntime.installState === 'installed' : null;
   const [modelDownload, setModelDownload] = useState<
     | { phase: 'idle' }
     | { phase: 'downloading'; progress: ModelDownloadProgress }
@@ -613,1008 +222,255 @@ export function SettingsPanel({ isOpen, onClose, settings, onUpdateSettings, sta
     setModelDownload({ phase: 'idle' });
     downloadModelRef.current = null;
   }, [settings.model]);
-
-  useEffect(() => {
-    return () => {
-      downloadUnlistenRef.current?.();
-      downloadUnlistenRef.current = null;
-    };
+  useEffect(() => () => {
+    downloadUnlistenRef.current?.();
+    downloadUnlistenRef.current = null;
   }, []);
 
-  const handleModelDownload = useCallback(async () => {
+  const downloadModel = useCallback(async () => {
     const modelName = settings.model;
     downloadModelRef.current = modelName;
-    setModelDownload({
-      phase: 'downloading',
-      progress: { received: 0, total: 0, phase: 'downloading' },
-    });
+    setModelDownload({ phase: 'downloading', progress: { received: 0, total: 0, phase: 'downloading' } });
     let unlisten: (() => void) | null = null;
     try {
-      unlisten = await listen<ModelDownloadProgress>(
-        'download-progress',
-        (event) => {
-          if (downloadModelRef.current !== modelName) return;
-          setModelDownload({
-            phase: 'downloading',
-            progress: event.payload,
-          });
-        }
-      );
+      unlisten = await listen<ModelDownloadProgress>('download-progress', (event) => {
+        if (downloadModelRef.current === modelName) setModelDownload({ phase: 'downloading', progress: event.payload });
+      });
       downloadUnlistenRef.current = unlisten;
       await invoke('download_model', { modelName });
       unlisten();
       downloadUnlistenRef.current = null;
-      if (downloadModelRef.current === modelName) {
-        downloadModelRef.current = null;
-        setModelDownload({ phase: 'idle' });
-      }
-    } catch (err) {
+      if (downloadModelRef.current === modelName) setModelDownload({ phase: 'idle' });
+    } catch (error) {
       unlisten?.();
       downloadUnlistenRef.current = null;
-      if (downloadModelRef.current === modelName) {
-        downloadModelRef.current = null;
-        setModelDownload({ phase: 'error', message: String(err) });
-      }
+      if (downloadModelRef.current === modelName) setModelDownload({ phase: 'error', message: String(error) });
+    } finally {
+      if (downloadModelRef.current === modelName) downloadModelRef.current = null;
     }
   }, [settings.model]);
 
-  // Audio device enumeration
   const [audioDevices, setAudioDevices] = useState<string[]>([]);
   useEffect(() => {
     if (!isOpen) return;
-    invoke<string[]>('list_audio_devices')
-      .then(setAudioDevices)
-      .catch(() => setAudioDevices([]));
+    invoke<string[]>('list_audio_devices').then(setAudioDevices).catch(() => setAudioDevices([]));
   }, [isOpen]);
 
-  const savedDeviceMissing =
-    settings.microphone !== DEFAULT_SETTINGS.microphone &&
-    audioDevices.length > 0 &&
-    !audioDevices.includes(settings.microphone);
-
+  const isRecording = status !== 'idle';
   const isDoubleTap = settings.recordingMode === 'double_tap';
   const isBoth = settings.recordingMode === 'both';
   const keyLabel = isBoth ? 'Trigger Key' : isDoubleTap ? 'Double-Tap Key' : 'Hold Key';
-  const keyHelpText = isBoth
-    ? 'Hold to record, or double-tap to start and single tap to stop'
-    : isDoubleTap
-      ? 'Double-tap to start recording, single tap to stop'
-      : 'Hold to start recording, release to stop';
-  const isRecording = status !== 'idle';
-  const selectedModel = AVAILABLE_MODEL_OPTIONS.find(m => m.value === settings.model);
-  const supportsCoreMl = runtimeModels.some(model => model.backend === 'coreml' && model.supported);
-  const useNeuralEngine = selectedRuntime?.backend === 'coreml';
-  const isEnglishOnlyModel = selectedRuntime
-    ? !selectedRuntime.capabilities.multilingual
-    : true;
-  const activeModelDownload = modelDownload.phase === 'downloading'
-    ? modelDownload.progress
+  const keyHelp = isBoth
+    ? 'Hold to record, or double-tap to start and single-tap to stop.'
+    : isDoubleTap ? 'Double-tap to start and single-tap to stop.' : 'Hold to start and release to stop.';
+  const missingDevice = settings.microphone !== DEFAULT_SETTINGS.microphone
+    && audioDevices.length > 0
+    && !audioDevices.includes(settings.microphone);
+  const englishOnly = selectedRuntime ? !selectedRuntime.capabilities.multilingual : true;
+  const downloadProgress = modelDownload.phase === 'downloading'
+    ? modelDownloadPercent(modelDownload.progress)
     : null;
-  const downloadProgressPercent = activeModelDownload
-    ? modelDownloadPercent(activeModelDownload)
-    : null;
+  const saveToFile = settings.saveTranscript || settings.saveAudio;
+  const autoPasteOn = effectiveAutoPaste(settings);
+
+  const resetStats = () => {
+    if (confirmReset) {
+      if (confirmResetTimeoutRef.current) clearTimeout(confirmResetTimeoutRef.current);
+      confirmResetTimeoutRef.current = null;
+      setConfirmReset(false);
+      onResetStats();
+      return;
+    }
+    setConfirmReset(true);
+    confirmResetTimeoutRef.current = setTimeout(() => {
+      setConfirmReset(false);
+      confirmResetTimeoutRef.current = null;
+    }, 3000);
+  };
 
   return (
-    <div className="flex-1 flex overflow-hidden bg-surface text-on-surface">
-      {/* Left: category nav rail */}
-      <nav className="w-48 shrink-0 flex flex-col bg-surface-container-low overflow-y-auto">
-        <div className="flex items-center justify-between h-12 shrink-0 px-3">
+    <div className="flex flex-1 overflow-hidden bg-surface text-on-surface">
+      <nav aria-label="Settings pages" className="flex w-48 shrink-0 flex-col overflow-y-auto bg-surface-container-low">
+        <div className="flex h-12 shrink-0 items-center justify-between px-3">
           <h2 className="text-sm font-semibold text-on-surface">Settings</h2>
-          <button
-            onClick={onClose}
-            aria-label="Close settings"
-            className="p-1 rounded-md text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface transition-colors"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+          <button onClick={onClose} aria-label="Close settings" className="rounded-md p-1 text-on-surface-variant transition-colors hover:bg-surface-container-high hover:text-on-surface">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>
-        <div className="px-2 pb-3 space-y-0.5">
-          {SETTINGS_CATEGORIES.map((c) => (
+        <div className="space-y-0.5 px-2 pb-3">
+          {SETTINGS_CATEGORIES.map((category) => (
             <button
-              key={c.id}
+              key={category.id}
               type="button"
-              onClick={() => setActiveCat(c.id)}
-              className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
-                activeCat === c.id
-                  ? 'bg-surface-container-high text-primary font-medium'
-                  : 'text-on-surface-variant hover:bg-surface-container'
-              }`}
+              aria-current={activeCat === category.id ? 'page' : undefined}
+              onClick={() => setActiveCat(category.id)}
+              className={`w-full rounded-lg px-3 py-2 text-left text-sm transition-colors ${activeCat === category.id ? 'bg-surface-container-high font-medium text-primary' : 'text-on-surface-variant hover:bg-surface-container'}`}
             >
-              {c.label}
+              {category.label}
             </button>
           ))}
         </div>
       </nav>
 
-      {/* Right: active category content */}
-      <div className="flex-1 overflow-y-auto">
+      <div ref={contentRef} data-testid="settings-content" className="flex-1 overflow-y-auto">
         <div className="max-w-2xl px-6 py-5">
-        {configureError && (
-          <p role="alert" className="mb-4 rounded-lg bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
-            {configureError}
-          </p>
-        )}
-        <SettingsSection pageId="transcription" activePage={activeCat} title="Transcription" subtitle="Model, language, microphone">
-        {supportsCoreMl && (
-          <div className="flex items-center justify-between gap-6">
+          {configureError && <p role="alert" className="mb-4 rounded-lg bg-error/10 px-3 py-2 text-xs text-error">{configureError}</p>}
+
+          <SettingsSection pageId="recording" activePage={activeCat} title="Recording" subtitle="Microphone, voice detection, and shortcuts">
             <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Apple Neural Engine
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                {useNeuralEngine
-                  ? 'Parakeet v3 via Core ML (fastest)'
-                  : 'Enable to switch to the Core ML transcription path'}
-              </p>
+              <label className="mb-2 block text-sm font-medium text-on-surface">Microphone</label>
+              <Select value={settings.microphone} onChange={(microphone) => onUpdateSettings({ microphone })} disabled={isRecording} items={[{ value: 'system_default', label: 'System Default' }, ...audioDevices.map((name) => ({ value: name, label: name }))]} />
+              {missingDevice && <p className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">Selected device not found — Murmur will use System Default.</p>}
             </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={useNeuralEngine}
-              aria-label="Use Apple Neural Engine"
-              disabled={isRecording}
-              onClick={() => onUpdateSettings({
-                model: useNeuralEngine
-                  ? 'parakeet-tdt-0.6b-v2-fp16'
-                  : 'parakeet-tdt-0.6b-v3-coreml',
-              })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
-                useNeuralEngine ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  useNeuralEngine ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-        )}
-
-        {/* Model Selector */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Transcription Model
-          </label>
-          <Select
-            value={settings.model}
-            onChange={(value) => onUpdateSettings({ model: value })}
-            disabled={isRecording}
-            items={AVAILABLE_MODEL_OPTIONS.map((m) => ({ value: m.value, label: `${m.label} (${m.size})` }))}
-          />
-          <p className="mt-1 text-xs text-on-surface-variant">
-            Larger models are more accurate but slower.
-          </p>
-          {selectedRuntime && (
-            <p className="mt-1 text-xs text-on-surface-variant" data-testid="model-runtime-status">
-              {selectedRuntime.label}: {selectedRuntime.installState} · {selectedRuntime.lifecycleState}
-            </p>
-          )}
-          {isRecording && (
-            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-              Stop recording before changing model
-            </p>
-          )}
-
-          {/* Model not downloaded — inline download prompt */}
-          {modelAvailable === false && modelDownload.phase === 'idle' && (
-            <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
-              <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
-              <span>Model not downloaded</span>
-              <button
-                onClick={handleModelDownload}
-                className="underline hover:no-underline ml-auto flex-shrink-0"
-              >
-                Download
-              </button>
+            <div>
+              <p className="mb-2 text-sm font-medium text-on-surface">Voice Detection</p>
+              <VadSensitivitySlider value={settings.vadSensitivity} onCommit={(vadSensitivity) => onUpdateSettings({ vadSensitivity })} />
             </div>
-          )}
-
-          {/* Download in progress */}
-          {modelDownload.phase === 'downloading' && (
-            <div className="mt-2">
-              <div className="flex justify-between text-xs text-on-surface-variant mb-1">
-                <span>{activeModelDownload ? modelDownloadLabel(activeModelDownload) : 'Starting...'}</span>
-                {downloadProgressPercent !== null ? (
-                  <span>{downloadProgressPercent}%</span>
-                ) : (
-                  <span>Working...</span>
-                )}
+            <div>
+              <p className="mb-2 text-sm font-medium text-on-surface">Recording Trigger</p>
+              <div className="flex gap-2">
+                {RECORDING_MODE_OPTIONS.map((option) => (
+                  <button key={option.value} type="button" disabled={isRecording} onClick={() => onUpdateSettings({ recordingMode: option.value as RecordingMode })} className={`flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${settings.recordingMode === option.value ? 'border-primary bg-primary text-on-primary' : 'border-outline-variant/30 bg-surface-container-lowest text-on-surface hover:bg-surface-container'}`}>{option.label}</button>
+                ))}
               </div>
-              <div className="w-full h-1.5 bg-surface-container-highest rounded-full overflow-hidden">
-                <div
-                  role="progressbar"
-                  aria-valuenow={downloadProgressPercent ?? undefined}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuetext={downloadProgressPercent === null
-                    ? 'Model installation in progress'
-                    : `Download progress: ${downloadProgressPercent} percent`}
-                  className={`h-full rounded-full bg-primary ${
-                    downloadProgressPercent === null
-                      ? 'model-download-indeterminate'
-                      : 'transition-all duration-200'
-                  }`}
-                  style={downloadProgressPercent === null
-                    ? undefined
-                    : { width: `${downloadProgressPercent}%` }}
-                />
+              {isRecording && <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">Stop recording before changing mode.</p>}
+            </div>
+            {accessibilityGranted === false && (
+              <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                <span>Accessibility permission is required for keyboard detection.</span>
+                <button type="button" onClick={requestAccessibility} className="ml-auto underline">Grant</button>
               </div>
+            )}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-on-surface">{keyLabel}</label>
+              <Select value={settings.doubleTapKey} onChange={(doubleTapKey) => onUpdateSettings({ doubleTapKey })} disabled={isRecording} items={DOUBLE_TAP_KEY_OPTIONS} />
+              <p className="mt-1 text-xs text-on-surface-variant">{keyHelp}</p>
             </div>
-          )}
+            {(isDoubleTap || isBoth) && <SettingToggle title="Hotkey Timing Feedback" description="Flash the overlay when a tap misses the double-tap window." checked={settings.hotkeyMissFeedback} onChange={() => onUpdateSettings({ hotkeyMissFeedback: !settings.hotkeyMissFeedback })} />}
+          </SettingsSection>
 
-          {/* Download error */}
-          {modelDownload.phase === 'error' && (
-            <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-600 dark:text-red-400">
-              <span>{modelDownload.message}</span>
-              <button
-                onClick={handleModelDownload}
-                className="underline hover:no-underline ml-auto flex-shrink-0"
-              >
-                Retry
-              </button>
-            </div>
-          )}
-        </div>
-
-        {/* Language Selector */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Language
-          </label>
-          <Select
-            value={settings.language}
-            onChange={(value) => onUpdateSettings({ language: value })}
-            disabled={isRecording || isEnglishOnlyModel}
-            items={LANGUAGE_OPTIONS}
-          />
-          {isEnglishOnlyModel ? (
-            <p className="mt-1 text-xs text-on-surface-variant">
-              English only model — switch to Whisper Large Turbo for other languages.
-            </p>
-          ) : isRecording ? (
-            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-              Stop recording before changing language
-            </p>
-          ) : (
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Auto Detect lets Whisper identify the language each recording.
-            </p>
-          )}
-        </div>
-
-        {/* Smart Punctuation Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="block text-sm font-medium text-on-surface">
-              Smart Punctuation
-            </label>
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Add periods, commas, and capitalization to transcriptions.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.smartPunctuation}
-            aria-label="Smart punctuation"
-            onClick={() => onUpdateSettings({ smartPunctuation: !settings.smartPunctuation })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-              settings.smartPunctuation ? 'bg-primary' : 'bg-surface-container-highest'
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                settings.smartPunctuation ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Microphone Selector */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Microphone
-          </label>
-          <Select
-            value={settings.microphone}
-            onChange={(value) => onUpdateSettings({ microphone: value })}
-            disabled={isRecording}
-            items={[
-              { value: 'system_default', label: 'System Default' },
-              ...audioDevices.map((name) => ({ value: name, label: name })),
-            ]}
-          />
-          {savedDeviceMissing && (
-            <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
-              <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
-              <span>Selected device not found — will use System Default</span>
-            </div>
-          )}
-        </div>
-
-        {/* Idle Timeout */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Release Model After Inactivity
-          </label>
-          <Select
-            value={String(settings.idleTimeoutMinutes)}
-            onChange={(value) => onUpdateSettings({ idleTimeoutMinutes: Number(value) })}
-            disabled={isRecording}
-            items={IDLE_TIMEOUT_OPTIONS.map((o) => ({ value: String(o.value), label: o.label }))}
-          />
-          <p className="mt-1 text-xs text-on-surface-variant">
-            Free memory by unloading the model when idle. Set to Never to keep it loaded.
-          </p>
-        </div>
-
-        {/* Transcript Cleanup Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="block text-sm font-medium text-on-surface">
-              Transcript Cleanup
-            </label>
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Strip filler words (um, uh) and tidy spacing before pasting.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.cleanupEnabled}
-            aria-label="Transcript cleanup"
-            onClick={() => onUpdateSettings({ cleanupEnabled: !settings.cleanupEnabled })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-              settings.cleanupEnabled ? 'bg-primary' : 'bg-surface-container-highest'
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                settings.cleanupEnabled ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Cleanup sub-options — only meaningful while cleanup is enabled. */}
-        {settings.cleanupEnabled && (
-          <div className="ml-3 pl-3 space-y-3">
-            <div className="flex items-center justify-between">
-              <label className="text-xs text-on-surface-variant">
-                Remove filler words (um, uh)
-              </label>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={settings.cleanupRemoveFiller}
-                aria-label="Remove filler words"
-                onClick={() => onUpdateSettings({ cleanupRemoveFiller: !settings.cleanupRemoveFiller })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                  settings.cleanupRemoveFiller ? 'bg-primary' : 'bg-surface-container-highest'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
-                    settings.cleanupRemoveFiller ? 'translate-x-4' : 'translate-x-1'
-                  }`}
-                />
-              </button>
-            </div>
-            <div className="flex items-center justify-between">
-              <label className="text-xs text-on-surface-variant">
-                Capitalize sentences
-              </label>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={settings.cleanupCapitalize}
-                aria-label="Capitalize sentences"
-                onClick={() => onUpdateSettings({ cleanupCapitalize: !settings.cleanupCapitalize })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                  settings.cleanupCapitalize ? 'bg-primary' : 'bg-surface-container-highest'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
-                    settings.cleanupCapitalize ? 'translate-x-4' : 'translate-x-1'
-                  }`}
-                />
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Smart Formatting Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="block text-sm font-medium text-on-surface">
-              Smart Formatting
-            </label>
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Format explicit spoken lists, email/URL/symbol cues, and same-utterance corrections locally.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.smartFormattingEnabled}
-            aria-label="Smart formatting"
-            onClick={() => onUpdateSettings({ smartFormattingEnabled: !settings.smartFormattingEnabled })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-              settings.smartFormattingEnabled ? 'bg-primary' : 'bg-surface-container-highest'
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                settings.smartFormattingEnabled ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-        </SettingsSection>
-
-        <SettingsSection pageId="recording" activePage={activeCat} title="Recording" subtitle="Trigger mode, shortcut key">
-        {/* Voice Detection */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Voice Detection
-          </label>
-          <VadSensitivitySlider
-            value={settings.vadSensitivity}
-            onCommit={(value) => onUpdateSettings({ vadSensitivity: value })}
-          />
-
-        </div>
-
-        {/* Recording Trigger */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            Recording Trigger
-          </label>
-          <div className="flex gap-2">
-            {RECORDING_MODE_OPTIONS.map((option) => (
-              <button
-                key={option.value}
+          <SettingsSection pageId="transcription" activePage={activeCat} title="Transcription" subtitle="Model, language, and runtime lifecycle">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-on-surface">Transcription Model</label>
+              <Select
+                value={settings.model}
+                onChange={(model) => onUpdateSettings({ model })}
                 disabled={isRecording}
-                onClick={() => onUpdateSettings({ recordingMode: option.value as RecordingMode })}
-                className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
-                  settings.recordingMode === option.value
-                    ? 'bg-primary text-on-primary border-primary'
-                    : 'bg-surface-container-lowest text-on-surface border-outline-variant/20 hover:bg-surface-container'
-                } ${isRecording ? 'opacity-50 cursor-not-allowed' : ''}`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-          {isRecording && (
-            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-              Stop recording before changing mode
-            </p>
-          )}
-        </div>
-
-        {/* Accessibility notice — both modes use rdev which requires it */}
-        {accessibilityGranted === false && (
-          <div className="flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
-            <span className="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
-            <span>Accessibility permission required for keyboard detection</span>
-            <button
-              onClick={handleRequestPermission}
-              className="underline hover:no-underline ml-auto flex-shrink-0"
-            >
-              Grant
-            </button>
-          </div>
-        )}
-
-        {/* Trigger Key Selector */}
-        <div>
-          <label className="block text-sm font-medium text-on-surface mb-2">
-            {keyLabel}
-          </label>
-          <Select
-            value={settings.doubleTapKey}
-            onChange={(value) => onUpdateSettings({ doubleTapKey: value })}
-            disabled={isRecording}
-            items={DOUBLE_TAP_KEY_OPTIONS}
-          />
-          <p className="mt-1 text-xs text-on-surface-variant">
-            {keyHelpText}
-          </p>
-        </div>
-
-        {(isDoubleTap || isBoth) && (
-          <div className="flex items-center justify-between gap-6">
-            <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Hotkey Timing Feedback
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Flash the overlay when a tap misses the double-tap window
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.hotkeyMissFeedback}
-              aria-label="Hotkey timing feedback"
-              onClick={() => onUpdateSettings({ hotkeyMissFeedback: !settings.hotkeyMissFeedback })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.hotkeyMissFeedback ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.hotkeyMissFeedback ? 'translate-x-6' : 'translate-x-1'
-                }`}
+                items={AVAILABLE_MODEL_OPTIONS.map((model) => ({ value: model.value, label: `${model.label}${model.backend === 'coreml' ? ' — Recommended' : ''} (${model.size})` }))}
               />
-            </button>
-          </div>
-        )}
-        </SettingsSection>
-
-        <SettingsSection pageId="output" activePage={activeCat} title="Output" subtitle="Auto-paste, launch at login">
-        {/* Auto-Paste Toggle */}
-        <div>
-          <div className="flex items-center justify-between">
-            <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Auto-Paste
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Automatically paste transcription (requires Accessibility permission)
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.autoPaste}
-              aria-label="Auto paste"
-              onClick={() => onUpdateSettings({ autoPaste: !settings.autoPaste })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.autoPaste ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.autoPaste ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-          {settings.autoPaste && accessibilityGranted !== null && (
-            <div className={`mt-2 flex items-center gap-2 text-xs ${
-              accessibilityGranted
-                ? 'text-emerald-600 dark:text-emerald-400'
-                : 'text-amber-600 dark:text-amber-400'
-            }`}>
-              <span className={`w-2 h-2 rounded-full ${
-                accessibilityGranted ? 'bg-emerald-500' : 'bg-amber-500'
-              }`} />
-              <span>
-                {accessibilityGranted
-                  ? 'Accessibility permission granted'
-                  : 'Accessibility permission required'}
-              </span>
-              {accessibilityGranted === false && (
-                <button
-                  onClick={handleRequestPermission}
-                  className="underline hover:no-underline"
-                >
-                  Grant
-                </button>
+              <p className="mt-1 text-xs text-on-surface-variant">Parakeet Core ML is recommended on supported Macs. Larger models can be more accurate but use more storage and memory.</p>
+              {selectedRuntime && <p className="mt-1 text-xs text-on-surface-variant" data-testid="model-runtime-status">{selectedRuntime.label}: {selectedRuntime.backend} / {selectedRuntime.accelerator} / {selectedRuntime.size} · {selectedRuntime.installState} · {selectedRuntime.lifecycleState}</p>}
+              {isRecording && <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">Stop recording before changing model.</p>}
+              {modelAvailable === false && modelDownload.phase === 'idle' && (
+                <div className="mt-2 flex items-center rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                  <span>Model not downloaded</span><button type="button" onClick={() => void downloadModel()} className="ml-auto underline">Download</button>
+                </div>
               )}
+              {modelDownload.phase === 'downloading' && (
+                <div className="mt-2">
+                  <div className="mb-1 flex justify-between text-xs text-on-surface-variant"><span>{modelDownloadLabel(modelDownload.progress)}</span><span>{downloadProgress === null ? 'Working…' : `${downloadProgress}%`}</span></div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-surface-container-highest"><div role="progressbar" aria-valuenow={downloadProgress ?? undefined} aria-valuemin={0} aria-valuemax={100} aria-valuetext={downloadProgress === null ? 'Model installation in progress' : `Download progress: ${downloadProgress} percent`} className={`h-full rounded-full bg-primary ${downloadProgress === null ? 'model-download-indeterminate' : 'transition-all duration-200'}`} style={downloadProgress === null ? undefined : { width: `${downloadProgress}%` }} /></div>
+                </div>
+              )}
+              {modelDownload.phase === 'error' && <div className="mt-2 flex items-center rounded-lg border border-error/30 bg-error/10 px-3 py-2 text-xs text-error"><span>{modelDownload.message}</span><button type="button" onClick={() => void downloadModel()} className="ml-auto underline">Retry</button></div>}
             </div>
-          )}
-          {settings.autoPaste && saveToFile && (
-            <div className="mt-2 flex items-center gap-2 px-3 py-2 text-xs bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400">
-              <span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />
-              <span>Paused while saving audio or transcripts to file</span>
-            </div>
-          )}
-          {settings.autoPaste && (
-            <PasteDelaySlider
-              value={settings.autoPasteDelayMs}
-              onCommit={(value) => onUpdateSettings({ autoPasteDelayMs: value })}
-            />
-          )}
-        </div>
-
-        {/* Save Transcript to File Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="block text-sm font-medium text-on-surface">
-              Save Transcript to File
-            </label>
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Write each transcription to a .txt file
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.saveTranscript}
-            aria-label="Save transcript to file"
-            onClick={() => onUpdateSettings({ saveTranscript: !settings.saveTranscript })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-              settings.saveTranscript ? 'bg-primary' : 'bg-surface-container-highest'
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                settings.saveTranscript ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Save Audio to File Toggle */}
-        <div>
-          <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Save Audio to File
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Write each recording to a .wav file
-              </p>
+              <label className="mb-2 block text-sm font-medium text-on-surface">Language</label>
+              <Select value={settings.language} onChange={(language) => onUpdateSettings({ language })} disabled={isRecording || englishOnly} items={LANGUAGE_OPTIONS} />
+              <p className="mt-1 text-xs text-on-surface-variant">{englishOnly ? 'This model is English-only. Choose Whisper Large Turbo for other languages.' : 'Auto Detect lets Whisper identify the language for each recording.'}</p>
             </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.saveAudio}
-              aria-label="Save audio to file"
-              onClick={() => onUpdateSettings({ saveAudio: !settings.saveAudio })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.saveAudio ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.saveAudio ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-
-          {saveToFile && (
-            <div className="mt-3">
-              <label className="block text-xs text-on-surface-variant mb-1">
-                Output Folder
-              </label>
-              <div className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">
-                {settings.outputDir || 'Documents/Murmur (default)'}
-              </div>
-              <div className="mt-2 flex items-center gap-3">
-                <button
-                  onClick={handleChooseFolder}
-                  className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
-                >
-                  Choose Folder
-                </button>
-                {settings.outputDir && (
-                  <button
-                    onClick={() => onUpdateSettings({ outputDir: '' })}
-                    className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
-                  >
-                    Reset to default
-                  </button>
-                )}
-              </div>
-              <p className="mt-2 text-xs text-on-surface-variant">
-                Text is still copied to the clipboard, but auto-paste is paused while saving to file.
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Launch at Login Toggle */}
-        <div>
-          <div className="flex items-center justify-between">
             <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Launch at Login
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Automatically start when you log in
-              </p>
+              <label className="mb-2 block text-sm font-medium text-on-surface">Release Model After Inactivity</label>
+              <Select value={String(settings.idleTimeoutMinutes)} onChange={(value) => onUpdateSettings({ idleTimeoutMinutes: Number(value) })} disabled={isRecording} items={IDLE_TIMEOUT_OPTIONS.map((option) => ({ value: String(option.value), label: option.label }))} />
+              <p className="mt-1 text-xs text-on-surface-variant">Free memory by unloading an idle model; choose Never to keep it ready.</p>
             </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.launchAtLogin}
-              aria-label="Launch at login"
-              onClick={() => onUpdateSettings({ launchAtLogin: !settings.launchAtLogin })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.launchAtLogin ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.launchAtLogin ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-        </div>
+          </SettingsSection>
 
-        {/* Voice Commands Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <label className="block text-sm font-medium text-on-surface">
-              Voice Commands
-            </label>
-            <p className="mt-1 text-xs text-on-surface-variant">
-              Spoken tokens like "new line", "period", or "scratch that" transform the text before pasting.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.voiceCommandsEnabled}
-            aria-label="Voice commands"
-            onClick={() => onUpdateSettings({ voiceCommandsEnabled: !settings.voiceCommandsEnabled })}
-            className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-              settings.voiceCommandsEnabled ? 'bg-primary' : 'bg-surface-container-highest'
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                settings.voiceCommandsEnabled ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-
-        <VoiceCommandsManager
-          active={isOpen && activeCat === 'output'}
-          globallyEnabled={settings.voiceCommandsEnabled}
-          profiles={settings.appProfiles}
-        />
-        </SettingsSection>
-
-        <SettingsSection pageId="profiles" activePage={activeCat} title="Per-App Profiles" subtitle="Paste and formatting per frontmost app">
-          <AppProfilesEditor
-            profiles={settings.appProfiles}
-            onChange={(next) => onUpdateSettings({ appProfiles: next })}
-          />
-        </SettingsSection>
-
-        <SettingsSection pageId="vocab" activePage={activeCat} title="Vocabulary" subtitle="Bias transcription toward your terms">
-        <VocabularyAliasesEditor
-          entries={settings.vocabularyEntries}
-          voiceCommands={settings.voiceCommands}
-          onChange={(vocabularyEntries) => onUpdateSettings({
-            vocabularyEntries,
-            customVocabulary: vocabularyPrompt(vocabularyEntries),
-          })}
-        />
-
-        {/* Code-Aware Vocabulary Toggle */}
-        <div>
-          <div className="flex items-center justify-between">
-            <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Code-Aware Vocabulary
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Bias transcription toward common dev terms (useEffect, kubectl, stderr) — works out of the box, no folder needed. Optionally add a project folder for your own identifiers. With Smart Correction on (below), these terms are also fixed in the transcript on every model, including Parakeet.
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.codeVocabEnabled}
-              aria-label="Code-aware vocabulary"
-              onClick={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.codeVocabEnabled ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.codeVocabEnabled ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
-
-          {settings.codeVocabEnabled && (
-            <div className="mt-3">
-              <label className="block text-xs text-on-surface-variant mb-1">
-                Project Folder (optional)
-              </label>
-              <div className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">
-                {settings.codeVocabFolder || 'No folder — built-in dev terms only'}
+          <SettingsSection pageId="text-vocabulary" activePage={activeCat} title="Text & Vocabulary" subtitle="Cleanup, preferred terms, structured writing, and knowledge">
+            <SettingToggle title="Automatic Punctuation" label="Smart punctuation" description="Add periods, commas, and capitalization to transcriptions." checked={settings.smartPunctuation} onChange={() => onUpdateSettings({ smartPunctuation: !settings.smartPunctuation })} />
+            <SettingToggle title="Transcript Cleanup" description="Remove filler and tidy spacing before delivery." checked={settings.cleanupEnabled} onChange={() => onUpdateSettings({ cleanupEnabled: !settings.cleanupEnabled })} />
+            {settings.cleanupEnabled && (
+              <div className="ml-3 space-y-3 border-l border-outline-variant/30 pl-3">
+                <SettingToggle title="Remove filler words" description="Remove filler tokens such as um and uh." checked={settings.cleanupRemoveFiller} onChange={() => onUpdateSettings({ cleanupRemoveFiller: !settings.cleanupRemoveFiller })} />
+                <SettingToggle title="Capitalize sentences" description="Capitalize detected sentence starts." checked={settings.cleanupCapitalize} onChange={() => onUpdateSettings({ cleanupCapitalize: !settings.cleanupCapitalize })} />
               </div>
-              <div className="mt-2 flex items-center gap-3">
-                <button
-                  onClick={handleChooseCodeVocabFolder}
-                  className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
-                >
-                  Choose Folder
-                </button>
-                {settings.codeVocabFolder && (
-                  <button
-                    onClick={handleClearCodeVocabFolder}
-                    className="text-xs font-medium text-on-surface-variant underline transition-colors hover:text-primary hover:no-underline"
-                  >
-                    Clear
-                  </button>
-                )}
+            )}
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="text-sm font-medium text-on-surface">Names & Terms</h2>
+              <p className="mt-1 mb-3 text-xs text-on-surface-variant">Teach Murmur preferred spellings and exact spoken variants.</p>
+              <VocabularyAliasesEditor entries={settings.vocabularyEntries} voiceCommands={settings.voiceCommands} onChange={(vocabularyEntries) => onUpdateSettings({ vocabularyEntries, customVocabulary: vocabularyPrompt(vocabularyEntries) })} />
+            </div>
+            <SettingToggle title="Developer Terms" description="Bias recognition toward built-in development terms and, optionally, identifiers from one project folder." checked={settings.codeVocabEnabled} onChange={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })} />
+            {settings.codeVocabEnabled && (
+              <div className="ml-3 space-y-2 border-l border-outline-variant/30 pl-3">
+                <p className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">{settings.codeVocabFolder || 'No folder — built-in developer terms only'}</p>
+                <div className="flex gap-3">
+                  <button type="button" onClick={() => void chooseCodeFolder()} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>
+                  {settings.codeVocabFolder && <button type="button" onClick={clearCodeFolder} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Clear</button>}
+                </div>
+                <VocabScanStrip status={vocabScan.status} walker={vocabScan.walker} stats={vocabScan.stats} folder={settings.codeVocabFolder} onScan={() => void runVocabScan(settings.codeVocabFolder)} onCancel={vocabScan.cancel} />
+                <p className="text-xs text-on-surface-variant">The selected folder is scanned locally; dependency and build folders are skipped.</p>
               </div>
-
-              {/* Live scan feedback strip: idle / scanning / done+empty. */}
-              <VocabScanStrip
-                status={vocabScan.status}
-                walker={vocabScan.walker}
-                stats={vocabScan.stats}
-                folder={settings.codeVocabFolder}
-                onScan={() => void runVocabScan(settings.codeVocabFolder)}
-                onCancel={vocabScan.cancel}
-              />
-
-              <p className="mt-2 text-xs text-on-surface-variant">
-                Optional. When set, the folder is scanned once for your identifiers (dependency and build directories are skipped) and layered on top of the built-in terms. Re-select to rescan after big code changes.
-              </p>
+            )}
+            <SettingToggle title="Apply Preferred Spellings" label="Smart correction" description="Apply names, terms, and developer vocabulary after recognition on every model." checked={settings.correctionEnabled} onChange={() => onUpdateSettings({ correctionEnabled: !settings.correctionEnabled })} />
+            {settings.correctionEnabled && <div className="ml-3 border-l border-outline-variant/30 pl-3"><SettingToggle title="Correct Close Mishearings" label="Sounds-like matching" description="Recover close mishearings near your vocabulary; disable if you see unwanted swaps." checked={settings.correctionFuzzy} onChange={() => onUpdateSettings({ correctionFuzzy: !settings.correctionFuzzy })} /></div>}
+            <SettingToggle title="Structured Writing" label="Smart formatting" description="Apply explicitly spoken lists, symbols, punctuation, and same-utterance corrections locally." checked={settings.smartFormattingEnabled} onChange={() => onUpdateSettings({ smartFormattingEnabled: !settings.smartFormattingEnabled })} />
+            <SettingToggle title="Spoken Formatting" label="Voice commands" description="Use spoken tokens such as “new line,” “period,” or “scratch that” before delivery." checked={settings.voiceCommandsEnabled} onChange={() => onUpdateSettings({ voiceCommandsEnabled: !settings.voiceCommandsEnabled })} />
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="text-sm font-medium text-on-surface">Phrase Replacements & Snippets</h2>
+              <p className="mt-1 mb-3 text-xs text-on-surface-variant">Create exact spoken phrases that insert replacement text or a multiline snippet.</p>
+              <VoiceCommandsManager active={isOpen && activeCat === 'text-vocabulary'} globallyEnabled={settings.voiceCommandsEnabled} profiles={settings.appProfiles} />
             </div>
-          )}
-        </div>
-
-        {/* Smart Correction — post-model, applies vocab on every backend (Tiers 1-2). */}
-        <div>
-          <div className="flex items-center justify-between">
-            <div>
-              <label className="block text-sm font-medium text-on-surface">
-                Smart Correction
-              </label>
-              <p className="mt-1 text-xs text-on-surface-variant">
-                Fix vocabulary in the transcript after recognition, on every model. Turns "use effect" into useEffect and, with Code-Aware on, "standard error" into stderr.
-              </p>
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="mb-3 text-sm font-medium text-on-surface">Knowledge</h2>
+              <KnowledgeManager active={isOpen && activeCat === 'text-vocabulary'} profiles={settings.appProfiles} />
             </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.correctionEnabled}
-              aria-label="Smart correction"
-              onClick={() => onUpdateSettings({ correctionEnabled: !settings.correctionEnabled })}
-              className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                settings.correctionEnabled ? 'bg-primary' : 'bg-surface-container-highest'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-on-primary shadow transition-transform ${
-                  settings.correctionEnabled ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </div>
+          </SettingsSection>
 
-          {settings.correctionEnabled && (
-            <div className="mt-3 flex items-center justify-between gap-4">
+          <SettingsSection pageId="delivery" activePage={activeCat} title="Delivery" subtitle="Clipboard, paste, file output, and app-specific overrides">
+            <div className="rounded-xl border border-primary/20 bg-primary/5 p-3">
+              <h2 className="text-sm font-medium text-on-surface">Always copied to clipboard</h2>
+              <p className="mt-1 text-xs text-on-surface-variant">Every completed transcription is copied first. Auto-paste and file output only change what happens next.</p>
+            </div>
+            <SettingToggle title="Auto-Paste" label="Auto paste" description={saveToFile ? 'Paused while file output is on. Your saved preference will resume when file output is off.' : 'Paste the clipboard result into the active app (Accessibility permission required).'} checked={autoPasteOn} disabled={saveToFile} onChange={() => onUpdateSettings({ autoPaste: !settings.autoPaste })} />
+            {settings.autoPaste && saveToFile && <p role="status" className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">Auto-paste is paused; the stored preference remains on.</p>}
+            {autoPasteOn && accessibilityGranted !== null && <div className={`flex items-center gap-2 text-xs ${accessibilityGranted ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}><span>{accessibilityGranted ? 'Accessibility permission granted' : 'Accessibility permission required'}</span>{accessibilityGranted === false && <button type="button" onClick={requestAccessibility} className="underline">Grant</button>}</div>}
+            {autoPasteOn && <PasteDelaySlider value={settings.autoPasteDelayMs} onCommit={(autoPasteDelayMs) => onUpdateSettings({ autoPasteDelayMs })} />}
+            <SettingToggle title="Save Transcript to File" description="Write each completed transcription to a .txt file." checked={settings.saveTranscript} onChange={() => onUpdateSettings({ saveTranscript: !settings.saveTranscript })} />
+            <SettingToggle title="Save Audio to File" description="Write each recording to a .wav file." checked={settings.saveAudio} onChange={() => onUpdateSettings({ saveAudio: !settings.saveAudio })} />
+            {saveToFile && (
               <div>
-                <label className="block text-xs font-medium text-on-surface">
-                  Sounds-like matching
-                </label>
-                <p className="mt-1 text-xs text-on-surface-variant">
-                  Also recover close mishearings near your vocabulary (e.g. "red pivot" → "rePivot"). Turn off if you see unwanted swaps.
-                </p>
+                <p className="mb-1 text-xs text-on-surface-variant">Output Folder</p>
+                <p className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">{settings.outputDir || 'Documents/Murmur (default)'}</p>
+                <div className="mt-2 flex gap-3"><button type="button" onClick={() => void chooseOutputFolder()} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>{settings.outputDir && <button type="button" onClick={() => onUpdateSettings({ outputDir: '' })} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Reset to default</button>}</div>
+                <p className="mt-2 text-xs text-on-surface-variant">Clipboard copying stays on; only automatic paste is paused.</p>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={settings.correctionFuzzy}
-                aria-label="Sounds-like matching"
-                onClick={() => onUpdateSettings({ correctionFuzzy: !settings.correctionFuzzy })}
-                className={`relative inline-flex shrink-0 h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
-                  settings.correctionFuzzy ? 'bg-primary' : 'bg-surface-container-highest'
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-primary shadow transition-transform ${
-                    settings.correctionFuzzy ? 'translate-x-4' : 'translate-x-1'
-                  }`}
-                />
-              </button>
+            )}
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="text-sm font-medium text-on-surface">App Overrides</h2>
+              <p className="mt-1 mb-3 text-xs text-on-surface-variant">Override delivery and writing behavior for the frontmost macOS app.</p>
+              <AppOverridesEditor profiles={settings.appProfiles} onChange={(appProfiles) => onUpdateSettings({ appProfiles })} />
             </div>
-          )}
-        </div>
-        </SettingsSection>
+          </SettingsSection>
 
-        <SettingsSection pageId="knowledge" activePage={activeCat} title="Knowledge" subtitle="Inspect and manage personal knowledge stored on this Mac">
-          <KnowledgeManager active={isOpen && activeCat === 'knowledge'} profiles={settings.appProfiles} />
-        </SettingsSection>
+          <SettingsSection pageId="performance" activePage={activeCat} title="Performance" subtitle="Directional local model comparisons">
+            <PerformanceLab status={status} />
+          </SettingsSection>
 
-        <SettingsSection pageId="performance" activePage={activeCat} title="Performance Lab" subtitle="Compare local transcription engines">
-          <PerformanceLab status={status} />
-        </SettingsSection>
-
-        <SettingsSection pageId="about" activePage={activeCat} title="About" subtitle="Stats, logs, updates">
-        {/* Model Info */}
-        <div>
-          <div className="text-sm text-on-surface-variant">
-            <p><strong>Model:</strong> {selectedModel?.label}</p>
-            <p><strong>Backend:</strong> {selectedRuntime ? `${selectedRuntime.backend} (${selectedRuntime.accelerator})` : selectedModel?.backend}</p>
-            <p><strong>Size:</strong> {selectedModel?.size}</p>
-          </div>
-        </div>
-
-        {/* Reset Stats */}
-        <div>
-          <button
-            onClick={handleResetClick}
-            aria-label={confirmReset ? 'Confirm reset statistics' : 'Reset statistics'}
-            className={`w-full px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
-              confirmReset
-                ? 'border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40'
-                : 'border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary'
-            }`}
-          >
-            {confirmReset ? 'Confirm Reset' : 'Reset Stats'}
-          </button>
-        </div>
-
-        {/* Logs */}
-        <div>
-          <button
-            onClick={onViewLogs}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors"
-          >
-            View Logs
-          </button>
-        </div>
-
-        {/* Setup assistant */}
-        <div>
-          <button
-            onClick={onRerunSetup}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors"
-          >
-            Run Setup Assistant
-          </button>
-          <p className="mt-1.5 text-xs text-on-surface-variant">
-            Re-check permissions and the model step by step — useful if a
-            permission was revoked or stopped working.
-          </p>
-        </div>
-
-        {/* Updates */}
-        <div>
-          <button
-            onClick={onCheckForUpdate}
-            disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'}
-            className="w-full px-3 py-2 rounded-lg text-xs font-medium border border-outline-variant/20 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {updateStatus.phase === 'checking' ? 'Checking...' : 'Check for Updates'}
-          </button>
-          {updateStatus.phase === 'up-to-date' && (
-            <p className="mt-1.5 text-xs text-emerald-600 dark:text-emerald-400">
-              You're up to date
-            </p>
-          )}
-          {updateStatus.phase === 'available' && (
-            <p className="mt-1.5 text-xs text-primary">
-              v{updateStatus.version} available
-            </p>
-          )}
-          {updateStatus.phase === 'error' && (
-            <p className="mt-1.5 text-xs text-red-600 dark:text-red-400">
-              Update check failed
-            </p>
-          )}
-        </div>
-
-        {/* Version */}
-        {version && (
-          <div className="text-center">
-            <span className="text-xs text-on-surface-variant">v{version}</span>
-          </div>
-        )}
-        </SettingsSection>
+          <SettingsSection pageId="general" activePage={activeCat} title="General" subtitle="Startup, support, updates, and app information">
+            <SettingToggle title="Launch at Login" description="Start Murmur automatically when you log in." checked={settings.launchAtLogin} onChange={() => onUpdateSettings({ launchAtLogin: !settings.launchAtLogin })} />
+            <button type="button" onClick={onRerunSetup} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary">Run Setup Assistant</button>
+            <p className="-mt-3 text-xs text-on-surface-variant">Re-check permissions and model setup after a permission is revoked or stops working.</p>
+            <button type="button" onClick={onViewLogs} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary">View Logs</button>
+            <button type="button" aria-label={confirmReset ? 'Confirm reset statistics' : 'Reset statistics'} onClick={resetStats} className={`w-full rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${confirmReset ? 'border-error/40 bg-error/10 text-error' : 'border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container hover:text-primary'}`}>{confirmReset ? 'Confirm Reset' : 'Reset Stats'}</button>
+            <div>
+              <button type="button" onClick={() => void onCheckForUpdate()} disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary disabled:cursor-not-allowed disabled:opacity-50">{updateStatus.phase === 'checking' ? 'Checking…' : 'Check for Updates'}</button>
+              {updateStatus.phase === 'up-to-date' && <p className="mt-1.5 text-xs text-emerald-600 dark:text-emerald-400">You’re up to date.</p>}
+              {updateStatus.phase === 'available' && <p className="mt-1.5 text-xs text-primary">v{updateStatus.version} available</p>}
+              {updateStatus.phase === 'error' && <p className="mt-1.5 text-xs text-error">Update check failed.</p>}
+            </div>
+            {version && <p className="text-center text-xs text-on-surface-variant">Murmur v{version}</p>}
+          </SettingsSection>
         </div>
       </div>
     </div>

--- a/app/src/lib/benchmark.test.ts
+++ b/app/src/lib/benchmark.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   BenchmarkReport,
   MAX_SAVED_BENCHMARK_REPORTS,
@@ -7,6 +7,8 @@ import {
   loadBenchmarkReports,
   saveBenchmarkReports,
 } from './benchmark';
+
+beforeEach(() => localStorage.clear());
 
 function report(createdAt: string): BenchmarkReport {
   return {
@@ -18,6 +20,30 @@ function report(createdAt: string): BenchmarkReport {
     sharedInitMs: 1200,
     results: [],
     recommendations: { fastest: null, mostAccurate: null, balanced: null },
+  };
+}
+
+function versionedReport(createdAt: string): BenchmarkReport {
+  return {
+    ...report(createdAt),
+    reportVersion: 2,
+    environment: {
+      os: 'macOS', osVersion: '15.5', architecture: 'aarch64',
+      hardwareModel: 'Mac14,3', chip: 'Apple M2', memoryMb: 16384,
+    },
+    corpus: {
+      language: 'en', fixtureIds: ['short', 'medium'], fixtureCount: 2,
+      referenceWords: 29, provenance: 'Bundled macOS Samantha TTS fixtures',
+      limitation: 'Directional local comparison only.',
+    },
+    configuration: {
+      vadThreshold: 0.5,
+      executionPath: 'full-buffer final transcription after recording stops',
+      transcriptTransformProfile: 'default local delivery pipeline',
+      percentileMethod: 'nearest-rank over measured warm iterations',
+      modelRunOrder: ['tiny.en'],
+      sharedInitOrder: ['tiny.en'],
+    },
   };
 }
 
@@ -42,6 +68,25 @@ describe('addBenchmarkReport', () => {
 });
 
 describe('benchmark report storage', () => {
+  it('round-trips versioned trustworthy-state metadata', () => {
+    const current = versionedReport('2026-07-20T12:00:00Z');
+    saveBenchmarkReports([current]);
+    expect(loadBenchmarkReports()).toEqual([current]);
+  });
+
+  it('keeps pre-metadata reports readable after the additive schema change', () => {
+    const previous = report('2026-07-19T12:00:00Z');
+    localStorage.setItem('murmur-benchmark-reports', JSON.stringify([previous]));
+    expect(loadBenchmarkReports()).toEqual([previous]);
+  });
+
+  it('rejects incomplete or unknown versioned metadata instead of presenting it as trustworthy', () => {
+    const incomplete = { ...versionedReport('2026-07-20T12:00:00Z'), configuration: undefined };
+    const unknown = { ...versionedReport('2026-07-20T13:00:00Z'), reportVersion: 3 };
+    localStorage.setItem('murmur-benchmark-reports', JSON.stringify([incomplete, unknown]));
+    expect(loadBenchmarkReports()).toEqual([]);
+  });
+
   it('migrates a valid legacy report and clears the legacy key', () => {
     const legacy = report('2026-07-16T12:00:00Z');
     localStorage.setItem('murmur-benchmark-report', JSON.stringify(legacy));

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -61,6 +61,8 @@ export interface BenchmarkModelResult {
   label: string;
   backend: string;
   accelerator: string;
+  /** Catalog download size, separate from observed process memory. */
+  downloadSize?: string;
   modelLoadMs: number | null;
   firstInferenceMs: number | null;
   warmMedianMs: number | null;
@@ -83,6 +85,8 @@ export interface BenchmarkModelResult {
 }
 
 export interface BenchmarkReport {
+  /** Version 2 adds explicit environment, corpus, and execution metadata. */
+  reportVersion?: number;
   createdAt: string;
   appVersion: string;
   platform: string;
@@ -93,6 +97,30 @@ export interface BenchmarkReport {
    * compilation, ANE compile cache, etc). Represents real first-launch
    * latency but is not a per-model attribute. */
   sharedInitMs: number;
+  environment?: {
+    os: string;
+    osVersion: string | null;
+    architecture: string;
+    hardwareModel: string | null;
+    chip: string | null;
+    memoryMb: number | null;
+  };
+  corpus?: {
+    language: string;
+    fixtureIds: string[];
+    fixtureCount: number;
+    referenceWords: number;
+    provenance: string;
+    limitation: string;
+  };
+  configuration?: {
+    vadThreshold: number;
+    executionPath: string;
+    transcriptTransformProfile: string;
+    percentileMethod: string;
+    modelRunOrder: string[];
+    sharedInitOrder: string[];
+  };
   results: BenchmarkModelResult[];
   recommendations: {
     fastest: string | null;
@@ -151,6 +179,7 @@ function isModelResult(value: unknown): value is BenchmarkModelResult {
     && typeof value.label === 'string'
     && typeof value.backend === 'string'
     && typeof value.accelerator === 'string'
+    && (value.downloadSize === undefined || typeof value.downloadSize === 'string')
     && isNullableNumber(value.modelLoadMs)
     && isNullableNumber(value.firstInferenceMs)
     && isNullableNumber(value.warmMedianMs)
@@ -166,8 +195,47 @@ function isModelResult(value: unknown): value is BenchmarkModelResult {
     && isNullableString(value.error);
 }
 
+function isEnvironment(value: unknown): boolean {
+  return isRecord(value)
+    && typeof value.os === 'string'
+    && isNullableString(value.osVersion)
+    && typeof value.architecture === 'string'
+    && isNullableString(value.hardwareModel)
+    && isNullableString(value.chip)
+    && isNullableNumber(value.memoryMb);
+}
+
+function isCorpus(value: unknown): boolean {
+  return isRecord(value)
+    && typeof value.language === 'string'
+    && Array.isArray(value.fixtureIds)
+    && value.fixtureIds.every((fixture) => typeof fixture === 'string')
+    && isNumber(value.fixtureCount)
+    && isNumber(value.referenceWords)
+    && typeof value.provenance === 'string'
+    && typeof value.limitation === 'string';
+}
+
+function isConfiguration(value: unknown): boolean {
+  return isRecord(value)
+    && isNumber(value.vadThreshold)
+    && typeof value.executionPath === 'string'
+    && typeof value.transcriptTransformProfile === 'string'
+    && typeof value.percentileMethod === 'string'
+    && Array.isArray(value.modelRunOrder)
+    && value.modelRunOrder.every((model) => typeof model === 'string')
+    && Array.isArray(value.sharedInitOrder)
+    && value.sharedInitOrder.every((model) => typeof model === 'string');
+}
+
 function isBenchmarkReport(value: unknown): value is BenchmarkReport {
   if (!isRecord(value) || !isRecord(value.recommendations)) return false;
+  const metadataIsCompatible = value.reportVersion === undefined
+    ? value.environment === undefined && value.corpus === undefined && value.configuration === undefined
+    : value.reportVersion === 2
+      && isEnvironment(value.environment)
+      && isCorpus(value.corpus)
+      && isConfiguration(value.configuration);
   return typeof value.createdAt === 'string'
     && Number.isFinite(Date.parse(value.createdAt))
     && typeof value.appVersion === 'string'
@@ -175,6 +243,7 @@ function isBenchmarkReport(value: unknown): value is BenchmarkReport {
     && (value.preset === 'quick' || value.preset === 'standard' || value.preset === 'thorough')
     && isNumber(value.iterations)
     && isNumber(value.sharedInitMs)
+    && metadataIsCompatible
     && Array.isArray(value.results)
     && value.results.every(isModelResult)
     && isNullableString(value.recommendations.fastest)

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   loadSettings,
+  saveSettings,
   DEFAULT_SETTINGS,
   defaultModelForPlatform,
   modelOptionsForPlatform,
@@ -11,6 +12,62 @@ beforeEach(() => {
 });
 
 describe('loadSettings', () => {
+  it('round-trips every stored field and value through the unified Settings UI schema', () => {
+    const stored = {
+      ...DEFAULT_SETTINGS,
+      model: 'tiny.en' as const,
+      doubleTapKey: 'alt_l' as const,
+      language: 'es',
+      autoPaste: true,
+      autoPasteDelayMs: 230,
+      recordingMode: 'both' as const,
+      hotkeyMissFeedback: true,
+      microphone: 'Studio Mic',
+      launchAtLogin: true,
+      vadSensitivity: 75,
+      idleTimeoutMinutes: 15,
+      customVocabulary: 'Murmur',
+      vocabularyEntries: [{ id: 'murmur', written: 'Murmur', aliases: ['murmur app'], enabled: true, scope: { kind: 'global' as const } }],
+      disabled: true,
+      smartPunctuation: false,
+      saveTranscript: true,
+      saveAudio: true,
+      outputDir: '/tmp/murmur-output',
+      appProfiles: [{
+        bundleId: 'com.apple.Terminal',
+        label: 'Terminal',
+        autoPasteOverride: false,
+        cleanupOverride: true,
+        smartFormattingOverride: false,
+        cliFormattingOverride: true,
+        writingStyle: 'code_technical' as const,
+        ideContextEnabled: true,
+        ideProjectRoots: ['/tmp/project'],
+      }],
+      voiceCommandsEnabled: true,
+      voiceCommands: [{ phrase: 'standup', replacement: 'Yesterday:\nToday:' }],
+      cleanupEnabled: true,
+      smartFormattingEnabled: true,
+      cleanupRemoveFiller: false,
+      cleanupCapitalize: false,
+      codeVocabEnabled: true,
+      codeVocabFolder: '/tmp/project',
+      codeVocabLastScan: {
+        files: 2, skipped: 1, terms: 3, bytes: 44, capped: false, ms: 5,
+        sampleTerms: ['useEffect'], rankedTerms: [{ term: 'useEffect', freq: 2 }],
+        whisperCount: 1, adopted: true,
+      },
+      correctionEnabled: false,
+      correctionFuzzy: false,
+    };
+
+    saveSettings(stored);
+    const loaded = loadSettings();
+
+    expect(Object.keys(loaded).sort()).toEqual(Object.keys(DEFAULT_SETTINGS).sort());
+    expect(loaded).toEqual(stored);
+  });
+
   it('returns defaults when localStorage is empty', () => {
     const settings = loadSettings();
     expect(settings).toEqual(DEFAULT_SETTINGS);

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -15,6 +15,18 @@ One-session overrides are an explicit, typed resolver input but no trigger suppl
 
 Profiles select an optional `writingStyle` and can fine-tune `autoPaste`, transcript cleanup, Smart Formatting, CLI formatting, and local IDE project context. A style and IDE-context opt-in are always explicit user choices; Murmur never infers either one from an app name or bundle identifier.
 
+Settings > Delivery > App Overrides can add a profile from currently running
+regular macOS apps or through advanced manual bundle-ID entry. The picker returns
+only display name and bundle ID, excludes Murmur and helper/accessory processes,
+deduplicates and sorts entries, and caps the list at 64. It is fetched on demand,
+kept only in React memory, and never logged or persisted unless the user chooses
+an app. Non-macOS builds expose the same command as an empty list, so Linux
+compilation and manual bundle-ID compatibility remain intact.
+
+Each boolean override is an explicit **Use global setting / Always / Never**
+choice mapped to the existing `null / true / false` storage contract. Existing
+profiles and every stored field retain their values across the Settings redesign.
+
 | Writing style | Local deterministic behavior |
 |---|---|
 | Inherit | Preserves the current global/profile behavior byte-for-byte. |

--- a/docs/features/performance-lab.md
+++ b/docs/features/performance-lab.md
@@ -6,6 +6,11 @@ The Performance Lab compares installed transcription configurations on the
 current machine. It is available under **Settings > Performance** and runs
 entirely on device.
 
+The UI deliberately labels every run as a **directional local comparison**, not
+a universal model ranking. The bundled corpus is clean synthetic English speech
+and does not represent a user's voice, accent, microphone, room, or every
+dictation workload.
+
 Supported configurations are compatible model/backend pairs:
 
 | Model | Backend | Accelerator |
@@ -47,8 +52,8 @@ accuracy score.
 | Preset | Corpus | Measured runs per clip |
 | --- | --- | ---: |
 | Quick | Short and medium | 3 |
-| Standard | All four clips | 5 |
-| Thorough | All four clips | 10 |
+| Standard | Four original clips plus jargon, numbers, and disfluent stress fixtures (7 clips) | 5 |
+| Thorough | Standard plus extra-extra-long and fast fixtures (9 clips) | 10 |
 
 The bundled clips first pass through the same Silero VAD speech filter used by
 normal dictation at a fixed threshold, keeping runs comparable even when the
@@ -68,6 +73,16 @@ The report separates:
 - Duration-weighted corpus speed from each clip's median latency
 - Raw, normalized, and delivered WER across the corpus
 - Process memory increase observed at benchmark checkpoints
+- Catalog download size, kept separate from observed process memory
+
+New reports use report schema version 2 and record the environment (OS/version,
+architecture, hardware model/chip, and RAM when available), corpus fixture IDs
+and reference-word count, fixed VAD threshold, full-buffer final-after-stop
+execution path, default delivery transform profile, nearest-rank percentile
+method, model run order, and shared-initialization order. The metadata excludes
+hostname, serial number, paths, window titles, and other user content. Reports
+saved before this additive metadata remain readable and are identified in the UI
+as legacy saved reports.
 
 Recommendations remain explainable: **Fastest** has the strict lowest
 duration-weighted realtime factor, and **Accurate** has the lowest normalized
@@ -82,6 +97,12 @@ the complete metric table and transcript-level details. The latest ten reports
 stay in local storage and can be selected from the saved-run menu or copied as
 JSON. Benchmark audio and transcripts are bundled with Murmur; no audio or
 result is uploaded.
+
+P95 is nearest-rank over only 3, 5, or 10 measured warm samples per clip, so it
+is a coarse tail-latency signal. Cold model load excludes the one-time shared
+backend priming shown separately. Memory is a sequential process-RSS delta and
+can be affected by allocator retention from an earlier model; it is neither the
+catalog download size nor an isolated peak-memory measurement.
 
 ## Concurrency
 

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -90,7 +90,8 @@ Non-`NotFound` errors (process ran but exited non-zero, permission denied, etc.)
 | Clipboard copy | None |
 | Auto-paste | Accessibility |
 
-The settings panel shows accessibility permission status when auto-paste is enabled, with a "Grant" button that opens System Settings.
+Settings > Delivery shows accessibility permission status when effective
+auto-paste is enabled, with a "Grant" button that opens System Settings.
 
 ## Settings
 
@@ -101,7 +102,7 @@ Both are sent to the Rust backend via `configure_dictation` command.
 
 ## Save to File
 
-Live hotkey dictation can optionally persist its output to disk via two independent toggles in the Output settings section:
+Live hotkey dictation can optionally persist its output to disk via two independent toggles in Settings > Delivery:
 
 - `saveTranscript: boolean` — write each transcription to a sequentially numbered `.txt`.
 - `saveAudio: boolean` — write each recording to a matching `.wav` (16kHz mono, 16-bit PCM).
@@ -110,5 +111,9 @@ Live hotkey dictation can optionally persist its output to disk via two independ
 Writing happens in `file_output.rs`, called from `run_transcription_pipeline` after the cancellation checkpoints and before injection. The WAV is written from the original (pre-VAD) 16kHz samples; the `.txt` is only written when the transcript is non-empty. A short sequential base name (`murmur-0001`, `murmur-0002`, …) is shared by the pair. The next number is the highest existing `murmur-NNNN` in the folder plus one (older timestamped names are ignored when numbering).
 
 **Interaction with auto-paste:** when either toggle is on, the recording is treated as a "capture to file" action — the clipboard write still happens (clipboard-first is unconditional), but auto-paste is suppressed (`effective_auto_paste = auto_paste && !(save_transcript || save_audio)`). With both toggles off, behavior is unchanged. Write failures are non-fatal: they are logged and surfaced to the UI via the `file-output-failed` event (text remains in the clipboard).
+
+The UI mirrors this effective state without mutating the stored `autoPaste`
+preference: the switch appears off and paused while file output is active, and
+the saved preference resumes when both file toggles are off.
 
 **Known limitation:** recordings the VAD classifies as no-speech return early before the write step, so they save neither file.

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -113,7 +113,9 @@ Writing happens in `file_output.rs`, called from `run_transcription_pipeline` af
 **Interaction with auto-paste:** when either toggle is on, the recording is treated as a "capture to file" action — the clipboard write still happens (clipboard-first is unconditional), but auto-paste is suppressed (`effective_auto_paste = auto_paste && !(save_transcript || save_audio)`). With both toggles off, behavior is unchanged. Write failures are non-fatal: they are logged and surfaced to the UI via the `file-output-failed` event (text remains in the clipboard).
 
 The UI mirrors this effective state without mutating the stored `autoPaste`
-preference: the switch appears off and paused while file output is active, and
-the saved preference resumes when both file toggles are off.
+preference: the switch appears off and unavailable while file output is active.
+When the stored preference is on, the copy identifies it as paused and says it
+will resume when both file toggles are off; when it is already off, the copy
+says it remains off.
 
 **Known limitation:** recordings the VAD classifies as no-speech return early before the write step, so they save neither file.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -10,6 +10,20 @@ For the hook that manages settings, see [hooks.md](hooks.md). For the backend co
 
 All settings are stored in `localStorage` under the key `dictation-settings` as a single JSON object.
 
+The native Settings window has six pages in this order:
+
+1. **Recording** — microphone, voice detection, recording trigger, and shortcut feedback
+2. **Transcription** — one model selector, language, model lifecycle/download state, and idle release
+3. **Text & Vocabulary** — punctuation, cleanup, names and terms, developer terms, corrections, structured writing, spoken commands, and personal knowledge
+4. **Delivery** — clipboard-first behavior, auto-paste, file output, and app overrides
+5. **Performance** — the directional local Performance Lab
+6. **General** — launch at login, setup, logs, statistics, updates, and version
+
+Changing pages only changes presentation. It does not rename, discard, or
+reinterpret persisted fields. A round-trip compatibility test serializes and
+reloads every current `Settings` field, including tri-state app overrides and
+IDE roots.
+
 **Source file:** `app/src/lib/settings.ts`
 
 **TypeScript interface:**
@@ -54,6 +68,9 @@ New Apple Silicon macOS installs default to Core ML; other frontend builds
 default to CPU Parakeet. Rust initializes `base.en` until the frontend applies
 the persisted/platform default. Runtime capabilities, install state, and
 lifecycle state are not settings and are never persisted to localStorage.
+Settings exposes this through the single model selector and marks the supported
+Core ML entry Recommended; there is no second accelerator switch with hidden
+model-selection side effects.
 
 ---
 
@@ -80,7 +97,7 @@ lifecycle state are not settings and are never persisted to localStorage.
 
 | Setting | Type | Default | Valid Options/Range | Description |
 |---------|------|---------|-------------------|-------------|
-| `autoPaste` | `boolean` | `false` | `true` / `false` | Whether to automatically paste transcribed text after copying it to the clipboard. Requires macOS Accessibility permission. Text is always copied to the clipboard regardless of this setting. |
+| `autoPaste` | `boolean` | `false` | `true` / `false` | Stored preference for automatically pasting transcribed text after clipboard copy. Requires macOS Accessibility permission. Text is always copied. When either file-output toggle is on, the UI shows auto-paste off/paused without overwriting this preference; it resumes when file output is off. |
 | `autoPasteDelayMs` | `number` | `50` | 10-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. The backend clamps this value to the 10-500 range. The UI slider only appears when `autoPaste` is enabled. |
 | `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a sequentially numbered `.txt` (`murmur-0001`, `murmur-0002`, …) in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -97,7 +97,7 @@ model-selection side effects.
 
 | Setting | Type | Default | Valid Options/Range | Description |
 |---------|------|---------|-------------------|-------------|
-| `autoPaste` | `boolean` | `false` | `true` / `false` | Stored preference for automatically pasting transcribed text after clipboard copy. Requires macOS Accessibility permission. Text is always copied. When either file-output toggle is on, the UI shows auto-paste off/paused without overwriting this preference; it resumes when file output is off. |
+| `autoPaste` | `boolean` | `false` | `true` / `false` | Stored preference for automatically pasting transcribed text after clipboard copy. Requires macOS Accessibility permission. Text is always copied. When either file-output toggle is on, the UI shows auto-paste unavailable without overwriting this preference. An enabled preference is labeled paused and resumes when file output is off; a disabled preference remains off. |
 | `autoPasteDelayMs` | `number` | `50` | 10-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. The backend clamps this value to the 10-500 range. The UI slider only appears when `autoPaste` is enabled. |
 | `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a sequentially numbered `.txt` (`murmur-0001`, `murmur-0002`, …) in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |


### PR DESCRIPTION
## Summary
- reorganize Settings into six task-oriented pages and extract app overrides into an explicit, privacy-bounded editor with a macOS running-app picker plus manual bundle-ID fallback
- add versioned, privacy-safe environment/corpus/execution metadata and trustworthy-state copy to Performance Lab while preserving legacy saved reports
- preserve every stored Settings value, the final-after-stop/no-live-preview path, and the strict Fastest/Balanced recommendation contract

## Test plan
- [x] cargo check
- [x] cargo test -- --test-threads=1 — 425 passed, 7 ignored
- [x] npx tsc --noEmit
- [x] npm test -- --run — 193 passed
- [x] git diff --check origin/main...HEAD
- [x] successful debug .app bundle build with updater artifacts disabled for QA
- [x] native Settings smoke across Recording, Transcription, Text & Vocabulary, Delivery, Performance, and General
- [x] native app-override picker/privacy/tri-state/manual-duplicate behavior and file-output auto-paste suppression
- [x] two native Quick Core ML benchmark runs, trustworthy metadata/details, JSON copy, and saved-run selection
- [x] overlay implementation files match origin/main; recommendation function matches main byte-for-byte; branch adds no streaming/provisional/live-preview path
- [ ] browser screenshot pass — in-app browser selection returns Browser is not available: iab, and browser discovery returns []; native .app UI verification completed instead

Closes #258