### PR TITLE
feat(overlay): dev-only neon notch calibration band

### DIFF
--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -14,6 +14,7 @@ pub struct OverlayGeometry {
     pub pill_margin_idle: f64,
     pub pill_margin_active: f64,
     pub dropdown_h: f64,
+    pub wing_w: f64,
 }
 
 /// The window frame `set_overlay_expanded` actually applied. Returned so the
@@ -58,6 +59,7 @@ fn geometry_for(notch: Option<(f64, f64)>) -> OverlayGeometry {
         pill_margin_idle: 0.0,
         pill_margin_active: 0.0,
         dropdown_h: DROPDOWN_H,
+        wing_w: WING,
     }
 }
 
@@ -333,6 +335,8 @@ mod tests {
             assert!(g.window_w >= g.pill_idle_w + g.pill_margin_idle);
             assert_eq!(g.expanded_h, g.collapsed_h + g.dropdown_h);
             assert!(g.pill_active_w >= g.pill_idle_w);
+            assert!(g.wing_w > 0.0);
+            assert!(g.window_w >= 2.0 * g.wing_w);
         }
     }
 
@@ -349,8 +353,9 @@ mod tests {
                 g.pill_margin_idle,
                 g.pill_margin_active,
                 g.dropdown_h,
+                g.wing_w,
             ),
-            (257.0, 32.0, 76.0, 257.0, 257.0, 0.0, 0.0, 44.0)
+            (257.0, 32.0, 76.0, 257.0, 257.0, 0.0, 0.0, 44.0, 36.0)
         );
     }
 

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -13,6 +13,7 @@ import { OVERLAY_ISLAND_TRANSITION } from '../lib/overlayMotion';
 import { deriveVisual } from './overlay/deriveVisual';
 import { OverlayPill } from './overlay/OverlayPill';
 import { OverlayDropdown } from './overlay/OverlayDropdown';
