### PR TITLE
fix(overlay): keep the quick-settings card reachable while Murmur is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - **Local dictation evaluation harness** adds strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports through `murmur-eval` (#267).
 
+### Fixed
+- Disabling Murmur from the overlay no longer traps it disabled: the hover quick-settings card — which holds the "Enable Murmur" power button — now stays reachable while disabled, so the overlay's own control can turn Murmur back on. Previously the global-disable state gated off the overlay's hover-expand, leaving the tray "Disable Murmur" check item as the only way back.
+
 ## [0.19.0] - 2026-07-20
 
 ### Added

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -39,7 +39,7 @@ export function OverlayWidget() {
   // dwell/collapse/shrink timers, the serialized set_overlay_expanded writer, and
   // the single cursor poller. It is the only writer to the native resize path.
   const { phase, expanded, expandedRef, islandRef, onHoverStart, onHoverEnd } =
-    useOverlayExpansion({ disabled: runtime.disabled });
+    useOverlayExpansion();
 
   const waveform = useWaveform(status);
 

--- a/app/src/lib/hooks/useOverlayExpansion.test.tsx
+++ b/app/src/lib/hooks/useOverlayExpansion.test.tsx
@@ -47,19 +47,11 @@ describe('useOverlayExpansion', () => {
   let root: Root | null = null;
   let current: OverlayExpansion;
   let surfaceCalls: SurfaceCall[];
-  let lastProps: { disabled?: boolean; withIsland?: boolean } = {};
   const listeners = new Map<string, (e: { payload: unknown }) => void>();
 
-  function Harness(props: { disabled?: boolean; withIsland?: boolean }) {
-    current = useOverlayExpansion({
-      disabled: props.disabled ?? false,
-    });
+  function Harness(props: { withIsland?: boolean }) {
+    current = useOverlayExpansion();
     return props.withIsland ? <div ref={current.islandRef} /> : null;
-  }
-
-  async function rerender(props: { disabled?: boolean; withIsland?: boolean }) {
-    lastProps = { ...lastProps, ...props };
-    await act(async () => { root!.render(<Harness {...lastProps} />); });
   }
 
   function emitEvent(event: string, payload: unknown) {
@@ -74,12 +66,11 @@ describe('useOverlayExpansion', () => {
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
   }
 
-  async function mount(props: { disabled?: boolean; withIsland?: boolean } = {}) {
+  async function mount(props: { withIsland?: boolean } = {}) {
     // mount owns the root's whole lifecycle so beforeEach never leaks an empty
     // container. A prior mount (a test that re-mounts) is torn down first.
     if (root) { await act(async () => { root!.unmount(); }); }
     if (container) { container.remove(); }
-    lastProps = props;
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -122,7 +113,6 @@ describe('useOverlayExpansion', () => {
 
     root = null;
     container = null;
-    lastProps = {};
   });
 
   afterEach(async () => {
@@ -377,20 +367,9 @@ describe('useOverlayExpansion', () => {
     expect(surfaceCallCount()).toBe(before);
   });
 
-  it('poller performs no IPC while the overlay is hidden or the app is disabled (collapsed)', async () => {
-    // Disabled while collapsed → the entry detector is gated for battery.
-    await mount({ withIsland: true, disabled: true });
-    mocks.cursorPosition.mockClear();
-    mocks.outerPosition.mockClear();
-    const surfacesBefore = surfaceCallCount();
-    await act(async () => { vi.advanceTimersByTime(HOVER_OPEN_DWELL_MS * 4); });
-    await flush();
-    expect(mocks.cursorPosition).not.toHaveBeenCalled();
-    expect(mocks.outerPosition).not.toHaveBeenCalled();
-    expect(surfaceCallCount()).toBe(surfacesBefore);
-
-    // Enabled but hidden → still fully gated regardless of phase.
-    await rerender({ disabled: false });
+  it('poller performs no IPC while the overlay is hidden', async () => {
+    // Hidden → fully gated regardless of phase.
+    await mount({ withIsland: true });
     await act(async () => { emitEvent('overlay-visible-changed', false); });
     mocks.cursorPosition.mockClear();
     mocks.outerPosition.mockClear();
@@ -399,20 +378,28 @@ describe('useOverlayExpansion', () => {
     expect(mocks.cursorPosition).not.toHaveBeenCalled();
     expect(mocks.outerPosition).not.toHaveBeenCalled();
 
-    // Prove the gate is what stops it: visible + enabled → the poller does IPC.
+    // Prove visibility is what stops it: visible → the poller does IPC.
     await act(async () => { emitEvent('overlay-visible-changed', true); });
     await act(async () => { vi.advanceTimersByTime(HOVER_OPEN_DWELL_MS); });
     await flush();
     expect(mocks.cursorPosition).toHaveBeenCalled();
   });
 
-  it('blocks DOM hover entry while disabled as well as poller entry', async () => {
-    await mount({ disabled: true });
+  it('opens the dropdown on hover while disabled so the Enable control stays reachable', async () => {
+    // Global-disable must not gate the overlay expansion: the hover quick-settings
+    // card holds the "Enable Murmur" power button, so disabling Murmur must never
+    // remove its own re-enable affordance. (`disabled` is a global-disable state
+    // this hook no longer consumes — it drives Rust gating + visual dimming only.)
+    await mount({ withIsland: true });
     await act(async () => { current.onHoverStart(); });
-    await act(async () => { vi.advanceTimersByTime(HOVER_OPEN_DWELL_MS * 2); });
+    await act(async () => { vi.advanceTimersByTime(HOVER_OPEN_DWELL_MS); });
     await flush();
-    expect(current.phase).toBe('collapsed');
-    expect(surfaceCallCount()).toBe(0);
+    // Grow requested; resolve the surface ack to reveal the card.
+    const grow = surfaceCalls.find((c) => c.args.expanded);
+    expect(grow).toBeTruthy();
+    await act(async () => { grow!.resolve(APPLIED); });
+    await flush();
+    expect(current.phase).toBe('open');
   });
 
   it('drops a cursor result that resolves after the overlay becomes hidden', async () => {
@@ -439,11 +426,11 @@ describe('useOverlayExpansion', () => {
     expect(surfaceCalls.some((c) => c.args.expanded)).toBe(false);
   });
 
-  it('keeps the exit watchdog alive while open even when the app is disabled', async () => {
+  it('runs the exit watchdog while open to close the card after a missed mouseleave', async () => {
     // Cursor inside the (zero-sized jsdom) island bounds so the poller never
     // closes the card while we drive it open.
     mocks.cursorPosition.mockResolvedValue({ x: 0, y: 0 });
-    await mount({ withIsland: true, disabled: false });
+    await mount({ withIsland: true });
 
     // Open fully.
     await act(async () => { current.onHoverStart(); });
@@ -453,12 +440,9 @@ describe('useOverlayExpansion', () => {
     await flush();
     expect(current.phase).toBe('open');
 
-    // Disable the app while the dropdown is open (user clicks the Disable control),
-    // then a DOM mouseleave is missed and the cursor moves outside the card.
-    await rerender({ disabled: true });
+    // A DOM mouseleave is missed and the cursor moves outside the card — the poller
+    // is the safety net that must still detect the exit and collapse the card.
     mocks.cursorPosition.mockResolvedValue({ x: 9999, y: 9999 });
-
-    // The exit watchdog must still run and collapse the card despite `disabled`.
     await act(async () => { vi.advanceTimersByTime(HOVER_OPEN_DWELL_MS); });
     await flush();
     await act(async () => { vi.advanceTimersByTime(1); }); // fire the immediate close timer

--- a/app/src/lib/hooks/useOverlayExpansion.ts
+++ b/app/src/lib/hooks/useOverlayExpansion.ts
@@ -58,11 +58,6 @@ function withSurfaceAckTimeout<T>(request: Promise<T>): Promise<T> {
   });
 }
 
-interface UseOverlayExpansionArgs {
-  /** Global-disable state — the cursor poller is gated off while disabled. */
-  disabled: boolean;
-}
-
 export interface OverlayExpansion {
   /** Current lifecycle phase. Drives re-renders. */
   phase: OverlayPhase;
@@ -86,7 +81,7 @@ export interface OverlayExpansion {
 // distinguish "the newer request won" from a real applied frame.
 const SUPERSEDED = Symbol('overlay-surface-superseded');
 
-export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): OverlayExpansion {
+export function useOverlayExpansion(): OverlayExpansion {
   const [phase, setPhase] = useState<OverlayPhase>('collapsed');
 
   const phaseRef = useRef<OverlayPhase>('collapsed');
@@ -105,13 +100,10 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
   const desiredRef = useRef(false);
 
   // Inputs mirrored into refs for the always-on poller / async callbacks.
-  const disabledRef = useRef(disabled);
   const visibleRef = useRef(true); // default visible on mount, matches show_overlay ordering
   const reducedMotionRef = useRef(prefersReducedMotion());
   const interactionGenerationRef = useRef(0);
   const pollInFlightRef = useRef(false);
-
-  useEffect(() => { disabledRef.current = disabled; }, [disabled]);
 
   const setPhaseSync = useCallback((next: OverlayPhase) => {
     phaseRef.current = next;
@@ -212,7 +204,7 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
 
   // Grow the window first, then reveal the card once the resize is acknowledged.
   const open = useCallback(() => {
-    if (!visibleRef.current || disabledRef.current) return;
+    if (!visibleRef.current) return;
     const ph = phaseRef.current;
     if (ph === 'opening' || ph === 'open') return;
     clearCloseTimers();
@@ -248,7 +240,7 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
   // so grazing the notch no longer pops the dropdown. Also cancels any pending
   // close/shrink so re-entry keeps the card up (or reopens cleanly while closing).
   const onHoverStart = useCallback(() => {
-    if (!visibleRef.current || disabledRef.current) return;
+    if (!visibleRef.current) return;
     if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
     if (shrinkTimerRef.current) { clearTimeout(shrinkTimerRef.current); shrinkTimerRef.current = null; }
     const ph = phaseRef.current;
@@ -333,7 +325,9 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
   // The overlay is non-activating and sits above the menu bar, so macOS can miss
   // DOM hover events. One interval branches on phase: strict entry bounds + dwell
   // while collapsed/closing, padded exit bounds while open. Ticks do no IPC while
-  // the overlay is hidden, and skip the collapsed entry detector while disabled.
+  // the overlay is hidden. The poller runs regardless of global-disable so the
+  // hover quick-settings card — which holds the "Enable Murmur" control — stays
+  // reachable; disabling Murmur must never remove its own re-enable affordance.
   useEffect(() => {
     const currentWindow = getCurrentWindow();
     const intervalId = setInterval(async () => {
@@ -341,11 +335,6 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
       if (!visibleRef.current) return; // hidden: no IPC
       const ph = phaseRef.current;
       const pollGeneration = interactionGenerationRef.current;
-      // Disabled gates ONLY the collapsed entry detector (battery). The exit
-      // watchdog must stay alive during an active interaction: with the dropdown
-      // open, a missed DOM mouseleave — the exact failure this poller exists for —
-      // would otherwise leave the card stuck open after the user clicks Disable.
-      if (disabledRef.current && ph === 'collapsed') return;
       const island = islandRef.current;
       if (!island) return;
       if (ph === 'opening') return; // transient; nothing to poll
@@ -359,8 +348,7 @@ export function useOverlayExpansion({ disabled }: UseOverlayExpansionArgs): Over
         if (!mountedRef.current
           || !visibleRef.current
           || interactionGenerationRef.current !== pollGeneration
-          || phaseRef.current !== ph
-          || (disabledRef.current && ph === 'collapsed')) return;
+          || phaseRef.current !== ph) return;
         const scale = window.devicePixelRatio || 1;
         const rect = island.getBoundingClientRect();
 


### PR DESCRIPTION
## The bug

The overlay's power button toggles global-disable. But that same button lives **inside** the hover quick-settings card, and disabling Murmur gated off the overlay's hover-expand — so once disabled, the card no longer opened on hover and the **"Enable Murmur"** control became unreachable *from the overlay*. The only way back was the tray **"Disable Murmur"** check item, which is non-obvious. In effect, the overlay's disable button removed its own re-enable affordance.

(Aside on "it disabled on all my builds": the disabled state persists in settings localStorage, and every build shares the bundle id `com.localdictation` → one WebKit origin → the flag is shared across builds on one machine. That's a dev-only artifact — real users only run the production build — and is not addressed here.)

## The fix

`useOverlayExpansion` no longer consumes `disabled`. The hover-expand (`open` / `onHoverStart` / the collapsed-entry poll) previously early-returned while disabled; those gates are removed so the card opens on hover regardless of global-disable, keeping the "Enable Murmur" button reachable.

`disabled` still drives Rust recording gating (`useRecordingControls`) and the overlay's visual dimming (`deriveVisual`) — only the self-defeating expansion gate is dropped. The exit-watchdog behavior (poller closes a card left open by a missed `mouseleave`) never depended on `disabled` and is unchanged. The lost battery micro-optimization (skipping the cursor poll while disabled+idle) isn't worth stranding the user's only re-enable path.

## Verification
- `npx tsc --noEmit` clean; full vitest suite **194 passed**, including the updated `useOverlayExpansion` tests:
  - new: the dropdown opens on hover while disabled (Enable stays reachable);
  - retained: the exit watchdog still closes the card after a missed mouseleave;
  - the poller-gating test now asserts only the visibility gate.
- Frontend-only change (no Rust touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)