### PR TITLE
feat: sidecar release-pipeline signing and CI rehearsal (#312 Phase A3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,17 @@ jobs:
         with:
           workspaces: app/src-tauri
 
+      - name: Stub sidecar externalBin for compile checks
+        # tauri.macos.conf.json declares the local-LLM helper as an externalBin,
+        # and Tauri's build script requires the file to exist even for cargo
+        # check/test. This job never bundles or ships anything - the release
+        # pipeline builds and signs the real helper - so an empty stub satisfies
+        # the resource check without spending ~10 min compiling llama.cpp here.
+        run: |
+          mkdir -p app/src-tauri/binaries
+          : > app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin
+          chmod +x app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin
+
       - name: Compile check
         env:
           MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -126,24 +126,96 @@ jobs:
           fi
           echo "RUSTFLAGS=-C link-arg=$CLANG_RT -C link-arg=-mmacosx-version-min=14.0 -C link-arg=-Wl,-rpath,/usr/lib/swift" >> "$GITHUB_ENV"
 
-      - name: Build, sign, and notarize
-        uses: tauri-apps/tauri-action@v0
+      - name: Build local-LLM sidecar
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MACOSX_DEPLOYMENT_TARGET: "14.0"
           CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
           CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+        run: |
+          # RUSTFLAGS (libclang_rt for ggml-metal symbols) is already exported by
+          # the previous step; the sidecar links the same Metal ggml backend and
+          # needs it too. The script places the arm64 binary at the target-triple
+          # path Tauri's macOS externalBin overlay expects.
+          python3 scripts/build_local_llm_sidecar.py --release
+
+      - name: Import Developer ID certificate
+        env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/murmur-signing.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          CERT="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT"
+          security import "$CERT" -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$CERT"
+
+      - name: Build unsigned application
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          # Tauri applies one entitlement file to the main binary and every
+          # externalBin, so its stock signing cannot give the helper its stricter
+          # sandbox-only entitlements. Build unsigned; the repository-owned
+          # finalizer signs nested code inside-out afterwards. Only the .app
+          # bundle is produced here; the DMG and updater archive are rebuilt from
+          # the finalized, notarized app in the next step.
+          cd app && npx tauri build --no-sign --bundles app --verbose
+
+      - name: Finalize, notarize, and repackage
+        env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        with:
-          projectPath: app
+        run: |
+          BUNDLE_MACOS=app/src-tauri/target/release/bundle/macos
+          APP=$(find "$BUNDLE_MACOS" -maxdepth 1 -name '*.app' -print -quit)
+          if [ -z "$APP" ]; then
+            echo "ERROR: unsigned application bundle is missing"
+            exit 1
+          fi
+          VERSION=$(python3 -c "import json,sys;print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
+
+          # Sign nested code inside-out with per-binary entitlements and fail
+          # closed unless strict verification passes (helper sandbox entitlement,
+          # arm64, hardened runtime, fixed identifier, shared Team ID).
+          python3 scripts/finalize_macos_bundle.py \
+            --app "$APP" \
+            --identity "$APPLE_SIGNING_IDENTITY" \
+            --main-entitlements app/src-tauri/entitlements.plist \
+            --helper-entitlements app/src-tauri/local-llm-sidecar.entitlements.plist \
+            --expected-team-id "$APPLE_TEAM_ID"
+
+          # Notarize + staple the finalized app, then rebuild the DMG and the
+          # updater .app.tar.gz (+ Ed25519 signature) FROM that finalized app.
+          python3 scripts/notarize_and_repackage_macos.py \
+            --app "$APP" \
+            --app-dir app \
+            --identity "$APPLE_SIGNING_IDENTITY" \
+            --version "$VERSION" \
+            --arch aarch64 \
+            --dmg-out app/src-tauri/target/release/bundle/dmg \
+            --apple-id "$APPLE_ID" \
+            --apple-password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --tauri-signing-key "$TAURI_SIGNING_PRIVATE_KEY" \
+            --tauri-signing-password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
 
       - name: Smoke test signed application
         run: |
@@ -173,6 +245,7 @@ jobs:
       - name: Stage immutable macOS artifacts
         env:
           SOURCE_SHA: ${{ needs.context.outputs.source-sha }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           mkdir -p release-artifacts
           find app/src-tauri/target/release/bundle/dmg -maxdepth 1 -type f -name '*.dmg' \
@@ -182,12 +255,36 @@ jobs:
             -exec cp {} release-artifacts/ \;
           ARCH=$(uname -m)
           [ "$ARCH" = "arm64" ] && ARCH=aarch64
+
+          # Record local-LLM helper provenance from the finalized bundle: hash,
+          # architecture, designated requirement, Team ID, and entitlement digest.
+          APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
+          HELPER="$APP/Contents/MacOS/murmur-llm-sidecar"
+          if [ ! -f "$HELPER" ]; then
+            echo "ERROR: finalized bundle is missing the local-LLM helper"
+            exit 1
+          fi
+          HELPER_SHA=$(shasum -a 256 "$HELPER" | awk '{print $1}')
+          HELPER_ARCH=$(lipo -archs "$HELPER" | tr -d ' \n')
+          HELPER_DR=$(codesign -d -r- "$HELPER" 2>&1 | sed -n 's/^#* *designated => //p')
+          if [ -z "$HELPER_DR" ]; then
+            echo "ERROR: could not read the helper designated requirement"
+            exit 1
+          fi
+          codesign -d --entitlements :- --xml "$HELPER" > "$RUNNER_TEMP/helper-entitlements.xml" 2>/dev/null
+          HELPER_ENT_SHA=$(shasum -a 256 "$RUNNER_TEMP/helper-entitlements.xml" | awk '{print $1}')
+
           python3 scripts/release_artifacts.py record \
             --platform macos \
             --platform-key "darwin-${ARCH}" \
             --artifacts release-artifacts \
             --commit-sha "$SOURCE_SHA" \
-            --run-id "$GITHUB_RUN_ID"
+            --run-id "$GITHUB_RUN_ID" \
+            --helper-sha256 "$HELPER_SHA" \
+            --helper-arch "$HELPER_ARCH" \
+            --helper-designated-requirement "$HELPER_DR" \
+            --helper-team-id "$APPLE_TEAM_ID" \
+            --helper-entitlement-sha256 "$HELPER_ENT_SHA"
 
       - name: Upload immutable macOS artifacts
         uses: actions/upload-artifact@v4
@@ -206,6 +303,11 @@ jobs:
             echo "- restore hit: \`${{ steps.rust-cache.outputs.cache-hit || 'false' }}\`"
             echo "- write authorized: \`${{ needs.context.outputs.cache-write }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete signing keychain
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/murmur-signing.keychain-db" 2>/dev/null || true
 
   release-linux:
     needs: context

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -143,9 +143,12 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
+          set -euo pipefail
+          [ -n "$APPLE_CERTIFICATE" ] && [ -n "$APPLE_CERTIFICATE_PASSWORD" ] || {
+            echo "ERROR: APPLE_CERTIFICATE and APPLE_CERTIFICATE_PASSWORD must be set"; exit 1; }
           KEYCHAIN="$RUNNER_TEMP/murmur-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -183,7 +186,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          SIGNING_KEYCHAIN: ${{ runner.temp }}/murmur-signing.keychain-db
         run: |
+          set -euo pipefail
+          for VAR in APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID TAURI_SIGNING_PRIVATE_KEY; do
+            [ -n "${!VAR}" ] || { echo "ERROR: $VAR must be set"; exit 1; }
+          done
           BUNDLE_MACOS=app/src-tauri/target/release/bundle/macos
           APP=$(find "$BUNDLE_MACOS" -maxdepth 1 -name '*.app' -print -quit)
           if [ -z "$APP" ]; then
@@ -204,18 +212,18 @@ jobs:
 
           # Notarize + staple the finalized app, then rebuild the DMG and the
           # updater .app.tar.gz (+ Ed25519 signature) FROM that finalized app.
+          # Apple/Tauri secrets are read from the environment by the script.
           python3 scripts/notarize_and_repackage_macos.py \
             --app "$APP" \
             --app-dir app \
             --identity "$APPLE_SIGNING_IDENTITY" \
             --version "$VERSION" \
             --arch aarch64 \
-            --dmg-out app/src-tauri/target/release/bundle/dmg \
-            --apple-id "$APPLE_ID" \
-            --apple-password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --tauri-signing-key "$TAURI_SIGNING_PRIVATE_KEY" \
-            --tauri-signing-password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+            --dmg-out app/src-tauri/target/release/bundle/dmg
+
+          # Mirror the rehearsal's Gatekeeper evidence on the release path.
+          xcrun stapler validate "$APP"
+          spctl --assess --type execute -vvv "$APP"
 
       - name: Smoke test signed application
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,6 +341,7 @@ jobs:
             --artifacts artifacts \
             --expected-sha '${{ needs.resolve.outputs.source-sha }}' \
             --expected-run-id '${{ needs.resolve.outputs.artifact-run-id }}' \
+            --require-macos-helper \
             --output validated-release.json
 
       - name: Report non-publishing promotion rehearsal

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -1,0 +1,266 @@
+name: Sidecar Signing Rehearsal
+
+# Non-publishing rehearsal of the signed local-LLM sidecar packaging chain
+# (Stage 0 gate 2 of the signed-local-LLM ADR). It builds the sidecar, builds the
+# app unsigned, finalizes it with per-binary entitlements, strictly verifies both
+# binaries, notarizes + staples, rebuilds the DMG and updater archive from the
+# finalized app, then quarantines, launches, and probes the sandboxed helper.
+#
+# It NEVER publishes: no release is created, no asset is uploaded to a release,
+# and no updater manifest is generated. All evidence is uploaded only as
+# workflow artifacts for inspection.
+
+on:
+  workflow_dispatch:
+    inputs:
+      download_model:
+        description: >-
+          Download the 1.1GB Qwen GGUF and run the full descriptor + Metal proof.
+          Default false: the rehearsal proves helper spawn + fail-closed
+          descriptor rejection without the model. The full Metal proof also needs
+          a Metal-capable runner.
+        type: boolean
+        default: false
+  # Uncomment to iterate on this workflow directly from the feature branch:
+  # push:
+  #   branches: [issue/312-sidecar-release]
+
+concurrency:
+  group: sidecar-rehearsal-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rehearse-macos:
+    runs-on: macos-latest
+    env:
+      MODEL_ID: qwen2.5-1.5b-instruct-q4_k_m
+      MODEL_SIZE: "1117320736"
+      MODEL_SHA256: 6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e
+      MODEL_URL: >-
+        https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/dd26da440ef0330c47919d1ecae0966d24022222/qwen2.5-1.5b-instruct-q4_k_m.gguf
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: cd app && npm ci
+
+      - name: Prepare evidence directory
+        run: mkdir -p "$RUNNER_TEMP/rehearsal-evidence"
+
+      - name: Locate clang runtime for ggml-metal symbol resolution
+        run: |
+          CLANG_RT=$(find /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang \
+            -name "libclang_rt.osx.a" 2>/dev/null | sort -V | tail -1)
+          if [ -z "$CLANG_RT" ]; then
+            echo "ERROR: libclang_rt.osx.a not found"
+            exit 1
+          fi
+          echo "RUSTFLAGS=-C link-arg=$CLANG_RT -C link-arg=-mmacosx-version-min=14.0 -C link-arg=-Wl,-rpath,/usr/lib/swift" >> "$GITHUB_ENV"
+
+      - name: Build local-LLM sidecar
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+        run: python3 scripts/build_local_llm_sidecar.py --release
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/murmur-signing.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          CERT="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT"
+          security import "$CERT" -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$CERT"
+
+      - name: Build unsigned application
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: cd app && npx tauri build --no-sign --bundles app --verbose
+
+      - name: Finalize bundle with per-binary entitlements
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          BUNDLE_MACOS=app/src-tauri/target/release/bundle/macos
+          APP=$(find "$BUNDLE_MACOS" -maxdepth 1 -name '*.app' -print -quit)
+          echo "APP=$APP" >> "$GITHUB_ENV"
+          python3 scripts/finalize_macos_bundle.py \
+            --app "$APP" \
+            --identity "$APPLE_SIGNING_IDENTITY" \
+            --main-entitlements app/src-tauri/entitlements.plist \
+            --helper-entitlements app/src-tauri/local-llm-sidecar.entitlements.plist \
+            --expected-team-id "$APPLE_TEAM_ID" \
+            | tee "$RUNNER_TEMP/rehearsal-evidence/finalize.log"
+
+      - name: Strict verification of both binaries
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          LOG="$RUNNER_TEMP/rehearsal-evidence/verification.log"
+          EXEC=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
+          MAIN="$APP/Contents/MacOS/$EXEC"
+          HELPER="$APP/Contents/MacOS/murmur-llm-sidecar"
+          {
+            echo "## codesign --verify --deep --strict"
+            codesign --verify --deep --strict --verbose=2 "$APP" 2>&1
+
+            echo "## helper signature"
+            codesign -dvv "$HELPER" 2>&1
+            echo "## helper entitlements"
+            codesign -d --entitlements :- --xml "$HELPER" 2>/dev/null
+            echo "## main entitlements"
+            codesign -d --entitlements :- --xml "$MAIN" 2>/dev/null
+          } | tee "$LOG"
+
+          # arm64-only helper.
+          test "$(lipo -archs "$HELPER" | tr -d ' \n')" = "arm64"
+          # Hardened runtime on both binaries.
+          codesign -dvv "$HELPER" 2>&1 | grep -qi 'flags=.*runtime'
+          codesign -dvv "$MAIN" 2>&1 | grep -qi 'flags=.*runtime'
+          # Fixed helper identifier and shared Team ID.
+          codesign -dvv "$HELPER" 2>&1 | grep -q 'Identifier=com.localdictation.local-llm-sidecar'
+          codesign -dvv "$HELPER" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID"
+          codesign -dvv "$MAIN" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID"
+          # Helper is sandboxed; main is not.
+          codesign -d --entitlements :- --xml "$HELPER" 2>/dev/null | grep -q 'com.apple.security.app-sandbox'
+          if codesign -d --entitlements :- --xml "$HELPER" 2>/dev/null | grep -q 'device.microphone'; then
+            echo "ERROR: helper must not carry microphone entitlement"; exit 1
+          fi
+          if codesign -d --entitlements :- --xml "$MAIN" 2>/dev/null | grep -q 'app-sandbox'; then
+            echo "ERROR: main app must remain unsandboxed"; exit 1
+          fi
+          echo "strict verification passed" | tee -a "$LOG"
+
+      - name: Notarize, staple, and rebuild DMG + updater archive
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          VERSION=$(python3 -c "import json;print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
+          python3 scripts/notarize_and_repackage_macos.py \
+            --app "$APP" \
+            --app-dir app \
+            --identity "$APPLE_SIGNING_IDENTITY" \
+            --version "$VERSION" \
+            --arch aarch64 \
+            --dmg-out app/src-tauri/target/release/bundle/dmg \
+            --apple-id "$APPLE_ID" \
+            --apple-password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --tauri-signing-key "$TAURI_SIGNING_PRIVATE_KEY" \
+            --tauri-signing-password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+            | tee "$RUNNER_TEMP/rehearsal-evidence/repackage.json"
+
+      - name: Assess Gatekeeper, quarantine, and launch
+        run: |
+          set -euo pipefail
+          LOG="$RUNNER_TEMP/rehearsal-evidence/launch.log"
+          {
+            echo "## stapler validate"
+            xcrun stapler validate "$APP"
+            echo "## spctl assess"
+            spctl --assess --type execute -vvv "$APP"
+          } | tee "$LOG"
+
+          # Quarantine the notarized+stapled app, then confirm it still launches.
+          xattr -w com.apple.quarantine "0081;$(printf '%x' "$(date +%s)");SidecarRehearsal;" "$APP"
+          EXEC=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
+          "$APP/Contents/MacOS/$EXEC" &
+          PID=$!
+          for i in 1 2 3 4 5; do
+            sleep 1
+            if ! kill -0 "$PID" 2>/dev/null; then
+              echo "ERROR: quarantined app exited after ${i}s" | tee -a "$LOG"
+              exit 1
+            fi
+          done
+          echo "quarantined app alive for 5s" | tee -a "$LOG"
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+
+      - name: Download model for full descriptor proof
+        if: ${{ inputs.download_model }}
+        run: |
+          set -euo pipefail
+          MODEL="$RUNNER_TEMP/$MODEL_ID.gguf"
+          curl --fail --location --silent --show-error --output "$MODEL" "$MODEL_URL"
+          ACTUAL_SIZE=$(stat -f%z "$MODEL")
+          ACTUAL_SHA=$(shasum -a 256 "$MODEL" | awk '{print $1}')
+          if [ "$ACTUAL_SIZE" != "$MODEL_SIZE" ] || [ "$ACTUAL_SHA" != "$MODEL_SHA256" ]; then
+            echo "ERROR: downloaded model does not match the signed catalog identity"
+            exit 1
+          fi
+          echo "MODEL_PATH=$MODEL" >> "$GITHUB_ENV"
+
+      - name: Probe sandboxed helper (fail-closed, model-gated Metal proof)
+        run: |
+          set -euo pipefail
+          HELPER="$APP/Contents/MacOS/murmur-llm-sidecar"
+          EVIDENCE="$RUNNER_TEMP/rehearsal-evidence/descriptor-probe.json"
+          if [ "${{ inputs.download_model }}" = "true" ]; then
+            echo "Running full descriptor + Metal proof against the cached model"
+            python3 scripts/probe_local_llm_descriptor.py \
+              --helper "$HELPER" \
+              --model "$MODEL_PATH" \
+              --model-id "$MODEL_ID" \
+              --expected-size "$MODEL_SIZE" \
+              --expected-sha256 "$MODEL_SHA256" \
+              --evidence "$EVIDENCE"
+          else
+            echo "Running spawn + fail-closed proof without the 1.1GB model"
+            echo "(full descriptor + Metal proof requires download_model=true and a Metal-capable runner)"
+            python3 scripts/probe_local_llm_descriptor.py \
+              --helper "$HELPER" \
+              --skip-model \
+              --model-id "$MODEL_ID" \
+              --evidence "$EVIDENCE"
+          fi
+
+      - name: Upload rehearsal evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sidecar-signing-rehearsal-${{ github.sha }}
+          path: ${{ runner.temp }}/rehearsal-evidence
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Delete signing keychain
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/murmur-signing.keychain-db" 2>/dev/null || true

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -81,9 +81,12 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
+          set -euo pipefail
+          [ -n "$APPLE_CERTIFICATE" ] && [ -n "$APPLE_CERTIFICATE_PASSWORD" ] || {
+            echo "ERROR: APPLE_CERTIFICATE and APPLE_CERTIFICATE_PASSWORD must be set"; exit 1; }
           KEYCHAIN="$RUNNER_TEMP/murmur-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -111,6 +114,9 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          set -euo pipefail
+          [ -n "$APPLE_SIGNING_IDENTITY" ] && [ -n "$APPLE_TEAM_ID" ] || {
+            echo "ERROR: APPLE_SIGNING_IDENTITY and APPLE_TEAM_ID must be set"; exit 1; }
           BUNDLE_MACOS=app/src-tauri/target/release/bundle/macos
           APP=$(find "$BUNDLE_MACOS" -maxdepth 1 -name '*.app' -print -quit)
           echo "APP=$APP" >> "$GITHUB_ENV"
@@ -170,8 +176,15 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          SIGNING_KEYCHAIN: ${{ runner.temp }}/murmur-signing.keychain-db
         run: |
+          set -euo pipefail
+          for VAR in APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID TAURI_SIGNING_PRIVATE_KEY; do
+            [ -n "${!VAR}" ] || { echo "ERROR: $VAR must be set"; exit 1; }
+          done
           VERSION=$(python3 -c "import json;print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
+          # Apple/Tauri secrets are read from the environment by the script, not
+          # passed as argv.
           python3 scripts/notarize_and_repackage_macos.py \
             --app "$APP" \
             --app-dir app \
@@ -179,11 +192,6 @@ jobs:
             --version "$VERSION" \
             --arch aarch64 \
             --dmg-out app/src-tauri/target/release/bundle/dmg \
-            --apple-id "$APPLE_ID" \
-            --apple-password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --tauri-signing-key "$TAURI_SIGNING_PRIVATE_KEY" \
-            --tauri-signing-password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
             | tee "$RUNNER_TEMP/rehearsal-evidence/repackage.json"
 
       - name: Assess Gatekeeper, quarantine, and launch
@@ -197,21 +205,26 @@ jobs:
             spctl --assess --type execute -vvv "$APP"
           } | tee "$LOG"
 
-          # Quarantine the notarized+stapled app, then confirm it still launches.
+          # Quarantine the notarized+stapled app, then launch it through
+          # LaunchServices/Gatekeeper (`open`, not a direct exec) so the quarantine
+          # assessment path is actually exercised. `open -W` blocks until the app
+          # exits; if it stays alive for 5s the wrapper is still running.
           xattr -w com.apple.quarantine "0081;$(printf '%x' "$(date +%s)");SidecarRehearsal;" "$APP"
-          EXEC=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
-          "$APP/Contents/MacOS/$EXEC" &
-          PID=$!
+          open -W "$APP" &
+          OPEN_PID=$!
           for i in 1 2 3 4 5; do
             sleep 1
-            if ! kill -0 "$PID" 2>/dev/null; then
-              echo "ERROR: quarantined app exited after ${i}s" | tee -a "$LOG"
+            if ! kill -0 "$OPEN_PID" 2>/dev/null; then
+              echo "ERROR: quarantined app failed to launch or exited within ${i}s" | tee -a "$LOG"
+              wait "$OPEN_PID" 2>/dev/null || true
               exit 1
             fi
           done
-          echo "quarantined app alive for 5s" | tee -a "$LOG"
-          kill "$PID" 2>/dev/null || true
-          wait "$PID" 2>/dev/null || true
+          echo "quarantined app launched via LaunchServices and alive for 5s" | tee -a "$LOG"
+          EXEC=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
+          osascript -e "tell application \"$EXEC\" to quit" 2>/dev/null || pkill -f "$APP" 2>/dev/null || true
+          kill "$OPEN_PID" 2>/dev/null || true
+          wait "$OPEN_PID" 2>/dev/null || true
 
       - name: Download model for full descriptor proof
         if: ${{ inputs.download_model }}
@@ -259,6 +272,7 @@ jobs:
           path: ${{ runner.temp }}/rehearsal-evidence
           if-no-files-found: warn
           retention-days: 14
+          overwrite: true
 
       - name: Delete signing keychain
         if: always()

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -21,9 +21,12 @@ on:
           a Metal-capable runner.
         type: boolean
         default: false
-  # Uncomment to iterate on this workflow directly from the feature branch:
-  # push:
-  #   branches: [issue/312-sidecar-release]
+  # Push trigger scoped to the feature branch: workflow_dispatch is only
+  # registered once this file reaches the default branch, so pre-merge rehearsal
+  # runs (the ADR Stage 0 gate-2 evidence) fire on push instead. Remove or keep
+  # commented after merge; dispatch takes over from main.
+  push:
+    branches: [issue/312-sidecar-release]
 
 concurrency:
   group: sidecar-rehearsal-${{ github.ref }}

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -21,12 +21,12 @@ on:
           a Metal-capable runner.
         type: boolean
         default: false
-  # Push trigger scoped to the feature branch: workflow_dispatch is only
-  # registered once this file reaches the default branch, so pre-merge rehearsal
-  # runs (the ADR Stage 0 gate-2 evidence) fire on push instead. Remove or keep
-  # commented after merge; dispatch takes over from main.
-  push:
-    branches: [issue/312-sidecar-release]
+  # Pre-merge iteration used a push trigger scoped to the feature branch
+  # (workflow_dispatch is only registered once this file reaches the default
+  # branch). Gate-2 evidence was produced by run 29793936645; the trigger is
+  # re-commented now that dispatch takes over from main.
+  # push:
+  #   branches: [issue/312-sidecar-release]
 
 concurrency:
   group: sidecar-rehearsal-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,18 @@ Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React), local whisper.cpp
 ## Commands
 
 ```bash
+python3 scripts/build_local_llm_sidecar.py  # Build the macOS local-LLM sidecar FIRST (see note)
 cd app && npm run tauri dev        # Dev with hot reload
 cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
 ```
+
+> **macOS note:** `tauri.macos.conf.json` declares the `murmur-llm-sidecar` externalBin, so
+> on macOS `tauri dev`/`tauri build` fail on a fresh clone until the sidecar binary exists at
+> `app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. Run
+> `python3 scripts/build_local_llm_sidecar.py` once first (it is a no-op on non-arm64-macOS).
+> The binary is gitignored; release CI builds it before bundling.
 
 ## Docs
 

--- a/app/src-tauri/tauri.macos.conf.json
+++ b/app/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": ["binaries/murmur-llm-sidecar"]
+  }
+}

--- a/docs/decisions/2026-07-20-signed-local-llm-sidecar.md
+++ b/docs/decisions/2026-07-20-signed-local-llm-sidecar.md
@@ -1,6 +1,6 @@
 # ADR: Signed local-LLM sidecar runtime
 
-- Status: Proposed; acceptance is gated on the Stage 0 proofs below
+- Status: Accepted (2026-07-21) — both Stage 0 gates passed. Gate 1: local fd-descriptor + Metal proof (2026-07-20, Apple M4). Gate 2: trusted non-publishing CI rehearsal run 29793936645 — app and DMG notarization Accepted (submissions 528f5cb5-2485-4651-bea0-843725ac84c7, 83225a76-1cf9-49b7-bcaf-a6964853e976), stapled + quarantined app passes Gatekeeper (`spctl`: Notarized Developer ID), sandboxed helper descriptor probe fails closed (controlled exit 70)
 - Date: 2026-07-20
 - Issue: #312 (originally #300, superseded)
 - Unblocks: #312 phases B–D (originally #254)

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -29,7 +29,7 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 **Rationale:** The active 2026-06-23 decision proves in-process Whisper + llama.cpp is unsafe because their ggml ABIs collide. Tauri's stock macOS signer also applies one entitlement set to the app and external binaries, so a repository-owned no-sign/finalize path is required to preserve a stricter helper sandbox. The design is accepted only after the inherited-descriptor/Metal and split-entitlement signing gates pass, followed by a signed/notarized/quarantined non-publishing rehearsal.
 
-**Status:** proposed — see [ADR](2026-07-20-signed-local-llm-sidecar.md)
+**Status:** active — ADR accepted 2026-07-21 after the CI signing rehearsal (run 29793936645) delivered the outstanding notarization/staple/Gatekeeper/probe evidence; see [ADR](2026-07-20-signed-local-llm-sidecar.md)
 
 **References:** issue #312 (originally #300, superseded); unblocks #312 phases B–D (originally #254).
 

--- a/scripts/finalize_macos_bundle.py
+++ b/scripts/finalize_macos_bundle.py
@@ -47,20 +47,52 @@ def sign(
     run(command)
 
 
-def sign_nested_code(app: Path, identity: str) -> None:
-    frameworks = app / "Contents" / "Frameworks"
-    if not frameworks.is_dir():
+# Mach-O magic numbers (thin 32/64-bit both endiannesses, and fat/universal).
+_MACHO_MAGICS = {
+    b"\xcf\xfa\xed\xfe",  # 64-bit, little-endian (arm64/x86_64)
+    b"\xce\xfa\xed\xfe",  # 32-bit, little-endian
+    b"\xfe\xed\xfa\xcf",  # 64-bit, big-endian
+    b"\xfe\xed\xfa\xce",  # 32-bit, big-endian
+    b"\xca\xfe\xba\xbe",  # fat/universal, big-endian
+    b"\xbe\xba\xfe\xca",  # fat/universal, little-endian
+}
+
+
+def _is_macho(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(4) in _MACHO_MAGICS
+    except OSError:
+        return False
+
+
+def sign_nested_code(app: Path, identity: str, exclude: set[Path]) -> None:
+    """Sign every nested Mach-O in the bundle inside-out (deepest first).
+
+    Notarization rejects any nested Mach-O that is ad-hoc/unsigned or lacks the
+    hardened runtime or a secure timestamp, so this scans the whole bundle by
+    Mach-O magic (not only ``Contents/Frameworks`` by extension) and signs each
+    with Developer ID + hardened runtime + secure timestamp. The main executable
+    and the helper are excluded here because they are signed immediately after
+    with their own per-binary entitlements and identifiers.
+    """
+    contents = app / "Contents"
+    if not contents.is_dir():
         return
-    candidates = sorted(
-        (
-            path
-            for path in frameworks.rglob("*")
-            if path.is_file() and (path.suffix in {".dylib", ".so"} or path.parent.suffix == ".framework")
-        ),
-        key=lambda path: len(path.parts),
-        reverse=True,
-    )
-    for path in candidates:
+    excluded = {path.resolve() for path in exclude}
+    candidates = {
+        path
+        for path in contents.rglob("*")
+        if path.is_file()
+        and not path.is_symlink()
+        and path.resolve() not in excluded
+        and (
+            path.suffix in {".dylib", ".so"}
+            or path.parent.suffix == ".framework"
+            or _is_macho(path)
+        )
+    }
+    for path in sorted(candidates, key=lambda path: len(path.parts), reverse=True):
         sign(path, identity, None)
 
 
@@ -101,7 +133,7 @@ def main() -> int:
     if not main_binary.is_file() or main_binary == helper:
         raise SystemExit("app bundle has an invalid main executable")
 
-    sign_nested_code(app, args.identity)
+    sign_nested_code(app, args.identity, exclude={helper, main_binary})
     sign(helper, args.identity, args.helper_entitlements, HELPER_IDENTIFIER)
     sign(main_binary, args.identity, args.main_entitlements)
     sign(app, args.identity, args.main_entitlements)

--- a/scripts/notarize_and_repackage_macos.py
+++ b/scripts/notarize_and_repackage_macos.py
@@ -90,7 +90,20 @@ def store_notary_profile(apple_id: str, team_id: str, password: str, keychain: s
     run(command, input=password + "\n")
 
 
-def notarize(archive: Path, keychain: str) -> None:
+def _fetch_notary_log(submission_id: str, keychain: str) -> str:
+    """Fetch the per-file notarization log (paths + reasons, no secrets).
+
+    Runs without ``check`` so a failed fetch still returns whatever the tool
+    printed instead of masking the real rejection.
+    """
+    command = ["xcrun", "notarytool", "log", submission_id, "--keychain-profile", NOTARY_PROFILE]
+    if keychain:
+        command += ["--keychain", keychain]
+    result = subprocess.run(command, text=True, capture_output=True)
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def notarize(archive: Path, keychain: str) -> str:
     command = [
         "xcrun",
         "notarytool",
@@ -105,9 +118,20 @@ def notarize(archive: Path, keychain: str) -> None:
     if keychain:
         command += ["--keychain", keychain]
     output = run(command)
-    status = json.loads(output).get("status")
+    result = json.loads(output)
+    submission_id = str(result.get("id") or "")
+    status = result.get("status")
     if status != "Accepted":
-        raise SystemExit(f"notarization was not accepted: status={status!r}")
+        # Surface Apple's per-file rejection reasons for this submission. The log
+        # JSON lists offending paths and issue messages and carries no secrets.
+        if submission_id:
+            print(f"notarization log for submission {submission_id}:")
+            print(_fetch_notary_log(submission_id, keychain))
+        raise SystemExit(
+            f"notarization was not accepted: status={status!r} id={submission_id!r}"
+        )
+    print(f"notarization accepted: submission {submission_id} for {archive.name}")
+    return submission_id
 
 
 def staple(target: Path) -> None:

--- a/scripts/notarize_and_repackage_macos.py
+++ b/scripts/notarize_and_repackage_macos.py
@@ -17,6 +17,19 @@ rehearsal share one implementation:
 
 It never weakens ``finalize_macos_bundle.py``; that finalizer must already have
 run and verified the bundle before this script is invoked.
+
+Secret handling: Apple and Tauri credentials are read from the environment, never
+passed as command-line arguments (which would be visible in ``ps`` and could leak
+into a raised traceback). The app-specific password is stored once into a
+notarytool keychain profile (fed on stdin), and every ``notarytool submit`` then
+references only the profile name. The Tauri updater signer reads its key and
+password from ``TAURI_PRIVATE_KEY`` / ``TAURI_PRIVATE_KEY_PASSWORD`` in the child
+environment. On failure, subprocess output is dropped and only the leading,
+non-sensitive part of the argv is surfaced.
+
+Required environment: ``APPLE_ID``, ``APPLE_PASSWORD``, ``APPLE_TEAM_ID``,
+``TAURI_SIGNING_PRIVATE_KEY``. Optional: ``TAURI_SIGNING_PRIVATE_KEY_PASSWORD``
+and ``SIGNING_KEYCHAIN`` (path to the keychain that holds the notary profile).
 """
 
 from __future__ import annotations
@@ -30,34 +43,71 @@ import subprocess
 import tempfile
 
 
-def run(command: list[str], *, cwd: Path | None = None, env: dict | None = None) -> str:
-    result = subprocess.run(
-        command, cwd=cwd, env=env, text=True, check=True, capture_output=True
-    )
+NOTARY_PROFILE = "MurmurNotary"
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict | None = None,
+    input: str | None = None,
+) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            input=input,
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Never surface captured output (may echo a secret) and never let the
+        # chained CalledProcessError (which holds the full argv) reach the
+        # traceback. Show only the leading, non-sensitive part of the command.
+        raise SystemExit(
+            f"command failed (exit {exc.returncode}): {' '.join(command[:3])}"
+        ) from None
     return result.stdout
 
 
-def notarize(archive: Path, apple_id: str, password: str, team_id: str) -> None:
-    output = run(
-        [
-            "xcrun",
-            "notarytool",
-            "submit",
-            str(archive),
-            "--apple-id",
-            apple_id,
-            "--password",
-            password,
-            "--team-id",
-            team_id,
-            "--wait",
-            "--output-format",
-            "json",
-        ]
-    )
+def store_notary_profile(apple_id: str, team_id: str, password: str, keychain: str) -> None:
+    command = [
+        "xcrun",
+        "notarytool",
+        "store-credentials",
+        NOTARY_PROFILE,
+        "--apple-id",
+        apple_id,
+        "--team-id",
+        team_id,
+    ]
+    if keychain:
+        command += ["--keychain", keychain]
+    # The app-specific password is fed on stdin so it never appears in argv/ps.
+    run(command, input=password + "\n")
+
+
+def notarize(archive: Path, keychain: str) -> None:
+    command = [
+        "xcrun",
+        "notarytool",
+        "submit",
+        str(archive),
+        "--keychain-profile",
+        NOTARY_PROFILE,
+        "--wait",
+        "--output-format",
+        "json",
+    ]
+    if keychain:
+        command += ["--keychain", keychain]
+    output = run(command)
     status = json.loads(output).get("status")
     if status != "Accepted":
-        raise SystemExit(f"notarization was not accepted: status={status!r} ({output})")
+        raise SystemExit(f"notarization was not accepted: status={status!r}")
 
 
 def staple(target: Path) -> None:
@@ -112,26 +162,31 @@ def build_updater_archive(app: Path) -> Path:
     return tarball
 
 
-def tauri_sign(tarball: Path, app_dir: Path, key: str, key_password: str) -> Path:
+def tauri_sign(tarball: Path, app_dir: Path) -> Path:
+    # The signer subcommand reads TAURI_PRIVATE_KEY / TAURI_PRIVATE_KEY_PASSWORD
+    # from the environment, so the key never appears in argv/ps. Map the release
+    # build's TAURI_SIGNING_* names onto the signer's names.
+    env = os.environ.copy()
+    env["TAURI_PRIVATE_KEY"] = os.environ["TAURI_SIGNING_PRIVATE_KEY"]
+    env["TAURI_PRIVATE_KEY_PASSWORD"] = os.environ.get(
+        "TAURI_SIGNING_PRIVATE_KEY_PASSWORD", ""
+    )
     run(
-        [
-            "npx",
-            "--no-install",
-            "tauri",
-            "signer",
-            "sign",
-            "--private-key",
-            key,
-            "--password",
-            key_password,
-            str(tarball),
-        ],
+        ["npx", "--no-install", "tauri", "signer", "sign", str(tarball)],
         cwd=app_dir,
+        env=env,
     )
     signature = Path(f"{tarball}.sig")
     if not signature.is_file():
         raise SystemExit(f"updater signature was not produced: {signature}")
     return signature
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise SystemExit(f"missing required environment variable: {name}")
+    return value
 
 
 def main() -> int:
@@ -142,35 +197,39 @@ def main() -> int:
     parser.add_argument("--version", required=True)
     parser.add_argument("--arch", default="aarch64")
     parser.add_argument("--dmg-out", type=Path, required=True)
-    parser.add_argument("--apple-id", required=True)
-    parser.add_argument("--apple-password", required=True)
-    parser.add_argument("--team-id", required=True)
-    parser.add_argument("--tauri-signing-key", required=True)
-    parser.add_argument("--tauri-signing-password", default="")
     args = parser.parse_args()
+
+    # Secrets come from the environment, never argv.
+    apple_id = _require_env("APPLE_ID")
+    apple_password = _require_env("APPLE_PASSWORD")
+    team_id = _require_env("APPLE_TEAM_ID")
+    _require_env("TAURI_SIGNING_PRIVATE_KEY")
+    keychain = os.environ.get("SIGNING_KEYCHAIN", "")
 
     app = args.app.resolve()
     if not app.is_dir():
         raise SystemExit(f"app bundle not found: {app}")
 
+    # Store the app-specific password once into a notarytool keychain profile so
+    # the repeated submit calls carry only the profile name.
+    store_notary_profile(apple_id, team_id, apple_password, keychain)
+
     # 1. Notarize and staple the finalized app.
     with tempfile.TemporaryDirectory(prefix="murmur-notarize-") as tmp:
         app_zip = Path(tmp) / f"{app.stem}.zip"
         run(["ditto", "-c", "-k", "--keepParent", str(app), str(app_zip)])
-        notarize(app_zip, args.apple_id, args.apple_password, args.team_id)
+        notarize(app_zip, keychain)
     staple(app)
 
     # 2. DMG built from the stapled app, then signed, notarized, and stapled.
     dmg = build_dmg(app, args.version, args.arch, args.dmg_out.resolve())
     codesign_dmg(dmg, args.identity)
-    notarize(dmg, args.apple_id, args.apple_password, args.team_id)
+    notarize(dmg, keychain)
     staple(dmg)
 
     # 3. Updater archive + Ed25519 signature from the stapled app.
     tarball = build_updater_archive(app)
-    signature = tauri_sign(
-        tarball, args.app_dir.resolve(), args.tauri_signing_key, args.tauri_signing_password
-    )
+    signature = tauri_sign(tarball, args.app_dir.resolve())
 
     print(
         json.dumps(

--- a/scripts/notarize_and_repackage_macos.py
+++ b/scripts/notarize_and_repackage_macos.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Notarize a finalized Murmur .app and rebuild the DMG and updater archive.
+
+The signed-local-LLM ADR requires the release pipeline to build the app with
+``--no-sign``, sign nested code inside-out with per-binary entitlements via
+``finalize_macos_bundle.py``, and only then notarize. Because Tauri's own signing
+path cannot give the helper its stricter sandbox entitlements, the DMG and the
+updater ``.app.tar.gz`` must be produced from the *finalized, notarized* app
+rather than from Tauri's stock bundle output. This script performs exactly that
+post-finalization repackaging so the release build and the non-publishing signing
+rehearsal share one implementation:
+
+  1. notarize the finalized ``.app`` and staple the ticket onto it,
+  2. build a DMG from the stapled app, code-sign it, notarize it, and staple it,
+  3. tar+gzip the stapled app into ``<AppName>.app.tar.gz`` and produce its
+     Ed25519 signature with the Tauri updater signer.
+
+It never weakens ``finalize_macos_bundle.py``; that finalizer must already have
+run and verified the bundle before this script is invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def run(command: list[str], *, cwd: Path | None = None, env: dict | None = None) -> str:
+    result = subprocess.run(
+        command, cwd=cwd, env=env, text=True, check=True, capture_output=True
+    )
+    return result.stdout
+
+
+def notarize(archive: Path, apple_id: str, password: str, team_id: str) -> None:
+    output = run(
+        [
+            "xcrun",
+            "notarytool",
+            "submit",
+            str(archive),
+            "--apple-id",
+            apple_id,
+            "--password",
+            password,
+            "--team-id",
+            team_id,
+            "--wait",
+            "--output-format",
+            "json",
+        ]
+    )
+    status = json.loads(output).get("status")
+    if status != "Accepted":
+        raise SystemExit(f"notarization was not accepted: status={status!r} ({output})")
+
+
+def staple(target: Path) -> None:
+    run(["xcrun", "stapler", "staple", str(target)])
+
+
+def codesign_dmg(dmg: Path, identity: str) -> None:
+    run(["codesign", "--force", "--timestamp", "--sign", identity, str(dmg)])
+
+
+def build_dmg(app: Path, version: str, arch: str, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    volume = app.stem  # "Murmur.app" -> "Murmur"
+    dmg = out_dir / f"{volume}_{version}_{arch}.dmg"
+    if dmg.exists():
+        dmg.unlink()
+    with tempfile.TemporaryDirectory(prefix="murmur-dmg-stage-") as staging:
+        stage = Path(staging)
+        shutil.copytree(app, stage / app.name, symlinks=True)
+        os.symlink("/Applications", stage / "Applications")
+        run(
+            [
+                "hdiutil",
+                "create",
+                "-volname",
+                volume,
+                "-srcfolder",
+                str(stage),
+                "-ov",
+                "-format",
+                "UDZO",
+                str(dmg),
+            ]
+        )
+    return dmg
+
+
+def build_updater_archive(app: Path) -> Path:
+    macos_dir = app.parent
+    tarball = macos_dir / f"{app.name}.tar.gz"
+    for stale in (tarball, Path(f"{tarball}.sig")):
+        if stale.exists():
+            stale.unlink()
+    # COPYFILE_DISABLE avoids AppleDouble (._*) members so the archive matches a
+    # portable tar; the Tauri updater only requires the .app at the archive root.
+    env = os.environ.copy()
+    env["COPYFILE_DISABLE"] = "1"
+    run(
+        ["tar", "-C", str(macos_dir), "-czf", str(tarball), app.name],
+        env=env,
+    )
+    return tarball
+
+
+def tauri_sign(tarball: Path, app_dir: Path, key: str, key_password: str) -> Path:
+    run(
+        [
+            "npx",
+            "--no-install",
+            "tauri",
+            "signer",
+            "sign",
+            "--private-key",
+            key,
+            "--password",
+            key_password,
+            str(tarball),
+        ],
+        cwd=app_dir,
+    )
+    signature = Path(f"{tarball}.sig")
+    if not signature.is_file():
+        raise SystemExit(f"updater signature was not produced: {signature}")
+    return signature
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--app-dir", type=Path, required=True, help="Tauri project dir")
+    parser.add_argument("--identity", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--arch", default="aarch64")
+    parser.add_argument("--dmg-out", type=Path, required=True)
+    parser.add_argument("--apple-id", required=True)
+    parser.add_argument("--apple-password", required=True)
+    parser.add_argument("--team-id", required=True)
+    parser.add_argument("--tauri-signing-key", required=True)
+    parser.add_argument("--tauri-signing-password", default="")
+    args = parser.parse_args()
+
+    app = args.app.resolve()
+    if not app.is_dir():
+        raise SystemExit(f"app bundle not found: {app}")
+
+    # 1. Notarize and staple the finalized app.
+    with tempfile.TemporaryDirectory(prefix="murmur-notarize-") as tmp:
+        app_zip = Path(tmp) / f"{app.stem}.zip"
+        run(["ditto", "-c", "-k", "--keepParent", str(app), str(app_zip)])
+        notarize(app_zip, args.apple_id, args.apple_password, args.team_id)
+    staple(app)
+
+    # 2. DMG built from the stapled app, then signed, notarized, and stapled.
+    dmg = build_dmg(app, args.version, args.arch, args.dmg_out.resolve())
+    codesign_dmg(dmg, args.identity)
+    notarize(dmg, args.apple_id, args.apple_password, args.team_id)
+    staple(dmg)
+
+    # 3. Updater archive + Ed25519 signature from the stapled app.
+    tarball = build_updater_archive(app)
+    signature = tauri_sign(
+        tarball, args.app_dir.resolve(), args.tauri_signing_key, args.tauri_signing_password
+    )
+
+    print(
+        json.dumps(
+            {
+                "app": str(app),
+                "dmg": str(dmg),
+                "updater_archive": str(tarball),
+                "updater_signature": str(signature),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_local_llm_descriptor.py
+++ b/scripts/probe_local_llm_descriptor.py
@@ -12,6 +12,7 @@ import select
 import stat
 import struct
 import subprocess
+import tempfile
 import time
 
 
@@ -25,6 +26,15 @@ MAX_FRAME = 64 * 1024
 # the 1.1 GB GGUF into CI.
 CATALOG_SIZE = 1_117_320_736
 CATALOG_SHA256 = "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e"
+
+# The helper's main() maps every controlled run() error (protocol mismatch, limit
+# mismatch, and every descriptor rejection in verify_inherited_model) to this
+# fixed exit code and suppresses stderr in release builds. Dyld/arch/sandbox/
+# signature launch failures instead surface as an OSError at spawn time or a
+# signal death (negative return code) or a shell/loader code such as 126/127 —
+# never a clean 70 — so exit==70 uniquely identifies a controlled fail-closed
+# rejection rather than a crash at launch. See sidecars/local-llm/src/main.rs.
+HELPER_CONTROLLED_EXIT = 70
 
 
 def _limits() -> dict[str, int]:
@@ -85,17 +95,28 @@ def run_skip_model(helper: Path, model_id: str, evidence: Path | None) -> int:
     """Prove spawn + failure-closed descriptor handling without the real model.
 
     A bogus, tiny fd 3 is inherited while the hello frame advertises the signed
-    catalog identity. The helper must reject the descriptor identity mismatch and
-    exit non-zero WITHOUT ever emitting a `ready` frame. This exercises the signed
-    sandboxed binary's ability to spawn and its fail-closed model verification
-    while deferring the full Metal/inference proof (which needs the cached model).
-    """
-    import tempfile
+    catalog identity. This exercises the signed sandboxed binary's ability to
+    spawn and its fail-closed model verification while deferring the full Metal/
+    inference proof (which needs the cached model).
 
-    with tempfile.NamedTemporaryFile(prefix="murmur-bogus-model-", delete=True) as bogus:
-        bogus.write(b"not the real gguf model")
-        bogus.flush()
-        model_fd = os.open(bogus.name, os.O_RDONLY | os.O_NOFOLLOW)
+    Fail-closed is only accepted when the helper rejects the descriptor through a
+    *controlled* path, distinguished from a crash at launch (dyld/arch/sandbox/
+    signature failure):
+
+      * an explicit protocol ``error`` frame as the first frame, or
+      * a clean exit with the helper's dedicated controlled-error code and no
+        ``ready``/``result`` frame.
+
+    A ``ready``/``result`` frame, a zero exit, a signal death, or any other exit
+    code is treated as a probe FAILURE. The temp fd is managed without a live
+    Python file object across ``dup2`` so fd 3 is never double-closed.
+    """
+    fd, bogus_path = tempfile.mkstemp(prefix="murmur-bogus-model-")
+    try:
+        os.write(fd, b"not the real gguf model")
+        os.close(fd)  # release the writable fd before opening the read-only fd 3
+
+        model_fd = os.open(bogus_path, os.O_RDONLY | os.O_NOFOLLOW)
         try:
             if model_fd != MODEL_FD:
                 os.dup2(model_fd, MODEL_FD, inheritable=True)
@@ -127,29 +148,55 @@ def run_skip_model(helper: Path, model_id: str, evidence: Path | None) -> int:
                 },
                 "limits": _limits(),
             }
-            process.stdin.write(frame(hello))
-            process.stdin.flush()
+            try:
+                process.stdin.write(frame(hello))
+                process.stdin.flush()
+            except BrokenPipeError as error:
+                process.wait(timeout=5.0)
+                raise SystemExit(
+                    "sidecar closed stdin before reading hello; likely crashed at "
+                    f"launch (exit={process.returncode!r})"
+                ) from error
 
-            emitted_ready = False
+            first: dict[str, object] | None
             try:
                 first = read_frame(process.stdout, 30.0)
-                emitted_ready = first.get("type") == "ready"
             except (EOFError, TimeoutError):
                 first = None
-
-            if emitted_ready:
+            frame_type = first.get("type") if isinstance(first, dict) else None
+            if frame_type in ("ready", "result"):
                 raise SystemExit(
-                    "sidecar emitted 'ready' for a mismatched descriptor; fail-closed broken"
+                    f"sidecar produced a {frame_type!r} frame for a mismatched "
+                    "descriptor; fail-closed is broken"
                 )
 
             try:
-                process.wait(timeout=10.0)
+                process.wait(timeout=15.0)
             except subprocess.TimeoutExpired:
                 process.kill()
                 raise SystemExit("sidecar did not exit after descriptor rejection")
-            if process.returncode == 0:
+
+            stderr_text = ""
+            if process.stderr is not None:
+                stderr_text = (
+                    process.stderr.read().decode("utf-8", errors="replace").strip()
+                )
+
+            error_code = None
+            if frame_type == "error":
+                # Future-proof path: an explicit protocol error frame is itself a
+                # fail-closed signal. Record its code. (The current helper rejects
+                # descriptors by exiting rather than framing, so this branch is
+                # typically not taken.)
+                error_code = first.get("code") if isinstance(first, dict) else None
+                discriminator = "error-frame"
+            elif frame_type is None and process.returncode == HELPER_CONTROLLED_EXIT:
+                discriminator = "controlled-exit-code"
+            else:
+                detail = stderr_text or "release stderr suppressed"
                 raise SystemExit(
-                    f"sidecar exited 0 despite descriptor mismatch: frame={first!r}"
+                    "sidecar did not fail closed through a controlled path: "
+                    f"exit={process.returncode!r} first_frame={first!r} ({detail})"
                 )
 
             evidence_payload = {
@@ -160,7 +207,10 @@ def run_skip_model(helper: Path, model_id: str, evidence: Path | None) -> int:
                 "expected_size": CATALOG_SIZE,
                 "expected_sha256": CATALOG_SHA256,
                 "emitted_ready": False,
+                "discriminator": discriminator,
                 "helper_exit_code": process.returncode,
+                "helper_error_code": error_code,
+                "helper_stderr": stderr_text,  # empty in release (stderr suppressed)
                 "helper_first_frame": first,
                 "fixed_inference": "deferred (needs cached model)",
                 "protocol_version": VERSION,
@@ -174,6 +224,11 @@ def run_skip_model(helper: Path, model_id: str, evidence: Path | None) -> int:
             print(json.dumps(evidence_payload, sort_keys=True))
         finally:
             os.close(model_fd)
+    finally:
+        try:
+            os.unlink(bogus_path)
+        except OSError:
+            pass
     return 0
 
 

--- a/scripts/probe_local_llm_descriptor.py
+++ b/scripts/probe_local_llm_descriptor.py
@@ -20,6 +20,24 @@ VERSION = 1
 MODEL_FD = 3
 MAX_FRAME = 64 * 1024
 
+# Signed-catalog identity of the only v1 model (see the signed-local-LLM ADR).
+# Used by --skip-model to drive the helper's descriptor check without shipping
+# the 1.1 GB GGUF into CI.
+CATALOG_SIZE = 1_117_320_736
+CATALOG_SHA256 = "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e"
+
+
+def _limits() -> dict[str, int]:
+    return {
+        "maxFrameBytes": 65536,
+        "maxInstructionBytes": 4096,
+        "maxInputBytes": 16384,
+        "maxOutputBytes": 16384,
+        "maxOutputTokens": 2048,
+        "maxContextTokens": 8192,
+        "maxDeadlineMs": 30000,
+    }
+
 
 def frame(payload: dict[str, object]) -> bytes:
     body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
@@ -63,16 +81,126 @@ def hash_fd(fd: int) -> tuple[int, str]:
     return metadata.st_size, digest.hexdigest()
 
 
+def run_skip_model(helper: Path, model_id: str, evidence: Path | None) -> int:
+    """Prove spawn + failure-closed descriptor handling without the real model.
+
+    A bogus, tiny fd 3 is inherited while the hello frame advertises the signed
+    catalog identity. The helper must reject the descriptor identity mismatch and
+    exit non-zero WITHOUT ever emitting a `ready` frame. This exercises the signed
+    sandboxed binary's ability to spawn and its fail-closed model verification
+    while deferring the full Metal/inference proof (which needs the cached model).
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(prefix="murmur-bogus-model-", delete=True) as bogus:
+        bogus.write(b"not the real gguf model")
+        bogus.flush()
+        model_fd = os.open(bogus.name, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            if model_fd != MODEL_FD:
+                os.dup2(model_fd, MODEL_FD, inheritable=True)
+                os.close(model_fd)
+                model_fd = MODEL_FD
+            os.set_inheritable(model_fd, True)
+
+            process = subprocess.Popen(
+                [str(helper)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                close_fds=True,
+                pass_fds=(model_fd,),
+                env={},
+                cwd="/",
+            )
+            assert process.stdin is not None and process.stdout is not None
+            nonce = "skip-model-failure-closed-probe"
+            hello = {
+                "type": "hello",
+                "protocol": PROTOCOL,
+                "version": VERSION,
+                "sessionNonce": nonce,
+                "model": {
+                    "id": model_id,
+                    "sha256": CATALOG_SHA256,
+                    "sizeBytes": CATALOG_SIZE,
+                },
+                "limits": _limits(),
+            }
+            process.stdin.write(frame(hello))
+            process.stdin.flush()
+
+            emitted_ready = False
+            try:
+                first = read_frame(process.stdout, 30.0)
+                emitted_ready = first.get("type") == "ready"
+            except (EOFError, TimeoutError):
+                first = None
+
+            if emitted_ready:
+                raise SystemExit(
+                    "sidecar emitted 'ready' for a mismatched descriptor; fail-closed broken"
+                )
+
+            try:
+                process.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                raise SystemExit("sidecar did not exit after descriptor rejection")
+            if process.returncode == 0:
+                raise SystemExit(
+                    f"sidecar exited 0 despite descriptor mismatch: frame={first!r}"
+                )
+
+            evidence_payload = {
+                "schema_version": 1,
+                "sandboxed_helper": str(helper),
+                "mode": "skip-model",
+                "model_id": model_id,
+                "expected_size": CATALOG_SIZE,
+                "expected_sha256": CATALOG_SHA256,
+                "emitted_ready": False,
+                "helper_exit_code": process.returncode,
+                "helper_first_frame": first,
+                "fixed_inference": "deferred (needs cached model)",
+                "protocol_version": VERSION,
+                "result": "failed-closed-as-expected",
+            }
+            if evidence:
+                evidence.parent.mkdir(parents=True, exist_ok=True)
+                evidence.write_text(
+                    json.dumps(evidence_payload, indent=2, sort_keys=True) + "\n"
+                )
+            print(json.dumps(evidence_payload, sort_keys=True))
+        finally:
+            os.close(model_fd)
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--helper", type=Path, required=True)
-    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--model", type=Path)
     parser.add_argument("--model-id", default="qwen2.5-1.5b-instruct-q4_k_m")
-    parser.add_argument("--expected-size", type=int, required=True)
-    parser.add_argument("--expected-sha256", required=True)
+    parser.add_argument("--expected-size", type=int)
+    parser.add_argument("--expected-sha256")
+    parser.add_argument(
+        "--skip-model",
+        action="store_true",
+        help="prove spawn + fail-closed descriptor rejection without the real model",
+    )
     parser.add_argument("--evidence", type=Path)
     args = parser.parse_args()
     helper = args.helper.resolve()
+
+    if args.skip_model:
+        return run_skip_model(helper, args.model_id, args.evidence)
+
+    if args.model is None or args.expected_size is None or args.expected_sha256 is None:
+        raise SystemExit(
+            "--model, --expected-size, and --expected-sha256 are required "
+            "unless --skip-model is set"
+        )
     model = args.model.resolve()
 
     model_fd = os.open(model, os.O_RDONLY | os.O_NOFOLLOW)

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -14,6 +14,8 @@ from typing import Any
 SCHEMA_VERSION = 1
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+TEAM_ID_RE = re.compile(r"^[A-Z0-9]{10}$")
+HELPER_IDENTIFIER = "com.localdictation.local-llm-sidecar"
 HELPER_FIELDS = (
     "sha256",
     "architecture",
@@ -105,6 +107,26 @@ def _require_helper(helper: dict[str, Any]) -> dict[str, Any]:
     if str(helper["architecture"]) != "arm64":
         raise ArtifactError(
             f"helper architecture must be arm64, got {helper['architecture']!r}"
+        )
+
+    team_id = str(helper["team_id"])
+    if not TEAM_ID_RE.fullmatch(team_id):
+        raise ArtifactError(f"helper team_id must be a 10-character Apple Team ID, got {team_id!r}")
+
+    # The designated requirement must pin the fixed helper identifier to a real
+    # Apple-anchored Developer ID certificate for this exact Team ID. This rejects
+    # bare-cdhash ad-hoc requirements, which carry no identity or anchor.
+    dr = str(helper["designated_requirement"])
+    required_clauses = (
+        f'identifier "{HELPER_IDENTIFIER}"',
+        "anchor apple generic",
+        "subject.OU",
+    )
+    missing_clauses = [clause for clause in required_clauses if clause not in dr]
+    if missing_clauses or f'"{team_id}"' not in dr:
+        raise ArtifactError(
+            "helper designated_requirement must pin the fixed identifier, an Apple "
+            f"anchor, and subject.OU = {team_id!r}; got {dr!r}"
         )
     return {field: str(helper[field]) for field in HELPER_FIELDS}
 
@@ -227,6 +249,8 @@ def validate_platform(
 
     helper = payload.get("helper")
     if helper is not None:
+        if platform != "macos":
+            raise ArtifactError(f"{platform} provenance must not carry a helper block")
         payload["helper"] = _require_helper(helper)
     elif require_helper:
         raise ArtifactError(

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -13,6 +13,14 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+HELPER_FIELDS = (
+    "sha256",
+    "architecture",
+    "designated_requirement",
+    "team_id",
+    "entitlement_sha256",
+)
 PLATFORM_SUFFIXES = {
     "macos": (".dmg", ".app.tar.gz", ".app.tar.gz.sig"),
     "linux": (".deb", ".AppImage", ".AppImage.sig"),
@@ -77,12 +85,37 @@ def _signature_text(path: Path) -> str:
     return value
 
 
+def _require_helper(helper: dict[str, Any]) -> dict[str, Any]:
+    """Validate the shape of the local-LLM helper provenance block.
+
+    The signed-local-LLM ADR requires provenance to additionally record the
+    helper hash, architecture, designated requirement, Team ID, and entitlement
+    digest. This checks internal consistency; the workflow that records it proves
+    those values against the finalized bundle.
+    """
+    if not isinstance(helper, dict):
+        raise ArtifactError("helper provenance must be an object")
+    missing = [field for field in HELPER_FIELDS if not str(helper.get(field, "")).strip()]
+    if missing:
+        raise ArtifactError(f"helper provenance is missing fields: {missing}")
+    if not SHA256_RE.fullmatch(str(helper["sha256"])):
+        raise ArtifactError("helper sha256 must be a 64-character hex digest")
+    if not SHA256_RE.fullmatch(str(helper["entitlement_sha256"])):
+        raise ArtifactError("helper entitlement_sha256 must be a 64-character hex digest")
+    if str(helper["architecture"]) != "arm64":
+        raise ArtifactError(
+            f"helper architecture must be arm64, got {helper['architecture']!r}"
+        )
+    return {field: str(helper[field]) for field in HELPER_FIELDS}
+
+
 def create_provenance(
     platform: str,
     platform_key: str,
     root: Path,
     commit_sha: str,
     run_id: str | int,
+    helper: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if platform not in PLATFORM_SUFFIXES:
         raise ArtifactError(f"unsupported platform: {platform}")
@@ -123,6 +156,10 @@ def create_provenance(
             for path in files
         ],
     }
+    if helper is not None:
+        if platform != "macos":
+            raise ArtifactError("helper provenance is only recorded for macos")
+        payload["helper"] = _require_helper(helper)
     (root / "provenance.json").write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
@@ -134,6 +171,7 @@ def validate_platform(
     root: Path,
     expected_sha: str,
     expected_run_id: str | int,
+    require_helper: bool = False,
 ) -> dict[str, Any]:
     expected_sha = _require_sha(expected_sha, "expected commit SHA")
     expected_run_id = _require_run_id(expected_run_id)
@@ -187,6 +225,14 @@ def validate_platform(
     if updater not in files or signature not in files:
         raise ArtifactError(f"{platform} updater files are absent from the artifact set")
 
+    helper = payload.get("helper")
+    if helper is not None:
+        payload["helper"] = _require_helper(helper)
+    elif require_helper:
+        raise ArtifactError(
+            f"{platform} provenance is missing the required local-LLM helper block"
+        )
+
     payload["signature"] = _signature_text(signature)
     return payload
 
@@ -196,10 +242,15 @@ def validate_release(
     expected_sha: str,
     expected_run_id: str | int,
     output: Path | None = None,
+    require_macos_helper: bool = False,
 ) -> dict[str, Any]:
     platforms = {
         platform: validate_platform(
-            platform, artifacts_root / platform, expected_sha, expected_run_id
+            platform,
+            artifacts_root / platform,
+            expected_sha,
+            expected_run_id,
+            require_helper=(require_macos_helper and platform == "macos"),
         )
         for platform in ("macos", "linux")
     }
@@ -297,12 +348,22 @@ def _parser() -> argparse.ArgumentParser:
     record.add_argument("--artifacts", type=Path, required=True)
     record.add_argument("--commit-sha", required=True)
     record.add_argument("--run-id", required=True)
+    record.add_argument("--helper-sha256")
+    record.add_argument("--helper-arch")
+    record.add_argument("--helper-designated-requirement")
+    record.add_argument("--helper-team-id")
+    record.add_argument("--helper-entitlement-sha256")
 
     validate = subparsers.add_parser("validate")
     validate.add_argument("--artifacts", type=Path, required=True)
     validate.add_argument("--expected-sha", required=True)
     validate.add_argument("--expected-run-id", required=True)
     validate.add_argument("--output", type=Path, required=True)
+    validate.add_argument(
+        "--require-macos-helper",
+        action="store_true",
+        help="fail unless the macOS provenance records the local-LLM helper block",
+    )
 
     manifests = subparsers.add_parser("manifests")
     manifests.add_argument("--validated", type=Path, required=True)
@@ -314,16 +375,35 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _helper_from_args(args: argparse.Namespace) -> dict[str, Any] | None:
+    provided = {
+        "sha256": args.helper_sha256,
+        "architecture": args.helper_arch,
+        "designated_requirement": args.helper_designated_requirement,
+        "team_id": args.helper_team_id,
+        "entitlement_sha256": args.helper_entitlement_sha256,
+    }
+    supplied = {key: value for key, value in provided.items() if value}
+    if not supplied:
+        return None
+    if len(supplied) != len(provided):
+        missing = sorted(set(provided) - set(supplied))
+        raise ArtifactError(f"incomplete helper provenance arguments: missing {missing}")
+    return supplied
+
+
 def main() -> None:
     args = _parser().parse_args()
     try:
         if args.command == "record":
+            helper = _helper_from_args(args)
             payload = create_provenance(
                 args.platform,
                 args.platform_key,
                 args.artifacts,
                 args.commit_sha,
                 args.run_id,
+                helper=helper,
             )
             print(
                 f"recorded {args.platform} provenance for {payload['commit_sha']} "
@@ -331,7 +411,11 @@ def main() -> None:
             )
         elif args.command == "validate":
             payload = validate_release(
-                args.artifacts, args.expected_sha, args.expected_run_id, args.output
+                args.artifacts,
+                args.expected_sha,
+                args.expected_run_id,
+                args.output,
+                require_macos_helper=args.require_macos_helper,
             )
             print(
                 f"validated immutable release artifacts for {payload['commit_sha']} "

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -88,6 +88,44 @@ class ReleaseArtifactTests(unittest.TestCase):
         with self.assertRaisesRegex(ArtifactError, "artifact names differ"):
             validate_release(self.artifacts, SHA, RUN_ID)
 
+    HELPER = {
+        "sha256": "a" * 64,
+        "architecture": "arm64",
+        "designated_requirement": (
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic'
+        ),
+        "team_id": "ABCDE12345",
+        "entitlement_sha256": "b" * 64,
+    }
+
+    def _rerecord_macos_with_helper(self, helper: dict) -> None:
+        macos = self.artifacts / "macos"
+        (macos / "provenance.json").unlink()
+        create_provenance("macos", "darwin-aarch64", macos, SHA, RUN_ID, helper=helper)
+
+    def test_helper_provenance_recorded_and_validated(self) -> None:
+        self._rerecord_macos_with_helper(self.HELPER)
+        result = validate_release(self.artifacts, SHA, RUN_ID, require_macos_helper=True)
+        self.assertEqual(result["platforms"]["macos"]["helper"], self.HELPER)
+
+    def test_require_macos_helper_fails_without_block(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "missing the required local-LLM helper"):
+            validate_release(self.artifacts, SHA, RUN_ID, require_macos_helper=True)
+
+    def test_helper_wrong_architecture_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "architecture must be arm64"):
+            self._rerecord_macos_with_helper({**self.HELPER, "architecture": "x86_64"})
+
+    def test_helper_bad_entitlement_digest_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "entitlement_sha256"):
+            self._rerecord_macos_with_helper({**self.HELPER, "entitlement_sha256": "short"})
+
+    def test_helper_provenance_rejected_for_linux(self) -> None:
+        linux = self.artifacts / "linux"
+        (linux / "provenance.json").unlink()
+        with self.assertRaisesRegex(ArtifactError, "only recorded for macos"):
+            create_provenance("linux", "linux-x86_64", linux, SHA, RUN_ID, helper=self.HELPER)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -92,7 +92,8 @@ class ReleaseArtifactTests(unittest.TestCase):
         "sha256": "a" * 64,
         "architecture": "arm64",
         "designated_requirement": (
-            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic'
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] = "ABCDE12345"'
         ),
         "team_id": "ABCDE12345",
         "entitlement_sha256": "b" * 64,
@@ -100,7 +101,7 @@ class ReleaseArtifactTests(unittest.TestCase):
 
     def _rerecord_macos_with_helper(self, helper: dict) -> None:
         macos = self.artifacts / "macos"
-        (macos / "provenance.json").unlink()
+        (macos / "provenance.json").unlink(missing_ok=True)
         create_provenance("macos", "darwin-aarch64", macos, SHA, RUN_ID, helper=helper)
 
     def test_helper_provenance_recorded_and_validated(self) -> None:
@@ -125,6 +126,36 @@ class ReleaseArtifactTests(unittest.TestCase):
         (linux / "provenance.json").unlink()
         with self.assertRaisesRegex(ArtifactError, "only recorded for macos"):
             create_provenance("linux", "linux-x86_64", linux, SHA, RUN_ID, helper=self.HELPER)
+
+    def test_helper_bad_team_id_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "team_id must be a 10-character"):
+            self._rerecord_macos_with_helper({**self.HELPER, "team_id": "abcde12345"})
+        with self.assertRaisesRegex(ArtifactError, "team_id must be a 10-character"):
+            self._rerecord_macos_with_helper({**self.HELPER, "team_id": "SHORT"})
+
+    def test_helper_adhoc_cdhash_designated_requirement_rejected(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+            self._rerecord_macos_with_helper(
+                {**self.HELPER, "designated_requirement": 'cdhash H"deadbeefcafe"'}
+            )
+
+    def test_helper_designated_requirement_wrong_team_rejected(self) -> None:
+        dr = (
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] = "ZZZZZ99999"'
+        )
+        with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+            self._rerecord_macos_with_helper({**self.HELPER, "designated_requirement": dr})
+
+    def test_validate_rejects_helper_block_on_linux(self) -> None:
+        # A helper block must never appear on a non-macos platform, even if a
+        # provenance file is hand-edited to smuggle one in.
+        linux = self.artifacts / "linux"
+        payload = json.loads((linux / "provenance.json").read_text())
+        payload["helper"] = self.HELPER
+        (linux / "provenance.json").write_text(json.dumps(payload))
+        with self.assertRaisesRegex(ArtifactError, "must not carry a helper block"):
+            validate_release(self.artifacts, SHA, RUN_ID)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase A3 of #312: the signed sidecar enters the trusted release pipeline, per the ADR's "Packaging and update trust chain".

- **externalBin** via `tauri.macos.conf.json` overlay (macOS-only merge — Linux/Windows builds untouched; local dev note added to CLAUDE.md).
- **Release build rework** (macOS job): sidecar built with the CI RUSTFLAGS, `tauri build --no-sign`, repo-owned finalizer applies per-binary entitlements inside-out (sandbox-only for the helper, existing entitlements for the app), then `notarize_and_repackage_macos.py`: notarize + staple the app, rebuild DMG and updater `.app.tar.gz` + Ed25519 sig **from the stapled app**, `stapler validate` + `spctl --assess` after repackage. Secrets flow via env / notarytool keychain profile — never argv.
- **Provenance** records helper hash, arch, designated requirement, Team ID, entitlement digest; `release.yml` validates with `--require-macos-helper` (team-id regex, DR structure, cdhash rejected).
- **`sidecar-signing-rehearsal.yml`** (workflow_dispatch, non-publishing): full sign→notarize→staple→quarantine→launch chain plus a `--skip-model` descriptor probe that passes only on a protocol error frame or the helper's controlled exit 70 — crash/launch failures are rejected. Full Metal/model proof gated behind `download_model=true`.

## Merge gate

**Do not merge until the rehearsal workflow runs green from this branch** — that run is the ADR's outstanding Stage-0 gate-2 evidence (Developer ID, notarization, stapling, quarantine, updater archive). On green, the ADR flips Proposed → Accepted in a follow-up commit.

## Verification

- py_compile all scripts; 30 release-artifact unit tests pass; `validate_workflow_policy.py` pass; YAML valid; ad-hoc finalizer + `--skip-model` probe verified locally against the real helper (pass) and non-helper binaries (rejected).
- Two independent adversarial review rounds; all findings (pipefail false-greens, probe fd management, crash-vs-reject discrimination, provenance tightening, secrets hygiene) addressed and re-verified.

Part of #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)