+import { NotchCalibrationBand } from './overlay/NotchCalibrationBand';
 
 export function OverlayWidget() {
   const geometry = useOverlayGeometry();
@@ -116,6 +117,7 @@ export function OverlayWidget() {
         onMouseMove={onHoverStart}
         onMouseLeave={onHoverEnd}
         style={{
+          position: 'relative',
           borderRadius: '0 0 12px 12px',
           // One constant island width in every state — the island IS the window.
           // Only height animates (see OVERLAY_ISLAND_TRANSITION).
@@ -135,6 +137,7 @@ export function OverlayWidget() {
           status={status}
           barRefs={waveform.barRefs}
         />
+        <NotchCalibrationBand geometry={geometry} />
         <OverlayDropdown
           geometry={geometry}
           expanded={expanded}

--- a/app/src/components/overlay/NotchCalibrationBand.tsx
+++ b/app/src/components/overlay/NotchCalibrationBand.tsx
@@ -1,0 +1,41 @@
+import type { OverlayGeometry } from '../../lib/overlayGeometry';
+
+interface NotchCalibrationBandProps {
+  geometry: OverlayGeometry;
+}
+
+/**
+ * Dev-build-only visual aid: draws a translucent neon-magenta band over the
+ * exact zone the overlay believes the physical notch occupies — the island's
+ * center section between the two wings, full notch height (0 to
+ * `geometry.collapsedH`). On real notched hardware this band must render
+ * fully hidden behind the physical notch; any visible magenta means the
+ * geometry or window positioning is wrong.
+ *
+ * Gated by `import.meta.env.DEV`, the same mechanism the main window's "Dev"
+ * banner uses (see App.tsx). That flag is only true under the Vite dev
+ * server (`npm run tauri dev`) — it is false in a bundled debug .app, since
+ * `vite build` (which produces the bundled frontend for every Tauri build,
+ * debug or release) always sets it to false. The band therefore shows only
+ * during `tauri dev`, matching the existing dev banner's behavior exactly.
+ */
+export function NotchCalibrationBand({ geometry }: NotchCalibrationBandProps) {
+  if (!import.meta.env.DEV) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        left: geometry.wingW,
+        right: geometry.wingW,
+        top: 0,
+        height: geometry.collapsedH,
+        background: 'rgba(255, 0, 200, 0.5)',
+        outline: '1px solid rgba(255, 0, 200, 0.9)',
+        pointerEvents: 'none',
+        zIndex: 10,
+      }}
+    />
+  );
+}

--- a/app/src/components/overlay/overlay-geometry.fixture.json
+++ b/app/src/components/overlay/overlay-geometry.fixture.json
@@ -1,4 +1,4 @@
 {
-  "notched":  { "windowW":257,"collapsedH":32,"expandedH":76,"pillIdleW":257,"pillActiveW":257,"pillMarginIdle":0,"pillMarginActive":0,"dropdownH":44 },
-  "fallback": { "windowW":152,"collapsedH":37,"expandedH":81,"pillIdleW":152,"pillActiveW":152,"pillMarginIdle":0,"pillMarginActive":0,"dropdownH":44 }
+  "notched":  { "windowW":257,"collapsedH":32,"expandedH":76,"pillIdleW":257,"pillActiveW":257,"pillMarginIdle":0,"pillMarginActive":0,"dropdownH":44,"wingW":36 },
+  "fallback": { "windowW":152,"collapsedH":37,"expandedH":81,"pillIdleW":152,"pillActiveW":152,"pillMarginIdle":0,"pillMarginActive":0,"dropdownH":44,"wingW":36 }
 }

--- a/app/src/components/overlay/overlayGeometry.test.ts
+++ b/app/src/components/overlay/overlayGeometry.test.ts
@@ -19,6 +19,8 @@ describe('overlay geometry contract fixture', () => {
     expect(g.windowW).toBeGreaterThanOrEqual(g.pillIdleW + g.pillMarginIdle);
     expect(g.expandedH).toBe(g.collapsedH + g.dropdownH);
     expect(g.pillActiveW).toBeGreaterThanOrEqual(g.pillIdleW);
+    expect(g.wingW).toBeGreaterThan(0);
+    expect(g.windowW).toBeGreaterThanOrEqual(2 * g.wingW);
   });
 
   it('locks the characterization values', () => {
@@ -26,13 +28,13 @@ describe('overlay geometry contract fixture', () => {
       windowW: 257, collapsedH: 32, expandedH: 76,
       pillIdleW: 257, pillActiveW: 257,
       pillMarginIdle: 0, pillMarginActive: 0,
-      dropdownH: 44,
+      dropdownH: 44, wingW: 36,
     });
     expect(fixture.fallback).toEqual({
       windowW: 152, collapsedH: 37, expandedH: 81,
       pillIdleW: 152, pillActiveW: 152,
       pillMarginIdle: 0, pillMarginActive: 0,
-      dropdownH: 44,
+      dropdownH: 44, wingW: 36,
     });
   });
 

--- a/app/src/lib/hooks/useOverlayGeometry.test.tsx
+++ b/app/src/lib/hooks/useOverlayGeometry.test.tsx
@@ -33,6 +33,7 @@ const notched: OverlayGeometry = {
   pillMarginIdle: 0,
   pillMarginActive: 0,
   dropdownH: 44,
+  wingW: 36,
 };
 
 const fallback: OverlayGeometry = {
@@ -44,6 +45,7 @@ const fallback: OverlayGeometry = {
   pillMarginIdle: 0,
   pillMarginActive: 0,
   dropdownH: 44,
+  wingW: 36,
 };
 
 function deferred<T>() {

--- a/app/src/lib/overlayGeometry.ts
+++ b/app/src/lib/overlayGeometry.ts
@@ -2,11 +2,11 @@ export interface OverlayGeometry {
   windowW: number; collapsedH: number; expandedH: number;
   pillIdleW: number; pillActiveW: number;
   pillMarginIdle: number; pillMarginActive: number;
-  dropdownH: number;
+  dropdownH: number; wingW: number;
 }
 
 const KEYS = ['windowW', 'collapsedH', 'expandedH', 'pillIdleW', 'pillActiveW',
-  'pillMarginIdle', 'pillMarginActive', 'dropdownH'] as const;
+  'pillMarginIdle', 'pillMarginActive', 'dropdownH', 'wingW'] as const;
 
 export function isOverlayGeometry(v: unknown): v is OverlayGeometry {
   if (typeof v !== 'object' || v === null) return false;


### PR DESCRIPTION
## Summary

Adds a translucent neon-magenta band drawn over the exact zone the overlay believes the physical notch occupies (the island's center section between the two wings, full notch height). Purpose: on notched hardware the band must be fully hidden behind the physical notch — any visible magenta means overlay geometry or window positioning is wrong. Shown only in dev builds.

- **`wingW` contract addition**: `geometry_for()` in `app/src-tauri/src/commands/overlay.rs` now returns a `wingW` field (the existing `WING = 36.0` const, for both the notched and fallback cases) since the band needs the wing width and no existing field in the 8-field `OverlayGeometry` contract exposed it. Updated the contract on all three sides:
  - Rust: `characterization` test tuple/expected values, and a new `invariants` assertion (`wing_w > 0`, `window_w >= 2 * wing_w`).
  - `app/src/components/overlay/overlay-geometry.fixture.json` — added `wingW: 36` to both fixtures.
  - `app/src/lib/overlayGeometry.ts` (TS type + `isOverlayGeometry` key list) and `overlayGeometry.test.ts` (characterization + invariant checks).
  - Also updated the two hand-built `OverlayGeometry` mocks in `useOverlayGeometry.test.tsx` to include `wingW` (required now that the interface has 9 fields).
- **Dev-gating mechanism**: the existing "Dev" banner in `App.tsx` (the main window) is gated on `import.meta.env.DEV`. That's the only dev-build indicator found in the frontend — there's no Rust-side flag exposed to the frontend for `debug_assertions` (that constant is used server-side only, e.g. in `telemetry.rs` for log file naming). `import.meta.env.DEV` is set by Vite and is true only under the Vite dev server (`npm run tauri dev`); it is false in any bundled app, including a debug-signed `.app`, since `vite build` always runs to produce the frontend bundle regardless of the Rust build profile. The new band uses the exact same `import.meta.env.DEV` check, so it shows under the same conditions as the existing Dev banner — dev server only, not in a bundled debug build.
- **New component**: `app/src/components/overlay/NotchCalibrationBand.tsx` — absolutely positioned (`left`/`right: geometry.wingW`, `top: 0`, `height: geometry.collapsedH`), `rgba(255,0,200,0.5)` fill with a `1px solid rgba(255,0,200,0.9)` outline, `pointer-events: none`, rendered above `OverlayPill` inside the island in `OverlayWidget.tsx` (which now has `position: relative` on the island div to anchor it).

## Test plan
- [x] `cd app/src-tauri && cargo test -- --test-threads=1` — 428 passed, 0 failed (5 ignored)
- [x] `cd app && npx tsc --noEmit` — clean
- [x] `cd app && npm test` — 28 files, 196 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)