### PR TITLE
Add local dictation evaluation harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,17 @@ jobs:
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
         run: cd app/src-tauri && cargo test --lib -- --test-threads=1
 
+      - name: Run deterministic dictation evaluation
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+        run: >-
+          cd app/src-tauri &&
+          cargo run --bin murmur-eval -- deterministic
+          --output target/murmur-eval/ci-report.json
+
   linux:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.github == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Local dictation evaluation harness** adds strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports through `murmur-eval` (#267).
+
 ## [0.19.0] - 2026-07-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Read these before working on a feature:
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 - **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 - **[docs/features/voice-commands.md](docs/features/voice-commands.md)** — Typed replacements, multiline snippets, safe variables, scopes, and clipboard permission
+- **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion
 - **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map

--- a/app/src-tauri/eval/fixtures/deterministic/corpus-v1.json
+++ b/app/src-tauri/eval/fixtures/deterministic/corpus-v1.json
@@ -1,0 +1,161 @@
+[
+  {
+    "fixtureVersion": 1,
+    "id": "backtracking-standalone",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 dogfooding example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "Ship it Friday, actually, make that Monday", "expectedRawAsr": ["Ship it Friday, actually, make that Monday"]},
+    "context": {"stages": {"smartFormatting": true}},
+    "expected": {"finalText": "Ship it Monday.", "deliveredText": "Ship it Monday.", "stages": [{"name": "smart_formatting", "outcome": "applied", "changed": true, "text": "Ship it Monday."}]},
+    "timing": {"rawAsrMs": 18, "transformMs": 2, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "backtracking-long-natural-sentence",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 long-sentence regression", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "Please tell the release team to ship it Friday, actually, make that Monday before lunch", "expectedRawAsr": ["Please tell the release team to ship it Friday, actually, make that Monday before lunch"]},
+    "context": {"stages": {"smartFormatting": true}},
+    "expected": {"finalText": "Please tell the release team to ship it Monday before lunch.", "deliveredText": "Please tell the release team to ship it Monday before lunch.", "stages": [{"name": "smart_formatting", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 27, "transformMs": 3, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "numbered-list",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Smart Formatting documented example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "The three priorities are first reliability, second latency, third accuracy", "expectedRawAsr": ["The three priorities are first reliability, second latency, third accuracy"]},
+    "context": {"stages": {"smartFormatting": true}},
+    "expected": {"finalText": "The three priorities are:\n1. Reliability\n2. Latency\n3. Accuracy", "deliveredText": "The three priorities are:\n1. Reliability\n2. Latency\n3. Accuracy", "stages": [{"name": "smart_formatting", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 24, "transformMs": 2, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "bulleted-list-custom-command",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 list corpus", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "Packing list new line bullet charger new line bullet cable", "expectedRawAsr": ["Packing list new line bullet charger new line bullet cable"]},
+    "context": {"stages": {"voiceCommands": true}, "resources": {"voiceCommands": [{"id": "bullet", "phrase": "bullet", "commandType": "text_replacement", "content": "-", "allowClipboardRead": false, "appScoped": false}]}},
+    "expected": {"finalText": "Packing list\n- charger\n- cable", "deliveredText": "Packing list\n- charger\n- cable", "stages": [{"name": "voice_commands", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 20, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "spoken-punctuation-and-paragraph",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 punctuation corpus", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "Hello comma world period new paragraph Next line question mark", "expectedRawAsr": ["Hello comma world period new paragraph Next line question mark"]},
+    "context": {"stages": {"voiceCommands": true}},
+    "expected": {"finalText": "Hello, world.\n\nNext line?", "deliveredText": "Hello, world.\n\nNext line?", "stages": [{"name": "voice_commands", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 21, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "npm-tauri-asr-variants",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 Tauri/Tori/Tory failure", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "npm run Tory dev", "expectedRawAsr": ["npm run Tauri dev", "npm run Tori dev", "npm run Tory dev"]},
+    "context": {"stages": {"smartCorrection": true, "cliCommand": true}, "resources": {"vocabularyAliases": [{"spoken": "Tori", "written": "Tauri"}, {"spoken": "Tory", "written": "Tauri"}]}},
+    "expected": {"finalText": "npm run tauri dev", "deliveredText": "npm run tauri dev", "commandCase": true, "stages": [{"name": "smart_correction", "outcome": "applied", "changed": true}, {"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 16, "transformMs": 2, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "npx-ccusage-latest",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "CLI formatter documented example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "npx cc usage at latest", "expectedRawAsr": ["npx cc usage at latest"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "npx ccusage@latest", "deliveredText": "npx ccusage@latest", "commandCase": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 15, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "git-checkout-branch",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "CLI formatter documented example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "git checkout dash b feature slash evaluation", "expectedRawAsr": ["git checkout dash b feature slash evaluation"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "git checkout -b feature/evaluation", "deliveredText": "git checkout -b feature/evaluation", "commandCase": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 14, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "cargo-test-threads",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "CLI formatter documented example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "cargo test dash dash dash test threads equals one", "expectedRawAsr": ["cargo test dash dash dash test threads equals one"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "cargo test -- --test-threads=1", "deliveredText": "cargo test -- --test-threads=1", "commandCase": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 18, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "docker-remove",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 common Docker corpus", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "docker run dash dash rm hello world", "expectedRawAsr": ["docker run dash dash rm hello world"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "docker run --rm hello world", "deliveredText": "docker run --rm hello world", "commandCase": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 17, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "kubectl-namespace",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 common kubectl corpus", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "kubectl get pods dash n murmur", "expectedRawAsr": ["kubectl get pods dash n murmur"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "kubectl get pods -n murmur", "deliveredText": "kubectl get pods -n murmur", "commandCase": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 16, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "cursor-profile-project-context",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Issue #267 Cursor/project context example", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "mention recording dot rs and overlay widget", "expectedRawAsr": ["mention recording dot rs and overlay widget"]},
+    "context": {"bundleId": "com.todesktop.230313mzl4w4u92", "matchedProfile": "cursor", "stages": {"ideContext": true}, "resources": {"ideSymbols": ["OverlayWidget"], "ideFiles": ["src/recording.rs"]}},
+    "expected": {"finalText": "@src/recording.rs and OverlayWidget", "deliveredText": "@src/recording.rs and OverlayWidget", "stages": [{"name": "ide_context", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 19, "transformMs": 2, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "fixed-clock-and-fake-clipboard",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Voice Commands 2.0 deterministic runtime seam", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "insert standup", "expectedRawAsr": ["insert standup"]},
+    "context": {"fixedNow": "2026-07-20T09:07:00-04:00", "clipboardText": "fixture-only note", "stages": {"voiceCommands": true}, "resources": {"voiceCommands": [{"id": "standup", "phrase": "insert standup", "commandType": "snippet", "content": "Standup {{date}} {{time}}: {{clipboard}}", "allowClipboardRead": true, "appScoped": false}]}},
+    "expected": {"finalText": "Standup 2026-07-20 09:07: fixture-only note", "deliveredText": "Standup 2026-07-20 09:07: fixture-only note", "stages": [{"name": "voice_commands", "outcome": "applied", "changed": true}]},
+    "timing": {"rawAsrMs": 12, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "negative-git-and-cargo-prose",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "CLI false-positive regression", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "I use git and cargo every day", "expectedRawAsr": ["I use git and cargo every day"]},
+    "context": {"stages": {"smartFormatting": true, "cliCommand": true}},
+    "expected": {"finalText": "I use git and cargo every day", "deliveredText": "I use git and cargo every day", "noChangePreservation": true, "stages": [{"name": "smart_formatting", "outcome": "applied", "changed": false}, {"name": "cli_command", "outcome": "applied", "changed": false}]},
+    "timing": {"rawAsrMs": 13, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "negative-npm-prose",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "CLI false-positive regression", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "npm is a package manager", "expectedRawAsr": ["npm is a package manager"]},
+    "context": {"stages": {"cliCommand": true}},
+    "expected": {"finalText": "npm is a package manager", "deliveredText": "npm is a package manager", "noChangePreservation": true, "stages": [{"name": "cli_command", "outcome": "applied", "changed": false}]},
+    "timing": {"rawAsrMs": 12, "transformMs": 1, "deliveryMs": 1}
+  },
+  {
+    "fixtureVersion": 1,
+    "id": "final-only-long-recording",
+    "tier": "deterministic",
+    "provenance": {"kind": "curatedSynthetic", "source": "Final-only replacement for removed incremental/live-preview behavior", "containsRealUserData": false, "deletion": "Delete this JSON entry and any generated local reports."},
+    "input": {"rawAsr": "This long fixture represents one authoritative transcript produced only after recording stops, with no provisional chunks, overlap reconciliation, or incremental fallback.", "expectedRawAsr": ["This long fixture represents one authoritative transcript produced only after recording stops, with no provisional chunks, overlap reconciliation, or incremental fallback."]},
+    "expected": {"finalText": "This long fixture represents one authoritative transcript produced only after recording stops, with no provisional chunks, overlap reconciliation, or incremental fallback.", "deliveredText": "This long fixture represents one authoritative transcript produced only after recording stops, with no provisional chunks, overlap reconciliation, or incremental fallback.", "noChangePreservation": true, "delivery": {"attempts": 1, "partialCount": 0, "firstPartialMs": null, "finalOnly": true}},
+    "timing": {"rawAsrMs": 4200, "transformMs": 1, "deliveryMs": 1}
+  }
+]

--- a/app/src-tauri/eval/fixtures/hardware/xlong-whisper-v1.json
+++ b/app/src-tauri/eval/fixtures/hardware/xlong-whisper-v1.json
@@ -1,0 +1,26 @@
+{
+  "fixtureVersion": 1,
+  "id": "hardware-xlong-whisper-final-only",
+  "tier": "hardware",
+  "provenance": {
+    "kind": "projectTestAudio",
+    "source": "Repository-owned synthetic bench/audio/xlong.wav",
+    "containsRealUserData": false,
+    "deletion": "Delete this manifest, bench/audio/xlong.wav, and generated local reports."
+  },
+  "requirements": {
+    "audio": {"path": "bench/audio/xlong.wav", "sampleRateHz": 16000, "channels": 1},
+    "model": {"name": "base.en", "backend": "whisper", "installedOnly": true, "language": "en", "smartPunctuation": true}
+  },
+  "input": {
+    "rawAsr": null,
+    "referenceTranscript": "Murmur is a privacy first macOS voice to text application built with Tauri, combining a Rust backend with a React frontend for a fast and lightweight experience. Local transcription runs entirely on device using either the Parakeet transducer model through sherpa onnx or the whisper backend accelerated with Metal on Apple silicon, so no audio ever leaves the machine. The recording pipeline supports both a hold down mode and a double tap mode for dictating code comments and chat messages throughout the day.",
+    "expectedRawAsr": ["Mermer is a privacy-first Mac OS voice to text application built with Tori, combining a rust back-end with the React front-end for a fast-end lightweight experience. Local transcription runs entirely on device using either the Parakeet Transducer model through Sherpa Onyx or the Whisper back-end accelerated with metal on Apple Silicon, so no audio ever leaves the machine. The recording pipeline supports both a hold-down mode and a double-tap mode for dictating code comments and chat messages throughout the day."]
+  },
+  "expected": {
+    "finalText": "Mermer is a privacy-first Mac OS voice to text application built with Tori, combining a rust back-end with the React front-end for a fast-end lightweight experience. Local transcription runs entirely on device using either the Parakeet Transducer model through Sherpa Onyx or the Whisper back-end accelerated with metal on Apple Silicon, so no audio ever leaves the machine. The recording pipeline supports both a hold-down mode and a double-tap mode for dictating code comments and chat messages throughout the day.",
+    "deliveredText": "Mermer is a privacy-first Mac OS voice to text application built with Tori, combining a rust back-end with the React front-end for a fast-end lightweight experience. Local transcription runs entirely on device using either the Parakeet Transducer model through Sherpa Onyx or the Whisper back-end accelerated with metal on Apple Silicon, so no audio ever leaves the machine. The recording pipeline supports both a hold-down mode and a double-tap mode for dictating code comments and chat messages throughout the day.",
+    "delivery": {"attempts": 1, "partialCount": 0, "firstPartialMs": null, "finalOnly": true}
+  },
+  "timing": {"rawAsrMs": 0, "transformMs": 0, "deliveryMs": 0}
+}

--- a/app/src-tauri/src/benchmark.rs
+++ b/app/src-tauri/src/benchmark.rs
@@ -662,7 +662,7 @@ fn edit_distance(reference: &[String], hypothesis: &[String]) -> usize {
 }
 
 /// Raw WER: lowercase + punctuation split only. Returns (errors, reference words).
-fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
+pub(crate) fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
     let reference = words(reference);
     let hypothesis = words(hypothesis);
     (edit_distance(&reference, &hypothesis), reference.len())
@@ -670,7 +670,7 @@ fn word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
 
 /// Normalized WER: applies `normalized_words` before scoring so formatting/ITN
 /// differences do not count. Returns (errors, normalized reference words).
-fn normalized_word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
+pub(crate) fn normalized_word_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
     let reference = normalized_words(reference);
     let hypothesis = normalized_words(hypothesis);
     (edit_distance(&reference, &hypothesis), reference.len())

--- a/app/src-tauri/src/bin/murmur-eval.rs
+++ b/app/src-tauri/src/bin/murmur-eval.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use ui_lib::evaluation::{self, EvaluationTier, RunOptions};
+
+fn usage() -> &'static str {
+    "Usage: murmur-eval <deterministic|hardware> [--fixtures DIR] [--output FILE] [--workspace-root DIR] [--machine-label LABEL]"
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("murmur-eval: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let tier = match args.next().as_deref() {
+        Some("deterministic") => EvaluationTier::Deterministic,
+        Some("hardware") => EvaluationTier::Hardware,
+        Some("--help" | "-h") => {
+            println!("{}", usage());
+            return Ok(());
+        }
+        _ => return Err(usage().to_string()),
+    };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut fixtures = manifest_dir.join("eval/fixtures").join(tier.as_str());
+    let mut output = manifest_dir
+        .join("target/murmur-eval")
+        .join(format!("{}-report.json", tier.as_str()));
+    let mut workspace_root = manifest_dir.join("../..");
+    let mut machine_label = "local-machine".to_string();
+
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .ok_or_else(|| format!("missing value for {flag}; {}", usage()))?;
+        match flag.as_str() {
+            "--fixtures" => fixtures = PathBuf::from(value),
+            "--output" => output = PathBuf::from(value),
+            "--workspace-root" => workspace_root = PathBuf::from(value),
+            "--machine-label" => machine_label = value,
+            _ => return Err(format!("unknown option '{flag}'; {}", usage())),
+        }
+    }
+
+    let report = evaluation::run(&RunOptions {
+        tier,
+        fixtures_dir: fixtures,
+        workspace_root,
+        machine_label,
+    })?;
+    evaluation::write_report(&report, &output)?;
+    println!(
+        "murmur-eval {}: {} passed, {} failed, {} skipped; report {}",
+        tier.as_str(),
+        report.summary.passed,
+        report.summary.failed,
+        report.summary.skipped,
+        output.display()
+    );
+    if report.summary.failed > 0 {
+        return Err("evaluation failures were reported".to_string());
+    }
+    Ok(())
+}

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -707,6 +707,7 @@ async fn run_transcription_pipeline(
         correction_matcher: transformations.correction_matcher.clone(),
         cli_lexicon,
         ide_context_index: transformations.ide_context_index.clone(),
+        voice_command_runtime: None,
     };
     let transformed = crate::transcript_transform::transform_transcript(
         text,

--- a/app/src-tauri/src/evaluation.rs
+++ b/app/src-tauri/src/evaluation.rs
@@ -1,0 +1,1272 @@
+//! Local, fixture-driven evaluation for recognition, transformation, and delivery.
+//!
+//! The deterministic tier consumes curated text fixtures only. The opt-in
+//! hardware tier reads explicitly referenced project WAV files and installed
+//! models. Neither tier reads dictation history, app settings, the system
+//! clipboard, microphone input, or frontmost-window state.
+
+use chrono::{DateTime, FixedOffset, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::cli_command::{CliFormattingMode, CliLexicon};
+use crate::correction::CorrectionMatcher;
+use crate::knowledge_store::VoiceCommandKind;
+use crate::transcript_transform::{
+    transform_transcript_observed, StageReport, StageTextObserver, TranscriptContext,
+    TranscriptSource, TranscriptStageConfig, TranscriptTransformResources,
+};
+use crate::voice_commands::{ResolvedVoiceCommand, VoiceCommandRuntime};
+
+pub const FIXTURE_VERSION: u32 = 1;
+pub const REPORT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EvaluationTier {
+    Deterministic,
+    Hardware,
+}
+
+impl EvaluationTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Deterministic => "deterministic",
+            Self::Hardware => "hardware",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RunOptions {
+    pub tier: EvaluationTier,
+    pub fixtures_dir: PathBuf,
+    pub workspace_root: PathBuf,
+    pub machine_label: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct EvaluationFixture {
+    fixture_version: u32,
+    id: String,
+    tier: EvaluationTier,
+    provenance: FixtureProvenance,
+    #[serde(default)]
+    requirements: FixtureRequirements,
+    input: FixtureInput,
+    #[serde(default)]
+    context: FixtureContext,
+    expected: FixtureExpected,
+    timing: FixtureTiming,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum FixtureDocument {
+    One(EvaluationFixture),
+    Many(Vec<EvaluationFixture>),
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureProvenance {
+    kind: String,
+    source: String,
+    contains_real_user_data: bool,
+    deletion: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureRequirements {
+    audio: Option<AudioRequirement>,
+    model: Option<ModelRequirement>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AudioRequirement {
+    path: String,
+    sample_rate_hz: u32,
+    channels: u16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ModelRequirement {
+    name: String,
+    backend: String,
+    installed_only: bool,
+    language: String,
+    smart_punctuation: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureInput {
+    raw_asr: Option<String>,
+    #[serde(default)]
+    reference_transcript: Option<String>,
+    expected_raw_asr: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureContext {
+    #[serde(default)]
+    session_id: u64,
+    #[serde(default)]
+    bundle_id: Option<String>,
+    #[serde(default)]
+    matched_profile: Option<String>,
+    #[serde(default)]
+    cli_formatting_mode: FixtureCliMode,
+    #[serde(default)]
+    stages: FixtureStageConfig,
+    #[serde(default)]
+    resources: FixtureResources,
+    #[serde(default = "default_fixed_now")]
+    fixed_now: String,
+    #[serde(default)]
+    clipboard_text: Option<String>,
+}
+
+impl Default for FixtureContext {
+    fn default() -> Self {
+        Self {
+            session_id: 0,
+            bundle_id: None,
+            matched_profile: None,
+            cli_formatting_mode: FixtureCliMode::Auto,
+            stages: FixtureStageConfig::default(),
+            resources: FixtureResources::default(),
+            fixed_now: default_fixed_now(),
+            clipboard_text: None,
+        }
+    }
+}
+
+fn default_fixed_now() -> String {
+    "2026-07-20T09:07:00-04:00".to_string()
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum FixtureCliMode {
+    Auto,
+    Enabled,
+    Disabled,
+}
+
+impl Default for FixtureCliMode {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+impl From<FixtureCliMode> for CliFormattingMode {
+    fn from(value: FixtureCliMode) -> Self {
+        match value {
+            FixtureCliMode::Auto => Self::Auto,
+            FixtureCliMode::Enabled => Self::Enabled,
+            FixtureCliMode::Disabled => Self::Disabled,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureStageConfig {
+    cleanup: bool,
+    cleanup_remove_filler: bool,
+    cleanup_capitalize: bool,
+    voice_commands: bool,
+    smart_correction: bool,
+    smart_formatting: bool,
+    ide_context: bool,
+    cli_command: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureResources {
+    vocabulary_terms: Vec<String>,
+    vocabulary_aliases: Vec<FixturePair>,
+    fuzzy_correction: bool,
+    include_builtin_corrections: bool,
+    voice_commands: Vec<FixtureVoiceCommand>,
+    cli_prompt: Option<String>,
+    ide_symbols: Vec<String>,
+    ide_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixturePair {
+    spoken: String,
+    written: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureVoiceCommand {
+    id: String,
+    phrase: String,
+    command_type: VoiceCommandKind,
+    content: String,
+    allow_clipboard_read: bool,
+    app_scoped: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureExpected {
+    final_text: String,
+    delivered_text: String,
+    #[serde(default)]
+    command_case: bool,
+    #[serde(default)]
+    no_change_preservation: bool,
+    #[serde(default)]
+    stages: Vec<ExpectedStage>,
+    #[serde(default)]
+    delivery: ExpectedDelivery,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedStage {
+    name: String,
+    outcome: String,
+    changed: bool,
+    text: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedDelivery {
+    attempts: usize,
+    partial_count: usize,
+    first_partial_ms: Option<u64>,
+    final_only: bool,
+}
+
+impl Default for ExpectedDelivery {
+    fn default() -> Self {
+        Self {
+            attempts: 1,
+            partial_count: 0,
+            first_partial_ms: None,
+            final_only: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureTiming {
+    raw_asr_ms: u64,
+    transform_ms: u64,
+    delivery_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvaluationReport {
+    pub report_version: u32,
+    pub fixture_version: u32,
+    pub generated_at: String,
+    pub tier: EvaluationTier,
+    pub privacy: ReportPrivacy,
+    pub environment: ReportEnvironment,
+    pub summary: ReportSummary,
+    pub cases: Vec<CaseReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportPrivacy {
+    pub local_only: bool,
+    pub history_ingestion: bool,
+    pub network_used: bool,
+    pub system_clipboard_used: bool,
+    pub fixture_provenance_required: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportEnvironment {
+    pub app_version: &'static str,
+    pub os: &'static str,
+    pub arch: &'static str,
+    pub machine_label: String,
+    pub logical_cpus: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub aggregate_raw_wer: Option<f64>,
+    pub aggregate_normalized_wer: Option<f64>,
+    pub aggregate_cer: Option<f64>,
+    pub transformation_match_rate: Option<f64>,
+    pub command_exact_match_rate: Option<f64>,
+    pub no_change_preservation_rate: Option<f64>,
+    pub delivery_match_rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaseReport {
+    pub id: String,
+    pub status: CaseStatus,
+    pub failures: Vec<String>,
+    pub provenance: CaseProvenance,
+    pub context: CaseContext,
+    pub model: Option<ModelMetadata>,
+    pub recognition: RecognitionMetrics,
+    pub transformation: TransformationMetrics,
+    pub delivery: DeliveryMetrics,
+    pub latency: LatencyMetrics,
+    pub runtime: RuntimeMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CaseStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaseProvenance {
+    pub kind: String,
+    pub source: String,
+    pub contains_real_user_data: bool,
+    pub deletion: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaseContext {
+    pub bundle_id: Option<String>,
+    pub matched_profile: Option<String>,
+    pub fixture_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMetadata {
+    pub name: String,
+    pub backend: String,
+    pub accelerator: String,
+    pub audio_path: String,
+    pub sample_rate_hz: u32,
+    pub channels: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RecognitionMetrics {
+    pub expected_raw: Option<String>,
+    pub actual_raw: Option<String>,
+    pub raw_word_errors: Option<usize>,
+    pub normalized_word_errors: Option<usize>,
+    pub reference_words: Option<usize>,
+    pub normalized_reference_words: Option<usize>,
+    pub reference_characters: Option<usize>,
+    pub character_errors: Option<usize>,
+    pub raw_wer: Option<f64>,
+    pub normalized_wer: Option<f64>,
+    pub cer: Option<f64>,
+    pub bounded_alternative_match: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformationMetrics {
+    pub expected_final: String,
+    pub actual_final: Option<String>,
+    pub exact_match: bool,
+    pub command_exact_match: Option<bool>,
+    pub no_change_preserved: Option<bool>,
+    pub stages: Vec<StageMetric>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageMetric {
+    pub name: String,
+    pub outcome: String,
+    pub changed: bool,
+    pub duration_us: u64,
+    pub text: String,
+    pub expectation_match: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryMetrics {
+    pub expected: String,
+    pub delivered: Option<String>,
+    pub exact_match: bool,
+    pub attempts: usize,
+    pub partial_count: usize,
+    pub first_partial_ms: Option<u64>,
+    pub first_partial_applicability: &'static str,
+    pub final_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LatencyMetrics {
+    pub raw_asr_ms: u64,
+    pub transformation_ms: u64,
+    pub finalization_ms: u64,
+    pub delivery_ms: u64,
+    pub total_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeMetadata {
+    pub incremental_completion: &'static str,
+    pub fallback_used: bool,
+    pub fallback_stages: Vec<String>,
+    pub memory_before_mb: Option<u64>,
+    pub memory_after_mb: Option<u64>,
+    pub memory_delta_mb: Option<i64>,
+}
+
+#[derive(Clone)]
+struct FixedVoiceCommandRuntime {
+    now: DateTime<FixedOffset>,
+    clipboard: Option<String>,
+}
+
+impl VoiceCommandRuntime for FixedVoiceCommandRuntime {
+    fn now(&self) -> DateTime<FixedOffset> {
+        self.now
+    }
+
+    fn clipboard_text(&self) -> Result<String, String> {
+        self.clipboard
+            .clone()
+            .ok_or_else(|| "Fixture clipboard is unavailable.".to_string())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryStageObserver {
+    stages: Vec<(StageReport, String)>,
+}
+
+impl StageTextObserver for InMemoryStageObserver {
+    fn observe(&mut self, report: &StageReport, text: &str) {
+        self.stages.push((report.clone(), text.to_string()));
+    }
+}
+
+#[derive(Default)]
+struct InMemoryDeliverySink {
+    values: Vec<String>,
+}
+
+impl InMemoryDeliverySink {
+    fn deliver(&mut self, text: String) {
+        self.values.push(text);
+    }
+}
+
+#[derive(Default)]
+struct FixedEvaluationClock {
+    elapsed_ms: u64,
+}
+
+impl FixedEvaluationClock {
+    fn advance(&mut self, amount_ms: u64) {
+        self.elapsed_ms = self.elapsed_ms.saturating_add(amount_ms);
+    }
+}
+
+pub fn run(options: &RunOptions) -> Result<EvaluationReport, String> {
+    let fixtures = load_fixtures(&options.fixtures_dir, options.tier)?;
+    let mut cases = Vec::with_capacity(fixtures.len());
+    for (path, fixture) in fixtures {
+        cases.push(run_fixture(&path, fixture, options));
+    }
+    let summary = summarize(&cases);
+    Ok(EvaluationReport {
+        report_version: REPORT_VERSION,
+        fixture_version: FIXTURE_VERSION,
+        generated_at: Utc::now().to_rfc3339(),
+        tier: options.tier,
+        privacy: ReportPrivacy {
+            local_only: true,
+            history_ingestion: false,
+            network_used: false,
+            system_clipboard_used: false,
+            fixture_provenance_required: true,
+        },
+        environment: ReportEnvironment {
+            app_version: env!("CARGO_PKG_VERSION"),
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            machine_label: options.machine_label.clone(),
+            logical_cpus: std::thread::available_parallelism().ok().map(usize::from),
+        },
+        summary,
+        cases,
+    })
+}
+
+pub fn write_report(report: &EvaluationReport, output: &Path) -> Result<(), String> {
+    if let Some(parent) = output.parent().filter(|path| !path.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Could not create report directory: {error}"))?;
+    }
+    let json = serde_json::to_string_pretty(report)
+        .map_err(|error| format!("Could not serialize evaluation report: {error}"))?;
+    fs::write(output, format!("{json}\n"))
+        .map_err(|error| format!("Could not write {}: {error}", output.display()))
+}
+
+fn load_fixtures(
+    fixtures_dir: &Path,
+    tier: EvaluationTier,
+) -> Result<Vec<(PathBuf, EvaluationFixture)>, String> {
+    let mut paths = Vec::new();
+    collect_json(fixtures_dir, &mut paths)?;
+    paths.sort();
+    if paths.is_empty() {
+        return Err(format!(
+            "No JSON fixtures found under {}",
+            fixtures_dir.display()
+        ));
+    }
+    let mut ids = HashSet::new();
+    let mut fixtures = Vec::with_capacity(paths.len());
+    for path in paths {
+        let bytes = fs::read(&path)
+            .map_err(|error| format!("Could not read {}: {error}", path.display()))?;
+        let document: FixtureDocument = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("Invalid strict fixture {}: {error}", path.display()))?;
+        let document_fixtures = match document {
+            FixtureDocument::One(fixture) => vec![fixture],
+            FixtureDocument::Many(fixtures) => fixtures,
+        };
+        for fixture in document_fixtures {
+            validate_fixture(&fixture, tier, &path)?;
+            if !ids.insert(fixture.id.clone()) {
+                return Err(format!("Duplicate fixture id '{}'", fixture.id));
+            }
+            fixtures.push((path.clone(), fixture));
+        }
+    }
+    Ok(fixtures)
+}
+
+fn collect_json(directory: &Path, output: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = fs::read_dir(directory).map_err(|error| {
+        format!(
+            "Could not read fixture directory {}: {error}",
+            directory.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("Could not read fixture entry: {error}"))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_json(&path, output)?;
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            output.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn validate_fixture(
+    fixture: &EvaluationFixture,
+    tier: EvaluationTier,
+    path: &Path,
+) -> Result<(), String> {
+    let fail = |message: &str| format!("Fixture {}: {message}", path.display());
+    if fixture.fixture_version != FIXTURE_VERSION {
+        return Err(fail("unsupported fixtureVersion; expected 1"));
+    }
+    if fixture.tier != tier {
+        return Err(fail("tier does not match the selected suite"));
+    }
+    if fixture.id.trim().is_empty() || fixture.input.expected_raw_asr.is_empty() {
+        return Err(fail("id and expectedRawAsr must be non-empty"));
+    }
+    if fixture.provenance.contains_real_user_data {
+        return Err(fail("real-user data is forbidden in evaluator fixtures"));
+    }
+    if fixture.provenance.source.trim().is_empty()
+        || fixture.provenance.deletion.trim().is_empty()
+        || fixture.provenance.kind.trim().is_empty()
+    {
+        return Err(fail("provenance kind, source, and deletion are required"));
+    }
+    if fixture.expected.delivery.partial_count != 0
+        || fixture.expected.delivery.first_partial_ms.is_some()
+        || !fixture.expected.delivery.final_only
+    {
+        return Err(fail(
+            "Murmur is final-only: partialCount must be 0, firstPartialMs null, and finalOnly true",
+        ));
+    }
+    match tier {
+        EvaluationTier::Deterministic => {
+            if fixture.input.raw_asr.is_none()
+                || fixture.requirements.audio.is_some()
+                || fixture.requirements.model.is_some()
+            {
+                return Err(fail(
+                    "deterministic fixtures require rawAsr and forbid audio/model requirements",
+                ));
+            }
+        }
+        EvaluationTier::Hardware => {
+            let Some(model) = fixture.requirements.model.as_ref() else {
+                return Err(fail("hardware fixtures require model metadata"));
+            };
+            if fixture.requirements.audio.is_none() || fixture.input.raw_asr.is_some() {
+                return Err(fail(
+                    "hardware fixtures require audio and must obtain rawAsr from the model",
+                ));
+            }
+            if !model.installed_only {
+                return Err(fail("hardware fixtures must set installedOnly true"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_fixture(_path: &Path, fixture: EvaluationFixture, options: &RunOptions) -> CaseReport {
+    let mut failures = Vec::new();
+    let memory_before = (options.tier == EvaluationTier::Hardware)
+        .then(current_memory_mb)
+        .flatten();
+    let (raw_asr, model, measured_raw_ms, skip_reason) = match options.tier {
+        EvaluationTier::Deterministic => (
+            fixture.input.raw_asr.clone().unwrap_or_default(),
+            None,
+            fixture.timing.raw_asr_ms,
+            None,
+        ),
+        EvaluationTier::Hardware => run_hardware_recognition(&fixture, options),
+    };
+
+    if let Some(reason) = skip_reason {
+        return skipped_case(&fixture, reason, model, memory_before);
+    }
+
+    let recognition = score_recognition(
+        fixture
+            .input
+            .reference_transcript
+            .as_deref()
+            .unwrap_or(&fixture.input.expected_raw_asr[0]),
+        &fixture.input.expected_raw_asr,
+        &raw_asr,
+    );
+    if !recognition.bounded_alternative_match {
+        failures.push("raw ASR did not match a bounded expected alternative".to_string());
+    }
+    let transform_started = Instant::now();
+    let (actual_final, stages, transform_error) = run_transform(&fixture, &raw_asr);
+    let measured_transform_ms = if options.tier == EvaluationTier::Hardware {
+        transform_started.elapsed().as_millis() as u64
+    } else {
+        fixture.timing.transform_ms
+    };
+    if let Some(error) = transform_error {
+        failures.push(error);
+    }
+
+    let stage_metrics = score_stages(&fixture.expected.stages, stages, &mut failures);
+    let exact_match = actual_final
+        .as_ref()
+        .is_some_and(|text| text == &fixture.expected.final_text);
+    if !exact_match {
+        failures.push("final transformed text mismatch".to_string());
+    }
+    let command_exact_match = fixture.expected.command_case.then_some(exact_match);
+    let no_change_preserved = fixture
+        .expected
+        .no_change_preservation
+        .then(|| actual_final.as_ref().is_some_and(|text| text == &raw_asr));
+    if no_change_preserved == Some(false) {
+        failures.push("ordinary prose changed".to_string());
+    }
+
+    let mut sink = InMemoryDeliverySink::default();
+    if let Some(text) = actual_final.clone() {
+        sink.deliver(text);
+    }
+    let delivered = sink.values.last().cloned();
+    let delivery_match = delivered
+        .as_ref()
+        .is_some_and(|text| text == &fixture.expected.delivered_text);
+    if !delivery_match || sink.values.len() != fixture.expected.delivery.attempts {
+        failures.push("delivery expectation mismatch".to_string());
+    }
+
+    let mut clock = FixedEvaluationClock::default();
+    clock.advance(measured_raw_ms);
+    clock.advance(measured_transform_ms);
+    let finalization_ms = clock.elapsed_ms;
+    let delivery_ms = if options.tier == EvaluationTier::Hardware {
+        0
+    } else {
+        fixture.timing.delivery_ms
+    };
+    clock.advance(delivery_ms);
+    let fallback_stages = stage_metrics
+        .iter()
+        .filter(|stage| stage.outcome == "fallback")
+        .map(|stage| stage.name.clone())
+        .collect::<Vec<_>>();
+    let memory_after = (options.tier == EvaluationTier::Hardware)
+        .then(current_memory_mb)
+        .flatten();
+
+    CaseReport {
+        id: fixture.id.clone(),
+        status: if failures.is_empty() {
+            CaseStatus::Passed
+        } else {
+            CaseStatus::Failed
+        },
+        failures,
+        provenance: provenance_report(&fixture),
+        context: context_report(&fixture),
+        model,
+        recognition,
+        transformation: TransformationMetrics {
+            expected_final: fixture.expected.final_text,
+            actual_final,
+            exact_match,
+            command_exact_match,
+            no_change_preserved,
+            stages: stage_metrics,
+        },
+        delivery: DeliveryMetrics {
+            expected: fixture.expected.delivered_text,
+            delivered,
+            exact_match: delivery_match,
+            attempts: sink.values.len(),
+            partial_count: 0,
+            first_partial_ms: None,
+            first_partial_applicability: "notApplicable",
+            final_only: true,
+        },
+        latency: LatencyMetrics {
+            raw_asr_ms: measured_raw_ms,
+            transformation_ms: measured_transform_ms,
+            finalization_ms,
+            delivery_ms,
+            total_ms: clock.elapsed_ms,
+        },
+        runtime: RuntimeMetadata {
+            incremental_completion: "notApplicableFinalOnly",
+            fallback_used: !fallback_stages.is_empty(),
+            fallback_stages,
+            memory_before_mb: memory_before,
+            memory_after_mb: memory_after,
+            memory_delta_mb: memory_before
+                .zip(memory_after)
+                .map(|(before, after)| after as i64 - before as i64),
+        },
+    }
+}
+
+fn run_hardware_recognition(
+    fixture: &EvaluationFixture,
+    options: &RunOptions,
+) -> (String, Option<ModelMetadata>, u64, Option<String>) {
+    let audio = fixture
+        .requirements
+        .audio
+        .as_ref()
+        .expect("validated audio");
+    let model = fixture
+        .requirements
+        .model
+        .as_ref()
+        .expect("validated model");
+    let model_metadata = ModelMetadata {
+        name: model.name.clone(),
+        backend: model.backend.clone(),
+        accelerator: crate::model_runtime::model_definition(&model.name)
+            .map(crate::model_runtime::model_accelerator)
+            .unwrap_or("unknown")
+            .to_string(),
+        audio_path: audio.path.clone(),
+        sample_rate_hz: audio.sample_rate_hz,
+        channels: audio.channels,
+    };
+    if !crate::model_runtime::model_installed(&model.name) {
+        return (
+            String::new(),
+            Some(model_metadata),
+            0,
+            Some(format!(
+                "required installed model '{}' is unavailable",
+                model.name
+            )),
+        );
+    }
+    let audio_path = options.workspace_root.join(&audio.path);
+    let workspace = match options.workspace_root.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            return (
+                String::new(),
+                Some(model_metadata),
+                0,
+                Some(format!("workspace root is unavailable: {error}")),
+            )
+        }
+    };
+    let audio_path = match audio_path.canonicalize() {
+        Ok(path) if path.starts_with(&workspace) => path,
+        Ok(_) => {
+            return (
+                String::new(),
+                Some(model_metadata),
+                0,
+                Some("audio path escapes the local workspace boundary".to_string()),
+            )
+        }
+        Err(error) => {
+            return (
+                String::new(),
+                Some(model_metadata),
+                0,
+                Some(format!("audio fixture is unavailable: {error}")),
+            )
+        }
+    };
+    if audio_path.extension().and_then(|value| value.to_str()) != Some("wav") {
+        return (
+            String::new(),
+            Some(model_metadata),
+            0,
+            Some("hardware audio fixture must be a WAV file".to_string()),
+        );
+    }
+    let wav_spec = match hound::WavReader::open(&audio_path) {
+        Ok(reader) => reader.spec(),
+        Err(error) => {
+            return (
+                String::new(),
+                Some(model_metadata),
+                0,
+                Some(format!("could not inspect WAV fixture: {error}")),
+            )
+        }
+    };
+    if wav_spec.sample_rate != audio.sample_rate_hz || wav_spec.channels != audio.channels {
+        return (
+            String::new(),
+            Some(model_metadata),
+            0,
+            Some(format!(
+                "WAV metadata mismatch: expected {} Hz/{} channel(s), got {} Hz/{} channel(s)",
+                audio.sample_rate_hz, audio.channels, wav_spec.sample_rate, wav_spec.channels
+            )),
+        );
+    }
+    let samples = match crate::audio_decode::decode_to_mono_16k(&audio_path.to_string_lossy()) {
+        Ok(samples) => samples,
+        Err(error) => return (String::new(), Some(model_metadata), 0, Some(error)),
+    };
+    let mut backend = match crate::model_runtime::create_backend(&model.name) {
+        Ok(backend) => backend,
+        Err(error) => return (String::new(), Some(model_metadata), 0, Some(error)),
+    };
+    if backend.name() != model.backend {
+        return (
+            String::new(),
+            Some(model_metadata),
+            0,
+            Some(format!(
+                "fixture backend '{}' does not match runtime backend '{}'",
+                model.backend,
+                backend.name()
+            )),
+        );
+    }
+    let started = Instant::now();
+    if let Err(error) = backend.load_model(&model.name) {
+        return (String::new(), Some(model_metadata), 0, Some(error));
+    }
+    let transcript = backend.transcribe(
+        &samples,
+        &model.language,
+        fixture.context.resources.cli_prompt.as_deref(),
+        model.smart_punctuation,
+    );
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    backend.reset();
+    match transcript {
+        Ok(text) => (text, Some(model_metadata), elapsed_ms, None),
+        Err(error) => (String::new(), Some(model_metadata), elapsed_ms, Some(error)),
+    }
+}
+
+fn run_transform(
+    fixture: &EvaluationFixture,
+    raw_asr: &str,
+) -> (Option<String>, Vec<(StageReport, String)>, Option<String>) {
+    let fixed_now = match DateTime::parse_from_rfc3339(&fixture.context.fixed_now) {
+        Ok(value) => value,
+        Err(error) => return (None, Vec::new(), Some(format!("invalid fixedNow: {error}"))),
+    };
+    let pairs = fixture
+        .context
+        .resources
+        .vocabulary_aliases
+        .iter()
+        .map(|pair| (pair.spoken.clone(), pair.written.clone()))
+        .collect::<Vec<_>>();
+    let matcher = CorrectionMatcher::build(
+        &fixture.context.resources.vocabulary_terms,
+        &pairs,
+        fixture.context.resources.fuzzy_correction,
+        fixture.context.resources.include_builtin_corrections,
+    );
+    let voice_commands = fixture
+        .context
+        .resources
+        .voice_commands
+        .iter()
+        .map(|command| ResolvedVoiceCommand {
+            id: command.id.clone(),
+            phrase: command.phrase.clone(),
+            command_type: command.command_type,
+            content: command.content.clone(),
+            allow_clipboard_read: command.allow_clipboard_read,
+            app_scoped: command.app_scoped,
+        })
+        .collect::<Vec<_>>();
+    let resources = &fixture.context.resources;
+    let context = TranscriptContext {
+        session_id: fixture.context.session_id,
+        source: TranscriptSource::Live,
+        context_handle: fixture.context.matched_profile.clone(),
+        cli_formatting_mode: fixture.context.cli_formatting_mode.into(),
+        stages: TranscriptStageConfig {
+            cleanup_enabled: fixture.context.stages.cleanup,
+            cleanup_remove_filler: fixture.context.stages.cleanup_remove_filler,
+            cleanup_capitalize: fixture.context.stages.cleanup_capitalize,
+            voice_commands_enabled: fixture.context.stages.voice_commands,
+            smart_correction_enabled: fixture.context.stages.smart_correction,
+            smart_formatting_enabled: fixture.context.stages.smart_formatting,
+            ide_context_enabled: fixture.context.stages.ide_context,
+            cli_command_enabled: fixture.context.stages.cli_command,
+        },
+    };
+    let mut observer = InMemoryStageObserver::default();
+    let output = transform_transcript_observed(
+        raw_asr.to_string(),
+        &context,
+        TranscriptTransformResources {
+            custom_commands: Vec::new(),
+            voice_commands,
+            correction_matcher: (!matcher.is_empty()).then(|| Arc::new(matcher)),
+            cli_lexicon: CliLexicon::from_context(resources.cli_prompt.as_deref(), &pairs),
+            ide_context_index: fixture.context.stages.ide_context.then(|| {
+                crate::ide_context::IdeContextIndex::from_eval_fixture(
+                    &resources.ide_symbols,
+                    &resources.ide_files,
+                )
+            }),
+            voice_command_runtime: Some(Arc::new(FixedVoiceCommandRuntime {
+                now: fixed_now,
+                clipboard: fixture.context.clipboard_text.clone(),
+            })),
+        },
+        &mut observer,
+    );
+    match output {
+        Ok(output) => (Some(output.text), observer.stages, None),
+        Err(error) => (None, observer.stages, Some(error.to_string())),
+    }
+}
+
+fn score_recognition(
+    reference: &str,
+    bounded_expected: &[String],
+    actual: &str,
+) -> RecognitionMetrics {
+    let (normalized_errors, normalized_words) =
+        crate::benchmark::normalized_word_errors(reference, actual);
+    let (raw_errors, raw_words) = crate::benchmark::word_errors(reference, actual);
+    let (char_errors, reference_characters) = character_errors(reference, actual);
+    RecognitionMetrics {
+        expected_raw: Some(reference.to_string()),
+        actual_raw: Some(actual.to_string()),
+        raw_word_errors: Some(raw_errors),
+        normalized_word_errors: Some(normalized_errors),
+        reference_words: Some(raw_words),
+        normalized_reference_words: Some(normalized_words),
+        reference_characters: Some(reference_characters),
+        character_errors: Some(char_errors),
+        raw_wer: ratio(raw_errors, raw_words),
+        normalized_wer: ratio(normalized_errors, normalized_words),
+        cer: ratio(char_errors, reference_characters),
+        bounded_alternative_match: bounded_expected.iter().any(|value| value == actual),
+    }
+}
+
+fn character_errors(reference: &str, hypothesis: &str) -> (usize, usize) {
+    let reference = reference.to_lowercase().chars().collect::<Vec<_>>();
+    let hypothesis = hypothesis.to_lowercase().chars().collect::<Vec<_>>();
+    let mut previous = (0..=hypothesis.len()).collect::<Vec<_>>();
+    for (row, expected) in reference.iter().enumerate() {
+        let mut current = vec![row + 1; hypothesis.len() + 1];
+        for (column, actual) in hypothesis.iter().enumerate() {
+            current[column + 1] = (previous[column + 1] + 1)
+                .min(current[column] + 1)
+                .min(previous[column] + usize::from(expected != actual));
+        }
+        previous = current;
+    }
+    (previous[hypothesis.len()], reference.len())
+}
+
+fn score_stages(
+    expected: &[ExpectedStage],
+    actual: Vec<(StageReport, String)>,
+    failures: &mut Vec<String>,
+) -> Vec<StageMetric> {
+    let expected = expected
+        .iter()
+        .map(|stage| (stage.name.as_str(), stage))
+        .collect::<HashMap<_, _>>();
+    actual
+        .into_iter()
+        .map(|(report, text)| {
+            let outcome = report.outcome.as_str().to_string();
+            let expectation_match = expected.get(report.stage).is_none_or(|expected| {
+                expected.outcome == outcome
+                    && expected.changed == report.changed
+                    && expected.text.as_ref().is_none_or(|value| value == &text)
+            });
+            if !expectation_match {
+                failures.push(format!("stage '{}' expectation mismatch", report.stage));
+            }
+            StageMetric {
+                name: report.stage.to_string(),
+                outcome,
+                changed: report.changed,
+                duration_us: report.duration_us,
+                text,
+                expectation_match,
+            }
+        })
+        .collect()
+}
+
+fn skipped_case(
+    fixture: &EvaluationFixture,
+    reason: String,
+    model: Option<ModelMetadata>,
+    memory_before: Option<u64>,
+) -> CaseReport {
+    CaseReport {
+        id: fixture.id.clone(),
+        status: CaseStatus::Skipped,
+        failures: vec![reason],
+        provenance: provenance_report(fixture),
+        context: context_report(fixture),
+        model,
+        recognition: RecognitionMetrics::default(),
+        transformation: TransformationMetrics {
+            expected_final: fixture.expected.final_text.clone(),
+            ..TransformationMetrics::default()
+        },
+        delivery: DeliveryMetrics {
+            expected: fixture.expected.delivered_text.clone(),
+            first_partial_applicability: "notApplicable",
+            final_only: true,
+            ..DeliveryMetrics::default()
+        },
+        latency: LatencyMetrics::default(),
+        runtime: RuntimeMetadata {
+            incremental_completion: "notApplicableFinalOnly",
+            memory_before_mb: memory_before,
+            ..RuntimeMetadata::default()
+        },
+    }
+}
+
+fn provenance_report(fixture: &EvaluationFixture) -> CaseProvenance {
+    CaseProvenance {
+        kind: fixture.provenance.kind.clone(),
+        source: fixture.provenance.source.clone(),
+        contains_real_user_data: fixture.provenance.contains_real_user_data,
+        deletion: fixture.provenance.deletion.clone(),
+    }
+}
+
+fn context_report(fixture: &EvaluationFixture) -> CaseContext {
+    CaseContext {
+        bundle_id: fixture.context.bundle_id.clone(),
+        matched_profile: fixture.context.matched_profile.clone(),
+        fixture_only: true,
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> Option<f64> {
+    (denominator > 0).then_some(numerator as f64 / denominator as f64)
+}
+
+fn current_memory_mb() -> Option<u64> {
+    memory_stats::memory_stats().map(|stats| stats.physical_mem as u64 / 1_048_576)
+}
+
+fn summarize(cases: &[CaseReport]) -> ReportSummary {
+    let mut summary = ReportSummary {
+        total: cases.len(),
+        passed: cases
+            .iter()
+            .filter(|case| case.status == CaseStatus::Passed)
+            .count(),
+        failed: cases
+            .iter()
+            .filter(|case| case.status == CaseStatus::Failed)
+            .count(),
+        skipped: cases
+            .iter()
+            .filter(|case| case.status == CaseStatus::Skipped)
+            .count(),
+        ..ReportSummary::default()
+    };
+    let scored = cases
+        .iter()
+        .filter(|case| case.status != CaseStatus::Skipped)
+        .collect::<Vec<_>>();
+    let raw_errors = scored
+        .iter()
+        .filter_map(|case| case.recognition.raw_word_errors)
+        .sum::<usize>();
+    let normalized_errors = scored
+        .iter()
+        .filter_map(|case| case.recognition.normalized_word_errors)
+        .sum::<usize>();
+    let reference_words = scored
+        .iter()
+        .filter_map(|case| case.recognition.reference_words)
+        .sum::<usize>();
+    let normalized_reference_words = scored
+        .iter()
+        .filter_map(|case| case.recognition.normalized_reference_words)
+        .sum::<usize>();
+    let character_errors = scored
+        .iter()
+        .filter_map(|case| case.recognition.character_errors)
+        .sum::<usize>();
+    let reference_characters = scored
+        .iter()
+        .filter_map(|case| case.recognition.reference_characters)
+        .sum::<usize>();
+    summary.aggregate_raw_wer = ratio(raw_errors, reference_words);
+    summary.aggregate_normalized_wer = ratio(normalized_errors, normalized_reference_words);
+    summary.aggregate_cer = ratio(character_errors, reference_characters);
+    summary.transformation_match_rate = rate(&scored, |case| case.transformation.exact_match);
+    summary.delivery_match_rate = rate(&scored, |case| case.delivery.exact_match);
+    let command = scored
+        .iter()
+        .filter(|case| case.transformation.command_exact_match.is_some())
+        .copied()
+        .collect::<Vec<_>>();
+    summary.command_exact_match_rate = rate(&command, |case| {
+        case.transformation.command_exact_match == Some(true)
+    });
+    let no_change = scored
+        .iter()
+        .filter(|case| case.transformation.no_change_preserved.is_some())
+        .copied()
+        .collect::<Vec<_>>();
+    summary.no_change_preservation_rate = rate(&no_change, |case| {
+        case.transformation.no_change_preserved == Some(true)
+    });
+    summary
+}
+
+fn rate<T>(values: &[T], predicate: impl Fn(&T) -> bool) -> Option<f64> {
+    (!values.is_empty()).then(|| {
+        values.iter().filter(|value| predicate(value)).count() as f64 / values.len() as f64
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn character_error_rate_counts_substitution() {
+        assert_eq!(character_errors("Tauri", "Tori"), (2, 5));
+    }
+
+    #[test]
+    fn deterministic_suite_is_fixture_driven_and_final_only() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("eval/fixtures/deterministic");
+        let report = run(&RunOptions {
+            tier: EvaluationTier::Deterministic,
+            fixtures_dir: root,
+            workspace_root: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.."),
+            machine_label: "test".to_string(),
+        })
+        .expect("deterministic fixtures should parse and execute");
+        assert!(report.summary.total >= 10);
+        assert_eq!(report.summary.failed, 0);
+        assert_eq!(report.summary.skipped, 0);
+        assert!(report.cases.iter().all(|case| {
+            case.delivery.partial_count == 0
+                && case.delivery.first_partial_ms.is_none()
+                && case.delivery.first_partial_applicability == "notApplicable"
+        }));
+    }
+
+    #[test]
+    fn strict_schema_rejects_unknown_fields_and_real_user_data() {
+        let fixture = r#"{
+          "fixtureVersion": 1,
+          "id": "bad",
+          "tier": "deterministic",
+          "unexpected": true
+        }"#;
+        assert!(serde_json::from_str::<EvaluationFixture>(fixture).is_err());
+
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("eval/fixtures/deterministic");
+        let mut fixtures = load_fixtures(&root, EvaluationTier::Deterministic).unwrap();
+        let (path, mut fixture) = fixtures.remove(0);
+        fixture.provenance.contains_real_user_data = true;
+        assert!(
+            validate_fixture(&fixture, EvaluationTier::Deterministic, &path)
+                .unwrap_err()
+                .contains("real-user data is forbidden")
+        );
+    }
+}

--- a/app/src-tauri/src/evaluation.rs
+++ b/app/src-tauri/src/evaluation.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -494,6 +494,23 @@ struct FixedEvaluationClock {
     elapsed_ms: u64,
 }
 
+enum HardwareRecognition {
+    Completed {
+        raw_asr: String,
+        model: ModelMetadata,
+        elapsed_ms: u64,
+    },
+    Skipped {
+        reason: String,
+        model: ModelMetadata,
+    },
+    Failed {
+        reason: String,
+        model: ModelMetadata,
+        elapsed_ms: u64,
+    },
+}
+
 impl FixedEvaluationClock {
     fn advance(&mut self, amount_ms: u64) {
         self.elapsed_ms = self.elapsed_ms.saturating_add(amount_ms);
@@ -566,6 +583,12 @@ fn load_fixtures(
             FixtureDocument::One(fixture) => vec![fixture],
             FixtureDocument::Many(fixtures) => fixtures,
         };
+        if document_fixtures.is_empty() {
+            return Err(format!(
+                "Invalid strict fixture {}: fixture arrays must not be empty",
+                path.display()
+            ));
+        }
         for fixture in document_fixtures {
             validate_fixture(&fixture, tier, &path)?;
             if !ids.insert(fixture.id.clone()) {
@@ -626,10 +649,63 @@ fn validate_fixture(
     if fixture.expected.delivery.partial_count != 0
         || fixture.expected.delivery.first_partial_ms.is_some()
         || !fixture.expected.delivery.final_only
+        || fixture.expected.delivery.attempts != 1
     {
         return Err(fail(
-            "Murmur is final-only: partialCount must be 0, firstPartialMs null, and finalOnly true",
+            "Murmur is final-only: attempts must be 1, partialCount must be 0, firstPartialMs null, and finalOnly true",
         ));
+    }
+    DateTime::parse_from_rfc3339(&fixture.context.fixed_now)
+        .map_err(|error| fail(&format!("fixedNow must be RFC 3339: {error}")))?;
+
+    const STAGES: &[&str] = &[
+        crate::transcript_transform::CLEANUP_STAGE,
+        crate::transcript_transform::VOICE_COMMANDS_STAGE,
+        crate::transcript_transform::SMART_CORRECTION_STAGE,
+        crate::transcript_transform::SMART_FORMATTING_STAGE,
+        crate::transcript_transform::IDE_CONTEXT_STAGE,
+        crate::transcript_transform::CLI_COMMAND_STAGE,
+    ];
+    const OUTCOMES: &[&str] = &["applied", "skipped", "fallback", "failed"];
+    let mut expected_stages = HashSet::new();
+    for stage in &fixture.expected.stages {
+        if !STAGES.contains(&stage.name.as_str()) {
+            return Err(fail(&format!("unknown expected stage '{}'", stage.name)));
+        }
+        if !OUTCOMES.contains(&stage.outcome.as_str()) {
+            return Err(fail(&format!(
+                "unknown expected outcome '{}' for stage '{}'",
+                stage.outcome, stage.name
+            )));
+        }
+        if !expected_stages.insert(stage.name.as_str()) {
+            return Err(fail(&format!("duplicate expected stage '{}'", stage.name)));
+        }
+    }
+
+    let mut command_ids = HashSet::new();
+    for command in &fixture.context.resources.voice_commands {
+        if command.id.trim().is_empty() || command.phrase.trim().is_empty() {
+            return Err(fail("voice-command id and phrase must be non-empty"));
+        }
+        if !command_ids.insert(command.id.as_str()) {
+            return Err(fail(&format!(
+                "duplicate voice-command id '{}'",
+                command.id
+            )));
+        }
+        if command.command_type == VoiceCommandKind::Snippet {
+            crate::voice_commands::validate_snippet_template(
+                &command.content,
+                command.allow_clipboard_read,
+            )
+            .map_err(|error| fail(&format!("invalid voice-command snippet: {error}")))?;
+        }
+    }
+    for file in &fixture.context.resources.ide_files {
+        if !is_clean_relative_path(file) {
+            return Err(fail("IDE fixture files must be clean root-relative paths"));
+        }
     }
     match tier {
         EvaluationTier::Deterministic => {
@@ -646,7 +722,10 @@ fn validate_fixture(
             let Some(model) = fixture.requirements.model.as_ref() else {
                 return Err(fail("hardware fixtures require model metadata"));
             };
-            if fixture.requirements.audio.is_none() || fixture.input.raw_asr.is_some() {
+            let Some(audio) = fixture.requirements.audio.as_ref() else {
+                return Err(fail("hardware fixtures require audio metadata"));
+            };
+            if fixture.input.raw_asr.is_some() {
                 return Err(fail(
                     "hardware fixtures require audio and must obtain rawAsr from the model",
                 ));
@@ -654,9 +733,42 @@ fn validate_fixture(
             if !model.installed_only {
                 return Err(fail("hardware fixtures must set installedOnly true"));
             }
+            let definition = crate::model_runtime::model_definition(&model.name)
+                .map_err(|error| fail(&error))?;
+            if model.backend != definition.backend.as_str() {
+                return Err(fail(
+                    "hardware model backend does not match the model catalog",
+                ));
+            }
+            if model.language.trim().is_empty() {
+                return Err(fail("hardware model language must be non-empty"));
+            }
+            if !is_clean_relative_path(&audio.path)
+                || Path::new(&audio.path)
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    != Some("wav")
+            {
+                return Err(fail(
+                    "hardware audio must be a clean workspace-relative WAV path",
+                ));
+            }
+            if audio.sample_rate_hz == 0 || audio.channels == 0 {
+                return Err(fail(
+                    "hardware audio sample rate and channel count must be non-zero",
+                ));
+            }
         }
     }
     Ok(())
+}
+
+fn is_clean_relative_path(value: &str) -> bool {
+    !value.trim().is_empty()
+        && !Path::new(value).is_absolute()
+        && Path::new(value)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
 }
 
 fn run_fixture(_path: &Path, fixture: EvaluationFixture, options: &RunOptions) -> CaseReport {
@@ -664,19 +776,44 @@ fn run_fixture(_path: &Path, fixture: EvaluationFixture, options: &RunOptions) -
     let memory_before = (options.tier == EvaluationTier::Hardware)
         .then(current_memory_mb)
         .flatten();
-    let (raw_asr, model, measured_raw_ms, skip_reason) = match options.tier {
+    let (raw_asr, model, measured_raw_ms) = match options.tier {
         EvaluationTier::Deterministic => (
             fixture.input.raw_asr.clone().unwrap_or_default(),
             None,
             fixture.timing.raw_asr_ms,
-            None,
         ),
-        EvaluationTier::Hardware => run_hardware_recognition(&fixture, options),
+        EvaluationTier::Hardware => match run_hardware_recognition(&fixture, options) {
+            HardwareRecognition::Completed {
+                raw_asr,
+                model,
+                elapsed_ms,
+            } => (raw_asr, Some(model), elapsed_ms),
+            HardwareRecognition::Skipped { reason, model } => {
+                return unexecuted_case(
+                    &fixture,
+                    CaseStatus::Skipped,
+                    reason,
+                    Some(model),
+                    0,
+                    memory_before,
+                )
+            }
+            HardwareRecognition::Failed {
+                reason,
+                model,
+                elapsed_ms,
+            } => {
+                return unexecuted_case(
+                    &fixture,
+                    CaseStatus::Failed,
+                    reason,
+                    Some(model),
+                    elapsed_ms,
+                    memory_before,
+                )
+            }
+        },
     };
-
-    if let Some(reason) = skip_reason {
-        return skipped_case(&fixture, reason, model, memory_before);
-    }
 
     let recognition = score_recognition(
         fixture
@@ -801,7 +938,7 @@ fn run_fixture(_path: &Path, fixture: EvaluationFixture, options: &RunOptions) -
 fn run_hardware_recognition(
     fixture: &EvaluationFixture,
     options: &RunOptions,
-) -> (String, Option<ModelMetadata>, u64, Option<String>) {
+) -> HardwareRecognition {
     let audio = fixture
         .requirements
         .audio
@@ -823,101 +960,105 @@ fn run_hardware_recognition(
         sample_rate_hz: audio.sample_rate_hz,
         channels: audio.channels,
     };
-    if !crate::model_runtime::model_installed(&model.name) {
-        return (
-            String::new(),
-            Some(model_metadata),
-            0,
-            Some(format!(
-                "required installed model '{}' is unavailable",
-                model.name
-            )),
-        );
-    }
     let audio_path = options.workspace_root.join(&audio.path);
     let workspace = match options.workspace_root.canonicalize() {
         Ok(path) => path,
         Err(error) => {
-            return (
-                String::new(),
-                Some(model_metadata),
-                0,
-                Some(format!("workspace root is unavailable: {error}")),
-            )
+            return HardwareRecognition::Failed {
+                reason: format!("workspace root is unavailable: {error}"),
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
         }
     };
     let audio_path = match audio_path.canonicalize() {
         Ok(path) if path.starts_with(&workspace) => path,
         Ok(_) => {
-            return (
-                String::new(),
-                Some(model_metadata),
-                0,
-                Some("audio path escapes the local workspace boundary".to_string()),
-            )
+            return HardwareRecognition::Failed {
+                reason: "audio path escapes the local workspace boundary".to_string(),
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
         }
         Err(error) => {
-            return (
-                String::new(),
-                Some(model_metadata),
-                0,
-                Some(format!("audio fixture is unavailable: {error}")),
-            )
+            return HardwareRecognition::Failed {
+                reason: format!("audio fixture is unavailable: {error}"),
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
         }
     };
     if audio_path.extension().and_then(|value| value.to_str()) != Some("wav") {
-        return (
-            String::new(),
-            Some(model_metadata),
-            0,
-            Some("hardware audio fixture must be a WAV file".to_string()),
-        );
+        return HardwareRecognition::Failed {
+            reason: "hardware audio fixture must be a WAV file".to_string(),
+            model: model_metadata,
+            elapsed_ms: 0,
+        };
     }
     let wav_spec = match hound::WavReader::open(&audio_path) {
         Ok(reader) => reader.spec(),
         Err(error) => {
-            return (
-                String::new(),
-                Some(model_metadata),
-                0,
-                Some(format!("could not inspect WAV fixture: {error}")),
-            )
+            return HardwareRecognition::Failed {
+                reason: format!("could not inspect WAV fixture: {error}"),
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
         }
     };
     if wav_spec.sample_rate != audio.sample_rate_hz || wav_spec.channels != audio.channels {
-        return (
-            String::new(),
-            Some(model_metadata),
-            0,
-            Some(format!(
+        return HardwareRecognition::Failed {
+            reason: format!(
                 "WAV metadata mismatch: expected {} Hz/{} channel(s), got {} Hz/{} channel(s)",
                 audio.sample_rate_hz, audio.channels, wav_spec.sample_rate, wav_spec.channels
-            )),
-        );
+            ),
+            model: model_metadata,
+            elapsed_ms: 0,
+        };
+    }
+    if !crate::model_runtime::model_installed(&model.name) {
+        return HardwareRecognition::Skipped {
+            reason: format!("required installed model '{}' is unavailable", model.name),
+            model: model_metadata,
+        };
     }
     let samples = match crate::audio_decode::decode_to_mono_16k(&audio_path.to_string_lossy()) {
         Ok(samples) => samples,
-        Err(error) => return (String::new(), Some(model_metadata), 0, Some(error)),
+        Err(error) => {
+            return HardwareRecognition::Failed {
+                reason: error,
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
+        }
     };
     let mut backend = match crate::model_runtime::create_backend(&model.name) {
         Ok(backend) => backend,
-        Err(error) => return (String::new(), Some(model_metadata), 0, Some(error)),
+        Err(error) => {
+            return HardwareRecognition::Failed {
+                reason: error,
+                model: model_metadata,
+                elapsed_ms: 0,
+            }
+        }
     };
     if backend.name() != model.backend {
-        return (
-            String::new(),
-            Some(model_metadata),
-            0,
-            Some(format!(
+        return HardwareRecognition::Failed {
+            reason: format!(
                 "fixture backend '{}' does not match runtime backend '{}'",
                 model.backend,
                 backend.name()
-            )),
-        );
+            ),
+            model: model_metadata,
+            elapsed_ms: 0,
+        };
     }
     let started = Instant::now();
     if let Err(error) = backend.load_model(&model.name) {
-        return (String::new(), Some(model_metadata), 0, Some(error));
+        return HardwareRecognition::Failed {
+            reason: error,
+            model: model_metadata,
+            elapsed_ms: started.elapsed().as_millis() as u64,
+        };
     }
     let transcript = backend.transcribe(
         &samples,
@@ -928,8 +1069,16 @@ fn run_hardware_recognition(
     let elapsed_ms = started.elapsed().as_millis() as u64;
     backend.reset();
     match transcript {
-        Ok(text) => (text, Some(model_metadata), elapsed_ms, None),
-        Err(error) => (String::new(), Some(model_metadata), elapsed_ms, Some(error)),
+        Ok(raw_asr) => HardwareRecognition::Completed {
+            raw_asr,
+            model: model_metadata,
+            elapsed_ms,
+        },
+        Err(reason) => HardwareRecognition::Failed {
+            reason,
+            model: model_metadata,
+            elapsed_ms,
+        },
     }
 }
 
@@ -1063,9 +1212,11 @@ fn score_stages(
         .iter()
         .map(|stage| (stage.name.as_str(), stage))
         .collect::<HashMap<_, _>>();
-    actual
+    let mut observed = HashSet::new();
+    let metrics = actual
         .into_iter()
         .map(|(report, text)| {
+            observed.insert(report.stage);
             let outcome = report.outcome.as_str().to_string();
             let expectation_match = expected.get(report.stage).is_none_or(|expected| {
                 expected.outcome == outcome
@@ -1084,18 +1235,27 @@ fn score_stages(
                 expectation_match,
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+    for stage in expected.values() {
+        if !observed.contains(stage.name.as_str()) {
+            failures.push(format!("expected stage '{}' was not observed", stage.name));
+        }
+    }
+    metrics
 }
 
-fn skipped_case(
+fn unexecuted_case(
     fixture: &EvaluationFixture,
+    status: CaseStatus,
     reason: String,
     model: Option<ModelMetadata>,
+    raw_asr_ms: u64,
     memory_before: Option<u64>,
 ) -> CaseReport {
+    let memory_after = current_memory_mb();
     CaseReport {
         id: fixture.id.clone(),
-        status: CaseStatus::Skipped,
+        status,
         failures: vec![reason],
         provenance: provenance_report(fixture),
         context: context_report(fixture),
@@ -1111,10 +1271,19 @@ fn skipped_case(
             final_only: true,
             ..DeliveryMetrics::default()
         },
-        latency: LatencyMetrics::default(),
+        latency: LatencyMetrics {
+            raw_asr_ms,
+            finalization_ms: raw_asr_ms,
+            total_ms: raw_asr_ms,
+            ..LatencyMetrics::default()
+        },
         runtime: RuntimeMetadata {
             incremental_completion: "notApplicableFinalOnly",
             memory_before_mb: memory_before,
+            memory_after_mb: memory_after,
+            memory_delta_mb: memory_before
+                .zip(memory_after)
+                .map(|(before, after)| after as i64 - before as i64),
             ..RuntimeMetadata::default()
         },
     }
@@ -1250,7 +1419,7 @@ mod tests {
     }
 
     #[test]
-    fn strict_schema_rejects_unknown_fields_and_real_user_data() {
+    fn strict_schema_rejects_unknown_fields_and_malformed_expectations() {
         let fixture = r#"{
           "fixtureVersion": 1,
           "id": "bad",
@@ -1260,13 +1429,87 @@ mod tests {
         assert!(serde_json::from_str::<EvaluationFixture>(fixture).is_err());
 
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("eval/fixtures/deterministic");
-        let mut fixtures = load_fixtures(&root, EvaluationTier::Deterministic).unwrap();
-        let (path, mut fixture) = fixtures.remove(0);
-        fixture.provenance.contains_real_user_data = true;
+        let (path, fixture) = load_fixtures(&root, EvaluationTier::Deterministic)
+            .unwrap()
+            .remove(0);
+
+        let mut real_user_fixture = fixture.clone();
+        real_user_fixture.provenance.contains_real_user_data = true;
         assert!(
-            validate_fixture(&fixture, EvaluationTier::Deterministic, &path)
+            validate_fixture(&real_user_fixture, EvaluationTier::Deterministic, &path)
                 .unwrap_err()
                 .contains("real-user data is forbidden")
         );
+
+        let mut misspelled_stage = fixture.clone();
+        misspelled_stage.expected.stages[0].name = "smart_formattting".to_string();
+        assert!(
+            validate_fixture(&misspelled_stage, EvaluationTier::Deterministic, &path)
+                .unwrap_err()
+                .contains("unknown expected stage")
+        );
+
+        let mut duplicate_stage = fixture.clone();
+        duplicate_stage
+            .expected
+            .stages
+            .push(duplicate_stage.expected.stages[0].clone());
+        assert!(
+            validate_fixture(&duplicate_stage, EvaluationTier::Deterministic, &path)
+                .unwrap_err()
+                .contains("duplicate expected stage")
+        );
+
+        let mut multiple_deliveries = fixture.clone();
+        multiple_deliveries.expected.delivery.attempts = 2;
+        assert!(
+            validate_fixture(&multiple_deliveries, EvaluationTier::Deterministic, &path)
+                .unwrap_err()
+                .contains("attempts must be 1")
+        );
+
+        let empty_dir = tempfile::tempdir().unwrap();
+        fs::write(empty_dir.path().join("empty.json"), "[]").unwrap();
+        assert!(
+            load_fixtures(empty_dir.path(), EvaluationTier::Deterministic)
+                .unwrap_err()
+                .contains("fixture arrays must not be empty")
+        );
+    }
+
+    #[test]
+    fn hardware_schema_and_runtime_errors_cannot_be_reported_as_skips() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("eval/fixtures/hardware");
+        let (path, fixture) = load_fixtures(&root, EvaluationTier::Hardware)
+            .unwrap()
+            .remove(0);
+
+        let mut unknown_model = fixture.clone();
+        unknown_model.requirements.model.as_mut().unwrap().name = "unknown-model".to_string();
+        assert!(
+            validate_fixture(&unknown_model, EvaluationTier::Hardware, &path)
+                .unwrap_err()
+                .contains("Unknown transcription model")
+        );
+
+        let mut escaping_audio = fixture.clone();
+        escaping_audio.requirements.audio.as_mut().unwrap().path = "../outside.wav".to_string();
+        assert!(
+            validate_fixture(&escaping_audio, EvaluationTier::Hardware, &path)
+                .unwrap_err()
+                .contains("clean workspace-relative WAV path")
+        );
+
+        let unavailable_workspace = tempfile::tempdir().unwrap().path().join("removed");
+        let result = run_hardware_recognition(
+            &fixture,
+            &RunOptions {
+                tier: EvaluationTier::Hardware,
+                fixtures_dir: root,
+                workspace_root: unavailable_workspace,
+                machine_label: "test".to_string(),
+            },
+        );
+        assert!(matches!(result, HardwareRecognition::Failed { .. }));
     }
 }

--- a/app/src-tauri/src/ide_context.rs
+++ b/app/src-tauri/src/ide_context.rs
@@ -49,6 +49,27 @@ pub(crate) struct IdeContextIndex {
 }
 
 impl IdeContextIndex {
+    /// Build a bounded, memory-only index from explicitly curated evaluation
+    /// fixture values. This never walks project roots or reads source files.
+    pub(crate) fn from_eval_fixture(symbols: &[String], files: &[String]) -> Arc<Self> {
+        let symbols = symbols
+            .iter()
+            .take(MAX_IDE_SYMBOLS)
+            .cloned()
+            .collect::<Vec<_>>();
+        let files = files
+            .iter()
+            .take(MAX_IDE_FILES)
+            .cloned()
+            .collect::<Vec<_>>();
+        Arc::new(Self {
+            symbol_matcher: Arc::new(CorrectionMatcher::build(&symbols, &[], false, false)),
+            file_aliases: Arc::new(build_file_aliases(&files)),
+            built_at: Instant::now(),
+            valid: AtomicBool::new(true),
+        })
+    }
+
     fn is_fresh(&self) -> bool {
         self.built_at.elapsed() < INDEX_TTL
     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod commands;
 mod correct_and_teach;
 mod correction;
 mod dictation_context;
+pub mod evaluation;
 mod file_output;
 mod frontmost;
 mod ide_context;

--- a/app/src-tauri/src/transcript_transform.rs
+++ b/app/src-tauri/src/transcript_transform.rs
@@ -90,7 +90,7 @@ pub(crate) enum StageFailurePolicy {
 }
 
 impl StageFailurePolicy {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Required => "required",
             Self::OptionalFallback => "optional_fallback",
@@ -107,7 +107,7 @@ pub(crate) enum StageOutcome {
 }
 
 impl StageOutcome {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Applied => "applied",
             Self::Skipped => "skipped",
@@ -184,6 +184,13 @@ pub(crate) struct TranscriptPipelineOutput {
     pub stages: Vec<StageReport>,
 }
 
+/// Evaluation-only observation seam. Production callers use
+/// [`transform_transcript`], which installs no observer. Implementations must
+/// keep observed text in memory and must never log it.
+pub(crate) trait StageTextObserver {
+    fn observe(&mut self, report: &StageReport, text: &str);
+}
+
 impl TranscriptPipelineOutput {
     pub(crate) fn was_changed(&self) -> bool {
         self.original_text != self.text
@@ -213,6 +220,7 @@ impl TranscriptPipeline {
             correction_matcher,
             cli_lexicon,
             ide_context_index,
+            voice_command_runtime,
         } = resources;
         Self::new(vec![
             Box::new(CleanupStage),
@@ -236,6 +244,8 @@ impl TranscriptPipeline {
                 } else {
                     voice_commands
                 },
+                runtime: voice_command_runtime
+                    .unwrap_or_else(|| Arc::new(crate::voice_commands::SystemVoiceCommandRuntime)),
             }),
             Box::new(SmartCorrectionStage {
                 matcher: correction_matcher,
@@ -256,6 +266,7 @@ impl TranscriptPipeline {
         &self,
         mut text: String,
         context: &TranscriptContext,
+        mut observer: Option<&mut dyn StageTextObserver>,
     ) -> Result<TranscriptPipelineOutput, TranscriptPipelineError> {
         let original_text = text.clone();
         let mut reports = Vec::with_capacity(self.stages.len());
@@ -273,6 +284,9 @@ impl TranscriptPipeline {
                     failure_policy: policy,
                 };
                 log_stage(context, &report);
+                if let Some(observer) = observer.as_deref_mut() {
+                    observer.observe(&report, &text);
+                }
                 reports.push(report);
                 continue;
             }
@@ -289,6 +303,9 @@ impl TranscriptPipeline {
                         failure_policy: policy,
                     };
                     log_stage(context, &report);
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.observe(&report, &text);
+                    }
                     reports.push(report);
                 }
                 Err(_error) if policy == StageFailurePolicy::OptionalFallback => {
@@ -300,6 +317,9 @@ impl TranscriptPipeline {
                         failure_policy: policy,
                     };
                     log_stage(context, &report);
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.observe(&report, &text);
+                    }
                     reports.push(report);
                 }
                 Err(error) => {
@@ -311,6 +331,9 @@ impl TranscriptPipeline {
                         failure_policy: policy,
                     };
                     log_stage(context, &report);
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.observe(&report, &text);
+                    }
                     return Err(TranscriptPipelineError {
                         stage: stage.name(),
                         code: error.code,
@@ -352,6 +375,7 @@ pub(crate) struct TranscriptTransformResources {
     pub correction_matcher: Option<Arc<CorrectionMatcher>>,
     pub cli_lexicon: CliLexicon,
     pub ide_context_index: Option<Arc<IdeContextIndex>>,
+    pub voice_command_runtime: Option<Arc<dyn crate::voice_commands::VoiceCommandRuntime>>,
 }
 
 impl TranscriptTransformResources {
@@ -362,6 +386,7 @@ impl TranscriptTransformResources {
             correction_matcher: None,
             cli_lexicon: CliLexicon::from_context(None, &[]),
             ide_context_index: None,
+            voice_command_runtime: None,
         }
     }
 }
@@ -372,7 +397,19 @@ pub(crate) fn transform_transcript(
     context: &TranscriptContext,
     resources: TranscriptTransformResources,
 ) -> Result<TranscriptPipelineOutput, TranscriptPipelineError> {
-    TranscriptPipeline::standard(resources).run(text, context)
+    TranscriptPipeline::standard(resources).run(text, context, None)
+}
+
+/// Runs the production pipeline while exposing each stage's in-memory output
+/// to the local evaluator. This is intentionally crate-private and is never
+/// used by the live dictation path.
+pub(crate) fn transform_transcript_observed(
+    text: String,
+    context: &TranscriptContext,
+    resources: TranscriptTransformResources,
+    observer: &mut dyn StageTextObserver,
+) -> Result<TranscriptPipelineOutput, TranscriptPipelineError> {
+    TranscriptPipeline::standard(resources).run(text, context, Some(observer))
 }
 
 struct CleanupStage;
@@ -406,6 +443,7 @@ impl TranscriptTransform for CleanupStage {
 
 struct VoiceCommandsStage {
     voice_commands: Vec<crate::voice_commands::ResolvedVoiceCommand>,
+    runtime: Arc<dyn crate::voice_commands::VoiceCommandRuntime>,
 }
 
 impl TranscriptTransform for VoiceCommandsStage {
@@ -426,7 +464,7 @@ impl TranscriptTransform for VoiceCommandsStage {
             text,
             true,
             &self.voice_commands,
-            &crate::voice_commands::SystemVoiceCommandRuntime,
+            self.runtime.as_ref(),
         )
         .text)
     }
@@ -594,6 +632,7 @@ mod tests {
             correction_matcher: with_matcher.then(correction_matcher),
             cli_lexicon: CliLexicon::from_context(None, &[]),
             ide_context_index: None,
+            voice_command_runtime: None,
         }
     }
 
@@ -996,7 +1035,7 @@ mod tests {
             }),
         ]);
         let output = pipeline
-            .run("raw".to_string(), &live_context(all_stages()))
+            .run("raw".to_string(), &live_context(all_stages()), None)
             .unwrap();
         assert_eq!(output.text, "raw-a-b");
         assert_eq!(
@@ -1036,7 +1075,7 @@ mod tests {
         let pipeline = TranscriptPipeline::new(vec![Box::new(FailingStage {
             policy: StageFailurePolicy::Required,
         })]);
-        let error = match pipeline.run("raw".to_string(), &live_context(all_stages())) {
+        let error = match pipeline.run("raw".to_string(), &live_context(all_stages()), None) {
             Ok(_) => panic!("required stage failure unexpectedly succeeded"),
             Err(error) => error,
         };
@@ -1056,7 +1095,7 @@ mod tests {
             }),
         ]);
         let output = pipeline
-            .run("raw".to_string(), &live_context(all_stages()))
+            .run("raw".to_string(), &live_context(all_stages()), None)
             .unwrap();
         assert_eq!(output.text, "raw-kept");
         assert_eq!(output.stages[0].outcome, StageOutcome::Fallback);

--- a/app/src-tauri/src/voice_commands.rs
+++ b/app/src-tauri/src/voice_commands.rs
@@ -49,7 +49,7 @@ pub(crate) struct VoiceCommandApplication {
     pub clipboard_read: bool,
 }
 
-pub(crate) trait VoiceCommandRuntime {
+pub(crate) trait VoiceCommandRuntime: Send + Sync {
     fn now(&self) -> DateTime<FixedOffset>;
     fn clipboard_text(&self) -> Result<String, String>;
 }
@@ -546,12 +546,12 @@ fn delete_previous_sentence(out: &mut String) {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     struct FixedRuntime {
         now: DateTime<FixedOffset>,
         clipboard: Result<String, String>,
-        reads: Cell<u32>,
+        reads: AtomicU32,
     }
 
     impl VoiceCommandRuntime for FixedRuntime {
@@ -560,7 +560,7 @@ mod tests {
         }
 
         fn clipboard_text(&self) -> Result<String, String> {
-            self.reads.set(self.reads.get() + 1);
+            self.reads.fetch_add(1, Ordering::Relaxed);
             self.clipboard.clone()
         }
     }
@@ -570,7 +570,7 @@ mod tests {
         FixedRuntime {
             now: zone.with_ymd_and_hms(2026, 7, 20, 9, 7, 0).unwrap(),
             clipboard: clipboard.map(str::to_string).map_err(str::to_string),
-            reads: Cell::new(0),
+            reads: AtomicU32::new(0),
         }
     }
 
@@ -788,7 +788,7 @@ mod tests {
             "Yesterday:\n- done\nToday 2026-07-20 09:07:\n- ship"
         );
         assert!(applied.matched);
-        assert_eq!(runtime.reads.get(), 0);
+        assert_eq!(runtime.reads.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -807,13 +807,13 @@ mod tests {
             &runtime,
         );
         assert_eq!(missed.text, "ordinary prose");
-        assert_eq!(runtime.reads.get(), 0);
+        assert_eq!(runtime.reads.load(Ordering::Relaxed), 0);
 
         let applied = apply_voice_commands_with_resolved("paste note", true, &[command], &runtime);
         assert_eq!(applied.text, "Note:\nalpha\nbeta");
         assert!(applied.clipboard_required);
         assert!(applied.clipboard_read);
-        assert_eq!(runtime.reads.get(), 1);
+        assert_eq!(runtime.reads.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -854,7 +854,7 @@ mod tests {
             apply_voice_commands_with_resolved("remove me", true, &[empty], &runtime).text,
             ""
         );
-        assert_eq!(runtime.reads.get(), 0);
+        assert_eq!(runtime.reads.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/docs/features/evaluation-harness.md
+++ b/docs/features/evaluation-harness.md
@@ -28,6 +28,7 @@ cargo run --bin murmur-eval -- hardware \
 ```
 
 Hardware fixtures reference repository-owned WAV files and an exact backend/model. The runner refuses missing models instead of downloading them, restricts audio to the selected workspace root, and records OS, architecture, logical CPU count, user-supplied machine label, model/backend/accelerator, latency, and memory metadata where available. Missing installed hardware is reported as skipped.
+Malformed fixtures, invalid workspace/audio boundaries, backend mismatches, model-load failures, and inference failures are evaluation failures and make the CLI exit non-zero; only a valid fixture whose declared model is not installed is skipped.
 
 ## Fixture contract
 

--- a/docs/features/evaluation-harness.md
+++ b/docs/features/evaluation-harness.md
@@ -1,0 +1,74 @@
+# Local Dictation Evaluation Harness
+
+`murmur-eval` runs repeatable, local evaluations across three separate boundaries:
+
+1. raw ASR text against a curated expected transcript or bounded alternatives;
+2. final text from the production transformation pipeline, including per-stage outcomes;
+3. final text written to an in-memory delivery sink.
+
+It does not read Murmur history, app settings, the microphone, the system clipboard, or frontmost-window state. It does not upload fixtures or reports.
+
+## Commands and tiers
+
+Run the deterministic suite from `app/src-tauri`:
+
+```bash
+cargo run --bin murmur-eval -- deterministic \
+  --output target/murmur-eval/deterministic-report.json
+```
+
+This is the CI tier. It uses fixture-provided raw ASR, a fixed clock, a fake clipboard-backed `VoiceCommandRuntime`, fixture-only profile/IDE context, and an in-memory delivery sink. It has no microphone, model, Metal, network, clipboard, paste, or window dependency.
+
+The hardware tier is explicit and opt-in:
+
+```bash
+cargo run --bin murmur-eval -- hardware \
+  --machine-label local-mac \
+  --output target/murmur-eval/hardware-report.json
+```
+
+Hardware fixtures reference repository-owned WAV files and an exact backend/model. The runner refuses missing models instead of downloading them, restricts audio to the selected workspace root, and records OS, architecture, logical CPU count, user-supplied machine label, model/backend/accelerator, latency, and memory metadata where available. Missing installed hardware is reported as skipped.
+
+## Fixture contract
+
+Fixtures live under `app/src-tauri/eval/fixtures/{deterministic,hardware}`. Every `.json` file may contain one strict fixture object or an array of fixtures. `fixtureVersion` is currently `1`; unknown fields, unsupported versions, duplicate IDs, tier mismatches, and incomplete provenance fail before evaluation.
+
+Each fixture declares:
+
+- an ID and tier;
+- local provenance, deletion guidance, and `containsRealUserData: false`;
+- fixture-provided raw ASR for deterministic runs, or a workspace-relative WAV plus exact installed model/backend for hardware runs;
+- a recognition reference transcript and one or more bounded acceptable raw-ASR outputs (the first bounded output is the reference when `referenceTranscript` is omitted);
+- fixture-only stage switches, profile metadata, vocabulary, voice commands, CLI prompt, and IDE symbols/files;
+- expected final and delivered text plus selected stage outcomes;
+- fixed deterministic timing values.
+
+Adding a case requires only another valid JSON object; evaluator code does not contain a fixture registry.
+
+The repository corpus covers standalone and longer-sentence backtracking, numbered and bulleted lists, spoken punctuation/paragraphs, npm/npx/Git/Cargo/Docker/kubectl command formatting, Tauri/Tori/Tory aliases, Cursor profile/project file and symbol context, fixed date/time plus fake clipboard snippets, long final-only behavior, and ordinary-prose false-positive cases.
+
+## Metrics and final-only behavior
+
+Reports are versioned JSON and keep recognition, transformation, and delivery results separate. They include raw and normalized WER (using the same normalization as Performance Lab), CER, bounded-alternative match, exact command/final/delivery match, no-change preservation, stage outcome/change/text observations, fixed or measured latency, fallback stages, and memory metadata when available.
+
+Stage text observation exists only inside the evaluator and remains in the local report; production telemetry continues to log privacy-safe stage metadata without transcript text.
+
+Murmur no longer has incremental transcription or live preview. Every report therefore uses:
+
+```json
+{
+  "partialCount": 0,
+  "firstPartialMs": null,
+  "firstPartialApplicability": "notApplicable",
+  "finalOnly": true,
+  "incrementalCompletion": "notApplicableFinalOnly"
+}
+```
+
+Fixtures that claim partial output are rejected.
+
+## Privacy, provenance, and deletion
+
+Only explicitly curated synthetic or repository project-test fixtures are accepted. `containsRealUserData: true` is rejected, there is no importer for transcription history, and hardware audio must resolve inside the chosen workspace. The runner never uploads data and never reads the real clipboard; fixture clipboard text is an in-memory fake used only after a permitted fixture command matches.
+
+Reports may contain the curated fixture transcripts and per-stage text, so keep them local. By default they are written under ignored `app/src-tauri/target/murmur-eval/`. To delete evaluation data, remove the generated report. To remove a fixture, delete its JSON entry and any explicitly referenced repository WAV. No database or hidden evaluator cache needs cleanup.


### PR DESCRIPTION
## Summary
- add strict versioned local fixtures and the `murmur-eval` deterministic/hardware CLI
- report raw ASR, transformed, and delivered metrics separately with final-only latency/fallback/memory metadata
- exercise production transform stages through an eval-only observer, fixed voice-command runtime, fixture-only context, and in-memory delivery
- document provenance, no-history/no-upload boundaries, and deletion; run the deterministic corpus in CI

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` (424 library passed, 5 ignored; integration/runner tests passed)
- [x] `npx tsc --noEmit`
- [x] `npm test -- --run` (28 files, 194 tests)
- [x] `cargo test evaluation::tests --lib -- --test-threads=1`
- [x] deterministic CLI: 16 passed, 0 failed, 0 skipped
- [x] opt-in hardware CLI: `base.en` + `bench/audio/xlong.wav`, 1 passed, 0 failed, 0 skipped
- [x] workflow policy validation (21 tests)
- [x] `git diff --check`
- [x] debug native bundle built; real app launched and reached responsive Ready state

The debug build produced the `.app` and DMG, then returned the expected missing `TAURI_SIGNING_PRIVATE_KEY` updater-signing error. No microphone transcription claim is made for this evaluator-only native smoke.

Closes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local dictation evaluation harness covering recognition accuracy, text transformations, voice commands, and final delivery.
  * Added deterministic fixture-based evaluations that run without audio hardware or installed models.
  * Added an optional hardware evaluation tier for testing installed speech-recognition models with synthetic audio.
  * Added machine-readable reports with accuracy, transformation, delivery, and timing results.

* **Documentation**
  * Added usage guidance, fixture requirements, reporting details, privacy safeguards, and cleanup instructions.

* **Tests**
  * Deterministic evaluations now run automatically in macOS CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->