### PR TITLE
feat(performance-lab): save benchmark reports to a configurable folder with reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Performance Lab report export** — each saved benchmark report can now be copied as full JSON, saved to a configurable folder (default `Documents/Murmur`) under a self-identifying `benchmark-<version>-<machine>-<createdAt>.json` name, and its folder revealed in Finder. An optional auto-save writes every completed run to disk so reports survive the 10-slot in-app cap. All local, no network (#308).
 - **Local dictation evaluation harness** adds strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports through `murmur-eval` (#267).
 
 ## [0.19.0] - 2026-07-20

--- a/app/src-tauri/src/commands/benchmark.rs
+++ b/app/src-tauri/src/commands/benchmark.rs
@@ -79,3 +79,30 @@ pub fn cancel_benchmark(state: tauri::State<'_, State>) -> bool {
     }
     running
 }
+
+/// Write a benchmark report (already serialized on the frontend) to the
+/// configured output folder under `file_name`. Returns the absolute path.
+#[tauri::command]
+pub fn save_benchmark_report(
+    report_json: String,
+    output_dir: String,
+    file_name: String,
+) -> Result<String, String> {
+    crate::file_output::write_benchmark_report(&output_dir, &file_name, &report_json)
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+/// Open the benchmark output folder (creating it if needed) in the system file
+/// manager, so the user can see and share saved reports.
+#[tauri::command]
+pub fn open_benchmark_output_folder(
+    app_handle: tauri::AppHandle,
+    output_dir: String,
+) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    let dir = crate::file_output::resolve_output_dir(&output_dir)?;
+    app_handle
+        .opener()
+        .open_path(dir.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|e| format!("Failed to open output folder: {}", e))
+}

--- a/app/src-tauri/src/file_output.rs
+++ b/app/src-tauri/src/file_output.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 /// Resolve the output directory: the user-chosen `output_dir` if non-empty,
 /// otherwise `<Documents>/Murmur` (falling back to `<home>/Murmur`).
-fn resolve_output_dir(output_dir: &str) -> Result<PathBuf, String> {
+pub(crate) fn resolve_output_dir(output_dir: &str) -> Result<PathBuf, String> {
     let dir = if !output_dir.trim().is_empty() {
         PathBuf::from(output_dir)
     } else {
@@ -128,6 +128,45 @@ pub fn write_dictation_outputs(
     Ok(written)
 }
 
+/// Write a pre-serialized benchmark report as JSON into the resolved output
+/// directory (see [`resolve_output_dir`]) under `file_name`. The caller builds
+/// the descriptive name (`benchmark-<version>-<machine>-<createdAt>.json`); this
+/// function sanitizes it to a bare file component so a crafted name cannot escape
+/// the directory, then writes the JSON verbatim. Returns the absolute path.
+///
+/// Privacy: like the rest of this module, it logs only a boolean, never the path.
+pub fn write_benchmark_report(
+    output_dir: &str,
+    file_name: &str,
+    json: &str,
+) -> Result<PathBuf, String> {
+    let dir = resolve_output_dir(output_dir)?;
+
+    // Reduce the requested name to a single path component so `../` or absolute
+    // paths cannot redirect the write outside `dir`, and force a `.json` suffix.
+    let mut safe = Path::new(file_name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Invalid benchmark report file name".to_string())?;
+    if !safe.to_ascii_lowercase().ends_with(".json") {
+        safe.push_str(".json");
+    }
+
+    let path = dir.join(&safe);
+    std::fs::write(&path, json)
+        .map_err(|e| format!("Failed to write benchmark report: {}", e))?;
+
+    tracing::info!(
+        target: "pipeline",
+        bytes = json.len(),
+        "benchmark report written to file"
+    );
+
+    Ok(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,6 +278,40 @@ mod tests {
         write_dictation_outputs(&[0.0f32], "fresh", true, true, dir.to_str().unwrap()).unwrap();
         assert!(dir.join("murmur-0001.wav").exists());
         assert!(dir.join("murmur-0001.txt").exists());
+    }
+
+    #[test]
+    fn writes_benchmark_report_json() {
+        let dir = temp_dir("bench_report");
+        let json = r#"{"reportVersion":2}"#;
+        let path = write_benchmark_report(
+            dir.to_str().unwrap(),
+            "benchmark-0.20.0-Apple-M4-2026-07-20T14-30-00-000Z.json",
+            json,
+        )
+        .unwrap();
+        assert_eq!(path.parent().unwrap(), dir);
+        assert_eq!(
+            path.file_name().unwrap().to_str().unwrap(),
+            "benchmark-0.20.0-Apple-M4-2026-07-20T14-30-00-000Z.json"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), json);
+    }
+
+    #[test]
+    fn benchmark_report_name_cannot_escape_directory() {
+        let dir = temp_dir("bench_traversal");
+        // A crafted traversal name is reduced to its bare file component.
+        let path = write_benchmark_report(dir.to_str().unwrap(), "../evil.json", "{}").unwrap();
+        assert_eq!(path, dir.join("evil.json"));
+        assert!(dir.join("evil.json").exists());
+    }
+
+    #[test]
+    fn benchmark_report_name_gets_json_suffix() {
+        let dir = temp_dir("bench_suffix");
+        let path = write_benchmark_report(dir.to_str().unwrap(), "report", "{}").unwrap();
+        assert_eq!(path, dir.join("report.json"));
     }
 
     #[test]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -202,6 +202,8 @@ pub fn run() {
             commands::benchmark::get_benchmark_activity,
             commands::benchmark::run_benchmark,
             commands::benchmark::cancel_benchmark,
+            commands::benchmark::save_benchmark_report,
+            commands::benchmark::open_benchmark_output_folder,
             commands::tray::update_tray_icon,
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -465,6 +465,33 @@ export function PerformanceLab({ status, settings, onUpdateSettings }: {
         )}
       </section>
 
+      <section className="border-t border-outline-variant/30 dark:border-outline-variant/30 pt-5">
+        <h3 className="text-sm font-semibold text-on-surface">Report export</h3>
+        <p className="mt-0.5 text-xs text-on-surface-variant dark:text-on-surface-variant">
+          Where saved reports are written, and whether every run is saved automatically. Configure before running.
+        </p>
+        <div className="mt-3 rounded-lg border border-outline-variant/30 bg-surface-container-low p-3 text-[11px] leading-relaxed text-on-surface-variant">
+          <p className="font-medium text-on-surface">Output folder</p>
+          <p className="mt-1 break-all rounded-md border border-outline-variant/30 bg-surface-container-lowest px-2.5 py-1.5 text-on-surface">
+            {settings.benchmarkOutputDir || 'Documents/Murmur (default)'}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-3">
+            <button type="button" onClick={() => void chooseFolder()} className="font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>
+            {settings.benchmarkOutputDir && <button type="button" onClick={() => onUpdateSettings({ benchmarkOutputDir: '' })} className="font-medium text-on-surface-variant underline hover:text-primary">Reset to default</button>}
+            <button type="button" onClick={() => void revealFolder()} className="font-medium text-on-surface-variant underline hover:text-primary">Reveal in Finder</button>
+          </div>
+          <label className="mt-3 flex items-center gap-2 text-on-surface">
+            <input
+              type="checkbox"
+              checked={settings.benchmarkAutoSave}
+              onChange={() => onUpdateSettings({ benchmarkAutoSave: !settings.benchmarkAutoSave })}
+              className="h-3.5 w-3.5 accent-primary"
+            />
+            <span>Auto-save every run to this folder (survives the {MAX_SAVED_BENCHMARK_REPORTS}-run in-app limit)</span>
+          </label>
+        </div>
+      </section>
+
       {report && !running && (
         <section className="space-y-4 border-t border-outline-variant/30 dark:border-outline-variant/30 pt-5">
           <div className="flex items-center justify-between gap-3">
@@ -499,17 +526,6 @@ export function PerformanceLab({ status, settings, onUpdateSettings }: {
               >
                 {saveState === 'saved' ? 'Saved' : saveState === 'saving' ? 'Saving…' : 'Save to file'}
               </button>
-              <button
-                type="button"
-                onClick={revealFolder}
-                title="Open output folder"
-                aria-label="Open output folder"
-                className="p-1.5 border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
-                  <path d="M3.75 3A1.75 1.75 0 0 0 2 4.75v10.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-8.5A1.75 1.75 0 0 0 16.25 5h-6.19l-1.2-1.44A1.75 1.75 0 0 0 7.52 3H3.75Z" />
-                </svg>
-              </button>
             </div>
           </div>
 
@@ -523,26 +539,6 @@ export function PerformanceLab({ status, settings, onUpdateSettings }: {
             <p className="mt-1">{report.configuration?.executionPath ?? 'Full-buffer final transcription after recording stops'}; VAD threshold {report.configuration?.vadThreshold ?? 0.5}; {report.configuration?.transcriptTransformProfile ?? 'default local delivery pipeline'}.</p>
             {report.configuration && <p className="mt-1">Model run order: {report.configuration.modelRunOrder.join(' → ') || 'none'}. Shared-init order: {report.configuration.sharedInitOrder.join(' → ') || 'none'}.</p>}
             <p className="mt-1">{report.corpus?.limitation ?? 'Directional local comparison only; the synthetic corpus is not representative of natural speakers or recording environments.'}</p>
-          </div>
-
-          <div className="rounded-lg border border-outline-variant/30 bg-surface-container-low p-3 text-[11px] leading-relaxed text-on-surface-variant">
-            <p className="font-medium text-on-surface">Report export folder</p>
-            <p className="mt-1 break-all rounded-md border border-outline-variant/30 bg-surface-container-lowest px-2.5 py-1.5 text-on-surface">
-              {settings.benchmarkOutputDir || 'Documents/Murmur (default)'}
-            </p>
-            <div className="mt-2 flex gap-3">
-              <button type="button" onClick={() => void chooseFolder()} className="font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>
-              {settings.benchmarkOutputDir && <button type="button" onClick={() => onUpdateSettings({ benchmarkOutputDir: '' })} className="font-medium text-on-surface-variant underline hover:text-primary">Reset to default</button>}
-            </div>
-            <label className="mt-3 flex items-center gap-2 text-on-surface">
-              <input
-                type="checkbox"
-                checked={settings.benchmarkAutoSave}
-                onChange={() => onUpdateSettings({ benchmarkAutoSave: !settings.benchmarkAutoSave })}
-                className="h-3.5 w-3.5 accent-primary"
-              />
-              <span>Auto-save every run to this folder (survives the {MAX_SAVED_BENCHMARK_REPORTS}-run in-app limit)</span>
-            </label>
           </div>
 
           <div className="flex items-center gap-2">

--- a/app/src/components/settings/PerformanceLab.tsx
+++ b/app/src/components/settings/PerformanceLab.tsx
@@ -1,18 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
+import { open } from '@tauri-apps/plugin-dialog';
 import {
   BenchmarkModel,
   BenchmarkModelResult,
   BenchmarkPreset,
   BenchmarkProgress,
   BenchmarkReport,
+  MAX_SAVED_BENCHMARK_REPORTS,
   addBenchmarkReport,
   cancelBenchmark,
   clearBenchmarkReports,
   getBenchmarkActivity,
   getBenchmarkModels,
   loadBenchmarkReports,
+  openBenchmarkOutputFolder,
   runBenchmark,
+  saveBenchmarkReport,
   saveBenchmarkReports,
 } from '../../lib/benchmark';
 import { downloadModel } from '../../lib/dictation';
@@ -21,6 +25,7 @@ import {
   modelDownloadPercent,
   type ModelDownloadProgress,
 } from '../../lib/modelDownload';
+import type { Settings } from '../../lib/settings';
 import type { DictationStatus } from '../../lib/types';
 
 const PRESETS: { id: BenchmarkPreset; label: string; detail: string }[] = [
@@ -125,7 +130,11 @@ function AccuracyChart({ report }: { report: BenchmarkReport }) {
   );
 }
 
-export function PerformanceLab({ status }: { status: DictationStatus }) {
+export function PerformanceLab({ status, settings, onUpdateSettings }: {
+  status: DictationStatus;
+  settings: Settings;
+  onUpdateSettings: (updates: Partial<Settings>) => void;
+}) {
   const [models, setModels] = useState<BenchmarkModel[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
   const [preset, setPreset] = useState<BenchmarkPreset>('standard');
@@ -140,6 +149,7 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved'>('idle');
   const [downloading, setDownloading] = useState<string | null>(null);
   const [downloadProgress, setDownloadProgress] = useState<ModelDownloadProgress | null>(null);
   const [fileTranscribing, setFileTranscribing] = useState(false);
@@ -237,6 +247,14 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
         const reports = saveBenchmarkReports(addBenchmarkReport(current.reports, next));
         return { reports, selectedAt: next.createdAt };
       });
+      if (settings.benchmarkAutoSave) {
+        // Best-effort: a write failure must not fail the completed run.
+        try {
+          await saveBenchmarkReport(next, settings.benchmarkOutputDir);
+        } catch (reason) {
+          if (mounted.current) setError(`Could not auto-save report: ${String(reason)}`);
+        }
+      }
     } catch (reason) {
       if (mounted.current && String(reason) !== 'Benchmark cancelled') setError(String(reason));
     } finally {
@@ -278,6 +296,42 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
       window.setTimeout(() => setCopied(false), 1600);
     } catch (reason) {
       setError(`Could not copy report: ${String(reason)}`);
+    }
+  };
+
+  const saveReport = async () => {
+    if (!report) return;
+    setError(null);
+    setSaveState('saving');
+    try {
+      await saveBenchmarkReport(report, settings.benchmarkOutputDir);
+      if (!mounted.current) return;
+      setSaveState('saved');
+      window.setTimeout(() => {
+        if (mounted.current) setSaveState('idle');
+      }, 1600);
+    } catch (reason) {
+      if (mounted.current) {
+        setSaveState('idle');
+        setError(`Could not save report: ${String(reason)}`);
+      }
+    }
+  };
+
+  const revealFolder = async () => {
+    try {
+      await openBenchmarkOutputFolder(settings.benchmarkOutputDir);
+    } catch (reason) {
+      setError(`Could not open output folder: ${String(reason)}`);
+    }
+  };
+
+  const chooseFolder = async () => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (typeof selected === 'string') onUpdateSettings({ benchmarkOutputDir: selected });
+    } catch {
+      // Cancellation leaves the stored folder untouched.
     }
   };
 
@@ -429,13 +483,34 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
                 Shared init (one-time): {milliseconds(report.sharedInitMs)}
               </p>
             </div>
-            <button
-              type="button"
-              onClick={copyReport}
-              className="shrink-0 px-2.5 py-1.5 text-xs font-medium border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface dark:text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80"
-            >
-              {copied ? 'Copied' : 'Copy JSON'}
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={copyReport}
+                className="px-2.5 py-1.5 text-xs font-medium border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface dark:text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80"
+              >
+                {copied ? 'Copied' : 'Copy JSON'}
+              </button>
+              <button
+                type="button"
+                onClick={saveReport}
+                disabled={saveState === 'saving'}
+                className="px-2.5 py-1.5 text-xs font-medium border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface dark:text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80 disabled:opacity-50"
+              >
+                {saveState === 'saved' ? 'Saved' : saveState === 'saving' ? 'Saving…' : 'Save to file'}
+              </button>
+              <button
+                type="button"
+                onClick={revealFolder}
+                title="Open output folder"
+                aria-label="Open output folder"
+                className="p-1.5 border border-outline-variant/30 dark:border-outline-variant/30 rounded-md text-on-surface-variant hover:bg-surface-container-low dark:hover:bg-primary/80"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path d="M3.75 3A1.75 1.75 0 0 0 2 4.75v10.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-8.5A1.75 1.75 0 0 0 16.25 5h-6.19l-1.2-1.44A1.75 1.75 0 0 0 7.52 3H3.75Z" />
+                </svg>
+              </button>
+            </div>
           </div>
 
           <div className="rounded-lg border border-outline-variant/30 bg-surface-container-low p-3 text-[11px] leading-relaxed text-on-surface-variant">
@@ -448,6 +523,26 @@ export function PerformanceLab({ status }: { status: DictationStatus }) {
             <p className="mt-1">{report.configuration?.executionPath ?? 'Full-buffer final transcription after recording stops'}; VAD threshold {report.configuration?.vadThreshold ?? 0.5}; {report.configuration?.transcriptTransformProfile ?? 'default local delivery pipeline'}.</p>
             {report.configuration && <p className="mt-1">Model run order: {report.configuration.modelRunOrder.join(' → ') || 'none'}. Shared-init order: {report.configuration.sharedInitOrder.join(' → ') || 'none'}.</p>}
             <p className="mt-1">{report.corpus?.limitation ?? 'Directional local comparison only; the synthetic corpus is not representative of natural speakers or recording environments.'}</p>
+          </div>
+
+          <div className="rounded-lg border border-outline-variant/30 bg-surface-container-low p-3 text-[11px] leading-relaxed text-on-surface-variant">
+            <p className="font-medium text-on-surface">Report export folder</p>
+            <p className="mt-1 break-all rounded-md border border-outline-variant/30 bg-surface-container-lowest px-2.5 py-1.5 text-on-surface">
+              {settings.benchmarkOutputDir || 'Documents/Murmur (default)'}
+            </p>
+            <div className="mt-2 flex gap-3">
+              <button type="button" onClick={() => void chooseFolder()} className="font-medium text-on-surface-variant underline hover:text-primary">Choose Folder</button>
+              {settings.benchmarkOutputDir && <button type="button" onClick={() => onUpdateSettings({ benchmarkOutputDir: '' })} className="font-medium text-on-surface-variant underline hover:text-primary">Reset to default</button>}
+            </div>
+            <label className="mt-3 flex items-center gap-2 text-on-surface">
+              <input
+                type="checkbox"
+                checked={settings.benchmarkAutoSave}
+                onChange={() => onUpdateSettings({ benchmarkAutoSave: !settings.benchmarkAutoSave })}
+                className="h-3.5 w-3.5 accent-primary"
+              />
+              <span>Auto-save every run to this folder (survives the {MAX_SAVED_BENCHMARK_REPORTS}-run in-app limit)</span>
+            </label>
           </div>
 
           <div className="flex items-center gap-2">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -469,7 +469,7 @@ export function SettingsPanel({
           </SettingsSection>
 
           <SettingsSection pageId="performance" activePage={activeCat} title="Performance" subtitle="Directional local model comparisons">
-            <PerformanceLab status={status} />
+            <PerformanceLab status={status} settings={settings} onUpdateSettings={onUpdateSettings} />
           </SettingsSection>
 
           <SettingsSection pageId="general" activePage={activeCat} title="General" subtitle="Startup, support, updates, and app information">

--- a/app/src/lib/benchmark.test.ts
+++ b/app/src/lib/benchmark.test.ts
@@ -3,6 +3,7 @@ import {
   BenchmarkReport,
   MAX_SAVED_BENCHMARK_REPORTS,
   addBenchmarkReport,
+  benchmarkReportFileName,
   clearBenchmarkReports,
   loadBenchmarkReports,
   saveBenchmarkReports,
@@ -64,6 +65,18 @@ describe('addBenchmarkReport', () => {
     expect(result).toHaveLength(MAX_SAVED_BENCHMARK_REPORTS);
     expect(result[0]).toBe(newest);
     expect(result).not.toContain(existing[0]);
+  });
+});
+
+describe('benchmarkReportFileName', () => {
+  it('uses the chip label and sanitizes the timestamp for versioned reports', () => {
+    const name = benchmarkReportFileName(versionedReport('2026-07-20T14:30:00.000Z'));
+    expect(name).toBe('benchmark-0-16-0-Apple-M2-2026-07-20T14-30-00-000Z.json');
+  });
+
+  it('falls back to the platform for legacy reports without environment', () => {
+    expect(benchmarkReportFileName(report('2026-07-16T09:00:00Z')))
+      .toBe('benchmark-0-16-0-macos-aarch64-2026-07-16T09-00-00Z.json');
   });
 });
 

--- a/app/src/lib/benchmark.ts
+++ b/app/src/lib/benchmark.ts
@@ -312,6 +312,44 @@ export function getBenchmarkActivity(): Promise<BenchmarkActivity> {
   return invoke('get_benchmark_activity');
 }
 
+/** Reduce a report field to a filesystem-safe filename segment. */
+function sanitizeNameSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown';
+}
+
+/**
+ * Build a self-identifying report filename:
+ * `benchmark-<appVersion>-<machine-or-platform>-<createdAt>.json`. The machine
+ * label prefers the chip, then the hardware model, then the platform, so files
+ * from different machines (#303 cross-machine comparison) sort and self-identify.
+ */
+export function benchmarkReportFileName(report: BenchmarkReport): string {
+  const version = sanitizeNameSegment(report.appVersion);
+  const machine = sanitizeNameSegment(
+    report.environment?.chip ?? report.environment?.hardwareModel ?? report.platform,
+  );
+  // ISO timestamps contain `:` and `.`, which are unsafe or awkward in filenames.
+  const stamp = report.createdAt.replace(/[:.]/g, '-');
+  return `benchmark-${version}-${machine}-${stamp}.json`;
+}
+
+/**
+ * Write the full report JSON to `outputDir` (empty → `Documents/Murmur`) under
+ * the {@link benchmarkReportFileName} name. Returns the absolute path written.
+ */
+export function saveBenchmarkReport(report: BenchmarkReport, outputDir: string): Promise<string> {
+  return invoke('save_benchmark_report', {
+    reportJson: JSON.stringify(report, null, 2),
+    outputDir,
+    fileName: benchmarkReportFileName(report),
+  });
+}
+
+/** Open the benchmark output folder in the system file manager. */
+export function openBenchmarkOutputFolder(outputDir: string): Promise<void> {
+  return invoke('open_benchmark_output_folder', { outputDir });
+}
+
 export function runBenchmark(modelNames: string[], preset: BenchmarkPreset): Promise<BenchmarkReport> {
   return invoke('run_benchmark', { request: { modelNames, preset } });
 }

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -203,6 +203,13 @@ export interface Settings {
   saveTranscript: boolean;
   saveAudio: boolean;
   outputDir: string;
+  /** Destination for saved Performance Lab benchmark reports. Empty = default
+   * `Documents/Murmur`. Kept separate from `outputDir` so benchmark JSON doesn't
+   * mix with saved dictation transcripts/audio. */
+  benchmarkOutputDir: string;
+  /** Write each benchmark report to `benchmarkOutputDir` automatically as it
+   * completes, so reports survive the 10-slot localStorage cap. */
+  benchmarkAutoSave: boolean;
   appProfiles: AppProfile[];
   voiceCommandsEnabled: boolean;
   /** User-defined voice commands applied after the built-in set. */
@@ -339,6 +346,8 @@ export const DEFAULT_SETTINGS: Settings = {
   saveTranscript: false,
   saveAudio: false,
   outputDir: '',
+  benchmarkOutputDir: '',
+  benchmarkAutoSave: false,
   appProfiles: [],
   voiceCommandsEnabled: false,
   voiceCommands: [],
@@ -459,6 +468,14 @@ export function loadSettings(): Settings {
       // non-string back to the default (empty = app-chosen Documents/Murmur).
       if (typeof parsed.outputDir !== 'string') {
         parsed.outputDir = DEFAULT_SETTINGS.outputDir;
+      }
+
+      // benchmarkOutputDir also feeds a filesystem path on the Rust side.
+      if (typeof parsed.benchmarkOutputDir !== 'string') {
+        parsed.benchmarkOutputDir = DEFAULT_SETTINGS.benchmarkOutputDir;
+      }
+      if (typeof parsed.benchmarkAutoSave !== 'boolean') {
+        parsed.benchmarkAutoSave = DEFAULT_SETTINGS.benchmarkAutoSave;
       }
 
       parsed.vocabularyEntries = sanitizeVocabularyEntries(

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -102,6 +102,8 @@ model-selection side effects.
 | `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a sequentially numbered `.txt` (`murmur-0001`, `murmur-0002`, …) in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |
 | `outputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved transcript/audio files. Empty means the app default (`Documents/Murmur`, created on first write). Set via a folder picker (`dialog:allow-open`). |
+| `benchmarkOutputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved Performance Lab benchmark reports (`benchmark-<version>-<machine>-<createdAt>.json`). Empty means the app default (`Documents/Murmur`, created on first write). Kept separate from `outputDir` so benchmark JSON doesn't mix with dictation transcripts/audio. Set via a folder picker in the Performance Lab. |
+| `benchmarkAutoSave` | `boolean` | `false` | `true` / `false` | When enabled, each completed benchmark run is written to `benchmarkOutputDir` automatically (in addition to the 10-slot in-app history), so reports survive the localStorage cap. Best-effort: a write failure surfaces an error but does not fail the run. |
 
 ## Vocabulary Settings
 
@@ -181,6 +183,8 @@ When settings change, `useSettings.updateSettings` pushes the following fields t
 | `hotkeyMissFeedback` | _(controls overlay rejection feedback)_ | Frontend only |
 | `microphone` | _(sent as param to `start_native_recording`)_ | Per recording |
 | `launchAtLogin` | _(sent via autostart plugin)_ | Via OS API |
+| `benchmarkOutputDir` | _(sent as param to `save_benchmark_report` / `open_benchmark_output_folder`)_ | On save/reveal |
+| `benchmarkAutoSave` | _(read in the Performance Lab; drives auto-save after each run)_ | Frontend only |
 
 **Optimistic updates with rollback:** If `configure_dictation` fails, the affected settings (model, language, autoPaste, autoPasteDelayMs, vadSensitivity) revert to their previous values. Similarly, if the autostart toggle fails, `launchAtLogin` reverts. A versioned configure ref prevents stale rollbacks from overwriting newer settings.
 


### PR DESCRIPTION
Closes #308

## What

Benchmark reports lived only in the web-view's `localStorage` (capped at 10 via `MAX_SAVED_BENCHMARK_REPORTS`), with no clean way to move a run between machines — extracting one meant decoding the WebKit localStorage SQLite blob by hand. #303 added environment/corpus metadata to make runs comparable across machines, but there was no export path.

This adds a full export story to the Performance Lab, per saved report:

- **Copy JSON** — already existed (`copyReport`), copies the full `BenchmarkReport`.
- **Save to file** — writes the full report JSON to a configurable folder under a self-identifying `benchmark-<appVersion>-<machine-or-platform>-<createdAt>.json` name so cross-machine files sort and self-identify.
- **Reveal folder** — opens the output folder in Finder via the `opener` plugin (called from Rust, so no capability change needed).
- **Configurable folder** — new `benchmarkOutputDir` setting (default `Documents/Murmur`), kept separate from the dictation `outputDir` so benchmark JSON doesn't mix with saved transcripts/audio. Folder picker + reset live in the Lab.
- **Auto-save every run** — optional `benchmarkAutoSave` toggle writes each completed run to disk (best-effort; a write failure surfaces an error but never fails the run), so reports survive the 10-slot cap.

All local, no network anywhere: save is `std::fs::write`; reveal uses the local opener plugin.

## Acceptance criteria
- [x] Copy button copies the full report JSON
- [x] Save-to-file writes JSON to the configured folder (default `Documents/Murmur`)
- [x] Output folder is user-configurable, persisted in settings (`benchmarkOutputDir`)
- [x] Reveal-in-Finder affordance opens the folder
- [x] Filenames encode version, platform/machine, and timestamp
- [x] No network access anywhere in the flow

## Changes
- **Rust** — `file_output::write_benchmark_report` (reuses `resolve_output_dir`, sanitizes the file name to a bare component, forces `.json`); commands `save_benchmark_report` + `open_benchmark_output_folder`.
- **Frontend** — `benchmarkReportFileName` / `saveBenchmarkReport` / `openBenchmarkOutputFolder` in `benchmark.ts`; two new settings + coercion; Performance Lab Save/reveal buttons, folder picker + reset, and auto-save toggle.
- **Docs** — CHANGELOG + `docs/reference/settings.md`.

## Verification
- `npx tsc --noEmit` clean; full vitest suite 196 passed (incl. new `benchmarkReportFileName` cases).
- macbook lane: `cargo check` warnings-clean; `cargo test --lib -- --test-threads=1` 428 passed (incl. 3 new `file_output` tests covering write, path-traversal containment, and `.json` suffix).
- UI layout mirrors the existing `outputDir` picker; not screenshotted here (no Tauri runtime on the Linux session box — the app runs on the macbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Performance Lab report export as full JSON files with descriptive filenames.
  * Added “Copy JSON,” “Save to file,” and “Open output folder” controls.
  * Added configurable export folder selection with a default Documents/Murmur location.
  * Added optional automatic saving of completed benchmark reports.
* **Documentation**
  * Documented the new benchmark export and auto-save settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->