### PR TITLE
fix(release): smoke-test packaged app binary

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -148,8 +148,13 @@ jobs:
       - name: Smoke test signed application
         run: |
           APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
-          BINARY="$APP/Contents/MacOS/$(ls "$APP/Contents/MacOS/" | head -1)"
-          if [ -z "$APP" ] || [ ! -x "$BINARY" ]; then
+          if [ -z "$APP" ]; then
+            echo "ERROR: signed application bundle is missing"
+            exit 1
+          fi
+          EXECUTABLE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
+          BINARY="$APP/Contents/MacOS/$EXECUTABLE"
+          if [ -z "$EXECUTABLE" ] || [ ! -x "$BINARY" ]; then
             echo "ERROR: signed application bundle or binary is missing"
             exit 1
           fi
@@ -264,9 +269,9 @@ jobs:
           rm -rf /tmp/murmur-deb-root
           mkdir -p /tmp/murmur-deb-root
           dpkg-deb -x "$DEB" /tmp/murmur-deb-root
-          DEB_BINARY=$(find /tmp/murmur-deb-root/usr/bin -maxdepth 1 -type f -perm -111 -print -quit)
-          if [ -z "$DEB_BINARY" ]; then
-            echo "ERROR: deb package has no executable in /usr/bin"
+          DEB_BINARY=/tmp/murmur-deb-root/usr/bin/ui
+          if [ ! -x "$DEB_BINARY" ]; then
+            echo "ERROR: deb package is missing the ui application executable"
             exit 1
           fi
           rm -f "$LOG"

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -160,6 +160,10 @@ def validate_release_build(workflow: str) -> int:
     assert "linux-release-${{ needs.context.outputs.source-sha }}" in workflow
     assert "shared-key: macos-release-v1" in workflow
     assert "shared-key: linux-cuda-release-v1" in workflow
+    assert "Print :CFBundleExecutable" in workflow
+    assert '$(ls "$APP/Contents/MacOS/" | head -1)' not in workflow
+    assert "DEB_BINARY=/tmp/murmur-deb-root/usr/bin/ui" in workflow
+    assert "find /tmp/murmur-deb-root/usr/bin -maxdepth 1" not in workflow
     linux_build = named_step_block(workflow, "Build signed packages", 6)
     assert "args: --bundles deb,appimage --verbose" in linux_build
     assert "rpm" not in linux_build


### PR DESCRIPTION
## Summary
- select the macOS executable declared by CFBundleExecutable instead of the first packaged binary
- smoke-test `/usr/bin/ui` from the deb instead of the first executable
- lock both selectors into workflow-policy validation

## Why
Issue #267 adds the packaged `murmur-eval` CLI. The v0.20.0 trusted build selected that CLI alphabetically, so both app smokes launched it without arguments and failed before artifacts could be promoted.

## Validation
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests.test_workflow_policy`
- `git diff --check`

This PR does not publish or tag a release. After independent validation and merge, the existing authorized v0.20.0 release will be retriggered from the corrected main head.