### PR TITLE
feat: local-LLM sidecar host supervisor and transform model install (#312 Phase A2)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2847,6 +2847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +4959,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5579,7 +5601,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5925,6 +5959,7 @@ dependencies = [
  "hound",
  "libc",
  "memory-stats",
+ "murmur-local-llm-protocol",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -5933,8 +5968,10 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "sherpa-onnx",
  "symphonia",
+ "sysinfo",
  "tar",
  "tauri",
  "tauri-build",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -15,6 +15,12 @@ resolver = "2"
 name = "ui_lib"
 crate-type = ["lib", "cdylib", "staticlib"]
 
+[features]
+# Exposes LlmSidecar::for_test + scenario env injection into the local-LLM
+# helper. Off by default so the injection path is not linkable in a release
+# binary (debug_assertions also enables it for the standard test build).
+llm-test-support = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -51,6 +51,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 aho-corasick = "1"
 libc = "0.2"
 rusqlite = { version = "0.40.1", default-features = false, features = ["backup", "bundled"] }
+# Local-LLM sidecar supervisor (#312): the app links ONLY the protocol crate,
+# never llama-cpp-2. sha2 verifies the pinned transform model before spawn and
+# while streaming its download; sysinfo reads the child helper's RSS by pid.
+murmur-local-llm-protocol = { path = "crates/local-llm-protocol" }
+sha2 = "0.10"
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -58,8 +58,17 @@ murmur-local-llm-protocol = { path = "crates/local-llm-protocol" }
 sha2 = "0.10"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 
+# Test-support helper: a protocol-v1 mock of the local-LLM sidecar, driven by
+# scenario env vars. Built as a normal bin so integration tests can locate it
+# via CARGO_BIN_EXE_mock_llm_helper. Not an externalBin, so it is never bundled.
+[[bin]]
+name = "mock_llm_helper"
+path = "tests/support/mock_llm_helper.rs"
+
 [dev-dependencies]
 tempfile = "3"
+# Async test harness for the local-LLM supervisor integration tests.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 # "test" feature only -- enables tauri::test::mock_app() for the headless
 # benchmark runner (tests/headless_benchmark.rs). Dev-dependency only: does
 # not affect release builds.

--- a/app/src-tauri/src/commands/benchmark.rs
+++ b/app/src-tauri/src/commands/benchmark.rs
@@ -58,6 +58,10 @@ pub async fn run_benchmark(
             });
         }
     }
+    // Only one heavy inference runtime may be resident: stop any local-LLM
+    // helper before benchmarking (fail-fast no-op while a transform is in
+    // flight). The benchmark slot is already claimed above.
+    state.transform_runtime.shutdown();
     let guard = BenchmarkRunGuard(coordinator.clone());
     super::models::ensure_vad_model(&app_handle)
         .await

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -8,5 +8,6 @@ pub(crate) mod native_window;
 pub mod overlay;
 pub mod permissions;
 pub mod recording;
+pub mod transform_model;
 pub mod transform_popover;
 pub mod tray;

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -831,6 +831,12 @@ pub async fn process_audio(
             tracing::warn!(target: "pipeline", "process_audio: blocked — transform in progress");
             return Err("Cannot process audio while a transform is in progress.".to_string());
         }
+        // Mutual exclusion with the local-LLM transform runtime: only one heavy
+        // inference runtime may be resident. Refuse while a transform is active.
+        if state.transform_runtime.is_transform_busy() {
+            tracing::warn!(target: "pipeline", "process_audio: blocked — transform runtime busy");
+            return Err("Cannot process audio while a text transform is in progress.".to_string());
+        }
         if dictation.status != DictationStatus::Idle {
             return Err("Cannot process audio while live dictation is active.".to_string());
         }
@@ -1948,6 +1954,15 @@ pub async fn start_native_recording(
         // same as the two guards above.
         if state.app_state.transform_status().blocks_recording() {
             tracing::warn!(target: "pipeline", "start_native_recording: blocked — transform in progress");
+            return Ok(serde_json::json!({
+                "type": "busy_transforming",
+                "state": "idle"
+            }));
+        }
+        // Only one heavy inference runtime may be resident: refuse to record
+        // while a local-LLM transform is in flight (supervisor busy).
+        if state.transform_runtime.is_transform_busy() {
+            tracing::warn!(target: "pipeline", "start_native_recording: blocked — transform runtime busy");
             return Ok(serde_json::json!({
                 "type": "busy_transforming",
                 "state": "idle"

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -812,6 +812,10 @@ pub async fn process_audio(
     audio_data: String,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
+    // Only one heavy inference runtime may be resident: stop any local-LLM
+    // helper before recording. Fail-fast no-op while a transform is in flight —
+    // the is_transform_busy guard below then refuses this recording.
+    state.transform_runtime.shutdown();
     let rid = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         // Same mutual exclusion as start_native_recording: this legacy base64
@@ -1928,6 +1932,10 @@ pub async fn start_native_recording(
         tracing::info!(target: "pipeline", "start_native_recording: app disabled — ignoring");
         return Ok(serde_json::json!({ "type": "app_disabled", "state": "idle" }));
     }
+    // Stop any resident local-LLM helper before recording (fail-fast no-op
+    // while a transform is in flight; the is_transform_busy guard below then
+    // refuses this recording).
+    state.transform_runtime.shutdown();
     // Check and update status in one lock; assign recording ID in the same
     // critical section so no concurrent cancel/start can slip between them.
     let rid = {
@@ -2331,6 +2339,10 @@ pub async fn transcribe_file(
     {
         return Err("Already transcribing a file.".to_string());
     }
+    // Only one heavy inference runtime may be resident: stop any local-LLM
+    // helper before running the file transcription (fail-fast no-op while a
+    // transform is in flight).
+    state.transform_runtime.shutdown();
     let _file_guard = FileTranscribeGuard {
         app_state: &state.app_state,
         app_handle: Some(app_handle.clone()),

--- a/app/src-tauri/src/commands/transform_model.rs
+++ b/app/src-tauri/src/commands/transform_model.rs
@@ -1,0 +1,251 @@
+//! Install + lifecycle commands for the pinned local-LLM transform model (#312).
+//!
+//! The download streams to an exact `.partial` path, enforces the compiled-in
+//! maximum and final size while streaming, computes SHA-256 while streaming,
+//! fsyncs, and atomically publishes under a hash-versioned directory beneath the
+//! app models dir. Any mismatch fails closed and deletes the partial. The helper
+//! has no downloader or URL handling — all trust lives here in the signed app.
+
+use crate::llm_sidecar::{
+    installed_model_path, transform_models_root, TRANSFORM_MODEL_FILENAME, TRANSFORM_MODEL_SHA256,
+    TRANSFORM_MODEL_SIZE_BYTES, TRANSFORM_MODEL_URL,
+};
+use crate::State;
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::LazyLock;
+use tauri::Emitter;
+
+/// Single-flight guard: only one transform-model download at a time.
+static DOWNLOAD_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+/// Coarse status flag so `transform_model_status` can report `downloading`.
+static DOWNLOADING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransformModelState {
+    NotDownloaded,
+    Downloading,
+    Ready,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformModelStatus {
+    pub state: TransformModelState,
+    /// Absolute path to the published model when ready; `None` otherwise.
+    pub path: Option<String>,
+    pub size_bytes: u64,
+    pub sha256: &'static str,
+}
+
+/// A published model of exactly the pinned size is considered ready. The full
+/// SHA-256 is re-verified before every spawn, so status stays cheap here.
+fn model_is_ready() -> Option<std::path::PathBuf> {
+    let path = installed_model_path()?;
+    let metadata = std::fs::metadata(&path).ok()?;
+    if metadata.is_file() && metadata.len() == TRANSFORM_MODEL_SIZE_BYTES {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[tauri::command]
+pub fn transform_model_status() -> TransformModelStatus {
+    let ready = model_is_ready();
+    let state = if ready.is_some() {
+        TransformModelState::Ready
+    } else if DOWNLOADING.load(Ordering::Acquire) {
+        TransformModelState::Downloading
+    } else {
+        TransformModelState::NotDownloaded
+    };
+    TransformModelStatus {
+        state,
+        path: ready.map(|p| p.to_string_lossy().into_owned()),
+        size_bytes: TRANSFORM_MODEL_SIZE_BYTES,
+        sha256: TRANSFORM_MODEL_SHA256,
+    }
+}
+
+/// Clears the `DOWNLOADING` flag on drop, even on early return / error.
+struct DownloadingFlag;
+impl DownloadingFlag {
+    fn set() -> Self {
+        DOWNLOADING.store(true, Ordering::Release);
+        Self
+    }
+}
+impl Drop for DownloadingFlag {
+    fn drop(&mut self) {
+        DOWNLOADING.store(false, Ordering::Release);
+    }
+}
+
+#[tauri::command]
+pub async fn download_transform_model(
+    app_handle: tauri::AppHandle,
+    _state: tauri::State<'_, State>,
+) -> Result<(), String> {
+    let _single_flight = DOWNLOAD_LOCK.lock().await;
+    if model_is_ready().is_some() {
+        return Ok(());
+    }
+    let _flag = DownloadingFlag::set();
+
+    let root = transform_models_root()
+        .ok_or_else(|| "Could not determine transform model directory".to_string())?;
+    tokio::fs::create_dir_all(&root)
+        .await
+        .map_err(|e| format!("Failed to create transform model directory: {}", e))?;
+
+    let partial = root.join(format!("{}.partial", TRANSFORM_MODEL_FILENAME));
+    // Clean any residue from a previous interrupted attempt.
+    let _ = tokio::fs::remove_file(&partial).await;
+
+    let (size, sha) = stream_verified_download(&app_handle, &partial).await.map_err(|e| {
+        let _ = std::fs::remove_file(&partial);
+        e
+    })?;
+
+    if size != TRANSFORM_MODEL_SIZE_BYTES || sha != TRANSFORM_MODEL_SHA256 {
+        let _ = tokio::fs::remove_file(&partial).await;
+        // Never log the observed hash/size content; the mismatch itself is the
+        // signal and the bytes are untrusted.
+        return Err("Transform model verification failed".to_string());
+    }
+
+    let final_dir = root.join(TRANSFORM_MODEL_SHA256);
+    tokio::fs::create_dir_all(&final_dir)
+        .await
+        .map_err(|e| format!("Failed to create model version directory: {}", e))?;
+    let final_path = final_dir.join(TRANSFORM_MODEL_FILENAME);
+
+    tokio::fs::rename(&partial, &final_path).await.map_err(|e| {
+        let _ = std::fs::remove_file(&partial);
+        format!("Failed to publish transform model: {}", e)
+    })?;
+
+    tracing::info!(
+        target: "system",
+        size_bytes = size,
+        "transform_model_installed"
+    );
+    let _ = app_handle.emit(
+        "download-progress",
+        serde_json::json!({ "received": size, "total": size, "phase": "installed" }),
+    );
+    Ok(())
+}
+
+/// Stream the pinned URL to `dest`, enforcing the maximum size while streaming
+/// and hashing as bytes arrive. Returns `(size_bytes, sha256_hex)`.
+async fn stream_verified_download(
+    app_handle: &tauri::AppHandle,
+    dest: &std::path::Path,
+) -> Result<(u64, String), String> {
+    use futures_util::StreamExt;
+    use sha2::{Digest, Sha256};
+    use tokio::io::AsyncWriteExt;
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(30 * 60))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let response = client
+        .get(TRANSFORM_MODEL_URL)
+        .send()
+        .await
+        .map_err(|e| format!("Download request failed: {}", e))?;
+    if !response.status().is_success() {
+        return Err(format!("Download failed with status: {}", response.status()));
+    }
+
+    // Report against the pinned size so progress is meaningful even without a
+    // server content-length.
+    let total = TRANSFORM_MODEL_SIZE_BYTES;
+    let mut received: u64 = 0;
+    let mut hasher = Sha256::new();
+
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|e| format!("Failed to create partial file: {}", e))?;
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Download error: {}", e))?;
+        received += chunk.len() as u64;
+        if received > TRANSFORM_MODEL_SIZE_BYTES {
+            return Err("Download exceeded the expected model size".to_string());
+        }
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("Failed to write partial file: {}", e))?;
+        let _ = app_handle.emit(
+            "download-progress",
+            serde_json::json!({ "received": received, "total": total, "phase": "downloading" }),
+        );
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| format!("Failed to flush partial file: {}", e))?;
+    // fsync so the published bytes survive a crash between rename and flush.
+    file.sync_all()
+        .await
+        .map_err(|e| format!("Failed to fsync partial file: {}", e))?;
+
+    let sha = format!("{:x}", hasher.finalize());
+    Ok((received, sha))
+}
+
+#[tauri::command]
+pub async fn remove_transform_model(state: tauri::State<'_, State>) -> Result<(), String> {
+    // Stop any resident helper first so the model file is not open.
+    state.transform_runtime.shutdown();
+
+    let root = transform_models_root()
+        .ok_or_else(|| "Could not determine transform model directory".to_string())?;
+    let final_dir = root.join(TRANSFORM_MODEL_SHA256);
+    if final_dir.exists() {
+        tokio::fs::remove_dir_all(&final_dir)
+            .await
+            .map_err(|e| format!("Failed to remove transform model: {}", e))?;
+    }
+    // Sweep any stray partial too.
+    let _ = tokio::fs::remove_file(root.join(format!("{}.partial", TRANSFORM_MODEL_FILENAME))).await;
+    tracing::info!(target: "system", "transform_model_removed");
+    Ok(())
+}
+
+#[tauri::command]
+pub fn reset_transform_runtime(state: tauri::State<'_, State>) {
+    state.transform_runtime.reset();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_shape_carries_only_bounded_metadata() {
+        let status = transform_model_status();
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("sha256"));
+        assert!(json.contains("sizeBytes"));
+        // No URL, revision, or free-form text leaks into the status payload.
+        assert!(!json.contains("huggingface"));
+    }
+
+    #[test]
+    fn catalog_pins_match_the_supervisor() {
+        assert_eq!(TRANSFORM_MODEL_SIZE_BYTES, 1_117_320_736);
+        assert_eq!(TRANSFORM_MODEL_SHA256.len(), 64);
+        assert!(TRANSFORM_MODEL_URL.ends_with(TRANSFORM_MODEL_FILENAME));
+    }
+}

--- a/app/src-tauri/src/commands/transform_model.rs
+++ b/app/src-tauri/src/commands/transform_model.rs
@@ -133,8 +133,10 @@ pub async fn download_transform_model(
         size_bytes = size,
         "transform_model_installed"
     );
+    // Dedicated channel so this never collides with the whisper/parakeet
+    // downloader UI on the shared "download-progress" event.
     let _ = app_handle.emit(
-        "download-progress",
+        "transform-model-download-progress",
         serde_json::json!({ "received": size, "total": size, "phase": "installed" }),
     );
     Ok(())
@@ -175,6 +177,12 @@ async fn stream_verified_download(
         .await
         .map_err(|e| format!("Failed to create partial file: {}", e))?;
 
+    // Throttle progress emits so a 1.1 GB stream doesn't flood the UI: emit on
+    // each whole-percent advance or at most every 250ms, on a dedicated channel
+    // that never collides with the whisper/parakeet downloader.
+    let mut last_emit = std::time::Instant::now();
+    let mut last_pct: u64 = u64::MAX;
+
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| format!("Download error: {}", e))?;
@@ -186,10 +194,18 @@ async fn stream_verified_download(
         file.write_all(&chunk)
             .await
             .map_err(|e| format!("Failed to write partial file: {}", e))?;
-        let _ = app_handle.emit(
-            "download-progress",
-            serde_json::json!({ "received": received, "total": total, "phase": "downloading" }),
-        );
+
+        let pct = received.saturating_mul(100) / total.max(1);
+        let now = std::time::Instant::now();
+        if pct != last_pct || now.duration_since(last_emit) >= std::time::Duration::from_millis(250)
+        {
+            last_pct = pct;
+            last_emit = now;
+            let _ = app_handle.emit(
+                "transform-model-download-progress",
+                serde_json::json!({ "received": received, "total": total, "phase": "downloading" }),
+            );
+        }
     }
 
     file.flush()

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -447,6 +447,15 @@ pub fn run() {
                 }
             }
         }
+
+        // App-exit teardown: stop any resident local-LLM helper so it never
+        // outlives the app (no-op when no child is running).
+        #[cfg(target_os = "macos")]
+        if let RunEvent::Exit = &_event {
+            if let Some(state) = _app_handle.try_state::<State>() {
+                state.transform_runtime.shutdown();
+            }
+        }
     });
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod ide_context;
 mod injector;
 mod keyboard;
 mod knowledge_store;
+pub mod llm_sidecar;
 mod model_runtime;
 mod platform;
 mod resource_monitor;
@@ -92,6 +93,45 @@ pub(crate) struct State {
     /// call, so `set_transform_popover_expanded` can resize/reposition for a
     /// new size class without the caller re-supplying the anchor.
     pub(crate) transform_popover_anchor: Mutex<Option<commands::transform_popover::Rect>>,
+    /// Host-side supervisor for the signed local-LLM transform sidecar (#312).
+    pub(crate) transform_runtime: std::sync::Arc<llm_sidecar::LlmSidecar>,
+}
+
+/// Production mutual-exclusion bridge: lets the sidecar refuse to start over a
+/// heavy ASR runtime and release the ASR model (via the existing
+/// `MemoryPressure` unload path) before it spawns.
+struct AppHostGuard {
+    app: tauri::AppHandle,
+}
+
+impl llm_sidecar::HostGuard for AppHostGuard {
+    fn heavy_runtime_active(&self) -> Option<&'static str> {
+        use tauri::Manager;
+        let state = self.app.state::<State>();
+        if state.benchmark.is_running() {
+            return Some("benchmark");
+        }
+        if state
+            .app_state
+            .file_transcribing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Some("fileTranscription");
+        }
+        if state.app_state.dictation.lock_or_recover().status != state::DictationStatus::Idle {
+            return Some("recording");
+        }
+        None
+    }
+
+    fn release_asr(&self) {
+        use tauri::Manager;
+        let state = self.app.state::<State>();
+        let _ = state
+            .app_state
+            .model_runtime
+            .unload(Some(&self.app), model_runtime::UnloadReason::MemoryPressure);
+    }
 }
 
 /// WebKitGTK environment defaults applied on Linux before GTK/webkit init.
@@ -145,6 +185,7 @@ pub fn run() {
             correct_and_teach: correct_and_teach::CorrectAndTeachState::default(),
             notch_info: Mutex::new(None),
             transform_popover_anchor: Mutex::new(None),
+            transform_runtime: std::sync::Arc::new(llm_sidecar::LlmSidecar::new()),
         })
         .invoke_handler(tauri::generate_handler![
             commands::recording::init_dictation,
@@ -207,6 +248,10 @@ pub fn run() {
             commands::models::get_model_runtime_catalog,
             commands::models::get_model_runtime_status,
             commands::models::download_model,
+            commands::transform_model::transform_model_status,
+            commands::transform_model::download_transform_model,
+            commands::transform_model::remove_transform_model,
+            commands::transform_model::reset_transform_runtime,
             frontmost::list_running_applications,
             commands::benchmark::get_benchmark_models,
             commands::benchmark::get_benchmark_activity,
@@ -270,6 +315,26 @@ pub fn run() {
 
             // Periodic heartbeat: memory telemetry + idle timeout
             resource_monitor::start_heartbeat(app.handle().clone());
+
+            // Install the local-LLM mutual-exclusion bridge and start its
+            // maintenance reaper (RSS ceiling + idle unload).
+            {
+                let state = app.state::<State>();
+                state
+                    .transform_runtime
+                    .set_host_guard(std::sync::Arc::new(AppHostGuard {
+                        app: app.handle().clone(),
+                    }));
+                let sidecar = std::sync::Arc::clone(&state.transform_runtime);
+                tauri::async_runtime::spawn(async move {
+                    let mut interval =
+                        tokio::time::interval(std::time::Duration::from_secs(30));
+                    loop {
+                        interval.tick().await;
+                        sidecar.maintenance_tick();
+                    }
+                });
+            }
 
             // Cache notch dimensions on the main thread (safe for NSScreen APIs).
             let notch = commands::overlay::detect_notch_info();

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -1,0 +1,1221 @@
+//! Host-side supervisor for the signed local-LLM sidecar (#312).
+//!
+//! The app links **only** `murmur-local-llm-protocol`; it never links
+//! `llama-cpp-2`. This module owns the child helper process lifecycle: it
+//! verifies the pinned model file, spawns the helper with an empty environment
+//! and the model handed over as inherited read-only fd 3, drives protocol v1
+//! over piped stdin/stdout, and enforces every app-side limit, deadline,
+//! cancellation, crash circuit-breaker, RSS ceiling, and idle-unload rule from
+//! the ADR (docs/decisions/2026-07-20-signed-local-llm-sidecar.md).
+//!
+//! Privacy: no instruction / input / output text ever reaches logs, telemetry,
+//! or error strings. Only durations, bucketed sizes, token counts, and stable
+//! enums are recorded.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use murmur_local_llm_protocol::{ErrorCode, FinishReason};
+
+// ---------------------------------------------------------------------------
+// Immutable catalog pins (single source of truth, shared with the installer).
+// ---------------------------------------------------------------------------
+
+/// Stable catalog identifier for the only v1 transform model.
+pub const TRANSFORM_MODEL_ID: &str = "qwen2.5-1.5b-instruct-q4_k_m";
+/// Model filename as published by the pinned Hugging Face revision.
+pub const TRANSFORM_MODEL_FILENAME: &str = "qwen2.5-1.5b-instruct-q4_k_m.gguf";
+/// Exact byte size the download and the pre-spawn verifier both enforce.
+pub const TRANSFORM_MODEL_SIZE_BYTES: u64 = 1_117_320_736;
+/// Lowercase hex SHA-256 the download and the pre-spawn verifier both enforce.
+pub const TRANSFORM_MODEL_SHA256: &str =
+    "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e";
+/// Immutable Hugging Face repository revision the model is fetched from.
+pub const TRANSFORM_MODEL_REVISION: &str = "dd26da440ef0330c47919d1ecae0966d24022222";
+/// Compile-time download URL pinned to the immutable revision above.
+pub const TRANSFORM_MODEL_URL: &str = "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/dd26da440ef0330c47919d1ecae0966d24022222/qwen2.5-1.5b-instruct-q4_k_m.gguf";
+
+/// Executable base name of the signed helper, as an `externalBin` and in dev.
+pub const HELPER_BIN_NAME: &str = "murmur-llm-sidecar";
+
+/// RSS ceiling below which the helper runs unremarked (2 GiB).
+const RSS_WARN_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+/// RSS ceiling above which the helper is force-killed (3 GiB).
+const RSS_KILL_BYTES: u64 = 3 * 1024 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Public error / output types (portable across all targets).
+// ---------------------------------------------------------------------------
+
+/// Successful transform result: text plus bounded metadata only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransformOutput {
+    pub output: String,
+    pub finish_reason: FinishReason,
+    pub output_tokens: u32,
+}
+
+/// Stable supervisor error enum. Mirrors the protocol `ErrorCode` and adds
+/// supervisor-level variants. Every `Display` string is a fixed label — it
+/// never embeds instruction, input, output, model path, or raw stderr.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransformError {
+    /// Local-LLM runtime is not supported on this platform.
+    Unsupported,
+    /// The pinned transform model is not installed.
+    NotDownloaded,
+    /// The circuit breaker has disabled the runtime until an explicit reset.
+    Disabled,
+    /// A transform is already in flight (one-in-flight rule).
+    Busy,
+    /// Instruction / input / deadline exceeded an app-side limit.
+    InvalidRequest,
+    /// A heavy ASR runtime (recording / benchmark / file transcription) is active.
+    HeavyRuntimeActive,
+    /// The helper executable could not be launched.
+    SpawnFailed,
+    /// The hello/ready handshake failed (nonce, protocol, or model mismatch).
+    HandshakeFailed,
+    /// The installed model file failed size / SHA-256 / regular-file checks.
+    ModelMismatch,
+    /// The deadline elapsed; the helper was cancelled and killed if unresponsive.
+    Timeout,
+    /// The request was cancelled cooperatively.
+    Cancelled,
+    /// The helper process died unexpectedly.
+    Crashed,
+    /// The helper returned output that violated protocol invariants.
+    OutputInvalid,
+    /// The helper spoke a malformed or out-of-contract frame.
+    Protocol,
+    /// The helper reported a resource-limit failure.
+    ResourceLimit,
+    /// An internal supervisor fault.
+    Internal,
+}
+
+impl TransformError {
+    /// Stable machine label for telemetry (no free-form text).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unsupported => "unsupported",
+            Self::NotDownloaded => "notDownloaded",
+            Self::Disabled => "disabled",
+            Self::Busy => "busy",
+            Self::InvalidRequest => "invalidRequest",
+            Self::HeavyRuntimeActive => "heavyRuntimeActive",
+            Self::SpawnFailed => "spawnFailed",
+            Self::HandshakeFailed => "handshakeFailed",
+            Self::ModelMismatch => "modelMismatch",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+            Self::Crashed => "crashed",
+            Self::OutputInvalid => "outputInvalid",
+            Self::Protocol => "protocol",
+            Self::ResourceLimit => "resourceLimit",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// Map a protocol `ErrorCode` reported by a healthy helper onto the stable
+    /// supervisor enum.
+    fn from_helper_code(code: ErrorCode) -> Self {
+        match code {
+            ErrorCode::DeadlineExceeded => Self::Timeout,
+            ErrorCode::Cancelled => Self::Cancelled,
+            ErrorCode::OutputInvalid => Self::OutputInvalid,
+            ErrorCode::ResourceLimit => Self::ResourceLimit,
+            ErrorCode::Busy => Self::Busy,
+            ErrorCode::ModelMismatch | ErrorCode::ModelLoadFailed => Self::ModelMismatch,
+            ErrorCode::InvalidFrame | ErrorCode::InvalidMessage | ErrorCode::ProtocolMismatch => {
+                Self::Protocol
+            }
+            ErrorCode::RuntimeUnavailable | ErrorCode::Internal => Self::Internal,
+        }
+    }
+}
+
+impl std::fmt::Display for TransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::error::Error for TransformError {}
+
+/// Bounded size bucket for telemetry. Never records exact lengths.
+pub fn size_bucket(len: usize) -> &'static str {
+    match len {
+        0 => "0",
+        1..=256 => "le256",
+        257..=1024 => "le1k",
+        1025..=4096 => "le4k",
+        4097..=16384 => "le16k",
+        _ => "gt16k",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mutual-exclusion bridge into the ASR runtime (injected by the host).
+// ---------------------------------------------------------------------------
+
+/// The supervisor is decoupled from Tauri via this bridge so it stays unit
+/// testable. The production implementation lives in `lib.rs` and forwards into
+/// `AppState` / `ModelRuntimeManager`.
+pub trait HostGuard: Send + Sync {
+    /// Return `Some(reason)` when a heavy ASR runtime is active and a transform
+    /// must be refused. Reason is a stable enum label for telemetry.
+    fn heavy_runtime_active(&self) -> Option<&'static str>;
+    /// Release the ASR model (via the existing `MemoryPressure` unload path)
+    /// before the helper spawns, so only one heavy runtime is ever resident.
+    fn release_asr(&self);
+}
+
+/// Default no-op bridge (tests, and before the host installs the real one).
+struct NoopHostGuard;
+impl HostGuard for NoopHostGuard {
+    fn heavy_runtime_active(&self) -> Option<&'static str> {
+        None
+    }
+    fn release_asr(&self) {}
+}
+
+// ---------------------------------------------------------------------------
+// Model path helpers + pre-spawn verification (portable / unix).
+// ---------------------------------------------------------------------------
+
+/// Root of the hash-versioned transform-model store, beneath the app models dir.
+pub fn transform_models_root() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| {
+        d.join("local-dictation")
+            .join("models")
+            .join("transform-llm")
+    })
+}
+
+/// Absolute path the installed, verified model publishes to.
+pub fn installed_model_path() -> Option<PathBuf> {
+    Some(
+        transform_models_root()?
+            .join(TRANSFORM_MODEL_SHA256)
+            .join(TRANSFORM_MODEL_FILENAME),
+    )
+}
+
+/// Stream a file and return `(size_bytes, sha256_hex)`. Used by the installer
+/// and by tests to derive pins for a fixture model.
+pub fn model_file_digest(path: &Path) -> std::io::Result<(u64, String)> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    let mut size = 0_u64;
+    loop {
+        let n = file.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        size += n as u64;
+        hasher.update(&buffer[..n]);
+    }
+    Ok((size, format!("{:x}", hasher.finalize())))
+}
+
+/// Open the model with `O_NOFOLLOW`, verify it is a regular file of exactly
+/// `expected_size` bytes hashing to `expected_sha` (lowercase hex), then rewind
+/// it to offset 0 so the inherited fd 3 starts at the beginning. Returns the
+/// open, verified, rewound handle ready to be handed to the child.
+#[cfg(unix)]
+fn open_and_verify_model(
+    path: &Path,
+    expected_size: u64,
+    expected_sha: &str,
+) -> Result<std::fs::File, TransformError> {
+    use sha2::{Digest, Sha256};
+    use std::io::{Read, Seek, SeekFrom};
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|_| TransformError::ModelMismatch)?;
+
+    let metadata = file.metadata().map_err(|_| TransformError::ModelMismatch)?;
+    if !metadata.is_file() || metadata.len() != expected_size {
+        return Err(TransformError::ModelMismatch);
+    }
+
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let n = file.read(&mut buffer).map_err(|_| TransformError::ModelMismatch)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected_sha {
+        return Err(TransformError::ModelMismatch);
+    }
+
+    file.seek(SeekFrom::Start(0))
+        .map_err(|_| TransformError::ModelMismatch)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_and_verify_model(
+    _path: &Path,
+    _expected_size: u64,
+    _expected_sha: &str,
+) -> Result<std::fs::File, TransformError> {
+    Err(TransformError::Unsupported)
+}
+
+// ---------------------------------------------------------------------------
+// Crash circuit breaker (pure, unit tested).
+// ---------------------------------------------------------------------------
+
+/// Three faults inside a rolling ten-minute window disable the runtime until an
+/// explicit `reset_transform_runtime`.
+#[derive(Default)]
+struct Breaker {
+    failures: Vec<std::time::Instant>,
+    /// Latched once the threshold is crossed; only `reset` clears it.
+    disabled: bool,
+}
+
+const BREAKER_WINDOW: Duration = Duration::from_secs(10 * 60);
+const BREAKER_THRESHOLD: usize = 3;
+
+impl Breaker {
+    fn record_failure(&mut self, now: std::time::Instant) {
+        self.failures
+            .retain(|t| now.duration_since(*t) < BREAKER_WINDOW);
+        self.failures.push(now);
+        if self.failures.len() >= BREAKER_THRESHOLD {
+            self.disabled = true;
+        }
+    }
+
+    fn is_disabled(&mut self, now: std::time::Instant) -> bool {
+        self.failures
+            .retain(|t| now.duration_since(*t) < BREAKER_WINDOW);
+        self.disabled
+    }
+
+    fn reset(&mut self) {
+        self.failures.clear();
+        self.disabled = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RSS policy (pure, unit tested).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RssAction {
+    Ok,
+    Warn,
+    Kill,
+}
+
+fn rss_action(bytes: u64) -> RssAction {
+    if bytes >= RSS_KILL_BYTES {
+        RssAction::Kill
+    } else if bytes >= RSS_WARN_BYTES {
+        RssAction::Warn
+    } else {
+        RssAction::Ok
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spawn plan: production pins/paths vs. an explicit test configuration.
+// ---------------------------------------------------------------------------
+
+/// Explicit configuration used by integration tests to drive the supervisor
+/// against the protocol mock helper. Not part of any stable external API.
+#[derive(Debug, Clone)]
+pub struct TestSpawnConfig {
+    pub helper_path: PathBuf,
+    pub model_path: PathBuf,
+    pub model_size: u64,
+    pub model_sha256: String,
+    /// Scenario env vars for the mock. The production path always `env_clear`s
+    /// with no extra vars; this exists solely so tests can steer the mock.
+    pub scenario_env: Vec<(String, String)>,
+    pub request_slack: Duration,
+    pub cancel_grace: Duration,
+    pub handshake_timeout: Duration,
+    pub idle_after: Duration,
+}
+
+enum SpawnPlan {
+    Production,
+    Test(TestSpawnConfig),
+}
+
+impl SpawnPlan {
+    fn cancel_grace(&self) -> Duration {
+        match self {
+            Self::Production => Duration::from_millis(250),
+            Self::Test(c) => c.cancel_grace,
+        }
+    }
+    fn request_slack(&self) -> Duration {
+        match self {
+            Self::Production => Duration::from_millis(1000),
+            Self::Test(c) => c.request_slack,
+        }
+    }
+    fn handshake_timeout(&self) -> Duration {
+        match self {
+            Self::Production => Duration::from_secs(30),
+            Self::Test(c) => c.handshake_timeout,
+        }
+    }
+    fn idle_after(&self) -> Duration {
+        match self {
+            Self::Production => Duration::from_secs(5 * 60),
+            Self::Test(c) => c.idle_after,
+        }
+    }
+    fn stderr_inherit(&self) -> bool {
+        // Release suppresses helper stderr (no sensitive crash artifacts);
+        // debug and tests inherit it for diagnosis.
+        cfg!(debug_assertions)
+    }
+    fn scenario_env(&self) -> &[(String, String)] {
+        match self {
+            Self::Production => &[],
+            Self::Test(c) => &c.scenario_env,
+        }
+    }
+    fn pins(&self) -> (u64, &str) {
+        match self {
+            Self::Production => (TRANSFORM_MODEL_SIZE_BYTES, TRANSFORM_MODEL_SHA256),
+            Self::Test(c) => (c.model_size, c.model_sha256.as_str()),
+        }
+    }
+    fn helper_path(&self) -> Result<PathBuf, TransformError> {
+        match self {
+            Self::Production => resolve_helper_path(),
+            Self::Test(c) => Ok(c.helper_path.clone()),
+        }
+    }
+    fn model_path(&self) -> Result<PathBuf, TransformError> {
+        match self {
+            Self::Production => {
+                let path = installed_model_path().ok_or(TransformError::NotDownloaded)?;
+                if path.is_file() {
+                    Ok(path)
+                } else {
+                    Err(TransformError::NotDownloaded)
+                }
+            }
+            Self::Test(c) => Ok(c.model_path.clone()),
+        }
+    }
+}
+
+/// Resolve the exact helper executable: the bundled `externalBin` sitting next
+/// to the app binary when packaged, else the dev build product under
+/// `target/{debug,release}/`.
+fn resolve_helper_path() -> Result<PathBuf, TransformError> {
+    let exe = std::env::current_exe().map_err(|_| TransformError::SpawnFailed)?;
+    let dir = exe.parent().ok_or(TransformError::SpawnFailed)?;
+    // Packaged (Contents/MacOS/murmur-llm-sidecar) and the common dev layout
+    // (target/<profile>/murmur-llm-sidecar) both put the helper next to the app.
+    let primary = dir.join(HELPER_BIN_NAME);
+    if primary.is_file() {
+        return Ok(primary);
+    }
+    // Dev fallback: the app ran from an unusual cwd; probe sibling profiles.
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("..").join(profile).join(HELPER_BIN_NAME);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(TransformError::SpawnFailed)
+}
+
+// ---------------------------------------------------------------------------
+// Unique per-process identifiers (no external crate).
+// ---------------------------------------------------------------------------
+
+fn unique_id(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{prefix}-{}-{nanos}-{n}", std::process::id())
+}
+
+// ===========================================================================
+// Supported platform: full supervisor.
+// ===========================================================================
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod supported {
+    use super::*;
+    use murmur_local_llm_protocol::{
+        read_frame, write_frame, FrameError, HelperMessage, HostMessage, ModelIdentity,
+        ProtocolLimits, HostMessage::Cancel as HostCancel, MAX_INPUT_BYTES, MAX_INSTRUCTION_BYTES,
+        MAX_OUTPUT_BYTES, MAX_OUTPUT_TOKENS, MAX_DEADLINE_MS, PROTOCOL_NAME, PROTOCOL_VERSION,
+    };
+    use std::sync::mpsc::{Receiver, RecvTimeoutError};
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    /// Events surfaced by the stdout reader thread.
+    enum HelperEvent {
+        Frame(HelperMessage),
+        /// Clean EOF / process exit (incomplete header on a closed pipe).
+        Exited,
+        /// A malformed, oversized, or truncated frame — fail closed and kill.
+        ProtocolViolation,
+    }
+
+    struct Child {
+        proc: std::process::Child,
+        stdin: std::process::ChildStdin,
+        events: Receiver<HelperEvent>,
+        session_nonce: String,
+        pid: u32,
+        /// Keeps the verified model fd alive for the process lifetime.
+        _model_file: std::fs::File,
+    }
+
+    struct Inner {
+        child: Option<Child>,
+        breaker: Breaker,
+        last_activity: Instant,
+    }
+
+    pub struct LlmSidecar {
+        plan: SpawnPlan,
+        host_guard: OnceLock<Arc<dyn HostGuard>>,
+        busy: AtomicBool,
+        inner: Mutex<Inner>,
+    }
+
+    impl LlmSidecar {
+        pub fn new() -> Self {
+            Self::with_plan(SpawnPlan::Production)
+        }
+
+        pub fn for_test(config: TestSpawnConfig) -> Self {
+            Self::with_plan(SpawnPlan::Test(config))
+        }
+
+        fn with_plan(plan: SpawnPlan) -> Self {
+            Self {
+                plan,
+                host_guard: OnceLock::new(),
+                busy: AtomicBool::new(false),
+                inner: Mutex::new(Inner {
+                    child: None,
+                    breaker: Breaker::default(),
+                    last_activity: Instant::now(),
+                }),
+            }
+        }
+
+        pub fn set_host_guard(&self, guard: Arc<dyn HostGuard>) {
+            let _ = self.host_guard.set(guard);
+        }
+
+        fn guard(&self) -> &dyn HostGuard {
+            match self.host_guard.get() {
+                Some(g) => g.as_ref(),
+                None => &NoopHostGuard,
+            }
+        }
+
+        fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+            self.inner.lock().unwrap_or_else(|p| p.into_inner())
+        }
+
+        /// True while a transform is in flight. Recording paths guard on this so
+        /// ASR never starts over a resident transform runtime.
+        pub fn is_transform_busy(&self) -> bool {
+            self.busy.load(Ordering::Acquire)
+        }
+
+        /// Test-support: whether a helper process is currently resident. Not
+        /// part of any stable external API.
+        pub fn has_live_child(&self) -> bool {
+            self.lock().child.is_some()
+        }
+
+        /// Async transform facade. Serializes to one in-flight request via a
+        /// busy flag (queue-reject: a second concurrent call gets `Busy`).
+        pub async fn transform(
+            self: &Arc<Self>,
+            instruction: &str,
+            input: &str,
+            deadline: Duration,
+        ) -> Result<TransformOutput, TransformError> {
+            // App-side limit enforcement (defence in depth over the helper).
+            if instruction.len() > MAX_INSTRUCTION_BYTES
+                || input.len() > MAX_INPUT_BYTES
+                || instruction.contains('\0')
+                || input.contains('\0')
+                || deadline.is_zero()
+                || deadline > Duration::from_millis(MAX_DEADLINE_MS)
+            {
+                return Err(TransformError::InvalidRequest);
+            }
+
+            if self
+                .busy
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                return Err(TransformError::Busy);
+            }
+
+            // Bucket sizes up front so no raw length leaves this frame.
+            let instruction_bucket = size_bucket(instruction.len());
+            let input_bucket = size_bucket(input.len());
+
+            let this = Arc::clone(self);
+            let instruction = instruction.to_string();
+            let input = input.to_string();
+            let started = Instant::now();
+            let join = tokio::task::spawn_blocking(move || {
+                this.transform_blocking(&instruction, &input, deadline)
+            })
+            .await;
+            self.busy.store(false, Ordering::Release);
+
+            let result = match join {
+                Ok(r) => r,
+                Err(_) => Err(TransformError::Internal),
+            };
+
+            // Telemetry: enums, durations, buckets, token counts only.
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            let (outcome, output_tokens) = match &result {
+                Ok(out) => ("ok", out.output_tokens),
+                Err(err) => (err.as_str(), 0),
+            };
+            tracing::info!(
+                target: "pipeline",
+                outcome,
+                duration_ms = elapsed_ms,
+                instruction_bucket,
+                input_bucket,
+                output_tokens,
+                "llm_transform"
+            );
+            result
+        }
+
+        fn transform_blocking(
+            &self,
+            instruction: &str,
+            input: &str,
+            deadline: Duration,
+        ) -> Result<TransformOutput, TransformError> {
+            let mut inner = self.lock();
+
+            if inner.breaker.is_disabled(Instant::now()) {
+                return Err(TransformError::Disabled);
+            }
+            if let Some(_reason) = self.guard().heavy_runtime_active() {
+                return Err(TransformError::HeavyRuntimeActive);
+            }
+
+            // Verify the model exists before touching the helper.
+            let model_path = self.plan.model_path()?;
+
+            // Lazy spawn. Release the ASR model first so only one heavy runtime
+            // is ever resident (mutual exclusion, ADR "Lifecycle and resources").
+            if inner.child.is_none() {
+                self.guard().release_asr();
+                match self.spawn_and_handshake(&model_path) {
+                    Ok(child) => inner.child = Some(child),
+                    Err(err) => {
+                        inner.breaker.record_failure(Instant::now());
+                        return Err(err);
+                    }
+                }
+            }
+
+            let request_id = unique_id("req");
+            let outcome = {
+                let child = inner.child.as_mut().expect("child present");
+                run_request(child, &request_id, instruction, input, deadline, &self.plan)
+            };
+
+            match outcome {
+                RequestOutcome::Ok(out) => {
+                    inner.last_activity = Instant::now();
+                    Ok(out)
+                }
+                RequestOutcome::HelperError(err) => {
+                    // Helper is still healthy; keep it for reuse.
+                    inner.last_activity = Instant::now();
+                    Err(err)
+                }
+                RequestOutcome::TimedOutKeepChild => {
+                    // Cancel was cooperatively confirmed; helper cleared context.
+                    inner.last_activity = Instant::now();
+                    Err(TransformError::Timeout)
+                }
+                RequestOutcome::TimedOutKilled => {
+                    kill_child(inner.child.take());
+                    Err(TransformError::Timeout)
+                }
+                RequestOutcome::Crashed => {
+                    kill_child(inner.child.take());
+                    inner.breaker.record_failure(Instant::now());
+                    Err(TransformError::Crashed)
+                }
+                RequestOutcome::Protocol => {
+                    kill_child(inner.child.take());
+                    inner.breaker.record_failure(Instant::now());
+                    Err(TransformError::Protocol)
+                }
+                RequestOutcome::OutputInvalid => {
+                    kill_child(inner.child.take());
+                    Err(TransformError::OutputInvalid)
+                }
+            }
+        }
+
+        fn spawn_and_handshake(&self, model_path: &Path) -> Result<Child, TransformError> {
+            use std::os::unix::io::AsRawFd;
+            use std::os::unix::process::CommandExt;
+            use murmur_local_llm_protocol::MODEL_FD;
+
+            let (size, sha) = self.plan.pins();
+            let model_file = open_and_verify_model(model_path, size, sha)?;
+            let helper_path = self.plan.helper_path()?;
+            let raw_fd = model_file.as_raw_fd();
+
+            let mut command = std::process::Command::new(&helper_path);
+            command
+                .current_dir("/")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(if self.plan.stderr_inherit() {
+                    std::process::Stdio::inherit()
+                } else {
+                    std::process::Stdio::null()
+                });
+            command.env_clear();
+            for (k, v) in self.plan.scenario_env() {
+                command.env(k, v);
+            }
+
+            // Hand the verified model over as inherited read-only fd 3. `dup2`
+            // clears FD_CLOEXEC on the new fd, but is a no-op (leaving CLOEXEC
+            // set) when oldfd already equals 3 — so clear it explicitly. No
+            // request-controlled args and no other inherited descriptors.
+            unsafe {
+                command.pre_exec(move || {
+                    if raw_fd != MODEL_FD && libc::dup2(raw_fd, MODEL_FD) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    if libc::fcntl(MODEL_FD, libc::F_SETFD, 0) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+
+            let mut proc = command.spawn().map_err(|_| TransformError::SpawnFailed)?;
+            let pid = proc.id();
+            let mut stdin = proc.stdin.take().ok_or(TransformError::SpawnFailed)?;
+            let stdout = proc.stdout.take().ok_or(TransformError::SpawnFailed)?;
+
+            // Reader thread: classifies frames, protocol violations, and EOF.
+            let (tx, rx) = std::sync::mpsc::channel::<HelperEvent>();
+            std::thread::spawn(move || {
+                let mut stdout = stdout;
+                loop {
+                    match read_frame::<HelperMessage>(&mut stdout) {
+                        Ok(frame) => {
+                            if tx.send(HelperEvent::Frame(frame)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(FrameError::IncompleteHeader) => {
+                            let _ = tx.send(HelperEvent::Exited);
+                            break;
+                        }
+                        Err(_) => {
+                            let _ = tx.send(HelperEvent::ProtocolViolation);
+                            break;
+                        }
+                    }
+                }
+            });
+
+            let session_nonce = unique_id("nonce");
+            let hello = HostMessage::Hello {
+                protocol: PROTOCOL_NAME.to_string(),
+                version: PROTOCOL_VERSION,
+                session_nonce: session_nonce.clone(),
+                model: ModelIdentity {
+                    id: TRANSFORM_MODEL_ID.to_string(),
+                    sha256: sha.to_string(),
+                    size_bytes: size,
+                },
+                limits: ProtocolLimits::default(),
+            };
+            if write_frame(&mut stdin, &hello).is_err() {
+                let _ = proc.kill();
+                return Err(TransformError::HandshakeFailed);
+            }
+
+            // Await Ready within the handshake / model-load deadline.
+            let deadline_at = Instant::now() + self.plan.handshake_timeout();
+            loop {
+                let now = Instant::now();
+                if now >= deadline_at {
+                    let _ = proc.kill();
+                    return Err(TransformError::HandshakeFailed);
+                }
+                match rx.recv_timeout(deadline_at - now) {
+                    Ok(HelperEvent::Frame(HelperMessage::Ready {
+                        protocol,
+                        version,
+                        session_nonce: got_nonce,
+                        model,
+                        ..
+                    })) => {
+                        if protocol != PROTOCOL_NAME
+                            || version != PROTOCOL_VERSION
+                            || got_nonce != session_nonce
+                            || model.sha256 != sha
+                            || model.size_bytes != size
+                        {
+                            let _ = proc.kill();
+                            return Err(TransformError::HandshakeFailed);
+                        }
+                        return Ok(Child {
+                            proc,
+                            stdin,
+                            events: rx,
+                            session_nonce,
+                            pid,
+                            _model_file: model_file,
+                        });
+                    }
+                    Ok(_) | Err(RecvTimeoutError::Disconnected) => {
+                        let _ = proc.kill();
+                        return Err(TransformError::HandshakeFailed);
+                    }
+                    Err(RecvTimeoutError::Timeout) => continue,
+                }
+            }
+        }
+
+        /// Periodic maintenance: RSS ceiling + idle unload. Driven by the host
+        /// heartbeat. Skips while a transform is in flight.
+        pub fn maintenance_tick(&self) {
+            if self.busy.load(Ordering::Acquire) {
+                return;
+            }
+            let mut inner = match self.inner.try_lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            let Some(child) = inner.child.as_ref() else {
+                return;
+            };
+            let pid = child.pid;
+
+            if let Some(bytes) = child_rss_bytes(pid) {
+                match rss_action(bytes) {
+                    RssAction::Ok => {}
+                    RssAction::Warn => {
+                        tracing::warn!(
+                            target: "pipeline",
+                            rss_mb = bytes / (1024 * 1024),
+                            "llm_sidecar_rss_warn"
+                        );
+                    }
+                    RssAction::Kill => {
+                        tracing::warn!(
+                            target: "pipeline",
+                            rss_mb = bytes / (1024 * 1024),
+                            "llm_sidecar_rss_kill"
+                        );
+                        kill_child(inner.child.take());
+                        return;
+                    }
+                }
+            }
+
+            if inner.last_activity.elapsed() >= self.plan.idle_after() {
+                let grace = self.plan.cancel_grace();
+                let child = inner.child.take();
+                shutdown_child(child, grace);
+                tracing::info!(target: "pipeline", "llm_sidecar_idle_unload");
+            }
+        }
+
+        /// Reset the crash circuit breaker and drop any resident helper.
+        pub fn reset(&self) {
+            let mut inner = self.lock();
+            inner.breaker.reset();
+            let grace = self.plan.cancel_grace();
+            let child = inner.child.take();
+            shutdown_child(child, grace);
+            tracing::info!(target: "pipeline", "llm_sidecar_reset");
+        }
+
+        /// Stop the helper (used before recording / removing the model).
+        pub fn shutdown(&self) {
+            let mut inner = self.lock();
+            let grace = self.plan.cancel_grace();
+            let child = inner.child.take();
+            shutdown_child(child, grace);
+        }
+    }
+
+    enum RequestOutcome {
+        Ok(TransformOutput),
+        HelperError(TransformError),
+        TimedOutKeepChild,
+        TimedOutKilled,
+        Crashed,
+        Protocol,
+        OutputInvalid,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_request(
+        child: &mut Child,
+        request_id: &str,
+        instruction: &str,
+        input: &str,
+        deadline: Duration,
+        plan: &SpawnPlan,
+    ) -> RequestOutcome {
+        let transform = HostMessage::Transform {
+            protocol: PROTOCOL_NAME.to_string(),
+            version: PROTOCOL_VERSION,
+            session_nonce: child.session_nonce.clone(),
+            request_id: request_id.to_string(),
+            instruction: instruction.to_string(),
+            input: input.to_string(),
+            max_output_tokens: MAX_OUTPUT_TOKENS,
+            deadline_ms: deadline.as_millis() as u64,
+        };
+        if write_frame(&mut child.stdin, &transform).is_err() {
+            return RequestOutcome::Crashed;
+        }
+
+        // Wait the deadline plus a small slack so a healthy helper can self-report
+        // DeadlineExceeded before we escalate to a cooperative cancel.
+        let wait = deadline + plan.request_slack();
+        let deadline_at = Instant::now() + wait;
+        loop {
+            let now = Instant::now();
+            if now >= deadline_at {
+                return cancel_and_settle(child, request_id, plan.cancel_grace());
+            }
+            match child.events.recv_timeout(deadline_at - now) {
+                Ok(HelperEvent::Frame(HelperMessage::Result {
+                    request_id: got,
+                    output,
+                    finish_reason,
+                    output_tokens,
+                    ..
+                })) => {
+                    if got != request_id {
+                        return RequestOutcome::Protocol;
+                    }
+                    if output.len() > MAX_OUTPUT_BYTES
+                        || output_tokens > MAX_OUTPUT_TOKENS
+                        || output.contains('\0')
+                    {
+                        return RequestOutcome::OutputInvalid;
+                    }
+                    return RequestOutcome::Ok(TransformOutput {
+                        output,
+                        finish_reason,
+                        output_tokens,
+                    });
+                }
+                Ok(HelperEvent::Frame(HelperMessage::Error { code, .. })) => {
+                    return RequestOutcome::HelperError(TransformError::from_helper_code(code));
+                }
+                // A stray cancelled/late frame: ignore and keep waiting.
+                Ok(HelperEvent::Frame(HelperMessage::Cancelled { .. })) => continue,
+                // Ready/Stopped mid-request or any violation: fail closed.
+                Ok(HelperEvent::Frame(HelperMessage::Ready { .. }))
+                | Ok(HelperEvent::Frame(HelperMessage::Stopped { .. }))
+                | Ok(HelperEvent::ProtocolViolation) => return RequestOutcome::Protocol,
+                Ok(HelperEvent::Exited) | Err(RecvTimeoutError::Disconnected) => {
+                    return RequestOutcome::Crashed
+                }
+                Err(RecvTimeoutError::Timeout) => continue,
+            }
+        }
+    }
+
+    /// Cooperative cancel: send a Cancel frame, wait `grace` for a Cancelled
+    /// confirmation, then kill if the helper never confirms.
+    fn cancel_and_settle(child: &mut Child, request_id: &str, grace: Duration) -> RequestOutcome {
+        let cancel = HostCancel {
+            protocol: PROTOCOL_NAME.to_string(),
+            version: PROTOCOL_VERSION,
+            session_nonce: child.session_nonce.clone(),
+            request_id: request_id.to_string(),
+        };
+        let _ = write_frame(&mut child.stdin, &cancel);
+
+        let grace_at = Instant::now() + grace;
+        loop {
+            let now = Instant::now();
+            if now >= grace_at {
+                return RequestOutcome::TimedOutKilled;
+            }
+            match child.events.recv_timeout(grace_at - now) {
+                Ok(HelperEvent::Frame(HelperMessage::Cancelled { request_id: got, .. }))
+                    if got == request_id =>
+                {
+                    return RequestOutcome::TimedOutKeepChild;
+                }
+                // A late Result / other frame during the grace window: the helper
+                // is responsive, so treat cancellation as confirmed and keep it.
+                Ok(HelperEvent::Frame(_)) => return RequestOutcome::TimedOutKeepChild,
+                Ok(HelperEvent::Exited)
+                | Ok(HelperEvent::ProtocolViolation)
+                | Err(RecvTimeoutError::Disconnected) => return RequestOutcome::TimedOutKilled,
+                Err(RecvTimeoutError::Timeout) => continue,
+            }
+        }
+    }
+
+    fn kill_child(child: Option<Child>) {
+        if let Some(mut child) = child {
+            let _ = child.proc.kill();
+            let _ = child.proc.wait();
+        }
+    }
+
+    fn shutdown_child(child: Option<Child>, grace: Duration) {
+        let Some(mut child) = child else {
+            return;
+        };
+        let shutdown = HostMessage::Shutdown {
+            protocol: PROTOCOL_NAME.to_string(),
+            version: PROTOCOL_VERSION,
+            session_nonce: child.session_nonce.clone(),
+        };
+        let _ = write_frame(&mut child.stdin, &shutdown);
+        let deadline = Instant::now() + grace;
+        loop {
+            match child.proc.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = child.proc.kill();
+                        let _ = child.proc.wait();
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => {
+                    let _ = child.proc.kill();
+                    let _ = child.proc.wait();
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Read a child process RSS in bytes by pid via sysinfo.
+    fn child_rss_bytes(pid: u32) -> Option<u64> {
+        use sysinfo::{Pid, ProcessesToUpdate, System};
+        let mut system = System::new();
+        let target = Pid::from_u32(pid);
+        system.refresh_processes(ProcessesToUpdate::Some(&[target]), true);
+        system.process(target).map(|p| p.memory())
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub use supported::LlmSidecar;
+
+// ===========================================================================
+// Unsupported platforms: uniform stub reporting Unsupported.
+// ===========================================================================
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+pub struct LlmSidecar {
+    host_guard: OnceLock<Arc<dyn HostGuard>>,
+    busy: AtomicBool,
+    _plan: SpawnPlan,
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+impl LlmSidecar {
+    pub fn new() -> Self {
+        Self::with_plan(SpawnPlan::Production)
+    }
+
+    pub fn for_test(config: TestSpawnConfig) -> Self {
+        Self::with_plan(SpawnPlan::Test(config))
+    }
+
+    fn with_plan(plan: SpawnPlan) -> Self {
+        Self {
+            host_guard: OnceLock::new(),
+            busy: AtomicBool::new(false),
+            _plan: plan,
+        }
+    }
+
+    pub fn set_host_guard(&self, guard: Arc<dyn HostGuard>) {
+        let _ = self.host_guard.set(guard);
+    }
+
+    pub fn is_transform_busy(&self) -> bool {
+        self.busy.load(Ordering::Acquire)
+    }
+
+    pub fn has_live_child(&self) -> bool {
+        false
+    }
+
+    pub async fn transform(
+        self: &Arc<Self>,
+        _instruction: &str,
+        _input: &str,
+        _deadline: Duration,
+    ) -> Result<TransformOutput, TransformError> {
+        Err(TransformError::Unsupported)
+    }
+
+    pub fn maintenance_tick(&self) {}
+    pub fn reset(&self) {}
+    pub fn shutdown(&self) {}
+}
+
+impl Default for LlmSidecar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ===========================================================================
+// Unit tests (portable + supported-platform).
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_constants_are_internally_consistent() {
+        assert_eq!(TRANSFORM_MODEL_SHA256.len(), 64);
+        assert!(TRANSFORM_MODEL_SHA256
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert_eq!(TRANSFORM_MODEL_REVISION.len(), 40);
+        assert!(TRANSFORM_MODEL_URL.contains(TRANSFORM_MODEL_REVISION));
+        assert!(TRANSFORM_MODEL_URL.ends_with(TRANSFORM_MODEL_FILENAME));
+        assert_eq!(TRANSFORM_MODEL_SIZE_BYTES, 1_117_320_736);
+        // The published model path is hash-versioned beneath the app models dir.
+        if let Some(path) = installed_model_path() {
+            assert!(path.to_string_lossy().contains(TRANSFORM_MODEL_SHA256));
+            assert!(path.ends_with(TRANSFORM_MODEL_FILENAME));
+        }
+    }
+
+    #[test]
+    fn size_buckets_are_monotonic_and_bounded() {
+        assert_eq!(size_bucket(0), "0");
+        assert_eq!(size_bucket(256), "le256");
+        assert_eq!(size_bucket(257), "le1k");
+        assert_eq!(size_bucket(4096), "le4k");
+        assert_eq!(size_bucket(16384), "le16k");
+        assert_eq!(size_bucket(16385), "gt16k");
+    }
+
+    #[test]
+    fn rss_policy_thresholds() {
+        assert_eq!(rss_action(0), RssAction::Ok);
+        assert_eq!(rss_action(RSS_WARN_BYTES - 1), RssAction::Ok);
+        assert_eq!(rss_action(RSS_WARN_BYTES), RssAction::Warn);
+        assert_eq!(rss_action(RSS_KILL_BYTES - 1), RssAction::Warn);
+        assert_eq!(rss_action(RSS_KILL_BYTES), RssAction::Kill);
+    }
+
+    #[test]
+    fn breaker_opens_after_three_failures_and_resets() {
+        let mut breaker = Breaker::default();
+        let now = std::time::Instant::now();
+        assert!(!breaker.is_disabled(now));
+        breaker.record_failure(now);
+        breaker.record_failure(now);
+        assert!(!breaker.is_disabled(now));
+        breaker.record_failure(now);
+        assert!(breaker.is_disabled(now));
+        breaker.reset();
+        assert!(!breaker.is_disabled(now));
+    }
+
+    #[test]
+    fn breaker_prunes_failures_outside_the_window() {
+        let mut breaker = Breaker::default();
+        let base = std::time::Instant::now();
+        breaker.record_failure(base);
+        breaker.record_failure(base);
+        // A third failure more than ten minutes later prunes the first two.
+        let later = base + BREAKER_WINDOW + Duration::from_secs(1);
+        breaker.record_failure(later);
+        assert!(!breaker.is_disabled(later));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn model_verification_accepts_exact_pins_and_rejects_mismatches() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!("murmur-llm-verify-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"deterministic fixture model bytes").unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+
+        let (size, sha) = model_file_digest(&path).unwrap();
+        // Exact pins verify and leave the handle rewound to offset 0.
+        let mut handle = open_and_verify_model(&path, size, &sha).unwrap();
+        use std::io::Read;
+        let mut first = [0_u8; 4];
+        handle.read_exact(&mut first).unwrap();
+        assert_eq!(&first, b"dete");
+
+        // Wrong hash and wrong size both fail closed.
+        let wrong_sha = "0".repeat(64);
+        assert_eq!(
+            open_and_verify_model(&path, size, &wrong_sha).unwrap_err(),
+            TransformError::ModelMismatch
+        );
+        assert_eq!(
+            open_and_verify_model(&path, size + 1, &sha).unwrap_err(),
+            TransformError::ModelMismatch
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -78,8 +78,12 @@ pub enum TransformError {
     SpawnFailed,
     /// The hello/ready handshake failed (nonce, protocol, or model mismatch).
     HandshakeFailed,
-    /// The installed model file failed size / SHA-256 / regular-file checks.
+    /// The installed model file failed size / SHA-256 / regular-file checks —
+    /// its content is wrong, so it is removed and re-download is required.
     ModelMismatch,
+    /// The model file could not be read (open / metadata / read I/O error). A
+    /// transient failure that fails closed WITHOUT deleting the model.
+    ModelUnreadable,
     /// The deadline elapsed; the helper was cancelled and killed if unresponsive.
     Timeout,
     /// The request was cancelled cooperatively.
@@ -109,6 +113,7 @@ impl TransformError {
             Self::SpawnFailed => "spawnFailed",
             Self::HandshakeFailed => "handshakeFailed",
             Self::ModelMismatch => "modelMismatch",
+            Self::ModelUnreadable => "modelUnreadable",
             Self::Timeout => "timeout",
             Self::Cancelled => "cancelled",
             Self::Crashed => "crashed",
@@ -238,13 +243,17 @@ fn open_and_verify_model(
     use std::io::{Read, Seek, SeekFrom};
     use std::os::unix::fs::OpenOptionsExt;
 
+    // I/O failures (open incl. O_NOFOLLOW ELOOP, metadata, read, seek) are
+    // transient/environmental → ModelUnreadable (fail closed, keep the model).
+    // Only a wrong size / hash / non-regular file is a content mismatch →
+    // ModelMismatch (the caller removes it so it can be re-downloaded).
     let mut file = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW)
         .open(path)
-        .map_err(|_| TransformError::ModelMismatch)?;
+        .map_err(|_| TransformError::ModelUnreadable)?;
 
-    let metadata = file.metadata().map_err(|_| TransformError::ModelMismatch)?;
+    let metadata = file.metadata().map_err(|_| TransformError::ModelUnreadable)?;
     if !metadata.is_file() || metadata.len() != expected_size {
         return Err(TransformError::ModelMismatch);
     }
@@ -252,7 +261,9 @@ fn open_and_verify_model(
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; 1024 * 1024];
     loop {
-        let n = file.read(&mut buffer).map_err(|_| TransformError::ModelMismatch)?;
+        let n = file
+            .read(&mut buffer)
+            .map_err(|_| TransformError::ModelUnreadable)?;
         if n == 0 {
             break;
         }
@@ -264,7 +275,7 @@ fn open_and_verify_model(
     }
 
     file.seek(SeekFrom::Start(0))
-        .map_err(|_| TransformError::ModelMismatch)?;
+        .map_err(|_| TransformError::ModelUnreadable)?;
     Ok(file)
 }
 
@@ -725,11 +736,15 @@ mod supported {
                     Ok(out)
                 }
                 RequestOutcome::HelperError(err) => {
-                    // The frame is well-formed so the helper is kept for reuse,
-                    // but a helper that errors every request must not respawn
-                    // indefinitely — count it toward the crash circuit breaker.
+                    // The frame is well-formed so the helper is kept for reuse.
+                    // A helper that faults every request must not respawn forever,
+                    // so most errors count toward the breaker — but a self-reported
+                    // DeadlineExceeded (Timeout) or Cancelled is a designed outcome,
+                    // not a runtime fault, and must never disable the runtime.
                     inner.last_activity = Instant::now();
-                    inner.breaker.record_failure(Instant::now());
+                    if !matches!(err, TransformError::Timeout | TransformError::Cancelled) {
+                        inner.breaker.record_failure(Instant::now());
+                    }
                     Err(err)
                 }
                 RequestOutcome::TimedOutKeepChild => {

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -342,7 +342,10 @@ fn rss_action(bytes: u64) -> RssAction {
 
 /// Explicit configuration used by integration tests to drive the supervisor
 /// against the protocol mock helper. Not part of any stable external API.
+/// `allow(dead_code)`: in a release build without `llm-test-support`, `for_test`
+/// is compiled out so these fields are never read there.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct TestSpawnConfig {
     pub helper_path: PathBuf,
     pub model_path: PathBuf,
@@ -359,6 +362,8 @@ pub struct TestSpawnConfig {
 
 enum SpawnPlan {
     Production,
+    // Only constructed by `for_test`, which is compiled out of release builds.
+    #[allow(dead_code)]
     Test(TestSpawnConfig),
 }
 
@@ -392,6 +397,9 @@ impl SpawnPlan {
         // debug and tests inherit it for diagnosis.
         cfg!(debug_assertions)
     }
+    // Only referenced by the equally-gated env-injection loop; compiled out of
+    // release builds so the scenario-env path is not present at all there.
+    #[cfg(any(debug_assertions, feature = "llm-test-support"))]
     fn scenario_env(&self) -> &[(String, String)] {
         match self {
             Self::Production => &[],
@@ -423,11 +431,29 @@ impl SpawnPlan {
             Self::Test(c) => Ok(c.model_path.clone()),
         }
     }
+
+    /// Remove a corrupt / wrong-content published model so status reports
+    /// `not_downloaded` and the user can re-download. Production only — a test
+    /// fixture model is never touched.
+    fn cleanup_bad_model(&self) {
+        if let Self::Production = self {
+            if let Some(dir) = transform_models_root().map(|r| r.join(TRANSFORM_MODEL_SHA256)) {
+                let _ = std::fs::remove_dir_all(&dir);
+            }
+        }
+    }
 }
 
-/// Resolve the exact helper executable: the bundled `externalBin` sitting next
-/// to the app binary when packaged, else the dev build product under
-/// `target/{debug,release}/`.
+/// Resolve the exact helper executable. Production resolves ONLY the bundled
+/// `externalBin` sitting next to the app binary (`Contents/MacOS/…`), honoring
+/// the ADR requirement to start the exact pinned nested executable — no `..`
+/// probing that could reach an unpinned path. A debug-only fallback covers the
+/// dev layout where the app ran from an unusual cwd.
+///
+/// NOTE: path pinning is necessary but not sufficient. Before shipping, the
+/// packaging integration (#312 PR-A3/C2) must additionally validate the helper
+/// against its fixed designated requirement via `SecStaticCodeCheckValidity`
+/// (ADR threat table "Helper replacement" row). See `spawn_and_handshake`.
 fn resolve_helper_path() -> Result<PathBuf, TransformError> {
     let exe = std::env::current_exe().map_err(|_| TransformError::SpawnFailed)?;
     let dir = exe.parent().ok_or(TransformError::SpawnFailed)?;
@@ -437,7 +463,9 @@ fn resolve_helper_path() -> Result<PathBuf, TransformError> {
     if primary.is_file() {
         return Ok(primary);
     }
-    // Dev fallback: the app ran from an unusual cwd; probe sibling profiles.
+    // Dev-only fallback: probe sibling target profiles. Never compiled into a
+    // release binary, so a packaged app resolves only the pinned sibling path.
+    #[cfg(debug_assertions)]
     for profile in ["debug", "release"] {
         let candidate = dir.join("..").join(profile).join(HELPER_BIN_NAME);
         if candidate.is_file() {
@@ -500,6 +528,21 @@ mod supported {
         child: Option<Child>,
         breaker: Breaker,
         last_activity: Instant,
+        /// Latched once we log an RSS warning, so the reaper warns once per
+        /// crossing rather than every 30s tick. Cleared when RSS drops back.
+        rss_warned: bool,
+    }
+
+    /// RAII guard that clears the in-flight `busy` flag on drop. It is moved
+    /// into the `spawn_blocking` closure so `busy` is released when the blocking
+    /// work finishes on EVERY path — including when the async future is dropped
+    /// (e.g. a `tokio::time::timeout` wrapper) mid-request. A blocking task is
+    /// never cancelled, so its guard always drops.
+    struct BusyGuard(Arc<LlmSidecar>);
+    impl Drop for BusyGuard {
+        fn drop(&mut self) {
+            self.0.busy.store(false, Ordering::Release);
+        }
     }
 
     pub struct LlmSidecar {
@@ -514,6 +557,10 @@ mod supported {
             Self::with_plan(SpawnPlan::Production)
         }
 
+        /// Test-only constructor allowing scenario env injection into the child.
+        /// Excluded from release builds (`debug_assertions` off, feature off) so
+        /// the env-injection path is not linkable in a shipped binary.
+        #[cfg(any(debug_assertions, feature = "llm-test-support"))]
         pub fn for_test(config: TestSpawnConfig) -> Self {
             Self::with_plan(SpawnPlan::Test(config))
         }
@@ -527,6 +574,7 @@ mod supported {
                     child: None,
                     breaker: Breaker::default(),
                     last_activity: Instant::now(),
+                    rss_warned: false,
                 }),
             }
         }
@@ -584,6 +632,10 @@ mod supported {
             {
                 return Err(TransformError::Busy);
             }
+            // Own the busy flag from here. Moving this guard into the blocking
+            // closure guarantees `busy` clears when the blocking work ends even
+            // if this async future is dropped at the `.await` below.
+            let busy_guard = BusyGuard(Arc::clone(self));
 
             // Bucket sizes up front so no raw length leaves this frame.
             let instruction_bucket = size_bucket(instruction.len());
@@ -594,10 +646,10 @@ mod supported {
             let input = input.to_string();
             let started = Instant::now();
             let join = tokio::task::spawn_blocking(move || {
+                let _busy = busy_guard;
                 this.transform_blocking(&instruction, &input, deadline)
             })
             .await;
-            self.busy.store(false, Ordering::Release);
 
             let result = match join {
                 Ok(r) => r,
@@ -646,6 +698,14 @@ mod supported {
                 self.guard().release_asr();
                 match self.spawn_and_handshake(&model_path) {
                     Ok(child) => inner.child = Some(child),
+                    Err(TransformError::ModelMismatch) => {
+                        // A corrupt / wrong-content model at the ready path. Remove
+                        // it (production only) so status reports not_downloaded and
+                        // the user can re-download. Not a helper fault → no breaker
+                        // trip; the file is gone so this cannot loop.
+                        self.plan.cleanup_bad_model();
+                        return Err(TransformError::ModelMismatch);
+                    }
                     Err(err) => {
                         inner.breaker.record_failure(Instant::now());
                         return Err(err);
@@ -665,8 +725,11 @@ mod supported {
                     Ok(out)
                 }
                 RequestOutcome::HelperError(err) => {
-                    // Helper is still healthy; keep it for reuse.
+                    // The frame is well-formed so the helper is kept for reuse,
+                    // but a helper that errors every request must not respawn
+                    // indefinitely — count it toward the crash circuit breaker.
                     inner.last_activity = Instant::now();
+                    inner.breaker.record_failure(Instant::now());
                     Err(err)
                 }
                 RequestOutcome::TimedOutKeepChild => {
@@ -690,6 +753,7 @@ mod supported {
                 }
                 RequestOutcome::OutputInvalid => {
                     kill_child(inner.child.take());
+                    inner.breaker.record_failure(Instant::now());
                     Err(TransformError::OutputInvalid)
                 }
             }
@@ -705,6 +769,13 @@ mod supported {
             let helper_path = self.plan.helper_path()?;
             let raw_fd = model_file.as_raw_fd();
 
+            // TODO(#312 PR-A3/C2 packaging integration): before spawn, validate
+            // `helper_path` with `SecStaticCodeCheckValidity` against the fixed
+            // designated requirement (identifier
+            // `com.localdictation.local-llm-sidecar`, matching Team ID, hardened
+            // runtime). Path pinning alone does not defend the ADR threat-model
+            // "Helper replacement" row — this is a hard gate for the signed,
+            // notarized build and must land before shipping the runtime.
             let mut command = std::process::Command::new(&helper_path);
             command
                 .current_dir("/")
@@ -716,14 +787,19 @@ mod supported {
                     std::process::Stdio::null()
                 });
             command.env_clear();
+            // Scenario env is injected only in test-support builds; production
+            // spawns with a strictly empty environment.
+            #[cfg(any(debug_assertions, feature = "llm-test-support"))]
             for (k, v) in self.plan.scenario_env() {
                 command.env(k, v);
             }
 
-            // Hand the verified model over as inherited read-only fd 3. `dup2`
-            // clears FD_CLOEXEC on the new fd, but is a no-op (leaving CLOEXEC
-            // set) when oldfd already equals 3 — so clear it explicitly. No
-            // request-controlled args and no other inherited descriptors.
+            // Hand the verified model over as inherited read-only fd 3, then
+            // close every other inherited descriptor above fd 3 so only
+            // stdin/stdout/stderr and the model fd survive exec. `dup2` clears
+            // FD_CLOEXEC on the new fd, but is a no-op (leaving CLOEXEC set) when
+            // oldfd already equals 3 — so clear it explicitly. Only
+            // async-signal-safe libc calls run here. No request-controlled args.
             unsafe {
                 command.pre_exec(move || {
                     if raw_fd != MODEL_FD && libc::dup2(raw_fd, MODEL_FD) < 0 {
@@ -731,6 +807,14 @@ mod supported {
                     }
                     if libc::fcntl(MODEL_FD, libc::F_SETFD, 0) < 0 {
                         return Err(std::io::Error::last_os_error());
+                    }
+                    let max_fd = libc::getdtablesize();
+                    let mut fd = MODEL_FD + 1;
+                    while fd < max_fd {
+                        // Ignore EBADF and other errors: closing unused fds is
+                        // best-effort hardening, not a correctness dependency.
+                        libc::close(fd);
+                        fd += 1;
                     }
                     Ok(())
                 });
@@ -777,7 +861,7 @@ mod supported {
                 limits: ProtocolLimits::default(),
             };
             if write_frame(&mut stdin, &hello).is_err() {
-                let _ = proc.kill();
+                kill_and_reap(&mut proc);
                 return Err(TransformError::HandshakeFailed);
             }
 
@@ -786,7 +870,7 @@ mod supported {
             loop {
                 let now = Instant::now();
                 if now >= deadline_at {
-                    let _ = proc.kill();
+                    kill_and_reap(&mut proc);
                     return Err(TransformError::HandshakeFailed);
                 }
                 match rx.recv_timeout(deadline_at - now) {
@@ -803,7 +887,7 @@ mod supported {
                             || model.sha256 != sha
                             || model.size_bytes != size
                         {
-                            let _ = proc.kill();
+                            kill_and_reap(&mut proc);
                             return Err(TransformError::HandshakeFailed);
                         }
                         return Ok(Child {
@@ -816,7 +900,7 @@ mod supported {
                         });
                     }
                     Ok(_) | Err(RecvTimeoutError::Disconnected) => {
-                        let _ = proc.kill();
+                        kill_and_reap(&mut proc);
                         return Err(TransformError::HandshakeFailed);
                     }
                     Err(RecvTimeoutError::Timeout) => continue,
@@ -830,61 +914,85 @@ mod supported {
             if self.busy.load(Ordering::Acquire) {
                 return;
             }
-            let mut inner = match self.inner.try_lock() {
-                Ok(g) => g,
-                Err(_) => return,
-            };
-            let Some(child) = inner.child.as_ref() else {
-                return;
-            };
-            let pid = child.pid;
+            // Decide under a short lock; do any blocking shutdown after release.
+            let (idle_child, kill_now) = {
+                let mut inner = match self.inner.try_lock() {
+                    Ok(g) => g,
+                    Err(_) => return,
+                };
+                let Some(child) = inner.child.as_ref() else {
+                    return;
+                };
+                let pid = child.pid;
 
-            if let Some(bytes) = child_rss_bytes(pid) {
-                match rss_action(bytes) {
-                    RssAction::Ok => {}
-                    RssAction::Warn => {
-                        tracing::warn!(
-                            target: "pipeline",
-                            rss_mb = bytes / (1024 * 1024),
-                            "llm_sidecar_rss_warn"
-                        );
-                    }
-                    RssAction::Kill => {
-                        tracing::warn!(
-                            target: "pipeline",
-                            rss_mb = bytes / (1024 * 1024),
-                            "llm_sidecar_rss_kill"
-                        );
-                        kill_child(inner.child.take());
-                        return;
+                let mut kill = false;
+                if let Some(bytes) = child_rss_bytes(pid) {
+                    match rss_action(bytes) {
+                        RssAction::Ok => inner.rss_warned = false,
+                        RssAction::Warn => {
+                            // Log once per crossing, not every tick.
+                            if !inner.rss_warned {
+                                tracing::warn!(
+                                    target: "pipeline",
+                                    rss_mb = bytes / (1024 * 1024),
+                                    "llm_sidecar_rss_warn"
+                                );
+                                inner.rss_warned = true;
+                            }
+                        }
+                        RssAction::Kill => {
+                            tracing::warn!(
+                                target: "pipeline",
+                                rss_mb = bytes / (1024 * 1024),
+                                "llm_sidecar_rss_kill"
+                            );
+                            kill = true;
+                        }
                     }
                 }
-            }
 
-            if inner.last_activity.elapsed() >= self.plan.idle_after() {
-                let grace = self.plan.cancel_grace();
-                let child = inner.child.take();
-                shutdown_child(child, grace);
+                if kill {
+                    (inner.child.take(), true)
+                } else if inner.last_activity.elapsed() >= self.plan.idle_after() {
+                    (inner.child.take(), false)
+                } else {
+                    return;
+                }
+            };
+
+            if kill_now {
+                kill_child(idle_child);
+            } else {
+                shutdown_child(idle_child, self.plan.cancel_grace());
                 tracing::info!(target: "pipeline", "llm_sidecar_idle_unload");
             }
         }
 
         /// Reset the crash circuit breaker and drop any resident helper.
+        /// Fail-fast when a transform is running: it owns the child and will
+        /// idle-unload on its own; the breaker is not disabled while it runs.
         pub fn reset(&self) {
-            let mut inner = self.lock();
-            inner.breaker.reset();
-            let grace = self.plan.cancel_grace();
-            let child = inner.child.take();
-            shutdown_child(child, grace);
+            let child = match self.inner.try_lock() {
+                Ok(mut inner) => {
+                    inner.breaker.reset();
+                    inner.child.take()
+                }
+                Err(_) => return,
+            };
+            shutdown_child(child, self.plan.cancel_grace());
             tracing::info!(target: "pipeline", "llm_sidecar_reset");
         }
 
-        /// Stop the helper (used before recording / removing the model).
+        /// Stop the helper (used before recording / file transcription /
+        /// benchmark, and on model removal). Takes the child out under a short
+        /// lock, then shuts it down outside the lock. Fail-fast (a no-op) when a
+        /// transform is in flight — the guard never blocks behind a ≤31s request.
         pub fn shutdown(&self) {
-            let mut inner = self.lock();
-            let grace = self.plan.cancel_grace();
-            let child = inner.child.take();
-            shutdown_child(child, grace);
+            let child = match self.inner.try_lock() {
+                Ok(mut inner) => inner.child.take(),
+                Err(_) => return,
+            };
+            shutdown_child(child, self.plan.cancel_grace());
         }
     }
 
@@ -896,6 +1004,44 @@ mod supported {
         Crashed,
         Protocol,
         OutputInvalid,
+    }
+
+    /// The ADR requires the protocol name, version, and per-process session
+    /// nonce on EVERY frame. Validate before acting on any helper message; a
+    /// mismatch is a protocol violation that fails closed.
+    fn helper_frame_valid(message: &HelperMessage, nonce: &str) -> bool {
+        let (protocol, version, session_nonce) = match message {
+            HelperMessage::Ready {
+                protocol,
+                version,
+                session_nonce,
+                ..
+            }
+            | HelperMessage::Result {
+                protocol,
+                version,
+                session_nonce,
+                ..
+            }
+            | HelperMessage::Cancelled {
+                protocol,
+                version,
+                session_nonce,
+                ..
+            }
+            | HelperMessage::Error {
+                protocol,
+                version,
+                session_nonce,
+                ..
+            }
+            | HelperMessage::Stopped {
+                protocol,
+                version,
+                session_nonce,
+            } => (protocol, version, session_nonce),
+        };
+        protocol == PROTOCOL_NAME && *version == PROTOCOL_VERSION && session_nonce == nonce
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -931,37 +1077,58 @@ mod supported {
                 return cancel_and_settle(child, request_id, plan.cancel_grace());
             }
             match child.events.recv_timeout(deadline_at - now) {
-                Ok(HelperEvent::Frame(HelperMessage::Result {
-                    request_id: got,
-                    output,
-                    finish_reason,
-                    output_tokens,
-                    ..
-                })) => {
-                    if got != request_id {
+                Ok(HelperEvent::Frame(frame)) => {
+                    if !helper_frame_valid(&frame, &child.session_nonce) {
                         return RequestOutcome::Protocol;
                     }
-                    if output.len() > MAX_OUTPUT_BYTES
-                        || output_tokens > MAX_OUTPUT_TOKENS
-                        || output.contains('\0')
-                    {
-                        return RequestOutcome::OutputInvalid;
+                    match frame {
+                        HelperMessage::Result {
+                            request_id: got,
+                            output,
+                            finish_reason,
+                            output_tokens,
+                            ..
+                        } => {
+                            if got != request_id {
+                                return RequestOutcome::Protocol;
+                            }
+                            if output.len() > MAX_OUTPUT_BYTES
+                                || output_tokens > MAX_OUTPUT_TOKENS
+                                || output.contains('\0')
+                            {
+                                return RequestOutcome::OutputInvalid;
+                            }
+                            return RequestOutcome::Ok(TransformOutput {
+                                output,
+                                finish_reason,
+                                output_tokens,
+                            });
+                        }
+                        HelperMessage::Error {
+                            code,
+                            request_id: err_request_id,
+                            ..
+                        } => {
+                            // An Error may omit the request id, but if present it
+                            // must name the in-flight request.
+                            if let Some(id) = err_request_id {
+                                if id != request_id {
+                                    return RequestOutcome::Protocol;
+                                }
+                            }
+                            return RequestOutcome::HelperError(TransformError::from_helper_code(
+                                code,
+                            ));
+                        }
+                        // A stray cancelled/late frame: ignore and keep waiting.
+                        HelperMessage::Cancelled { .. } => continue,
+                        // Ready/Stopped mid-request: fail closed.
+                        HelperMessage::Ready { .. } | HelperMessage::Stopped { .. } => {
+                            return RequestOutcome::Protocol
+                        }
                     }
-                    return RequestOutcome::Ok(TransformOutput {
-                        output,
-                        finish_reason,
-                        output_tokens,
-                    });
                 }
-                Ok(HelperEvent::Frame(HelperMessage::Error { code, .. })) => {
-                    return RequestOutcome::HelperError(TransformError::from_helper_code(code));
-                }
-                // A stray cancelled/late frame: ignore and keep waiting.
-                Ok(HelperEvent::Frame(HelperMessage::Cancelled { .. })) => continue,
-                // Ready/Stopped mid-request or any violation: fail closed.
-                Ok(HelperEvent::Frame(HelperMessage::Ready { .. }))
-                | Ok(HelperEvent::Frame(HelperMessage::Stopped { .. }))
-                | Ok(HelperEvent::ProtocolViolation) => return RequestOutcome::Protocol,
+                Ok(HelperEvent::ProtocolViolation) => return RequestOutcome::Protocol,
                 Ok(HelperEvent::Exited) | Err(RecvTimeoutError::Disconnected) => {
                     return RequestOutcome::Crashed
                 }
@@ -988,14 +1155,16 @@ mod supported {
                 return RequestOutcome::TimedOutKilled;
             }
             match child.events.recv_timeout(grace_at - now) {
-                Ok(HelperEvent::Frame(HelperMessage::Cancelled { request_id: got, .. }))
-                    if got == request_id =>
-                {
+                Ok(HelperEvent::Frame(frame)) => {
+                    // Even during cancellation, a frame with the wrong nonce /
+                    // protocol is a violation — kill rather than trust it.
+                    if !helper_frame_valid(&frame, &child.session_nonce) {
+                        return RequestOutcome::TimedOutKilled;
+                    }
+                    // A matching Cancelled, or any other well-formed frame,
+                    // proves the helper is responsive: cancellation confirmed.
                     return RequestOutcome::TimedOutKeepChild;
                 }
-                // A late Result / other frame during the grace window: the helper
-                // is responsive, so treat cancellation as confirmed and keep it.
-                Ok(HelperEvent::Frame(_)) => return RequestOutcome::TimedOutKeepChild,
                 Ok(HelperEvent::Exited)
                 | Ok(HelperEvent::ProtocolViolation)
                 | Err(RecvTimeoutError::Disconnected) => return RequestOutcome::TimedOutKilled,
@@ -1004,10 +1173,15 @@ mod supported {
         }
     }
 
+    /// Kill a raw process handle and reap it so it never lingers as a zombie.
+    fn kill_and_reap(proc: &mut std::process::Child) {
+        let _ = proc.kill();
+        let _ = proc.wait();
+    }
+
     fn kill_child(child: Option<Child>) {
         if let Some(mut child) = child {
-            let _ = child.proc.kill();
-            let _ = child.proc.wait();
+            kill_and_reap(&mut child.proc);
         }
     }
 
@@ -1072,6 +1246,7 @@ impl LlmSidecar {
         Self::with_plan(SpawnPlan::Production)
     }
 
+    #[cfg(any(debug_assertions, feature = "llm-test-support"))]
     pub fn for_test(config: TestSpawnConfig) -> Self {
         Self::with_plan(SpawnPlan::Test(config))
     }

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -1,0 +1,202 @@
+//! Integration tests for the local-LLM sidecar supervisor (#312).
+//!
+//! These drive the real supervisor against the protocol-v1 mock helper
+//! (`CARGO_BIN_EXE_mock_llm_helper`). No real GGUF model or llama.cpp is
+//! involved: the "model" is a small temp file whose pins the test derives.
+
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ui_lib::llm_sidecar::{
+    model_file_digest, LlmSidecar, TestSpawnConfig, TransformError, TransformOutput,
+};
+
+fn helper_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mock_llm_helper"))
+}
+
+/// A small fixture "model" file plus its exact pins.
+struct Fixture {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+    size: u64,
+    sha: String,
+}
+
+fn fixture_model() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fixture-model.gguf");
+    std::fs::write(&path, b"murmur local-llm fixture model bytes").unwrap();
+    let (size, sha) = model_file_digest(&path).unwrap();
+    Fixture {
+        _dir: dir,
+        path,
+        size,
+        sha,
+    }
+}
+
+fn config_with(scenario: &str, fixture: &Fixture, env: Vec<(String, String)>) -> TestSpawnConfig {
+    let mut scenario_env = vec![("MOCK_SCENARIO".to_string(), scenario.to_string())];
+    scenario_env.extend(env);
+    TestSpawnConfig {
+        helper_path: helper_path(),
+        model_path: fixture.path.clone(),
+        model_size: fixture.size,
+        model_sha256: fixture.sha.clone(),
+        scenario_env,
+        request_slack: Duration::from_millis(100),
+        cancel_grace: Duration::from_millis(150),
+        handshake_timeout: Duration::from_secs(5),
+        idle_after: Duration::from_secs(300),
+    }
+}
+
+fn sidecar(scenario: &str, fixture: &Fixture) -> Arc<LlmSidecar> {
+    Arc::new(LlmSidecar::for_test(config_with(scenario, fixture, vec![])))
+}
+
+async fn run_transform(
+    sidecar: &Arc<LlmSidecar>,
+    deadline: Duration,
+) -> Result<TransformOutput, TransformError> {
+    sidecar
+        .transform("Rewrite this politely.", "gimme the report", deadline)
+        .await
+}
+
+#[tokio::test]
+async fn successful_transform_round_trip() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("happy", &fixture);
+    let out = run_transform(&sidecar, Duration::from_secs(5)).await.unwrap();
+    assert_eq!(out.output, "mock-output");
+    assert_eq!(out.output_tokens, 3);
+    // The helper is healthy and kept resident for reuse.
+    assert!(sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn timeout_cancels_then_kills_and_reports_timeout() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("slow_ignore_cancel", &fixture);
+    let err = run_transform(&sidecar, Duration::from_millis(200))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Timeout);
+    // The helper never confirmed the cancel, so it was killed.
+    assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn cancel_path_keeps_confirmed_helper_alive() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("slow_ack_cancel", &fixture);
+    let err = run_transform(&sidecar, Duration::from_millis(200))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Timeout);
+    // The helper acknowledged the cooperative cancel, so it stays resident.
+    assert!(sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn crash_reports_crashed_and_trips_circuit_breaker() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("crash_on_transform", &fixture);
+    for _ in 0..3 {
+        let err = run_transform(&sidecar, Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert_eq!(err, TransformError::Crashed);
+        assert!(!sidecar.has_live_child());
+    }
+    // Three crashes in the window disable the runtime until an explicit reset.
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Disabled);
+
+    sidecar.reset();
+    // After reset the breaker is clear; the next attempt spawns again (and
+    // crashes again, proving it is no longer short-circuited as Disabled).
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Crashed);
+}
+
+#[tokio::test]
+async fn malformed_frame_fails_closed_and_kills() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("malformed_on_transform", &fixture);
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Protocol);
+    assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn oversized_frame_fails_closed_and_kills() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("oversized_on_transform", &fixture);
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Protocol);
+    assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn wrong_handshake_nonce_fails_closed() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("wrong_nonce", &fixture);
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::HandshakeFailed);
+    assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn one_transform_in_flight_rejects_the_second() {
+    let fixture = fixture_model();
+    // A deliberate delay so the two requests overlap.
+    let sidecar = Arc::new(LlmSidecar::for_test(config_with(
+        "happy",
+        &fixture,
+        vec![("MOCK_DELAY_MS".to_string(), "600".to_string())],
+    )));
+
+    let a = {
+        let s = Arc::clone(&sidecar);
+        tokio::spawn(async move { run_transform(&s, Duration::from_secs(5)).await })
+    };
+    // Give the first request time to claim the in-flight slot.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let b = run_transform(&sidecar, Duration::from_secs(5)).await;
+
+    let a = a.await.unwrap();
+    assert!(a.is_ok(), "first transform should succeed: {a:?}");
+    assert_eq!(b.unwrap_err(), TransformError::Busy);
+}
+
+#[tokio::test]
+async fn checksum_mismatch_model_refuses_to_spawn() {
+    let fixture = fixture_model();
+    let mut config = config_with("happy", &fixture, vec![]);
+    // Corrupt the pinned hash: the pre-spawn verifier must fail closed.
+    config.model_sha256 = "0".repeat(64);
+    let sidecar = Arc::new(LlmSidecar::for_test(config));
+
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::ModelMismatch);
+    // The helper was never launched.
+    assert!(!sidecar.has_live_child());
+}

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -186,6 +186,52 @@ async fn one_transform_in_flight_rejects_the_second() {
 }
 
 #[tokio::test]
+async fn wrong_nonce_on_result_frame_fails_closed() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("wrong_nonce_on_result", &fixture);
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    // Every frame's nonce is validated, not just the Ready handshake.
+    assert_eq!(err, TransformError::Protocol);
+    assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn dropping_the_transform_future_clears_busy_and_does_not_wedge() {
+    let fixture = fixture_model();
+    // Happy path with a delayed Result so the request is still in flight when
+    // the future is dropped.
+    let sidecar = Arc::new(LlmSidecar::for_test(config_with(
+        "happy",
+        &fixture,
+        vec![("MOCK_DELAY_MS".to_string(), "400".to_string())],
+    )));
+
+    {
+        // Drop the transform future well before the delayed Result arrives.
+        let fut = run_transform(&sidecar, Duration::from_secs(5));
+        let dropped = tokio::time::timeout(Duration::from_millis(50), fut).await;
+        assert!(dropped.is_err(), "future should be cancelled by the timeout");
+    }
+
+    // The blocking task keeps running and must clear `busy` when it finishes.
+    let mut cleared = false;
+    for _ in 0..100 {
+        if !sidecar.is_transform_busy() {
+            cleared = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(cleared, "busy flag wedged after the future was dropped");
+
+    // And the supervisor is not bricked: a fresh transform proceeds.
+    let out = run_transform(&sidecar, Duration::from_secs(5)).await.unwrap();
+    assert_eq!(out.output, "mock-output");
+}
+
+#[tokio::test]
 async fn checksum_mismatch_model_refuses_to_spawn() {
     let fixture = fixture_model();
     let mut config = config_with("happy", &fixture, vec![]);

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -130,6 +130,27 @@ async fn crash_reports_crashed_and_trips_circuit_breaker() {
 }
 
 #[tokio::test]
+async fn helper_deadline_errors_do_not_trip_the_breaker() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("error_deadline_on_transform", &fixture);
+    // Three self-reported DeadlineExceeded outcomes in the window are a designed
+    // result, not a fault: the runtime must stay enabled.
+    for _ in 0..3 {
+        let err = run_transform(&sidecar, Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert_eq!(err, TransformError::Timeout);
+        // The helper is healthy and kept for reuse.
+        assert!(sidecar.has_live_child());
+    }
+    // A fourth attempt still runs (Timeout), never short-circuited as Disabled.
+    let err = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert_eq!(err, TransformError::Timeout);
+}
+
+#[tokio::test]
 async fn malformed_frame_fails_closed_and_kills() {
     let fixture = fixture_model();
     let sidecar = sidecar("malformed_on_transform", &fixture);

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -21,8 +21,8 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use murmur_local_llm_protocol::{
-    read_frame, write_frame, FinishReason, HelperMessage, HostMessage, ModelIdentity, MODEL_FD,
-    PROTOCOL_NAME, PROTOCOL_VERSION,
+    read_frame, write_frame, ErrorCode, FinishReason, HelperMessage, HostMessage, ModelIdentity,
+    MODEL_FD, PROTOCOL_NAME, PROTOCOL_VERSION,
 };
 
 fn scenario() -> String {
@@ -130,6 +130,18 @@ fn main() {
                     }
                     "slow_ack_cancel" | "slow_ignore_cancel" => {
                         // Never send a Result; wait for the Cancel below.
+                    }
+                    "error_deadline_on_transform" => {
+                        // A self-reported DeadlineExceeded: a designed outcome the
+                        // supervisor maps to Timeout and must NOT count as a fault.
+                        let error = HelperMessage::Error {
+                            protocol: PROTOCOL_NAME.to_string(),
+                            version: PROTOCOL_VERSION,
+                            session_nonce: session_nonce.clone(),
+                            request_id: Some(request_id),
+                            code: ErrorCode::DeadlineExceeded,
+                        };
+                        let _ = write_frame(&mut stdout, &error);
                     }
                     "wrong_nonce_on_result" => {
                         // Well-formed Result frame but with a mismatched session

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -1,0 +1,177 @@
+//! Protocol-v1 mock of `murmur-llm-sidecar`, for supervisor integration tests.
+//!
+//! It never links llama.cpp and needs no real model. It performs the
+//! hello/ready handshake, verifies the inherited model fd 3 is a regular file
+//! (proving the supervisor's fd-passing), then behaves per the `MOCK_SCENARIO`
+//! environment variable the test sets when spawning:
+//!
+//! - `happy`               — reply Result immediately (optional `MOCK_DELAY_MS`)
+//! - `wrong_nonce`         — send Ready with a mismatched session nonce
+//! - `crash_on_transform`  — exit(101) on the first Transform
+//! - `malformed_on_transform` — emit an invalid-JSON frame
+//! - `oversized_on_transform` — emit a length prefix over the 64 KiB frame cap
+//! - `slow_ack_cancel`     — never Result; reply Cancelled to a Cancel
+//! - `slow_ignore_cancel`  — never Result; ignore Cancel (forces a kill)
+//!
+//! The real supervisor spawns with `env_clear`, so these vars only exist for the
+//! mock via the supervisor's test-only constructor.
+
+use std::io::Write;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use murmur_local_llm_protocol::{
+    read_frame, write_frame, FinishReason, HelperMessage, HostMessage, ModelIdentity, MODEL_FD,
+    PROTOCOL_NAME, PROTOCOL_VERSION,
+};
+
+fn scenario() -> String {
+    std::env::var("MOCK_SCENARIO").unwrap_or_else(|_| "happy".to_string())
+}
+
+/// Confirm fd 3 was inherited as a readable regular file.
+fn verify_model_fd() -> bool {
+    let dup = unsafe { libc::dup(MODEL_FD) };
+    if dup < 0 {
+        return false;
+    }
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::fstat(dup, &mut stat) };
+    unsafe { libc::close(dup) };
+    rc == 0 && (stat.st_mode & libc::S_IFMT) == libc::S_IFREG
+}
+
+fn main() {
+    if !verify_model_fd() {
+        std::process::exit(3);
+    }
+
+    let scenario = scenario();
+    let mut stdout = std::io::stdout();
+
+    // --- Handshake ---
+    let mut stdin = std::io::stdin();
+    let hello = match read_frame::<HostMessage>(&mut stdin) {
+        Ok(h) => h,
+        Err(_) => std::process::exit(4),
+    };
+    let (session_nonce, model) = match hello {
+        HostMessage::Hello {
+            session_nonce,
+            model,
+            ..
+        } => (session_nonce, model),
+        _ => std::process::exit(5),
+    };
+
+    let ready_nonce = if scenario == "wrong_nonce" {
+        "WRONG-NONCE".to_string()
+    } else {
+        session_nonce.clone()
+    };
+    let ready = HelperMessage::Ready {
+        protocol: PROTOCOL_NAME.to_string(),
+        version: PROTOCOL_VERSION,
+        session_nonce: ready_nonce,
+        runtime_version: "mock".to_string(),
+        model: ModelIdentity {
+            id: model.id,
+            sha256: model.sha256,
+            size_bytes: model.size_bytes,
+        },
+        backend: "mock".to_string(),
+    };
+    if write_frame(&mut stdout, &ready).is_err() {
+        std::process::exit(6);
+    }
+    if scenario == "wrong_nonce" {
+        // Let the supervisor reject the handshake and kill us.
+        std::thread::sleep(Duration::from_secs(5));
+        return;
+    }
+
+    // --- Reader thread: forward host frames even while "processing". ---
+    let (tx, rx) = mpsc::channel::<Option<HostMessage>>();
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        loop {
+            match read_frame::<HostMessage>(&mut stdin) {
+                Ok(frame) => {
+                    if tx.send(Some(frame)).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    let _ = tx.send(None);
+                    break;
+                }
+            }
+        }
+    });
+
+    while let Ok(Some(message)) = rx.recv() {
+        match message {
+            HostMessage::Transform { request_id, .. } => {
+                match scenario.as_str() {
+                    "crash_on_transform" => std::process::exit(101),
+                    "malformed_on_transform" => {
+                        // Valid length prefix, invalid JSON body → InvalidJson.
+                        let body = b"{ this is not json";
+                        let _ = stdout.write_all(&(body.len() as u32).to_be_bytes());
+                        let _ = stdout.write_all(body);
+                        let _ = stdout.flush();
+                    }
+                    "oversized_on_transform" => {
+                        // Length header beyond the 64 KiB cap → rejected pre-alloc.
+                        let too_large: u32 = 64 * 1024 + 1;
+                        let _ = stdout.write_all(&too_large.to_be_bytes());
+                        let _ = stdout.write_all(b"xx");
+                        let _ = stdout.flush();
+                    }
+                    "slow_ack_cancel" | "slow_ignore_cancel" => {
+                        // Never send a Result; wait for the Cancel below.
+                    }
+                    _ => {
+                        if let Ok(ms) = std::env::var("MOCK_DELAY_MS") {
+                            if let Ok(ms) = ms.parse::<u64>() {
+                                std::thread::sleep(Duration::from_millis(ms));
+                            }
+                        }
+                        let result = HelperMessage::Result {
+                            protocol: PROTOCOL_NAME.to_string(),
+                            version: PROTOCOL_VERSION,
+                            session_nonce: session_nonce.clone(),
+                            request_id,
+                            output: "mock-output".to_string(),
+                            finish_reason: FinishReason::Stop,
+                            output_tokens: 3,
+                        };
+                        let _ = write_frame(&mut stdout, &result);
+                    }
+                }
+            }
+            HostMessage::Cancel { request_id, .. } => {
+                if scenario == "slow_ack_cancel" {
+                    let cancelled = HelperMessage::Cancelled {
+                        protocol: PROTOCOL_NAME.to_string(),
+                        version: PROTOCOL_VERSION,
+                        session_nonce: session_nonce.clone(),
+                        request_id,
+                    };
+                    let _ = write_frame(&mut stdout, &cancelled);
+                }
+                // slow_ignore_cancel: intentionally drop it.
+            }
+            HostMessage::Shutdown { .. } => {
+                let stopped = HelperMessage::Stopped {
+                    protocol: PROTOCOL_NAME.to_string(),
+                    version: PROTOCOL_VERSION,
+                    session_nonce: session_nonce.clone(),
+                };
+                let _ = write_frame(&mut stdout, &stopped);
+                return;
+            }
+            HostMessage::Hello { .. } => std::process::exit(7),
+        }
+    }
+}

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -131,6 +131,20 @@ fn main() {
                     "slow_ack_cancel" | "slow_ignore_cancel" => {
                         // Never send a Result; wait for the Cancel below.
                     }
+                    "wrong_nonce_on_result" => {
+                        // Well-formed Result frame but with a mismatched session
+                        // nonce — the supervisor must reject every frame's nonce.
+                        let result = HelperMessage::Result {
+                            protocol: PROTOCOL_NAME.to_string(),
+                            version: PROTOCOL_VERSION,
+                            session_nonce: "WRONG-NONCE".to_string(),
+                            request_id,
+                            output: "mock-output".to_string(),
+                            finish_reason: FinishReason::Stop,
+                            output_tokens: 3,
+                        };
+                        let _ = write_frame(&mut stdout, &result);
+                    }
                     _ => {
                         if let Ok(ms) = std::env::var("MOCK_DELAY_MS") {
                             if let Ok(ms) = ms.parse::<u64>() {


### PR DESCRIPTION
## Summary

Phase A2 of #312: the host side of the sidecar runtime, per the ADR.

- **`llm_sidecar.rs` supervisor**: spawn per ADR (env_clear, fixed cwd, piped stdin/stdout, model as inherited read-only fd 3 opened O_NOFOLLOW and size+SHA-256-verified pre-spawn, fds >3 closed in pre_exec, no request-controlled args, production helper path pinned to the bundle — dev-only fallbacks are cfg-gated). Nonce/protocol/version validated on **every** inbound frame; malformed/oversized/unknown frames kill the helper. Async transform facade with app-side deadline → cooperative cancel → 250ms forced kill; one in-flight (RAII BusyGuard immune to future-drop); 3-crashes/10-min circuit breaker (designed outcomes — self-reported deadline/cancel — excluded); 5-min idle unload; RSS warn 2 GiB / kill 3 GiB; `RunEvent::Exit` teardown; all kills reaped.
- **Mutual exclusion**: ASR model released (`MemoryPressure` unload) before spawn; helper shut down at the start of recording / file transcription / benchmark; supervisor-busy guards sit adjacent to B1's status guards at all entry points.
- **Model install**: immutable catalog pinned to the ADR (revision, size, SHA-256); streaming download with in-flight hash + size enforcement, fsync, atomic publish to a hash-versioned dir; corrupt model auto-removed on spawn-time mismatch (transient I/O errors keep the model and fail closed). Commands: `transform_model_status` / `download_transform_model` / `remove_transform_model` / `reset_transform_runtime`; progress on `transform-model-download-progress` (throttled).
- **Tests**: 12 integration tests against a scenario-driven mock helper (round-trip, timeout-kill, crash+breaker, malformed/oversized frames, wrong nonce, cancel, one-in-flight, checksum-refusal, future-drop, deadline-no-breaker) — no real model or helper needed. Test-support constructor compile-gated out of release.
- **Privacy**: durations, bucketed sizes, token counts, enums only — never instruction/input/output text.

## Verification

- Rebased onto main with B1+C1; first tree where all three coexist: `cargo test --workspace -- --test-threads=1` → 472 unit + 12 integration + protocol 5, 0 failures; `cargo check --workspace` clean.
- Two independent adversarial review rounds; all 13 findings + re-review finding addressed and verified.

Part of #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)