### PR TITLE
feat: end-to-end selected-text transform flow (#312 Phase C2)

### DIFF
--- a/app/src-tauri/src/commands/transform_popover.rs
+++ b/app/src-tauri/src/commands/transform_popover.rs
@@ -190,12 +190,17 @@ fn active_screen_visible_frame(app: &tauri::AppHandle, state: &State) -> Rect {
 
     match monitor {
         Some(monitor) => {
+            // C1 carry-forward fix: bias to `true` when `primary_monitor()`
+            // errors/returns None. On a single-display Mac (the common case)
+            // the active monitor IS the primary, so failing to resolve it must
+            // still reserve the menu-bar / notch inset rather than place the
+            // popover under the notch.
             let is_primary = app
                 .primary_monitor()
                 .ok()
                 .flatten()
                 .map(|primary| primary.position() == monitor.position())
-                .unwrap_or(false);
+                .unwrap_or(true);
 
             visible_frame_for_monitor(
                 (monitor.position().x as f64, monitor.position().y as f64),
@@ -253,10 +258,21 @@ pub fn show_transform_popover(
     state: tauri::State<'_, State>,
     anchor: Option<Rect>,
 ) -> Result<(), String> {
+    show_popover_internal(&app, state.inner(), anchor)
+}
+
+/// Non-command core of `show_transform_popover`, callable directly from the
+/// transform-flow orchestrator (issue #312 PR-C2) with plain references rather
+/// than a `tauri::State` extractor.
+pub(crate) fn show_popover_internal(
+    app: &tauri::AppHandle,
+    state: &State,
+    anchor: Option<Rect>,
+) -> Result<(), String> {
     *state.transform_popover_anchor.lock_or_recover() = anchor;
     match app.get_webview_window("transform-review") {
         Some(window) => {
-            let screen_frame = active_screen_visible_frame(&app, &state);
+            let screen_frame = active_screen_visible_frame(app, state);
             let geometry = popover_geometry_for(anchor, screen_frame);
             let target = geometry.compact;
             window
@@ -280,6 +296,11 @@ pub fn show_transform_popover(
 /// Hide the transform review popover.
 #[tauri::command]
 pub fn hide_transform_popover(app: tauri::AppHandle) -> Result<(), String> {
+    hide_popover_internal(&app)
+}
+
+/// Non-command core of `hide_transform_popover` (issue #312 PR-C2).
+pub(crate) fn hide_popover_internal(app: &tauri::AppHandle) -> Result<(), String> {
     match app.get_webview_window("transform-review") {
         Some(window) => window.hide().map_err(|e| e.to_string()),
         None => {
@@ -306,8 +327,23 @@ pub fn set_transform_popover_expanded(
     state: tauri::State<'_, State>,
     expanded: bool,
 ) -> Result<PopoverBox, String> {
+    set_expanded_internal(&app, state.inner(), expanded)
+}
+
+/// Non-command core of `set_transform_popover_expanded` (issue #312 PR-C2).
+///
+/// C1 carry-forward fix: a missing `transform-review` window is now a hard
+/// `Err` (was `Ok` + warn), mirroring `overlay::set_overlay_expanded`. The
+/// caller gates a CSS reveal on the resolved box; silently returning a box the
+/// window was never actually resized to would let the popover reveal at the
+/// wrong size.
+pub(crate) fn set_expanded_internal(
+    app: &tauri::AppHandle,
+    state: &State,
+    expanded: bool,
+) -> Result<PopoverBox, String> {
     let anchor = *state.transform_popover_anchor.lock_or_recover();
-    let screen_frame = active_screen_visible_frame(&app, &state);
+    let screen_frame = active_screen_visible_frame(app, state);
     let geometry = popover_geometry_for(anchor, screen_frame);
     let target = if expanded { geometry.expanded } else { geometry.compact };
 
@@ -319,12 +355,13 @@ pub fn set_transform_popover_expanded(
             window
                 .set_position(tauri::LogicalPosition::new(target.x, target.y))
                 .map_err(|e| e.to_string())?;
+            Ok(target)
         }
         None => {
-            tracing::warn!(target: "system", "set_transform_popover_expanded: transform-review window not found — skipping");
+            tracing::warn!(target: "system", "set_transform_popover_expanded: transform-review window not found");
+            Err("transform-review window not found".to_string())
         }
     }
-    Ok(target)
 }
 
 /// Toggle whether the popover can take key focus. `false` during
@@ -341,6 +378,11 @@ pub fn set_transform_popover_expanded(
 /// window never gets a chance to visibly flash on screen.
 #[tauri::command]
 pub fn set_transform_popover_focusable(app: tauri::AppHandle, focusable: bool) -> Result<(), String> {
+    set_focusable_internal(&app, focusable)
+}
+
+/// Non-command core of `set_transform_popover_focusable` (issue #312 PR-C2).
+pub(crate) fn set_focusable_internal(app: &tauri::AppHandle, focusable: bool) -> Result<(), String> {
     match app.get_webview_window("transform-review") {
         Some(window) => {
             apply_popover_window_treatment(&window, !focusable);
@@ -384,9 +426,21 @@ pub struct TransformReviewContent {
     pub proposed: String,
 }
 
+/// Return the live transform session's instruction / original / proposed text
+/// for the review popover (issue #312 PR-C2 — replaces the C1 stub). Pulled by
+/// the transform-review window ONLY; this text is never broadcast in the
+/// `transform-state-changed` event, so potentially sensitive selected text
+/// stays out of the event bus, logs, and telemetry.
 #[tauri::command]
-pub fn get_transform_review_content() -> TransformReviewContent {
-    TransformReviewContent::default()
+pub fn get_transform_review_content(state: tauri::State<'_, State>) -> TransformReviewContent {
+    match crate::transform_apply::session_snapshot(&state.app_state) {
+        Some(session) => TransformReviewContent {
+            instruction: session.instruction.unwrap_or_default(),
+            original: session.snapshot.text,
+            proposed: session.proposed.unwrap_or_default(),
+        },
+        None => TransformReviewContent::default(),
+    }
 }
 
 /// Overwrite the transform-review window's size from `COMPACT_W`/`COMPACT_H`

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -951,12 +951,27 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                             // hotkey press must not blow away the session that
                             // pass owns out from under it.
                             let app_state = &handle.state::<crate::State>().app_state;
-                            if matches!(
-                                app_state.transform_status(),
-                                crate::state::TransformStatus::Idle
-                                    | crate::state::TransformStatus::ReviewPending
-                            ) {
-                                crate::transform_apply::clear_session(app_state);
+                            // N2 (B2 review): every session clear must be paired
+                            // with the matching status transition so the status
+                            // is never left stranded at ReviewPending with no
+                            // session. From Idle, just clear (status already
+                            // Idle). From ReviewPending, atomically move
+                            // ReviewPending -> Idle and only then clear — a
+                            // mid-flight pass (Capturing/Listening/Thinking/
+                            // Applying) is left untouched.
+                            match app_state.transform_status() {
+                                crate::state::TransformStatus::Idle => {
+                                    crate::transform_apply::clear_session(app_state);
+                                }
+                                crate::state::TransformStatus::ReviewPending => {
+                                    if app_state.try_transition_transform_status(
+                                        crate::state::TransformStatus::ReviewPending,
+                                        crate::state::TransformStatus::Idle,
+                                    ) {
+                                        crate::transform_apply::clear_session(app_state);
+                                    }
+                                }
+                                _ => {}
                             }
                             let _ = handle.emit("transform-key-pressed", ());
                         }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -235,6 +235,7 @@ pub fn run() {
             transform_flow::retry_transform_instruction,
             transform_flow::approve_transform,
             transform_flow::cancel_transform,
+            transform_flow::undo_transform_and_close,
             commands::knowledge::get_knowledge_store_status,
             commands::knowledge::retry_knowledge_store,
             commands::knowledge::list_knowledge,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub mod telemetry;
 pub mod transcriber;
 mod transcript_transform;
 mod transform_apply;
+pub mod transform_flow;
 mod vad;
 mod vocab;
 mod vocabulary_alias;
@@ -229,6 +230,11 @@ pub fn run() {
             commands::recording::transform_status,
             transform_apply::apply_transform_result,
             transform_apply::undo_transform,
+            transform_flow::start_transform_capture,
+            transform_flow::finish_transform_instruction,
+            transform_flow::retry_transform_instruction,
+            transform_flow::approve_transform,
+            transform_flow::cancel_transform,
             commands::knowledge::get_knowledge_store_status,
             commands::knowledge::retry_knowledge_store,
             commands::knowledge::list_knowledge,

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -560,6 +560,11 @@ mod supported {
         plan: SpawnPlan,
         host_guard: OnceLock<Arc<dyn HostGuard>>,
         busy: AtomicBool,
+        /// Set by [`Self::cancel_inflight_request`] so the blocking
+        /// `run_request` loop can send a cooperative Cancel frame instead of
+        /// waiting out the full deadline (BusyGuard only drops when that work
+        /// finishes — aborting the outer tokio task alone does not clear busy).
+        cancel_requested: AtomicBool,
         inner: Mutex<Inner>,
     }
 
@@ -581,6 +586,7 @@ mod supported {
                 plan,
                 host_guard: OnceLock::new(),
                 busy: AtomicBool::new(false),
+                cancel_requested: AtomicBool::new(false),
                 inner: Mutex::new(Inner {
                     child: None,
                     breaker: Breaker::default(),
@@ -609,6 +615,18 @@ mod supported {
         /// ASR never starts over a resident transform runtime.
         pub fn is_transform_busy(&self) -> bool {
             self.busy.load(Ordering::Acquire)
+        }
+
+        /// Request cooperative cancel of the in-flight transform (if any).
+        ///
+        /// The blocking `run_request` loop observes this flag, sends a protocol
+        /// Cancel frame, and settles via the same cancel-then-kill dance used
+        /// for deadline expiry. Dropping the outer async future alone does
+        /// **not** clear `busy` — only the blocking work finishing does — so
+        /// callers that abort a `tokio::spawn` wrapper must also call this
+        /// (see `cancel_transform`).
+        pub fn cancel_inflight_request(&self) {
+            self.cancel_requested.store(true, Ordering::Release);
         }
 
         /// Test-support: whether a helper process is currently resident. Not
@@ -647,6 +665,8 @@ mod supported {
             // closure guarantees `busy` clears when the blocking work ends even
             // if this async future is dropped at the `.await` below.
             let busy_guard = BusyGuard(Arc::clone(self));
+            // Clear any stale cancel signal from a prior request.
+            self.cancel_requested.store(false, Ordering::Release);
 
             // Bucket sizes up front so no raw length leaves this frame.
             let instruction_bucket = size_bucket(instruction.len());
@@ -727,7 +747,15 @@ mod supported {
             let request_id = unique_id("req");
             let outcome = {
                 let child = inner.child.as_mut().expect("child present");
-                run_request(child, &request_id, instruction, input, deadline, &self.plan)
+                run_request(
+                    child,
+                    &request_id,
+                    instruction,
+                    input,
+                    deadline,
+                    &self.plan,
+                    &self.cancel_requested,
+                )
             };
 
             match outcome {
@@ -755,6 +783,15 @@ mod supported {
                 RequestOutcome::TimedOutKilled => {
                     kill_child(inner.child.take());
                     Err(TransformError::Timeout)
+                }
+                RequestOutcome::CancelledKeepChild => {
+                    // User cancel confirmed; helper stays resident for reuse.
+                    inner.last_activity = Instant::now();
+                    Err(TransformError::Cancelled)
+                }
+                RequestOutcome::CancelledKilled => {
+                    kill_child(inner.child.take());
+                    Err(TransformError::Cancelled)
                 }
                 RequestOutcome::Crashed => {
                     kill_child(inner.child.take());
@@ -1016,9 +1053,21 @@ mod supported {
         HelperError(TransformError),
         TimedOutKeepChild,
         TimedOutKilled,
+        /// User-triggered cooperative cancel confirmed; helper stays resident.
+        CancelledKeepChild,
+        /// User-triggered cancel; helper unresponsive and was killed.
+        CancelledKilled,
         Crashed,
         Protocol,
         OutputInvalid,
+    }
+
+    /// Why `cancel_and_settle` was invoked — maps keep/kill onto the matching
+    /// timeout vs user-cancel `RequestOutcome` variants.
+    #[derive(Clone, Copy)]
+    enum CancelReason {
+        Deadline,
+        User,
     }
 
     /// The ADR requires the protocol name, version, and per-process session
@@ -1067,6 +1116,7 @@ mod supported {
         input: &str,
         deadline: Duration,
         plan: &SpawnPlan,
+        cancel_requested: &AtomicBool,
     ) -> RequestOutcome {
         let transform = HostMessage::Transform {
             protocol: PROTOCOL_NAME.to_string(),
@@ -1087,11 +1137,28 @@ mod supported {
         let wait = deadline + plan.request_slack();
         let deadline_at = Instant::now() + wait;
         loop {
+            // User cancel (e.g. Esc / short-tap) wins over the deadline wait.
+            if cancel_requested.load(Ordering::Acquire) {
+                return cancel_and_settle(
+                    child,
+                    request_id,
+                    plan.cancel_grace(),
+                    CancelReason::User,
+                );
+            }
             let now = Instant::now();
             if now >= deadline_at {
-                return cancel_and_settle(child, request_id, plan.cancel_grace());
+                return cancel_and_settle(
+                    child,
+                    request_id,
+                    plan.cancel_grace(),
+                    CancelReason::Deadline,
+                );
             }
-            match child.events.recv_timeout(deadline_at - now) {
+            // Poll in short slices so a cancel_requested flag is observed
+            // promptly even when the helper is silent.
+            let slice = (deadline_at - now).min(Duration::from_millis(50));
+            match child.events.recv_timeout(slice) {
                 Ok(HelperEvent::Frame(frame)) => {
                     if !helper_frame_valid(&frame, &child.session_nonce) {
                         return RequestOutcome::Protocol;
@@ -1154,7 +1221,12 @@ mod supported {
 
     /// Cooperative cancel: send a Cancel frame, wait `grace` for a Cancelled
     /// confirmation, then kill if the helper never confirms.
-    fn cancel_and_settle(child: &mut Child, request_id: &str, grace: Duration) -> RequestOutcome {
+    fn cancel_and_settle(
+        child: &mut Child,
+        request_id: &str,
+        grace: Duration,
+        reason: CancelReason,
+    ) -> RequestOutcome {
         let cancel = HostCancel {
             protocol: PROTOCOL_NAME.to_string(),
             version: PROTOCOL_VERSION,
@@ -1163,26 +1235,37 @@ mod supported {
         };
         let _ = write_frame(&mut child.stdin, &cancel);
 
+        let (keep, kill) = match reason {
+            CancelReason::Deadline => (
+                RequestOutcome::TimedOutKeepChild,
+                RequestOutcome::TimedOutKilled,
+            ),
+            CancelReason::User => (
+                RequestOutcome::CancelledKeepChild,
+                RequestOutcome::CancelledKilled,
+            ),
+        };
+
         let grace_at = Instant::now() + grace;
         loop {
             let now = Instant::now();
             if now >= grace_at {
-                return RequestOutcome::TimedOutKilled;
+                return kill;
             }
             match child.events.recv_timeout(grace_at - now) {
                 Ok(HelperEvent::Frame(frame)) => {
                     // Even during cancellation, a frame with the wrong nonce /
                     // protocol is a violation — kill rather than trust it.
                     if !helper_frame_valid(&frame, &child.session_nonce) {
-                        return RequestOutcome::TimedOutKilled;
+                        return kill;
                     }
                     // A matching Cancelled, or any other well-formed frame,
                     // proves the helper is responsive: cancellation confirmed.
-                    return RequestOutcome::TimedOutKeepChild;
+                    return keep;
                 }
                 Ok(HelperEvent::Exited)
                 | Ok(HelperEvent::ProtocolViolation)
-                | Err(RecvTimeoutError::Disconnected) => return RequestOutcome::TimedOutKilled,
+                | Err(RecvTimeoutError::Disconnected) => return kill,
                 Err(RecvTimeoutError::Timeout) => continue,
             }
         }
@@ -1252,6 +1335,7 @@ pub use supported::LlmSidecar;
 pub struct LlmSidecar {
     host_guard: OnceLock<Arc<dyn HostGuard>>,
     busy: AtomicBool,
+    cancel_requested: AtomicBool,
     _plan: SpawnPlan,
 }
 
@@ -1270,6 +1354,7 @@ impl LlmSidecar {
         Self {
             host_guard: OnceLock::new(),
             busy: AtomicBool::new(false),
+            cancel_requested: AtomicBool::new(false),
             _plan: plan,
         }
     }
@@ -1280,6 +1365,10 @@ impl LlmSidecar {
 
     pub fn is_transform_busy(&self) -> bool {
         self.busy.load(Ordering::Acquire)
+    }
+
+    pub fn cancel_inflight_request(&self) {
+        self.cancel_requested.store(true, Ordering::Release);
     }
 
     pub fn has_live_child(&self) -> bool {

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -338,6 +338,20 @@ pub struct AppState {
     /// Monotonic generation counter stamped onto every new `TransformSession`
     /// (issue #312 PR-B2). See `next_transform_session_generation`.
     pub transform_session_generation: AtomicU64,
+    /// Monotonic epoch bumped at the start of every apply/undo AND on cancel
+    /// (issue #312 PR-C2, B2 review nit N1). A `run_apply` paste fallback
+    /// schedules a ~300ms-delayed clipboard restore off the main thread; if a
+    /// newer apply/undo (or a cancel) begins inside that window, that stale
+    /// restore would clobber the newer op's house-rule clipboard write. The
+    /// delayed restore captures the epoch it was scheduled under and no-ops if
+    /// this counter has since advanced.
+    pub transform_apply_epoch: AtomicU64,
+    /// Abort handle for the in-flight sidecar transform task (issue #312
+    /// PR-C2). `finish_transform_instruction` spawns the `sidecar.transform`
+    /// future as a task and stores its abort handle here so `cancel_transform`
+    /// can cancel a `Thinking`-phase request cooperatively — dropping the
+    /// future clears the sidecar's busy flag (see `llm_sidecar::BusyGuard`).
+    pub transform_inflight: Mutex<Option<tokio::task::AbortHandle>>,
 }
 
 impl AppState {
@@ -437,6 +451,20 @@ impl AppState {
     pub fn next_transform_session_generation(&self) -> u64 {
         self.transform_session_generation.fetch_add(1, Ordering::SeqCst) + 1
     }
+
+    /// Bump and return the next apply epoch (issue #312 PR-C2, nit N1). Called
+    /// at the start of every apply/undo and by `cancel_transform`, so any
+    /// clipboard restore still pending from an earlier op sees a changed epoch
+    /// and declines to run.
+    pub fn next_transform_apply_epoch(&self) -> u64 {
+        self.transform_apply_epoch.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Current apply epoch, read by a pending clipboard restore to decide
+    /// whether it is still the most recent op (see `next_transform_apply_epoch`).
+    pub fn transform_apply_epoch(&self) -> u64 {
+        self.transform_apply_epoch.load(Ordering::SeqCst)
+    }
 }
 
 impl Default for AppState {
@@ -459,6 +487,8 @@ impl Default for AppState {
             transform_status: Mutex::new(TransformStatus::default()),
             transform_session: Mutex::new(None),
             transform_session_generation: AtomicU64::new(0),
+            transform_apply_epoch: AtomicU64::new(0),
+            transform_inflight: Mutex::new(None),
         }
     }
 }

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -349,8 +349,11 @@ pub struct AppState {
     /// Abort handle for the in-flight sidecar transform task (issue #312
     /// PR-C2). `finish_transform_instruction` spawns the `sidecar.transform`
     /// future as a task and stores its abort handle here so `cancel_transform`
-    /// can cancel a `Thinking`-phase request cooperatively — dropping the
-    /// future clears the sidecar's busy flag (see `llm_sidecar::BusyGuard`).
+    /// can abort the outer `tokio::spawn` wrapper. **Dropping that future does
+    /// not clear the sidecar's busy flag** — `BusyGuard` only drops when the
+    /// inner `spawn_blocking` work finishes. Callers must also invoke
+    /// `LlmSidecar::cancel_inflight_request` so the blocking loop sends a
+    /// protocol Cancel and settles promptly (see `cancel_transform`).
     pub transform_inflight: Mutex<Option<tokio::task::AbortHandle>>,
 }
 

--- a/app/src-tauri/src/transcript_transform.rs
+++ b/app/src-tauri/src/transcript_transform.rs
@@ -65,6 +65,26 @@ impl TranscriptStageConfig {
             cli_command_enabled: false,
         }
     }
+
+    /// Cleanup-only configuration for a spoken transform *instruction* (issue
+    /// #312 PR-C2). An instruction is a prompt, not dictation output: it must
+    /// never run voice-commands, CLI canonicalization, smart formatting, or
+    /// the IDE-context stage (all of which rewrite dictated prose/code and
+    /// would corrupt the natural-language instruction). Only lightweight
+    /// filler removal + sentence capitalization run, so "um, make this, uh,
+    /// more concise" becomes a clean prompt.
+    pub(crate) fn instruction_cleanup() -> Self {
+        Self {
+            cleanup_enabled: true,
+            cleanup_remove_filler: true,
+            cleanup_capitalize: true,
+            voice_commands_enabled: false,
+            smart_correction_enabled: false,
+            smart_formatting_enabled: false,
+            ide_context_enabled: false,
+            cli_command_enabled: false,
+        }
+    }
 }
 
 /// Immutable privacy-safe metadata and stage selection for one transformation
@@ -591,6 +611,24 @@ mod tests {
         input: String,
         output: String,
         cli: bool,
+    }
+
+    #[test]
+    fn instruction_cleanup_runs_cleanup_only_never_prose_or_command_stages() {
+        // Issue #312 PR-C2: a spoken transform instruction is a prompt, not
+        // dictation output. Cleanup may run (filler removal + capitalization),
+        // but voice-commands, CLI canonicalization, smart-formatting, and the
+        // IDE-context stage must all be OFF so the natural-language instruction
+        // is never rewritten as if it were dictated prose/code.
+        let cfg = TranscriptStageConfig::instruction_cleanup();
+        assert!(cfg.cleanup_enabled);
+        assert!(cfg.cleanup_remove_filler);
+        assert!(cfg.cleanup_capitalize);
+        assert!(!cfg.voice_commands_enabled, "voice-commands must be OFF for instructions");
+        assert!(!cfg.cli_command_enabled, "CLI formatting must be OFF for instructions");
+        assert!(!cfg.smart_formatting_enabled, "smart-formatting must be OFF for instructions");
+        assert!(!cfg.smart_correction_enabled, "smart-correction must be OFF for instructions");
+        assert!(!cfg.ide_context_enabled, "IDE-context must be OFF for instructions");
     }
 
     fn live_context(stages: TranscriptStageConfig) -> TranscriptContext {

--- a/app/src-tauri/src/transform_apply.rs
+++ b/app/src-tauri/src/transform_apply.rs
@@ -139,6 +139,11 @@ use crate::MutexExt;
 #[derive(Clone)]
 pub struct TransformSession {
     pub snapshot: crate::selection::TransformSnapshot,
+    /// The spoken instruction transcribed for this pass (issue #312 PR-C2).
+    /// Filled by `finish_transform_instruction` before the sidecar call.
+    /// Surfaced ONLY via `get_transform_review_content` (pulled by the popover
+    /// window) — never logged or attached to an event payload.
+    pub instruction: Option<String>,
     pub proposed: Option<String>,
     pub applied: bool,
     /// Monotonic id stamped at `start_session` time. See the module doc
@@ -150,6 +155,7 @@ impl TransformSession {
     pub fn new(snapshot: crate::selection::TransformSnapshot, generation: u64) -> Self {
         Self {
             snapshot,
+            instruction: None,
             proposed: None,
             applied: false,
             generation,
@@ -174,6 +180,19 @@ pub fn set_proposed_text(app_state: &AppState, text: String) -> bool {
     match session.as_mut() {
         Some(active) => {
             active.proposed = Some(text);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Fill in (or replace) the transcribed instruction for the active session
+/// (issue #312 PR-C2). Returns `false` if there is no active session.
+pub fn set_instruction(app_state: &AppState, instruction: String) -> bool {
+    let mut session = app_state.transform_session.lock_or_recover();
+    match session.as_mut() {
+        Some(active) => {
+            active.instruction = Some(instruction);
             true
         }
         None => false,
@@ -517,6 +536,7 @@ async fn run_apply(
     range_len: usize,
     expected_current: String,
     replacement: String,
+    apply_epoch: u64,
 ) -> Result<AppliedVia, ApplyError> {
     let (tx, rx) = tokio::sync::oneshot::channel::<native::NativeApplyOutcome>();
     app_handle
@@ -529,8 +549,24 @@ async fn run_apply(
     let outcome = rx.await.map_err(|_| ApplyError::Unsupported)?;
 
     if let Some(original) = outcome.pending_clipboard_restore {
+        // N1 (B2 review): a newer apply/undo/cancel bumps the apply epoch. If
+        // one begins inside this ~300ms window it re-writes the clipboard with
+        // its own house-rule text; this stale restore must NOT clobber that.
+        // Capture the epoch we were scheduled under and only restore if it is
+        // still current.
+        let app = app_handle.clone();
         tokio::task::spawn_blocking(move || {
             std::thread::sleep(std::time::Duration::from_millis(PASTE_CLIPBOARD_RESTORE_DELAY_MS));
+            use tauri::Manager;
+            if let Some(state) = app.try_state::<crate::State>() {
+                if state.app_state.transform_apply_epoch() != apply_epoch {
+                    tracing::info!(
+                        target: "transform",
+                        "pending clipboard restore skipped — a newer apply/undo/cancel superseded it"
+                    );
+                    return;
+                }
+            }
             let _ = crate::injector::write_clipboard_text(&original);
         });
     }
@@ -558,7 +594,8 @@ pub async fn apply_transform(
         // for `snapshot.text`, not the proposed replacement.
         let range_len = range_len_for(&snapshot.text);
         let expected_current = snapshot.text.clone();
-        let result = run_apply(app_handle, snapshot.pid, range_start, range_len, expected_current, text).await;
+        let apply_epoch = app_state.next_transform_apply_epoch();
+        let result = run_apply(app_handle, snapshot.pid, range_start, range_len, expected_current, text, apply_epoch).await;
         if result.is_ok() {
             set_applied(app_state, true, generation);
         }
@@ -598,7 +635,8 @@ pub async fn undo_applied_transform(
         // the bug this parametrization fixes.
         let range_len = range_len_for(&proposed);
         let original = snapshot.text.clone();
-        let result = run_apply(app_handle, snapshot.pid, range_start, range_len, proposed, original).await;
+        let apply_epoch = app_state.next_transform_apply_epoch();
+        let result = run_apply(app_handle, snapshot.pid, range_start, range_len, proposed, original, apply_epoch).await;
         result.map(|_| {
             set_applied(app_state, false, generation);
         })

--- a/app/src-tauri/src/transform_apply.rs
+++ b/app/src-tauri/src/transform_apply.rs
@@ -696,12 +696,17 @@ impl<'a> ApplyingGuard<'a> {
 
 impl Drop for ApplyingGuard<'_> {
     fn drop(&mut self) {
+        // Only leave Applying if we still own it. A concurrent cancel may have
+        // already forced Idle + cleared the session; overwriting that with
+        // ReviewPending would strand `blocks_recording` with no session.
         let target = if self.succeeded {
             TransformStatus::Idle
         } else {
             self.prior_status
         };
-        self.app_state.set_transform_status(target);
+        let _ = self
+            .app_state
+            .try_transition_transform_status(TransformStatus::Applying, target);
     }
 }
 

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1,0 +1,1419 @@
+//! End-to-end orchestrator for the AX-selection transform flow (issue #312,
+//! PR-C2). Wires together everything the earlier PRs in the series built:
+//!
+//! - B1's `selection::capture_selection` (read the AX selection, fail closed on
+//!   secure fields / oversized selections / AX errors),
+//! - B2's `transform_apply` session + apply/undo machinery,
+//! - A2's `llm_sidecar` async transform facade (with its own busy/deadline/
+//!   crash-breaker rules),
+//! - C1's `transform_popover` window commands + geometry contract,
+//! - the transform hotkey (`keyboard::start_transform_listener`, emitting
+//!   `transform-key-pressed` / `transform-key-released`).
+//!
+//! ## Shape
+//!
+//! The logical flow is captured as a **pure state machine** (`decide`) over
+//! `FlowState` × `FlowEvent`, exhaustively unit-tested — it is the single
+//! specification of "which transition, which side effects" and carries no I/O.
+//! The Tauri command wrappers below drive the real effects (AX capture, audio,
+//! sidecar, popover, event emission) and mirror that machine's transitions.
+//!
+//! Every observable side effect is funnelled through the [`FlowEffects`] trait
+//! so the async core (`core_start_capture`, `enter_thinking`, `run_transform`)
+//! is testable against a recording fake with no Tauri app, no AX server, and —
+//! for the sidecar step — the protocol mock helper (see
+//! `tests/transform_flow_integration.rs`).
+//!
+//! ## Privacy (hard invariant)
+//!
+//! Instruction / original / proposed text NEVER reaches an event payload, a
+//! log line, or telemetry. `transform-state-changed` carries only
+//! `{ state, errorCode }` (both stable enums). The review text is pulled by the
+//! popover window alone via `get_transform_review_content`. The state-machine
+//! action list and every `emit_*` here are structurally incapable of carrying
+//! that text.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::llm_sidecar::{LlmSidecar, TransformError};
+use crate::selection::{SelectionError, TransformSnapshot};
+use crate::state::{AppState, DictationStatus, TransformStatus};
+use crate::transform_apply::{self, ApplyError};
+use crate::MutexExt;
+
+/// Minimum hold before a transform-key release is treated as a real
+/// instruction rather than an accidental tap. Enforced frontend-side (the
+/// reducer in `useTransformFlow.ts`); mirrored here as the documented contract.
+pub const HOLD_MIN_MS: u64 = 300;
+
+/// Default deadline handed to the sidecar for one transform request. Kept
+/// below the protocol's `MAX_DEADLINE_MS` (30s) with margin.
+pub const DEFAULT_TRANSFORM_DEADLINE: Duration = Duration::from_millis(20_000);
+
+/// How long the "applied" confirmation lingers before the popover auto-hides.
+pub const APPLIED_LINGER_MS: u64 = 4_000;
+
+// ===========================================================================
+// Review state + error-code vocabulary (the ONLY strings that cross to the UI).
+// ===========================================================================
+
+/// The frontend `ReviewState` (see `lib/transformReview.ts`). Only the state
+/// name and an optional error code are ever emitted — never any text content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewState {
+    Listening,
+    Thinking,
+    Ready,
+    Failed,
+    Applied,
+}
+
+impl ReviewState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Listening => "listening",
+            Self::Thinking => "thinking",
+            Self::Ready => "ready",
+            Self::Failed => "failed",
+            Self::Applied => "applied",
+        }
+    }
+}
+
+/// Map a `SelectionError` to a stable popover error code. Total by construction
+/// (exhaustive `match`) — a new variant will fail to compile until mapped.
+pub fn selection_error_code(error: SelectionError) -> &'static str {
+    match error {
+        SelectionError::AccessibilityDenied => "accessibility_denied",
+        SelectionError::SecureField => "secure_field",
+        SelectionError::NoSelection => "no_selection",
+        SelectionError::TooLarge => "too_large",
+        SelectionError::AxUnavailable => "ax_unavailable",
+    }
+}
+
+/// Map a `TransformError` (sidecar facade) to a stable popover error code.
+/// Total by construction.
+pub fn transform_error_code(error: TransformError) -> &'static str {
+    match error {
+        TransformError::Unsupported => "unsupported",
+        TransformError::NotDownloaded => "model_not_downloaded",
+        TransformError::Disabled => "disabled",
+        TransformError::Busy => "busy",
+        TransformError::InvalidRequest => "invalid_request",
+        TransformError::HeavyRuntimeActive => "busy",
+        TransformError::SpawnFailed => "crashed",
+        TransformError::HandshakeFailed => "crashed",
+        // Wrong-content model was removed by the supervisor — re-download needed.
+        TransformError::ModelMismatch => "model_not_downloaded",
+        TransformError::ModelUnreadable => "model_unreadable",
+        TransformError::Timeout => "timeout",
+        TransformError::Cancelled => "cancelled",
+        TransformError::Crashed => "crashed",
+        TransformError::OutputInvalid => "output_invalid",
+        TransformError::Protocol => "crashed",
+        TransformError::ResourceLimit => "resource_limit",
+        TransformError::Internal => "internal",
+    }
+}
+
+/// Map an `ApplyError` (write-back) to a stable popover error code. Total by
+/// construction.
+pub fn apply_error_code(error: ApplyError) -> &'static str {
+    match error {
+        ApplyError::Unsupported => "unsupported",
+        ApplyError::Busy => "busy",
+        ApplyError::NoSession => "no_session",
+        ApplyError::NoProposedText => "no_proposed_text",
+        ApplyError::AlreadyApplied => "already_applied",
+        ApplyError::NotApplied => "not_applied",
+        ApplyError::ClipboardUnavailable => "clipboard_unavailable",
+        ApplyError::TargetGone => "target_gone",
+        ApplyError::SelectionChanged => "selection_changed",
+        ApplyError::PasteFailed => "paste_failed",
+    }
+}
+
+// ===========================================================================
+// Pure state machine (event × state -> next state + action list). Exhaustive.
+// ===========================================================================
+
+/// Logical (UI-level) state of one transform pass. Richer than the backend
+/// `TransformStatus` lock-state: it distinguishes the two "popover awaiting the
+/// user" cases (`Review` after a good proposal vs. `Failed` after an error) and
+/// the post-apply `Applied` state (undo available), which both map onto
+/// `TransformStatus::Idle`/`ReviewPending`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowState {
+    Idle,
+    Capturing,
+    Listening,
+    Thinking,
+    /// Proposal shown, awaiting Approve / Retry / Cancel.
+    Review,
+    /// Error popover shown, awaiting Retry / Cancel.
+    Failed,
+    /// Apply or undo in flight.
+    Applying,
+    /// Applied; Undo available until the linger elapses.
+    Applied,
+}
+
+/// Events the flow reacts to. Precondition/outcome detail (which error, etc.)
+/// is carried by the command layer's action, not the pure machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowEvent {
+    /// Transform hotkey pressed — begin a capture.
+    StartRequested,
+    /// Selection captured successfully.
+    CaptureOk,
+    /// Focused element is secure/password — abort silently + flash.
+    CaptureSecure,
+    /// Any other capture failure (no_selection / too_large / ax / denied).
+    CaptureError,
+    /// Transform hotkey released — stop listening, transcribe + transform.
+    InstructionRequested,
+    /// Transcribed instruction was blank.
+    InstructionBlank,
+    /// Sidecar returned a proposal.
+    TransformOk,
+    /// Transcription or sidecar failed.
+    TransformError,
+    /// User accepted the proposal.
+    Approve,
+    ApplyOk,
+    ApplyError,
+    /// User asked to re-speak on the same frozen snapshot.
+    Retry,
+    /// User cancelled (valid from any live state).
+    Cancel,
+    /// User undid an applied transform.
+    Undo,
+    UndoOk,
+    UndoError,
+}
+
+/// A side effect the flow requests. The pure machine only NAMES effects; the
+/// command layer performs them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowAction {
+    /// Start (freeze) a new session from the captured snapshot.
+    StartSession,
+    /// Drop the active session.
+    ClearSession,
+    ShowPopover,
+    HidePopover,
+    /// Brief overlay flash indicating a secure field was refused.
+    FlashSecureField,
+    StartInstructionCapture,
+    StopInstructionCapture,
+    /// Transcribe the instruction and call the sidecar.
+    RunTransform,
+    /// Cancel the in-flight sidecar request.
+    CancelInflight,
+    ApplyResult,
+    UndoResult,
+    /// Auto-hide the popover after the applied linger.
+    ScheduleLingerHide,
+    /// Emit `transform-state-changed` with this review state (+ maybe a code).
+    Emit(ReviewState),
+    SetFocusable(bool),
+    SetExpanded(bool),
+    /// A no-op that is logged (e.g. a hotkey press while already mid-flow).
+    Ignore,
+}
+
+/// Result of one `decide` step: the next logical state and the ordered actions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlowDecision {
+    pub next: FlowState,
+    pub actions: Vec<FlowAction>,
+}
+
+fn go(next: FlowState, actions: Vec<FlowAction>) -> FlowDecision {
+    FlowDecision { next, actions }
+}
+
+fn ignore(state: FlowState) -> FlowDecision {
+    FlowDecision {
+        next: state,
+        actions: vec![FlowAction::Ignore],
+    }
+}
+
+/// Common teardown for a cancel from a state that shows the popover.
+fn cancel_from(_state: FlowState) -> FlowDecision {
+    go(
+        FlowState::Idle,
+        vec![FlowAction::HidePopover, FlowAction::ClearSession],
+    )
+}
+
+/// Re-arm listening on the SAME frozen snapshot (Retry = re-speak).
+fn retry_to_listening() -> FlowDecision {
+    go(
+        FlowState::Listening,
+        vec![
+            FlowAction::SetExpanded(false),
+            FlowAction::SetFocusable(false),
+            FlowAction::Emit(ReviewState::Listening),
+            FlowAction::StartInstructionCapture,
+        ],
+    )
+}
+
+/// Pure transition function: `(state, event) -> decision`. Exhaustive over both
+/// axes (a missing arm is a compile error) so the whole table is covered by
+/// `tests::transition_table_is_exhaustive_and_stable`.
+pub fn decide(state: FlowState, event: FlowEvent) -> FlowDecision {
+    use FlowAction::*;
+    use FlowEvent as E;
+    use FlowState as S;
+
+    match (state, event) {
+        // ---- Idle -----------------------------------------------------------
+        (S::Idle, E::StartRequested) => go(S::Capturing, vec![]),
+        (S::Idle, _) => ignore(S::Idle),
+
+        // ---- Capturing ------------------------------------------------------
+        (S::Capturing, E::CaptureOk) => go(
+            S::Listening,
+            vec![
+                StartSession,
+                ShowPopover,
+                SetFocusable(false),
+                Emit(ReviewState::Listening),
+                StartInstructionCapture,
+            ],
+        ),
+        (S::Capturing, E::CaptureSecure) => {
+            go(S::Idle, vec![ClearSession, HidePopover, FlashSecureField])
+        }
+        (S::Capturing, E::CaptureError) => go(
+            S::Failed,
+            vec![ShowPopover, SetFocusable(true), Emit(ReviewState::Failed)],
+        ),
+        (S::Capturing, E::Cancel) => cancel_from(state),
+        (S::Capturing, _) => ignore(S::Capturing),
+
+        // ---- Listening ------------------------------------------------------
+        (S::Listening, E::InstructionRequested) => go(
+            S::Thinking,
+            vec![StopInstructionCapture, Emit(ReviewState::Thinking), RunTransform],
+        ),
+        (S::Listening, E::Cancel) => go(
+            S::Idle,
+            vec![StopInstructionCapture, HidePopover, ClearSession],
+        ),
+        (S::Listening, _) => ignore(S::Listening),
+
+        // ---- Thinking -------------------------------------------------------
+        (S::Thinking, E::TransformOk) => go(
+            S::Review,
+            vec![SetExpanded(true), SetFocusable(true), Emit(ReviewState::Ready)],
+        ),
+        (S::Thinking, E::TransformError) => go(
+            S::Failed,
+            vec![SetFocusable(true), Emit(ReviewState::Failed)],
+        ),
+        (S::Thinking, E::InstructionBlank) => go(
+            S::Failed,
+            vec![SetFocusable(true), Emit(ReviewState::Failed)],
+        ),
+        (S::Thinking, E::Cancel) => go(
+            S::Idle,
+            vec![CancelInflight, HidePopover, ClearSession],
+        ),
+        (S::Thinking, _) => ignore(S::Thinking),
+
+        // ---- Review (proposal shown) ---------------------------------------
+        (S::Review, E::Approve) => go(S::Applying, vec![ApplyResult]),
+        (S::Review, E::Retry) => retry_to_listening(),
+        (S::Review, E::Cancel) => cancel_from(state),
+        (S::Review, _) => ignore(S::Review),
+
+        // ---- Failed (error popover) ----------------------------------------
+        (S::Failed, E::Retry) => retry_to_listening(),
+        (S::Failed, E::Cancel) => cancel_from(state),
+        // A new hotkey press supersedes a failed popover.
+        (S::Failed, E::StartRequested) => go(S::Capturing, vec![ClearSession]),
+        (S::Failed, _) => ignore(S::Failed),
+
+        // ---- Applying (apply or undo in flight) ----------------------------
+        (S::Applying, E::ApplyOk) => go(
+            S::Applied,
+            vec![Emit(ReviewState::Applied), ScheduleLingerHide],
+        ),
+        (S::Applying, E::ApplyError) => go(
+            S::Failed,
+            vec![SetFocusable(true), Emit(ReviewState::Failed)],
+        ),
+        (S::Applying, E::UndoOk) => go(S::Idle, vec![HidePopover, ClearSession]),
+        (S::Applying, E::UndoError) => {
+            go(S::Applied, vec![Emit(ReviewState::Failed)])
+        }
+        (S::Applying, _) => ignore(S::Applying),
+
+        // ---- Applied (undo available) --------------------------------------
+        (S::Applied, E::Undo) => go(S::Applying, vec![UndoResult]),
+        (S::Applied, E::Cancel) => cancel_from(state),
+        (S::Applied, E::StartRequested) => go(S::Capturing, vec![ClearSession]),
+        (S::Applied, _) => ignore(S::Applied),
+    }
+}
+
+// ===========================================================================
+// Effects seam: everything observable, so the async core is testable.
+// ===========================================================================
+
+/// Anchor rect handed to the popover (mirrors `transform_popover::Rect`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AnchorRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Every side effect the async core performs, behind a trait so a recording
+/// fake can stand in for Tauri in tests.
+pub(crate) trait FlowEffects: Send + Sync {
+    /// Emit `transform-state-changed` — state name + optional error code ONLY.
+    fn emit_state(&self, state: ReviewState, error_code: Option<&str>);
+    fn show_popover(&self, anchor: Option<AnchorRect>);
+    fn hide_popover(&self);
+    fn set_focusable(&self, focusable: bool);
+    fn set_expanded(&self, expanded: bool);
+    fn flash_secure_field(&self);
+    fn schedule_linger_hide(&self);
+}
+
+fn snapshot_anchor(snapshot: &TransformSnapshot) -> Option<AnchorRect> {
+    snapshot.bounds.map(|r| AnchorRect {
+        x: r.x,
+        y: r.y,
+        width: r.width,
+        height: r.height,
+    })
+}
+
+/// Outcome of `core_start_capture`, telling the command whether to arm audio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StartOutcome {
+    /// Session frozen, popover shown listening — start the instruction audio.
+    Listening,
+    /// Aborted (secure field, capture error, or model not downloaded) — no
+    /// audio, nothing further for the command to do.
+    Aborted,
+}
+
+/// Core of `start_transform_capture` (see the command). Assumes the caller has
+/// already atomically claimed `TransformStatus::Capturing` under the dictation
+/// lock. Generic over the capture future so tests inject a fake snapshot
+/// WITHOUT weakening the production AX path in `selection.rs`.
+pub(crate) async fn core_start_capture<Fut>(
+    app_state: &AppState,
+    fx: &dyn FlowEffects,
+    model_ready: bool,
+    capture: Fut,
+) -> StartOutcome
+where
+    Fut: std::future::Future<Output = Result<TransformSnapshot, SelectionError>>,
+{
+    if !model_ready {
+        // Discoverable error surface: still show the popover, in a failed state.
+        app_state.set_transform_status(TransformStatus::ReviewPending);
+        fx.show_popover(None);
+        fx.set_focusable(true);
+        fx.emit_state(ReviewState::Failed, Some("model_not_downloaded"));
+        return StartOutcome::Aborted;
+    }
+
+    match capture.await {
+        Ok(snapshot) => {
+            let anchor = snapshot_anchor(&snapshot);
+            transform_apply::start_session(app_state, snapshot);
+            app_state.set_transform_status(TransformStatus::Listening);
+            fx.show_popover(anchor);
+            fx.set_focusable(false);
+            fx.emit_state(ReviewState::Listening, None);
+            StartOutcome::Listening
+        }
+        Err(SelectionError::SecureField) => {
+            // Never show content UI for a password field — abort silently.
+            app_state.set_transform_status(TransformStatus::Idle);
+            transform_apply::clear_session(app_state);
+            fx.hide_popover();
+            fx.flash_secure_field();
+            StartOutcome::Aborted
+        }
+        Err(other) => {
+            app_state.set_transform_status(TransformStatus::ReviewPending);
+            fx.show_popover(None);
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Failed, Some(selection_error_code(other)));
+            StartOutcome::Aborted
+        }
+    }
+}
+
+/// Transition `Listening -> Thinking` and emit it. Returns `false` if the flow
+/// was no longer `Listening` (e.g. cancelled) — the caller must not proceed.
+pub(crate) fn enter_thinking(app_state: &AppState, fx: &dyn FlowEffects) -> bool {
+    if app_state.try_transition_transform_status(TransformStatus::Listening, TransformStatus::Thinking)
+    {
+        fx.emit_state(ReviewState::Thinking, None);
+        true
+    } else {
+        false
+    }
+}
+
+/// Core of the transform step: given the transcription result (`Err` = blank),
+/// call the sidecar and drive the flow to `ready` or `failed`. The sidecar call
+/// runs as a cancellable task whose abort handle is stored in `inflight` so
+/// `cancel_transform` can abort a `Thinking`-phase request (dropping the future
+/// clears the sidecar's busy flag). Assumes `enter_thinking` already ran.
+pub(crate) async fn run_transform(
+    app_state: &AppState,
+    fx: &dyn FlowEffects,
+    sidecar: &Arc<LlmSidecar>,
+    inflight: &std::sync::Mutex<Option<tokio::task::AbortHandle>>,
+    instruction: Result<String, ()>,
+    original: String,
+    deadline: Duration,
+) {
+    let instruction = match instruction {
+        Ok(text) if !text.trim().is_empty() => text,
+        _ => {
+            app_state.set_transform_status(TransformStatus::ReviewPending);
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Failed, Some("no_instruction"));
+            return;
+        }
+    };
+    transform_apply::set_instruction(app_state, instruction.clone());
+
+    let sidecar = Arc::clone(sidecar);
+    let input = original;
+    let instr = instruction;
+    let join = tokio::spawn(async move { sidecar.transform(&instr, &input, deadline).await });
+    *inflight.lock_or_recover() = Some(join.abort_handle());
+    let joined = join.await;
+    *inflight.lock_or_recover() = None;
+
+    match joined {
+        // Aborted by `cancel_transform`, which already tore the flow down.
+        Err(err) if err.is_cancelled() => {}
+        Err(_) => {
+            app_state.set_transform_status(TransformStatus::ReviewPending);
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Failed, Some("internal"));
+        }
+        Ok(Ok(output)) => {
+            transform_apply::set_proposed_text(app_state, output.output);
+            app_state.set_transform_status(TransformStatus::ReviewPending);
+            fx.set_expanded(true);
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Ready, None);
+        }
+        Ok(Err(error)) => {
+            app_state.set_transform_status(TransformStatus::ReviewPending);
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Failed, Some(transform_error_code(error)));
+        }
+    }
+}
+
+// ===========================================================================
+// Production effects: real Tauri emission + popover window commands.
+// ===========================================================================
+
+pub(crate) struct TauriFlowEffects<'a> {
+    pub app: &'a tauri::AppHandle,
+    pub state: &'a crate::State,
+}
+
+impl FlowEffects for TauriFlowEffects<'_> {
+    fn emit_state(&self, state: ReviewState, error_code: Option<&str>) {
+        use tauri::Emitter;
+        // Payload carries ONLY the state name and an optional stable error
+        // code — never any instruction/original/proposed text.
+        let payload = match error_code {
+            Some(code) => serde_json::json!({ "state": state.as_str(), "errorCode": code }),
+            None => serde_json::json!({ "state": state.as_str() }),
+        };
+        let _ = self.app.emit("transform-state-changed", payload);
+    }
+
+    fn show_popover(&self, anchor: Option<AnchorRect>) {
+        let anchor = anchor.map(|a| crate::commands::transform_popover::Rect {
+            x: a.x,
+            y: a.y,
+            width: a.width,
+            height: a.height,
+        });
+        if let Err(e) =
+            crate::commands::transform_popover::show_popover_internal(self.app, self.state, anchor)
+        {
+            tracing::warn!(target: "transform", error = %e, "show_popover failed");
+        }
+    }
+
+    fn hide_popover(&self) {
+        let _ = crate::commands::transform_popover::hide_popover_internal(self.app);
+    }
+
+    fn set_focusable(&self, focusable: bool) {
+        let _ = crate::commands::transform_popover::set_focusable_internal(self.app, focusable);
+    }
+
+    fn set_expanded(&self, expanded: bool) {
+        if let Err(e) =
+            crate::commands::transform_popover::set_expanded_internal(self.app, self.state, expanded)
+        {
+            tracing::warn!(target: "transform", error = %e, "set_expanded failed");
+        }
+    }
+
+    fn flash_secure_field(&self) {
+        use tauri::Emitter;
+        // Content-free flash signal — no selection text is read for a secure
+        // field, so there is nothing to leak here.
+        let _ = self.app.emit("transform-secure-field", ());
+    }
+
+    fn schedule_linger_hide(&self) {
+        let app = self.app.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(APPLIED_LINGER_MS)).await;
+            use tauri::Manager;
+            if let Some(state) = app.try_state::<crate::State>() {
+                // Only auto-hide if we are still in the applied review (status
+                // Idle + an applied session). A newer flow leaves status
+                // non-Idle, so its popover is never yanked out from under it.
+                let still_applied = state.app_state.transform_status() == TransformStatus::Idle
+                    && transform_apply::session_snapshot(&state.app_state)
+                        .map(|s| s.applied)
+                        .unwrap_or(false);
+                if !still_applied {
+                    return;
+                }
+            }
+            let _ = crate::commands::transform_popover::hide_popover_internal(&app);
+        });
+    }
+}
+
+// ===========================================================================
+// Instruction transcription (cleanup-only) — a command-level effect.
+// ===========================================================================
+
+/// Transcribe the captured instruction audio into a clean prompt. Runs the
+/// shared ASR backend, then the deterministic transcript pipeline with the
+/// **cleanup-only** stage config (`instruction_cleanup`) — NEVER voice
+/// commands, CLI canonicalization, smart formatting, or the IDE-context stage
+/// (an instruction is a prompt, not dictation). `Err(())` means empty audio, a
+/// transcription failure, or a blank transcript — all surface as `no_instruction`.
+async fn transcribe_instruction(
+    app_handle: &tauri::AppHandle,
+    state: &crate::State,
+    samples: &[f32],
+) -> Result<String, ()> {
+    if samples.is_empty() {
+        return Err(());
+    }
+    let (model_name, language, smart_punctuation) = {
+        let dictation = state.app_state.dictation.lock_or_recover();
+        (
+            dictation.model_name.clone(),
+            dictation.language.clone(),
+            dictation.smart_punctuation,
+        )
+    };
+
+    let raw = state.app_state.model_runtime.with_ready_backend(
+        Some(app_handle),
+        &model_name,
+        crate::model_runtime::PreparationReason::Pipeline,
+        |backend| backend.transcribe(samples, &language, None, smart_punctuation),
+    );
+    let (raw, _load_report) = match raw {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::warn!(target: "transform", error = %e, "instruction transcription failed");
+            return Err(());
+        }
+    };
+
+    let context = crate::transcript_transform::TranscriptContext {
+        session_id: state.app_state.next_transcript_session_id(),
+        source: crate::transcript_transform::TranscriptSource::Live,
+        context_handle: None,
+        cli_formatting_mode: crate::cli_command::CliFormattingMode::Auto,
+        stages: crate::transcript_transform::TranscriptStageConfig::instruction_cleanup(),
+    };
+    let cleaned = crate::transcript_transform::transform_transcript(
+        raw,
+        &context,
+        crate::transcript_transform::TranscriptTransformResources::empty(),
+    )
+    .map(|out| out.text)
+    .unwrap_or_default();
+
+    let trimmed = cleaned.trim().to_string();
+    if trimmed.is_empty() {
+        Err(())
+    } else {
+        Ok(trimmed)
+    }
+}
+
+// ===========================================================================
+// Tauri commands (the thin wrappers the frontend calls).
+// ===========================================================================
+
+/// Begin a transform pass: check preconditions, claim the flow, capture the
+/// selection, and (on success) arm the instruction audio.
+///
+/// The claim (`Idle -> Capturing`) happens under the dictation lock, in the
+/// SAME critical section `start_native_recording` uses to check transform
+/// status — closing the symmetric race (dictation-start checks transform
+/// status; transform-start must check dictation status under the same lock).
+#[tauri::command]
+pub(crate) async fn start_transform_capture(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    // Serialize against dictation start/stop, taking the same locks in the
+    // same order (`recording_transition` then `dictation`) as
+    // `start_native_recording`, so the two audio paths can't tear each other's
+    // recorder down.
+    let _transition = state.app_state.recording_transition.lock().await;
+
+    let claimed = {
+        let dictation = state.app_state.dictation.lock_or_recover();
+        if dictation.status != DictationStatus::Idle {
+            tracing::info!(target: "transform", "start_transform_capture: ignored — dictation active");
+            false
+        } else if state.benchmark.is_running() {
+            tracing::info!(target: "transform", "start_transform_capture: ignored — benchmark running");
+            false
+        } else if state
+            .app_state
+            .file_transcribing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            tracing::info!(target: "transform", "start_transform_capture: ignored — file transcription running");
+            false
+        } else if state.transform_runtime.is_transform_busy() {
+            tracing::info!(target: "transform", "start_transform_capture: ignored — transform runtime busy");
+            false
+        } else {
+            // Atomic Idle -> Capturing under the dictation lock.
+            state
+                .app_state
+                .try_transition_transform_status(TransformStatus::Idle, TransformStatus::Capturing)
+        }
+    };
+    if !claimed {
+        return Ok(());
+    }
+
+    let model_ready = crate::commands::transform_model::transform_model_status().state
+        == crate::commands::transform_model::TransformModelState::Ready;
+
+    let fx = TauriFlowEffects {
+        app: &app_handle,
+        state: &state,
+    };
+    let outcome =
+        core_start_capture(&state.app_state, &fx, model_ready, crate::selection::capture_selection(&app_handle))
+            .await;
+
+    if outcome == StartOutcome::Listening {
+        // Arm audio for the spoken instruction. DictationStatus stays Idle —
+        // this audio belongs to the transform flow (TransformStatus::Listening).
+        if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), None) {
+            tracing::error!(target: "transform", error = %e, "instruction audio failed to start");
+            state.app_state.set_transform_status(TransformStatus::Idle);
+            transform_apply::clear_session(&state.app_state);
+            let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
+/// Finish the instruction utterance: stop audio, transition to thinking,
+/// transcribe (cleanup-only), and run the sidecar transform.
+#[tauri::command]
+pub(crate) async fn finish_transform_instruction(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    let _transition = state.app_state.recording_transition.lock().await;
+
+    // Tolerate a stray release: only proceed from Listening.
+    if state.app_state.transform_status() != TransformStatus::Listening {
+        return Ok(());
+    }
+
+    let samples = crate::audio::stop_recording().unwrap_or_default();
+
+    let fx = TauriFlowEffects {
+        app: &app_handle,
+        state: &state,
+    };
+    if !enter_thinking(&state.app_state, &fx) {
+        // Lost the race to a concurrent cancel.
+        return Ok(());
+    }
+
+    let original = match transform_apply::session_snapshot(&state.app_state) {
+        Some(session) => session.snapshot.text,
+        None => {
+            // Session vanished (cancelled) — bail cleanly.
+            state.app_state.set_transform_status(TransformStatus::Idle);
+            return Ok(());
+        }
+    };
+
+    let instruction = transcribe_instruction(&app_handle, &state, &samples).await;
+    run_transform(
+        &state.app_state,
+        &fx,
+        &state.transform_runtime,
+        &state.app_state.transform_inflight,
+        instruction,
+        original,
+        DEFAULT_TRANSFORM_DEADLINE,
+    )
+    .await;
+    Ok(())
+}
+
+/// Retry: re-arm listening for a NEW instruction on the SAME frozen snapshot.
+#[tauri::command]
+pub(crate) async fn retry_transform_instruction(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    let _transition = state.app_state.recording_transition.lock().await;
+
+    let fx = TauriFlowEffects {
+        app: &app_handle,
+        state: &state,
+    };
+
+    // Retry only means anything with a live session (a frozen snapshot). A
+    // failed popover with no session (e.g. model_not_downloaded) has nothing
+    // to re-speak against — treat Retry there as Cancel.
+    if transform_apply::session_snapshot(&state.app_state).is_none() {
+        state.app_state.set_transform_status(TransformStatus::Idle);
+        let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+        return Ok(());
+    }
+
+    if !state
+        .app_state
+        .try_transition_transform_status(TransformStatus::ReviewPending, TransformStatus::Listening)
+    {
+        // Not in review — ignore.
+        return Ok(());
+    }
+
+    fx.set_expanded(false);
+    fx.set_focusable(false);
+    fx.emit_state(ReviewState::Listening, None);
+
+    if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), None) {
+        tracing::error!(target: "transform", error = %e, "retry audio failed to start");
+        state.app_state.set_transform_status(TransformStatus::Idle);
+        transform_apply::clear_session(&state.app_state);
+        let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Approve: apply the proposed transform. On success emits `applied` and
+/// schedules the linger-hide; the session stays applied so `undo_transform`
+/// remains valid.
+#[tauri::command]
+pub(crate) async fn approve_transform(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    let fx = TauriFlowEffects {
+        app: &app_handle,
+        state: &state,
+    };
+
+    let mut guard =
+        match transform_apply::ApplyingGuard::try_new(&state.app_state, TransformStatus::ReviewPending)
+        {
+            Some(guard) => guard,
+            None => {
+                fx.emit_state(ReviewState::Failed, Some("busy"));
+                return Err("busy".to_string());
+            }
+        };
+
+    match transform_apply::apply_transform(&app_handle, &state.app_state).await {
+        Ok(_via) => {
+            guard.mark_succeeded(); // status -> Idle; session.applied stays true
+            fx.emit_state(ReviewState::Applied, None);
+            fx.schedule_linger_hide();
+            Ok(())
+        }
+        Err(error) => {
+            // Guard drop restores ReviewPending so Retry stays available.
+            fx.set_focusable(true);
+            fx.emit_state(ReviewState::Failed, Some(apply_error_code(error)));
+            Err(apply_error_code(error).to_string())
+        }
+    }
+}
+
+/// Cancel the flow from any state: abort an in-flight sidecar request, stop any
+/// instruction audio, clear the session, and hide the popover.
+#[tauri::command]
+pub(crate) async fn cancel_transform(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    let prev = state.app_state.transform_status();
+
+    // Abort the sidecar task (dropping the future clears the busy flag).
+    if let Some(handle) = state.app_state.transform_inflight.lock_or_recover().take() {
+        handle.abort();
+    }
+    // Invalidate any pending clipboard restore from a just-finished apply/undo
+    // (N1): a cancel means the user is done with this pass.
+    let _ = state.app_state.next_transform_apply_epoch();
+
+    // Stop instruction audio only if it was the transform's (Listening).
+    if prev == TransformStatus::Listening && crate::audio::is_recording() {
+        let _ = crate::audio::stop_recording();
+    }
+
+    state.app_state.set_transform_status(TransformStatus::Idle);
+    transform_apply::clear_session(&state.app_state);
+    let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+    Ok(())
+}
+
+// ===========================================================================
+// Test-only happy-path harness (drives the real sidecar via the mock helper).
+// ===========================================================================
+
+/// Recording fake for [`FlowEffects`]: captures the emitted review states and
+/// popover directives so tests can assert the flow's observable behaviour with
+/// no Tauri app.
+#[cfg(any(test, debug_assertions, feature = "llm-test-support"))]
+#[derive(Default)]
+pub(crate) struct RecordingFlowEffects {
+    inner: std::sync::Mutex<RecordingInner>,
+}
+
+#[cfg(any(test, debug_assertions, feature = "llm-test-support"))]
+#[derive(Default)]
+struct RecordingInner {
+    /// (state, error_code) pairs, in emit order.
+    emitted: Vec<(String, Option<String>)>,
+    popover_shown: bool,
+    focusable: Option<bool>,
+    expanded: Option<bool>,
+    secure_flash: bool,
+    linger_scheduled: bool,
+}
+
+#[cfg(any(test, debug_assertions, feature = "llm-test-support"))]
+impl RecordingFlowEffects {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Emitted review-state names in order (error codes dropped).
+    pub fn emitted_states(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .emitted
+            .iter()
+            .map(|(state, _)| state.clone())
+            .collect()
+    }
+
+    /// Emitted (state, error_code) pairs in order.
+    pub fn emitted(&self) -> Vec<(String, Option<String>)> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .emitted
+            .clone()
+    }
+
+    pub fn popover_shown(&self) -> bool {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).popover_shown
+    }
+
+    pub fn secure_flash(&self) -> bool {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).secure_flash
+    }
+}
+
+#[cfg(any(test, debug_assertions, feature = "llm-test-support"))]
+impl FlowEffects for RecordingFlowEffects {
+    fn emit_state(&self, state: ReviewState, error_code: Option<&str>) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .emitted
+            .push((state.as_str().to_string(), error_code.map(|s| s.to_string())));
+    }
+    fn show_popover(&self, _anchor: Option<AnchorRect>) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).popover_shown = true;
+    }
+    fn hide_popover(&self) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).popover_shown = false;
+    }
+    fn set_focusable(&self, focusable: bool) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).focusable = Some(focusable);
+    }
+    fn set_expanded(&self, expanded: bool) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).expanded = Some(expanded);
+    }
+    fn flash_secure_field(&self) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).secure_flash = true;
+    }
+    fn schedule_linger_hide(&self) {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).linger_scheduled = true;
+    }
+}
+
+/// Observable result of [`run_happy_path_for_test`].
+#[cfg(any(debug_assertions, feature = "llm-test-support"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HappyPathReport {
+    /// Review-state names emitted, in order (expected: listening, thinking, ready).
+    pub emitted_states: Vec<String>,
+    /// The proposed text stored on the session after the sidecar returned.
+    pub proposed: Option<String>,
+    /// The instruction stored on the session.
+    pub instruction: Option<String>,
+    /// Whether the popover was shown (listening).
+    pub popover_shown: bool,
+}
+
+/// Drive `start_capture -> finish -> ready` with a fake selection provider and
+/// the given (real, `for_test`) sidecar, recording the observable outcome.
+/// Constructs its own private `AppState` internally so it can exercise the
+/// crate-internal session/status machinery without exposing those types.
+///
+/// Gated the same way `LlmSidecar::for_test` is, so it never links into a
+/// shipped binary. Used by `tests/transform_flow_integration.rs`.
+#[cfg(any(debug_assertions, feature = "llm-test-support"))]
+pub async fn run_happy_path_for_test(
+    sidecar: &Arc<LlmSidecar>,
+    instruction: &str,
+    original: &str,
+) -> HappyPathReport {
+    use std::time::Instant;
+
+    let app_state = AppState::default();
+    let fx = RecordingFlowEffects::new();
+
+    // A fake captured selection — production AX code is untouched.
+    let original_owned = original.to_string();
+    let snapshot = TransformSnapshot {
+        bundle_id: Some("com.example.app".to_string()),
+        pid: 4242,
+        text: original_owned,
+        range: Some((0, original.encode_utf16().count())),
+        bounds: None,
+        captured_at: Instant::now(),
+    };
+
+    // Claim the flow the way the command does, then run the capture core.
+    assert!(app_state
+        .try_transition_transform_status(TransformStatus::Idle, TransformStatus::Capturing));
+    let outcome = core_start_capture(&app_state, &fx, true, async move { Ok(snapshot) }).await;
+    assert_eq!(outcome, StartOutcome::Listening);
+
+    // Release: thinking, then transform.
+    assert!(enter_thinking(&app_state, &fx));
+    let inflight = std::sync::Mutex::new(None);
+    run_transform(
+        &app_state,
+        &fx,
+        sidecar,
+        &inflight,
+        Ok(instruction.to_string()),
+        original.to_string(),
+        DEFAULT_TRANSFORM_DEADLINE,
+    )
+    .await;
+
+    let session = transform_apply::session_snapshot(&app_state);
+    HappyPathReport {
+        emitted_states: fx.emitted_states(),
+        proposed: session.as_ref().and_then(|s| s.proposed.clone()),
+        instruction: session.as_ref().and_then(|s| s.instruction.clone()),
+        popover_shown: fx.popover_shown(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- Pure state machine ------------------------------------------------
+
+    const ALL_STATES: [FlowState; 8] = [
+        FlowState::Idle,
+        FlowState::Capturing,
+        FlowState::Listening,
+        FlowState::Thinking,
+        FlowState::Review,
+        FlowState::Failed,
+        FlowState::Applying,
+        FlowState::Applied,
+    ];
+
+    const ALL_EVENTS: [FlowEvent; 16] = [
+        FlowEvent::StartRequested,
+        FlowEvent::CaptureOk,
+        FlowEvent::CaptureSecure,
+        FlowEvent::CaptureError,
+        FlowEvent::InstructionRequested,
+        FlowEvent::InstructionBlank,
+        FlowEvent::TransformOk,
+        FlowEvent::TransformError,
+        FlowEvent::Approve,
+        FlowEvent::ApplyOk,
+        FlowEvent::ApplyError,
+        FlowEvent::Retry,
+        FlowEvent::Cancel,
+        FlowEvent::Undo,
+        FlowEvent::UndoOk,
+        FlowEvent::UndoError,
+    ];
+
+    #[test]
+    fn transition_table_is_total_and_never_panics() {
+        // Exhaustive: every (state, event) pair yields a decision.
+        for state in ALL_STATES {
+            for event in ALL_EVENTS {
+                let decision = decide(state, event);
+                // An `Ignore` decision must not change state.
+                if decision.actions == vec![FlowAction::Ignore] {
+                    assert_eq!(decision.next, state, "Ignore must not change state");
+                }
+                // The only transition allowed to carry no actions is claiming
+                // the flow (Idle -> Capturing): the capture itself is a command
+                // effect, driven by the follow-up Capture* event. Every other
+                // transition names at least one action.
+                if decision.actions.is_empty() {
+                    assert_eq!(
+                        (state, event, decision.next),
+                        (FlowState::Idle, FlowEvent::StartRequested, FlowState::Capturing),
+                        "only Idle+StartRequested may have no actions",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn happy_path_transitions() {
+        assert_eq!(
+            decide(FlowState::Idle, FlowEvent::StartRequested).next,
+            FlowState::Capturing
+        );
+        let cap = decide(FlowState::Capturing, FlowEvent::CaptureOk);
+        assert_eq!(cap.next, FlowState::Listening);
+        assert!(cap.actions.contains(&FlowAction::StartSession));
+        assert!(cap.actions.contains(&FlowAction::Emit(ReviewState::Listening)));
+        assert!(cap.actions.contains(&FlowAction::StartInstructionCapture));
+
+        let think = decide(FlowState::Listening, FlowEvent::InstructionRequested);
+        assert_eq!(think.next, FlowState::Thinking);
+        assert!(think.actions.contains(&FlowAction::RunTransform));
+
+        let ready = decide(FlowState::Thinking, FlowEvent::TransformOk);
+        assert_eq!(ready.next, FlowState::Review);
+        assert!(ready.actions.contains(&FlowAction::Emit(ReviewState::Ready)));
+        assert!(ready.actions.contains(&FlowAction::SetFocusable(true)));
+
+        let applying = decide(FlowState::Review, FlowEvent::Approve);
+        assert_eq!(applying.next, FlowState::Applying);
+        assert!(applying.actions.contains(&FlowAction::ApplyResult));
+
+        let applied = decide(FlowState::Applying, FlowEvent::ApplyOk);
+        assert_eq!(applied.next, FlowState::Applied);
+        assert!(applied.actions.contains(&FlowAction::ScheduleLingerHide));
+    }
+
+    #[test]
+    fn secure_field_aborts_silently_and_flashes() {
+        let d = decide(FlowState::Capturing, FlowEvent::CaptureSecure);
+        assert_eq!(d.next, FlowState::Idle);
+        assert!(d.actions.contains(&FlowAction::FlashSecureField));
+        assert!(d.actions.contains(&FlowAction::HidePopover));
+        // NEVER shows the content popover for a secure field.
+        assert!(!d.actions.contains(&FlowAction::ShowPopover));
+        assert!(!d.actions.iter().any(|a| matches!(a, FlowAction::Emit(_))));
+    }
+
+    #[test]
+    fn capture_error_shows_failed_popover() {
+        let d = decide(FlowState::Capturing, FlowEvent::CaptureError);
+        assert_eq!(d.next, FlowState::Failed);
+        assert!(d.actions.contains(&FlowAction::ShowPopover));
+        assert!(d.actions.contains(&FlowAction::Emit(ReviewState::Failed)));
+        assert!(d.actions.contains(&FlowAction::SetFocusable(true)));
+    }
+
+    #[test]
+    fn cancel_is_valid_from_every_live_state() {
+        for state in [
+            FlowState::Capturing,
+            FlowState::Listening,
+            FlowState::Thinking,
+            FlowState::Review,
+            FlowState::Failed,
+            FlowState::Applied,
+        ] {
+            let d = decide(state, FlowEvent::Cancel);
+            assert_eq!(d.next, FlowState::Idle, "Cancel from {state:?} must idle");
+            assert!(
+                d.actions.contains(&FlowAction::HidePopover)
+                    && d.actions.contains(&FlowAction::ClearSession),
+                "Cancel from {state:?} must hide + clear",
+            );
+        }
+    }
+
+    #[test]
+    fn thinking_cancel_aborts_the_inflight_request() {
+        let d = decide(FlowState::Thinking, FlowEvent::Cancel);
+        assert!(d.actions.contains(&FlowAction::CancelInflight));
+    }
+
+    #[test]
+    fn retry_re_speaks_on_the_same_snapshot() {
+        for state in [FlowState::Review, FlowState::Failed] {
+            let d = decide(state, FlowEvent::Retry);
+            assert_eq!(d.next, FlowState::Listening);
+            assert!(d.actions.contains(&FlowAction::StartInstructionCapture));
+            assert!(d.actions.contains(&FlowAction::Emit(ReviewState::Listening)));
+            // Retry keeps the session — it never clears it.
+            assert!(!d.actions.contains(&FlowAction::ClearSession));
+        }
+    }
+
+    #[test]
+    fn undo_from_applied_runs_undo_then_idles() {
+        let d = decide(FlowState::Applied, FlowEvent::Undo);
+        assert_eq!(d.next, FlowState::Applying);
+        assert!(d.actions.contains(&FlowAction::UndoResult));
+        let done = decide(FlowState::Applying, FlowEvent::UndoOk);
+        assert_eq!(done.next, FlowState::Idle);
+        assert!(done.actions.contains(&FlowAction::HidePopover));
+    }
+
+    #[test]
+    fn new_press_supersedes_a_failed_or_applied_popover() {
+        for state in [FlowState::Failed, FlowState::Applied] {
+            let d = decide(state, FlowEvent::StartRequested);
+            assert_eq!(d.next, FlowState::Capturing);
+            assert!(d.actions.contains(&FlowAction::ClearSession));
+        }
+    }
+
+    #[test]
+    fn press_while_mid_flow_is_ignored() {
+        for state in [FlowState::Capturing, FlowState::Listening, FlowState::Thinking] {
+            let d = decide(state, FlowEvent::StartRequested);
+            assert_eq!(d.actions, vec![FlowAction::Ignore]);
+            assert_eq!(d.next, state);
+        }
+    }
+
+    // ---- Error-code mappings (total) ---------------------------------------
+
+    #[test]
+    fn selection_error_codes_are_total_and_stable() {
+        let cases = [
+            (SelectionError::AccessibilityDenied, "accessibility_denied"),
+            (SelectionError::SecureField, "secure_field"),
+            (SelectionError::NoSelection, "no_selection"),
+            (SelectionError::TooLarge, "too_large"),
+            (SelectionError::AxUnavailable, "ax_unavailable"),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(selection_error_code(error), expected);
+        }
+    }
+
+    #[test]
+    fn transform_error_codes_are_total_and_nonempty() {
+        // Every TransformError variant maps to a non-empty, snake/camel-stable
+        // code. Listing them all here fails to compile if a variant is added.
+        let all = [
+            TransformError::Unsupported,
+            TransformError::NotDownloaded,
+            TransformError::Disabled,
+            TransformError::Busy,
+            TransformError::InvalidRequest,
+            TransformError::HeavyRuntimeActive,
+            TransformError::SpawnFailed,
+            TransformError::HandshakeFailed,
+            TransformError::ModelMismatch,
+            TransformError::ModelUnreadable,
+            TransformError::Timeout,
+            TransformError::Cancelled,
+            TransformError::Crashed,
+            TransformError::OutputInvalid,
+            TransformError::Protocol,
+            TransformError::ResourceLimit,
+            TransformError::Internal,
+        ];
+        for error in all {
+            assert!(!transform_error_code(error).is_empty());
+        }
+        // Key discoverable codes are exact.
+        assert_eq!(transform_error_code(TransformError::NotDownloaded), "model_not_downloaded");
+        assert_eq!(transform_error_code(TransformError::Timeout), "timeout");
+        assert_eq!(transform_error_code(TransformError::Crashed), "crashed");
+        assert_eq!(transform_error_code(TransformError::OutputInvalid), "output_invalid");
+        assert_eq!(transform_error_code(TransformError::Busy), "busy");
+        assert_eq!(transform_error_code(TransformError::Disabled), "disabled");
+    }
+
+    #[test]
+    fn apply_error_codes_are_total_and_nonempty() {
+        let all = [
+            ApplyError::Unsupported,
+            ApplyError::Busy,
+            ApplyError::NoSession,
+            ApplyError::NoProposedText,
+            ApplyError::AlreadyApplied,
+            ApplyError::NotApplied,
+            ApplyError::ClipboardUnavailable,
+            ApplyError::TargetGone,
+            ApplyError::SelectionChanged,
+            ApplyError::PasteFailed,
+        ];
+        for error in all {
+            assert!(!apply_error_code(error).is_empty());
+        }
+        assert_eq!(apply_error_code(ApplyError::TargetGone), "target_gone");
+        assert_eq!(apply_error_code(ApplyError::SelectionChanged), "selection_changed");
+    }
+
+    // ---- Async core with a fake selection provider -------------------------
+
+    #[tokio::test]
+    async fn core_start_capture_ok_freezes_session_and_lists() {
+        use std::time::Instant;
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        assert!(app_state
+            .try_transition_transform_status(TransformStatus::Idle, TransformStatus::Capturing));
+
+        let snapshot = TransformSnapshot {
+            bundle_id: None,
+            pid: 1,
+            text: "hello world".to_string(),
+            range: Some((0, 11)),
+            bounds: None,
+            captured_at: Instant::now(),
+        };
+        let outcome = core_start_capture(&app_state, &fx, true, async move { Ok(snapshot) }).await;
+
+        assert_eq!(outcome, StartOutcome::Listening);
+        assert_eq!(app_state.transform_status(), TransformStatus::Listening);
+        assert!(transform_apply::session_snapshot(&app_state).is_some());
+        assert_eq!(fx.emitted_states(), vec!["listening".to_string()]);
+        assert!(fx.popover_shown());
+    }
+
+    #[tokio::test]
+    async fn core_start_capture_secure_aborts_without_popover() {
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        app_state.set_transform_status(TransformStatus::Capturing);
+
+        let outcome = core_start_capture(&app_state, &fx, true, async {
+            Err(SelectionError::SecureField)
+        })
+        .await;
+
+        assert_eq!(outcome, StartOutcome::Aborted);
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+        assert!(transform_apply::session_snapshot(&app_state).is_none());
+        assert!(fx.secure_flash());
+        assert!(!fx.popover_shown());
+        // No content UI, no state emission for a secure field.
+        assert!(fx.emitted_states().is_empty());
+    }
+
+    #[tokio::test]
+    async fn core_start_capture_model_not_ready_shows_failed_popover() {
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        app_state.set_transform_status(TransformStatus::Capturing);
+
+        let outcome = core_start_capture(&app_state, &fx, false, async {
+            Ok(TransformSnapshot {
+                bundle_id: None,
+                pid: 1,
+                text: "x".to_string(),
+                range: None,
+                bounds: None,
+                captured_at: std::time::Instant::now(),
+            })
+        })
+        .await;
+
+        assert_eq!(outcome, StartOutcome::Aborted);
+        assert_eq!(app_state.transform_status(), TransformStatus::ReviewPending);
+        assert_eq!(
+            fx.emitted(),
+            vec![("failed".to_string(), Some("model_not_downloaded".to_string()))]
+        );
+        assert!(fx.popover_shown());
+    }
+
+    #[tokio::test]
+    async fn run_transform_blank_instruction_fails_with_no_instruction() {
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        app_state.set_transform_status(TransformStatus::Thinking);
+        let sidecar = Arc::new(LlmSidecar::new());
+        let inflight = std::sync::Mutex::new(None);
+
+        run_transform(
+            &app_state,
+            &fx,
+            &sidecar,
+            &inflight,
+            Err(()),
+            "original".to_string(),
+            DEFAULT_TRANSFORM_DEADLINE,
+        )
+        .await;
+
+        assert_eq!(app_state.transform_status(), TransformStatus::ReviewPending);
+        assert_eq!(
+            fx.emitted(),
+            vec![("failed".to_string(), Some("no_instruction".to_string()))]
+        );
+    }
+}

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -32,6 +32,16 @@
 //! popover window alone via `get_transform_review_content`. The state-machine
 //! action list and every `emit_*` here are structurally incapable of carrying
 //! that text.
+//!
+//! ## Spec-by-test (`decide`)
+//!
+//! The pure `decide` table is the **specification** of logical transitions. The
+//! command layer is the authoritative I/O driver and may diverge where the
+//! table cannot express concurrent races (e.g. cancel during AX capture). Unit
+//! tests under `mod tests` assert the table matches the command layer at every
+//! documented divergence point (Review+StartRequested supersede, undo-without-
+//! epoch-bump, Applying+Cancel). Do not "fix" table drift by editing only
+//! one side — update both and the tests together.
 
 #![allow(dead_code)]
 
@@ -355,11 +365,18 @@ pub fn decide(state: FlowState, event: FlowEvent) -> FlowDecision {
         (S::Applying, E::UndoError) => {
             go(S::Applied, vec![Emit(ReviewState::Failed)])
         }
+        // Cancel during Applying: tear down; ApplyingGuard must not resurrect
+        // ReviewPending after the session is cleared (see cancel_transform).
+        (S::Applying, E::Cancel) => cancel_from(state),
         (S::Applying, _) => ignore(S::Applying),
 
         // ---- Applied (undo available) --------------------------------------
+        // UndoResult: apply-path undo that, on success, hides + clears session
+        // WITHOUT bumping the clipboard-restore epoch (see
+        // `undo_transform_and_close`). Failure keeps Applied and emits Failed.
         (S::Applied, E::Undo) => go(S::Applying, vec![UndoResult]),
         (S::Applied, E::Cancel) => cancel_from(state),
+        // A new hotkey press supersedes the applied linger popover.
         (S::Applied, E::StartRequested) => go(S::Capturing, vec![ClearSession]),
         (S::Applied, _) => ignore(S::Applied),
     }
@@ -425,7 +442,13 @@ where
 {
     if !model_ready {
         // Discoverable error surface: still show the popover, in a failed state.
-        app_state.set_transform_status(TransformStatus::ReviewPending);
+        // Bail if a short-tap cancel already left Capturing.
+        if !app_state.try_transition_transform_status(
+            TransformStatus::Capturing,
+            TransformStatus::ReviewPending,
+        ) {
+            return StartOutcome::Aborted;
+        }
         fx.show_popover(None);
         fx.set_focusable(true);
         fx.emit_state(ReviewState::Failed, Some("model_not_downloaded"));
@@ -434,9 +457,17 @@ where
 
     match capture.await {
         Ok(snapshot) => {
+            // Cancel during slow AX capture must not resurrect the flow:
+            // session re-install + mic arm + popover while the reducer thinks
+            // not-holding would wedge Listening with no release coming.
+            if !app_state.try_transition_transform_status(
+                TransformStatus::Capturing,
+                TransformStatus::Listening,
+            ) {
+                return StartOutcome::Aborted;
+            }
             let anchor = snapshot_anchor(&snapshot);
             transform_apply::start_session(app_state, snapshot);
-            app_state.set_transform_status(TransformStatus::Listening);
             fx.show_popover(anchor);
             fx.set_focusable(false);
             fx.emit_state(ReviewState::Listening, None);
@@ -444,14 +475,27 @@ where
         }
         Err(SelectionError::SecureField) => {
             // Never show content UI for a password field — abort silently.
-            app_state.set_transform_status(TransformStatus::Idle);
+            if !app_state.try_transition_transform_status(
+                TransformStatus::Capturing,
+                TransformStatus::Idle,
+            ) {
+                return StartOutcome::Aborted;
+            }
             transform_apply::clear_session(app_state);
             fx.hide_popover();
             fx.flash_secure_field();
             StartOutcome::Aborted
         }
         Err(other) => {
-            app_state.set_transform_status(TransformStatus::ReviewPending);
+            if !app_state.try_transition_transform_status(
+                TransformStatus::Capturing,
+                TransformStatus::ReviewPending,
+            ) {
+                // Cancelled during capture — tear down any partial UI.
+                transform_apply::clear_session(app_state);
+                fx.hide_popover();
+                return StartOutcome::Aborted;
+            }
             fx.show_popover(None);
             fx.set_focusable(true);
             fx.emit_state(ReviewState::Failed, Some(selection_error_code(other)));
@@ -475,8 +519,11 @@ pub(crate) fn enter_thinking(app_state: &AppState, fx: &dyn FlowEffects) -> bool
 /// Core of the transform step: given the transcription result (`Err` = blank),
 /// call the sidecar and drive the flow to `ready` or `failed`. The sidecar call
 /// runs as a cancellable task whose abort handle is stored in `inflight` so
-/// `cancel_transform` can abort a `Thinking`-phase request (dropping the future
-/// clears the sidecar's busy flag). Assumes `enter_thinking` already ran.
+/// `cancel_transform` can abort the outer wrapper; it **also** calls
+/// `LlmSidecar::cancel_inflight_request` so the blocking work sends a Cancel
+/// frame and clears `busy` promptly. Terminal status writes use
+/// `try_transition(Thinking → ReviewPending)` so a cancel landing mid-flight
+/// cannot resurrect ReviewPending (which would wedge dictation).
 pub(crate) async fn run_transform(
     app_state: &AppState,
     fx: &dyn FlowEffects,
@@ -489,13 +536,21 @@ pub(crate) async fn run_transform(
     let instruction = match instruction {
         Ok(text) if !text.trim().is_empty() => text,
         _ => {
-            app_state.set_transform_status(TransformStatus::ReviewPending);
-            fx.set_focusable(true);
-            fx.emit_state(ReviewState::Failed, Some("no_instruction"));
+            if app_state.try_transition_transform_status(
+                TransformStatus::Thinking,
+                TransformStatus::ReviewPending,
+            ) {
+                fx.set_focusable(true);
+                fx.emit_state(ReviewState::Failed, Some("no_instruction"));
+            }
             return;
         }
     };
-    transform_apply::set_instruction(app_state, instruction.clone());
+    // Cancel during transcription can clear the session before we get here —
+    // do not spawn the sidecar on a dead session.
+    if !transform_apply::set_instruction(app_state, instruction.clone()) {
+        return;
+    }
 
     let sidecar = Arc::clone(sidecar);
     let input = original;
@@ -509,21 +564,37 @@ pub(crate) async fn run_transform(
         // Aborted by `cancel_transform`, which already tore the flow down.
         Err(err) if err.is_cancelled() => {}
         Err(_) => {
-            app_state.set_transform_status(TransformStatus::ReviewPending);
-            fx.set_focusable(true);
-            fx.emit_state(ReviewState::Failed, Some("internal"));
+            if app_state.try_transition_transform_status(
+                TransformStatus::Thinking,
+                TransformStatus::ReviewPending,
+            ) {
+                fx.set_focusable(true);
+                fx.emit_state(ReviewState::Failed, Some("internal"));
+            }
         }
         Ok(Ok(output)) => {
+            if !app_state.try_transition_transform_status(
+                TransformStatus::Thinking,
+                TransformStatus::ReviewPending,
+            ) {
+                return;
+            }
             transform_apply::set_proposed_text(app_state, output.output);
-            app_state.set_transform_status(TransformStatus::ReviewPending);
             fx.set_expanded(true);
             fx.set_focusable(true);
             fx.emit_state(ReviewState::Ready, None);
         }
+        // Cooperative cancel from the sidecar: cancel_transform already tore
+        // the flow down — do not force ReviewPending.
+        Ok(Err(TransformError::Cancelled)) => {}
         Ok(Err(error)) => {
-            app_state.set_transform_status(TransformStatus::ReviewPending);
-            fx.set_focusable(true);
-            fx.emit_state(ReviewState::Failed, Some(transform_error_code(error)));
+            if app_state.try_transition_transform_status(
+                TransformStatus::Thinking,
+                TransformStatus::ReviewPending,
+            ) {
+                fx.set_focusable(true);
+                fx.emit_state(ReviewState::Failed, Some(transform_error_code(error)));
+            }
         }
     }
 }
@@ -602,6 +673,10 @@ impl FlowEffects for TauriFlowEffects<'_> {
                 if !still_applied {
                     return;
                 }
+                // Free the held selection text once Undo is no longer reachable
+                // from the UI (popover gone). Content is only available via
+                // get_transform_review_content, which returns empty after this.
+                transform_apply::clear_session(&state.app_state);
             }
             let _ = crate::commands::transform_popover::hide_popover_internal(&app);
         });
@@ -687,6 +762,7 @@ async fn transcribe_instruction(
 pub(crate) async fn start_transform_capture(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, crate::State>,
+    device_name: Option<String>,
 ) -> Result<(), String> {
     // Serialize against dictation start/stop, taking the same locks in the
     // same order (`recording_transition` then `dictation`) as
@@ -737,7 +813,8 @@ pub(crate) async fn start_transform_capture(
     if outcome == StartOutcome::Listening {
         // Arm audio for the spoken instruction. DictationStatus stays Idle —
         // this audio belongs to the transform flow (TransformStatus::Listening).
-        if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), None) {
+        // Pass the configured input device (same contract as start_native_recording).
+        if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), device_name) {
             tracing::error!(target: "transform", error = %e, "instruction audio failed to start");
             state.app_state.set_transform_status(TransformStatus::Idle);
             transform_apply::clear_session(&state.app_state);
@@ -801,6 +878,7 @@ pub(crate) async fn finish_transform_instruction(
 pub(crate) async fn retry_transform_instruction(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, crate::State>,
+    device_name: Option<String>,
 ) -> Result<(), String> {
     let _transition = state.app_state.recording_transition.lock().await;
 
@@ -830,7 +908,7 @@ pub(crate) async fn retry_transform_instruction(
     fx.set_focusable(false);
     fx.emit_state(ReviewState::Listening, None);
 
-    if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), None) {
+    if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), device_name) {
         tracing::error!(target: "transform", error = %e, "retry audio failed to start");
         state.app_state.set_transform_status(TransformStatus::Idle);
         transform_apply::clear_session(&state.app_state);
@@ -879,8 +957,11 @@ pub(crate) async fn approve_transform(
     }
 }
 
-/// Cancel the flow from any state: abort an in-flight sidecar request, stop any
-/// instruction audio, clear the session, and hide the popover.
+/// Cancel the flow from any state (including Applying): abort an in-flight
+/// sidecar request cooperatively, stop instruction audio, clear the session,
+/// and hide the popover. Clearing the session before hide means the next
+/// `get_transform_review_content` returns empty — no stale React flash of prior
+/// selection text.
 #[tauri::command]
 pub(crate) async fn cancel_transform(
     app_handle: tauri::AppHandle,
@@ -888,12 +969,16 @@ pub(crate) async fn cancel_transform(
 ) -> Result<(), String> {
     let prev = state.app_state.transform_status();
 
-    // Abort the sidecar task (dropping the future clears the busy flag).
+    // Cooperative cancel first: the blocking spawn_blocking work only clears
+    // BusyGuard when it finishes, so abort alone would leave busy held up to
+    // the deadline. cancel_inflight_request makes run_request send Cancel.
+    state.transform_runtime.cancel_inflight_request();
     if let Some(handle) = state.app_state.transform_inflight.lock_or_recover().take() {
         handle.abort();
     }
     // Invalidate any pending clipboard restore from a just-finished apply/undo
-    // (N1): a cancel means the user is done with this pass.
+    // (N1): a cancel means the user is done with this pass. (Do NOT use cancel
+    // after a successful undo — see undo_transform_and_close.)
     let _ = state.app_state.next_transform_apply_epoch();
 
     // Stop instruction audio only if it was the transform's (Listening).
@@ -901,10 +986,57 @@ pub(crate) async fn cancel_transform(
         let _ = crate::audio::stop_recording();
     }
 
+    // Force Idle even from Applying — ApplyingGuard drop will no-op once status
+    // is no longer Applying (try_transition).
     state.app_state.set_transform_status(TransformStatus::Idle);
     transform_apply::clear_session(&state.app_state);
     let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
     Ok(())
+}
+
+/// Undo an applied transform and close the popover **without** bumping the
+/// clipboard-restore epoch a second time.
+///
+/// `undo_applied_transform` already advances the epoch once (to protect the
+/// undo's own delayed clipboard restore). Chaining `cancel_transform` after
+/// undo would bump it again inside the 300ms restore window and clobber the
+/// user's prior clipboard on every paste-fallback undo.
+///
+/// On success: hide popover + clear session (undo unreachable once hidden).
+/// On failure: keep the Applied session and emit `failed` so Undo stays available.
+#[tauri::command]
+pub(crate) async fn undo_transform_and_close(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<'_, crate::State>,
+) -> Result<(), String> {
+    let fx = TauriFlowEffects {
+        app: &app_handle,
+        state: &state,
+    };
+
+    let mut guard =
+        match transform_apply::ApplyingGuard::try_new(&state.app_state, TransformStatus::Idle) {
+            Some(guard) => guard,
+            None => {
+                fx.emit_state(ReviewState::Failed, Some("busy"));
+                return Err("busy".to_string());
+            }
+        };
+
+    match transform_apply::undo_applied_transform(&app_handle, &state.app_state).await {
+        Ok(()) => {
+            guard.mark_succeeded();
+            // Hide + clear WITHOUT another epoch bump (cancel would bump).
+            transform_apply::clear_session(&state.app_state);
+            let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+            Ok(())
+        }
+        Err(error) => {
+            // Guard drop restores Idle; session stays applied so Undo retries.
+            fx.emit_state(ReviewState::Failed, Some(apply_error_code(error)));
+            Err(apply_error_code(error).to_string())
+        }
+    }
 }
 
 // ===========================================================================
@@ -1415,5 +1547,149 @@ mod tests {
             fx.emitted(),
             vec![("failed".to_string(), Some("no_instruction".to_string()))]
         );
+    }
+
+    // ---- Cancel races (C2 review findings 1–3) -----------------------------
+
+    #[tokio::test]
+    async fn run_transform_cancel_during_thinking_does_not_resurrect_review_pending() {
+        // Finding 1: cancel that lands after transcription but before / during
+        // the sidecar step must not force ReviewPending (which blocks_recording).
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        app_state.set_transform_status(TransformStatus::Thinking);
+        // No session → set_instruction returns false → bail before sidecar.
+        let sidecar = Arc::new(LlmSidecar::new());
+        let inflight = std::sync::Mutex::new(None);
+
+        run_transform(
+            &app_state,
+            &fx,
+            &sidecar,
+            &inflight,
+            Ok("make this shorter".to_string()),
+            "original".to_string(),
+            DEFAULT_TRANSFORM_DEADLINE,
+        )
+        .await;
+
+        // Status must stay Thinking (or whatever cancel left) — never forced
+        // to ReviewPending without a live session. We never set a session, so
+        // set_instruction bailed and status is unchanged.
+        assert_eq!(app_state.transform_status(), TransformStatus::Thinking);
+        assert!(fx.emitted_states().is_empty());
+        assert!(inflight.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn run_transform_respects_cancel_that_left_thinking() {
+        // Terminal branches only write ReviewPending via try_transition from
+        // Thinking — if cancel already forced Idle, blank-instruction must not
+        // resurrect ReviewPending.
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        // Simulate cancel winning the race: already Idle.
+        app_state.set_transform_status(TransformStatus::Idle);
+        let sidecar = Arc::new(LlmSidecar::new());
+        let inflight = std::sync::Mutex::new(None);
+
+        run_transform(
+            &app_state,
+            &fx,
+            &sidecar,
+            &inflight,
+            Err(()),
+            "original".to_string(),
+            DEFAULT_TRANSFORM_DEADLINE,
+        )
+        .await;
+
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+        assert!(fx.emitted_states().is_empty());
+    }
+
+    #[tokio::test]
+    async fn core_start_capture_cancel_during_ax_does_not_install_session() {
+        // Finding 3: short-tap cancel during slow AX capture must not re-install
+        // session / arm Listening after the cancel tore the flow down.
+        let app_state = Arc::new(AppState::default());
+        let fx = RecordingFlowEffects::new();
+        assert!(app_state
+            .try_transition_transform_status(TransformStatus::Idle, TransformStatus::Capturing));
+
+        let snapshot = TransformSnapshot {
+            bundle_id: None,
+            pid: 1,
+            text: "hello world".to_string(),
+            range: Some((0, 11)),
+            bounds: None,
+            captured_at: std::time::Instant::now(),
+        };
+
+        let cancel_state = Arc::clone(&app_state);
+        let outcome = core_start_capture(&app_state, &fx, true, async move {
+            // Simulate cancel mid-capture: leave Capturing before Ok lands.
+            cancel_state.set_transform_status(TransformStatus::Idle);
+            Ok(snapshot)
+        })
+        .await;
+
+        assert_eq!(outcome, StartOutcome::Aborted);
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+        assert!(transform_apply::session_snapshot(&app_state).is_none());
+        assert!(!fx.popover_shown());
+        assert!(fx.emitted_states().is_empty());
+    }
+
+    // ---- Spec-by-test divergence points (finding 8) ------------------------
+
+    #[test]
+    fn decide_review_start_requested_is_ignored_but_failed_and_applied_supersede() {
+        // Command layer supersedes Failed/Applied on a new press; mid-flow
+        // Review ignores StartRequested (session stays until Cancel/Approve).
+        let review = decide(FlowState::Review, FlowEvent::StartRequested);
+        assert_eq!(review.actions, vec![FlowAction::Ignore]);
+
+        for state in [FlowState::Failed, FlowState::Applied] {
+            let d = decide(state, FlowEvent::StartRequested);
+            assert_eq!(d.next, FlowState::Capturing);
+            assert!(d.actions.contains(&FlowAction::ClearSession));
+        }
+    }
+
+    #[test]
+    fn decide_applying_cancel_tears_down() {
+        // Finding 7/8: Cancel during Applying must idle (not ignore).
+        let d = decide(FlowState::Applying, FlowEvent::Cancel);
+        assert_eq!(d.next, FlowState::Idle);
+        assert!(d.actions.contains(&FlowAction::HidePopover));
+        assert!(d.actions.contains(&FlowAction::ClearSession));
+    }
+
+    #[test]
+    fn decide_undo_ok_clears_session_without_cancel_inflight() {
+        // Finding 4: successful undo hides + clears; it does not CancelInflight
+        // (and the command path must not bump the apply epoch a second time).
+        let d = decide(FlowState::Applying, FlowEvent::UndoOk);
+        assert_eq!(d.next, FlowState::Idle);
+        assert!(d.actions.contains(&FlowAction::HidePopover));
+        assert!(d.actions.contains(&FlowAction::ClearSession));
+        assert!(!d.actions.contains(&FlowAction::CancelInflight));
+    }
+
+    #[test]
+    fn undo_close_path_must_not_bump_epoch_twice() {
+        // Document the contract undo_transform_and_close implements: one epoch
+        // advance for the undo's clipboard restore, never a second bump from
+        // chaining cancel. Pure unit check of the epoch helper semantics.
+        let app_state = AppState::default();
+        let before = app_state.transform_apply_epoch();
+        let first = app_state.next_transform_apply_epoch(); // undo's own bump
+        assert_eq!(first, before + 1);
+        // Success path of undo_transform_and_close must stop here (no cancel).
+        assert_eq!(app_state.transform_apply_epoch(), first);
+        // Contrast: cancel_transform would bump again and break paste-fallback.
+        let second = app_state.next_transform_apply_epoch();
+        assert_eq!(second, first + 1);
     }
 }

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -219,6 +219,53 @@ async fn wrong_nonce_on_result_frame_fails_closed() {
 }
 
 #[tokio::test]
+async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears() {
+    // Finding 2: cancel_inflight_request must send a protocol Cancel, settle
+    // the blocking loop, and clear busy promptly — aborting only the outer
+    // tokio future is not enough (BusyGuard lives in spawn_blocking).
+    let fixture = fixture_model();
+    let sidecar = sidecar("slow_honor_cancel", &fixture);
+
+    let s = Arc::clone(&sidecar);
+    let handle = tokio::spawn(async move {
+        s.transform(
+            "Rewrite this politely.",
+            "gimme the report",
+            Duration::from_secs(30),
+        )
+        .await
+    });
+
+    // Wait until the in-flight slot is claimed.
+    let mut claimed = false;
+    for _ in 0..100 {
+        if sidecar.is_transform_busy() {
+            claimed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(claimed, "transform never became busy");
+
+    let started = std::time::Instant::now();
+    sidecar.cancel_inflight_request();
+    let err = handle.await.unwrap().unwrap_err();
+    assert_eq!(err, TransformError::Cancelled);
+    // Must clear well under the 30s deadline (cancel grace is ~150ms).
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "busy did not clear promptly after cooperative cancel: {:?}",
+        started.elapsed()
+    );
+    assert!(!sidecar.is_transform_busy());
+    // Helper acknowledged Cancel, so it stays resident (same as deadline cancel
+    // on slow_ack_cancel). A second Transform against this mock scenario would
+    // hang again — reusability of the supervisor after cancel is covered by
+    // the happy-path round-trip and dropping_the_transform_future tests.
+    assert!(sidecar.has_live_child());
+}
+
+#[tokio::test]
 async fn dropping_the_transform_future_clears_busy_and_does_not_wedge() {
     let fixture = fixture_model();
     // Happy path with a delayed Result so the request is still in flight when

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -11,6 +11,8 @@
 //! - `malformed_on_transform` — emit an invalid-JSON frame
 //! - `oversized_on_transform` — emit a length prefix over the 64 KiB frame cap
 //! - `slow_ack_cancel`     — never Result; reply Cancelled to a Cancel
+//! - `slow_honor_cancel`   — alias of `slow_ack_cancel` (cancel-honoring slow path
+//!                           for host-side cooperative-cancel tests)
 //! - `slow_ignore_cancel`  — never Result; ignore Cancel (forces a kill)
 //!
 //! The real supervisor spawns with `env_clear`, so these vars only exist for the
@@ -128,7 +130,7 @@ fn main() {
                         let _ = stdout.write_all(b"xx");
                         let _ = stdout.flush();
                     }
-                    "slow_ack_cancel" | "slow_ignore_cancel" => {
+                    "slow_ack_cancel" | "slow_honor_cancel" | "slow_ignore_cancel" => {
                         // Never send a Result; wait for the Cancel below.
                     }
                     "error_deadline_on_transform" => {
@@ -177,7 +179,7 @@ fn main() {
                 }
             }
             HostMessage::Cancel { request_id, .. } => {
-                if scenario == "slow_ack_cancel" {
+                if scenario == "slow_ack_cancel" || scenario == "slow_honor_cancel" {
                     let cancelled = HelperMessage::Cancelled {
                         protocol: PROTOCOL_NAME.to_string(),
                         version: PROTOCOL_VERSION,

--- a/app/src-tauri/tests/transform_flow_integration.rs
+++ b/app/src-tauri/tests/transform_flow_integration.rs
@@ -1,0 +1,87 @@
+//! Integration test for the transform-flow orchestrator (#312, PR-C2).
+//!
+//! Extends the mock-helper suite (`llm_sidecar_integration.rs`): it drives the
+//! full `start_capture -> finish -> ready` happy path with a MOCKED selection
+//! provider (a fake `TransformSnapshot` injected via the flow's async seam — the
+//! production AX capture in `selection.rs` is never weakened) against the real
+//! supervisor talking to the protocol-v1 mock helper. No AX server, no Tauri
+//! app, no real GGUF model.
+
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ui_lib::llm_sidecar::{model_file_digest, LlmSidecar, TestSpawnConfig};
+use ui_lib::transform_flow::run_happy_path_for_test;
+
+fn helper_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mock_llm_helper"))
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+    size: u64,
+    sha: String,
+}
+
+fn fixture_model() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fixture-model.gguf");
+    std::fs::write(&path, b"murmur transform-flow fixture model bytes").unwrap();
+    let (size, sha) = model_file_digest(&path).unwrap();
+    Fixture {
+        _dir: dir,
+        path,
+        size,
+        sha,
+    }
+}
+
+fn happy_sidecar(fixture: &Fixture) -> Arc<LlmSidecar> {
+    Arc::new(LlmSidecar::for_test(TestSpawnConfig {
+        helper_path: helper_path(),
+        model_path: fixture.path.clone(),
+        model_size: fixture.size,
+        model_sha256: fixture.sha.clone(),
+        scenario_env: vec![("MOCK_SCENARIO".to_string(), "happy".to_string())],
+        request_slack: Duration::from_millis(100),
+        cancel_grace: Duration::from_millis(150),
+        handshake_timeout: Duration::from_secs(5),
+        idle_after: Duration::from_secs(300),
+    }))
+}
+
+#[tokio::test]
+async fn happy_path_capture_finish_ready_produces_proposal() {
+    let fixture = fixture_model();
+    let sidecar = happy_sidecar(&fixture);
+
+    let report = run_happy_path_for_test(
+        &sidecar,
+        "Rewrite this politely.",
+        "gimme the report now",
+    )
+    .await;
+
+    // The flow emitted exactly the forward sequence — never an error state.
+    assert_eq!(
+        report.emitted_states,
+        vec![
+            "listening".to_string(),
+            "thinking".to_string(),
+            "ready".to_string()
+        ],
+        "expected listening -> thinking -> ready",
+    );
+    // The proposal from the mock helper landed on the session.
+    assert_eq!(report.proposed.as_deref(), Some("mock-output"));
+    // The instruction was frozen onto the session for the review popover.
+    assert_eq!(report.instruction.as_deref(), Some("Rewrite this politely."));
+    // The listening popover was shown.
+    assert!(report.popover_shown);
+    // Healthy helper is kept resident for reuse.
+    assert!(sidecar.has_live_child());
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -144,7 +144,13 @@ function App() {
   // Independent AX-selection transform hotkey (issue #312). Enabled only when
   // the user has configured a transform key; drives capture -> instruction ->
   // review via the transform-review popover window.
-  useTransformFlow({ enabled: hotkeysArmed && settings.transformHoldKey !== null, initialized, accessibilityGranted, transformHoldKey: settings.transformHoldKey });
+  useTransformFlow({
+    enabled: hotkeysArmed && settings.transformHoldKey !== null,
+    initialized,
+    accessibilityGranted,
+    transformHoldKey: settings.transformHoldKey,
+    microphone: settings.microphone,
+  });
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import { useHistoryManagement } from './lib/hooks/useHistoryManagement';
 import { useRecordingState } from './lib/hooks/useRecordingState';
 import { useHoldDownToggle } from './lib/hooks/useHoldDownToggle';
 import { useDoubleTapToggle } from './lib/hooks/useDoubleTapToggle';
+import { useTransformFlow } from './lib/hooks/useTransformFlow';
 import { useCombinedToggle } from './lib/hooks/useCombinedToggle';
 import { useShowAboutListener } from './lib/hooks/useShowAboutListener';
 import { useOverlaySettingsSync } from './lib/hooks/useOverlaySettingsSync';
@@ -140,6 +141,10 @@ function App() {
   useDoubleTapToggle({ enabled: hotkeysArmed && settings.recordingMode === 'double_tap', initialized, accessibilityGranted, doubleTapKey: settings.doubleTapKey, status, onToggle: toggleRecording });
   useCombinedToggle({ enabled: hotkeysArmed && settings.recordingMode === 'both', initialized, accessibilityGranted, triggerKey: settings.doubleTapKey, status, onStart: handleStart, onStop: handleStop, onToggle: toggleRecording });
   useEscapeCancel({ status, enabled: hotkeysArmed && initialized && accessibilityGranted === true });
+  // Independent AX-selection transform hotkey (issue #312). Enabled only when
+  // the user has configured a transform key; drives capture -> instruction ->
+  // review via the transform-review popover window.
+  useTransformFlow({ enabled: hotkeysArmed && settings.transformHoldKey !== null, initialized, accessibilityGranted, transformHoldKey: settings.transformHoldKey });
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -27,6 +27,10 @@ export function OverlayWidget() {
   const [disabled, setDisabled] = useState(false);
   const [showHotkeyMiss, setShowHotkeyMiss] = useState(false);
   const [status, setStatus] = useState<DictationStatus>('idle');
+  // True while the local-LLM transform is thinking (issue #312 PR-C2). Driven
+  // by the broadcast `transform-state-changed` event; the overlay is a
+  // separate webview so it listens directly.
+  const [transforming, setTransforming] = useState(false);
   const hotkeyMissFeedbackRef = useRef(false);
   const statusRef = useRef<DictationStatus>('idle');
 
@@ -48,7 +52,28 @@ export function OverlayWidget() {
     status, statusRef, disabledRef: runtime.disabledRef, expandedRef,
   });
 
-  const visual = deriveVisual(status, runtime.showCancelled, runtime.showHotkeyMiss, runtime.disabled);
+  const visual = deriveVisual(
+    status,
+    runtime.showCancelled,
+    runtime.showHotkeyMiss,
+    runtime.disabled,
+    transforming,
+    runtime.showSecureField,
+  );
+
+  // Track the transform flow's thinking phase for the overlay indicator.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<unknown>('transform-state-changed', (event) => {
+      const payload = event.payload as { state?: unknown } | null;
+      const state = payload && typeof payload === 'object' ? payload.state : undefined;
+      setTransforming(state === 'thinking');
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, []);
 
   // Log mount/unmount.
   useEffect(() => {

--- a/app/src/components/overlay/OverlayPill.tsx
+++ b/app/src/components/overlay/OverlayPill.tsx
@@ -48,6 +48,15 @@ export function OverlayPill({
             <div className="w-2.5 h-2.5 rounded-full bg-red-500" style={{ animation: 'pulse 0.8s ease-in-out infinite' }} />
           ) : indicator.kind === 'processing' ? (
             <span className="w-3 h-3 border-[1.5px] border-white/20 border-t-white/70 rounded-full animate-spin block" />
+          ) : indicator.kind === 'secureField' ? (
+            // Brief flash when a secure/password field is refused (issue #312).
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="secure field">
+              <rect x="5" y="11" width="14" height="9" rx="2" />
+              <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+            </svg>
+          ) : indicator.kind === 'transforming' ? (
+            // "Transforming…" — local LLM is thinking (issue #312).
+            <span className="w-2.5 h-2.5 rounded-full bg-violet-400 block" style={{ animation: 'pulse 0.8s ease-in-out infinite' }} />
           ) : (
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: indicator.dimmed ? 0.15 : 1 }}>
               <rect x="9" y="1" width="6" height="12" rx="3" />

--- a/app/src/components/overlay/deriveVisual.ts
+++ b/app/src/components/overlay/deriveVisual.ts
@@ -8,9 +8,11 @@ import type { DictationStatus } from '../../lib/types';
  */
 export type OverlayIndicator =
   | { kind: 'cancelled' }
+  | { kind: 'secureField' }
   | { kind: 'hotkeyMiss' }
   | { kind: 'recording' }
   | { kind: 'processing' }
+  | { kind: 'transforming' }
   | { kind: 'idle'; dimmed: boolean };
 
 export interface OverlayVisual {
@@ -35,26 +37,38 @@ export interface OverlayVisual {
  *   showCancelled ? X : showHotkeyMiss ? ! : status==='recording' ? dot
  *     : status==='processing' ? spinner : mic (dimmed if disabled)
  *
- * Priority: cancelled > hotkey-miss > recording > processing > idle. (Since
- * `status` is a single enum value, recording and processing can never both be
- * true, so their relative order does not change behavior — only idle's
- * position at the end, after both, matters.)
+ * Priority: cancelled > secure-field flash > hotkey-miss > recording >
+ * processing > transforming > idle. (Since `status` is a single enum value,
+ * recording and processing can never both be true, so their relative order
+ * does not change behavior — only idle's position at the end, after both,
+ * matters.)
+ *
+ * `transforming` and `showSecureField` (issue #312 PR-C2) are the transform
+ * flow's two overlay affordances: the "transforming…" indicator shown while
+ * the local LLM is thinking, and a brief flash when a password/secure field is
+ * refused. Both default off so the dictation call sites are unchanged.
  */
 export function deriveVisual(
   status: DictationStatus,
   showCancelled: boolean,
   showHotkeyMiss: boolean,
   disabled: boolean,
+  transforming: boolean = false,
+  showSecureField: boolean = false,
 ): OverlayVisual {
   const indicator: OverlayIndicator = showCancelled
     ? { kind: 'cancelled' }
-    : showHotkeyMiss
-      ? { kind: 'hotkeyMiss' }
-      : status === 'recording'
-        ? { kind: 'recording' }
-        : status === 'processing'
-          ? { kind: 'processing' }
-          : { kind: 'idle', dimmed: disabled };
+    : showSecureField
+      ? { kind: 'secureField' }
+      : showHotkeyMiss
+        ? { kind: 'hotkeyMiss' }
+        : status === 'recording'
+          ? { kind: 'recording' }
+          : status === 'processing'
+            ? { kind: 'processing' }
+            : transforming
+              ? { kind: 'transforming' }
+              : { kind: 'idle', dimmed: disabled };
 
   return {
     indicator,

--- a/app/src/lib/hooks/useOverlayRuntime.ts
+++ b/app/src/lib/hooks/useOverlayRuntime.ts
@@ -10,6 +10,8 @@ import {
 } from '../hotkeyFeedback';
 
 const CANCELLED_FLASH_MS = 800;
+/** How long the secure-field refusal flash shows (issue #312 PR-C2). */
+const SECURE_FIELD_FLASH_MS = 800;
 
 export interface UseOverlayRuntimeArgs {
   /** Current dictation status (reactive value, not just a ref). */
@@ -33,6 +35,8 @@ export interface UseOverlayRuntimeArgs {
 export interface OverlayRuntime {
   showCancelled: boolean;
   showHotkeyMiss: boolean;
+  /** Brief flash when a secure/password field was refused (issue #312). */
+  showSecureField: boolean;
   disabled: boolean;
   setDisabled: (value: boolean) => void;
   /** Ref mirror of `disabled`, read synchronously by useRecordingControls. */
@@ -58,6 +62,7 @@ export function useOverlayRuntime({
   hotkeyMissFeedbackRef,
 }: UseOverlayRuntimeArgs): OverlayRuntime {
   const [showCancelled, setShowCancelled] = useState(false);
+  const [showSecureField, setShowSecureField] = useState(false);
   const disabledRef = useRef(disabled);
   const hotkeyMissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -133,6 +138,29 @@ export function useOverlayRuntime({
     };
   }, []);
 
+  // Brief flash when the transform flow refuses a secure/password field
+  // (issue #312 PR-C2). Mirrors the recording-cancelled flash mechanism.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    listen('transform-secure-field', () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      setShowSecureField(true);
+      timeoutId = setTimeout(() => {
+        if (!cancelled) setShowSecureField(false);
+        timeoutId = null;
+      }, SECURE_FIELD_FLASH_MS);
+    }).then((fn) => {
+      if (cancelled) { fn(); } else { unlisten = fn; }
+    });
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      unlisten?.();
+    };
+  }, []);
+
   // Subscribe to app-disabled-changed events from Rust
   useEffect(() => {
     let cancelled = false;
@@ -146,5 +174,5 @@ export function useOverlayRuntime({
     return () => { cancelled = true; unlisten?.(); };
   }, [setDisabled]);
 
-  return { showCancelled, showHotkeyMiss, disabled, setDisabled, disabledRef };
+  return { showCancelled, showSecureField, showHotkeyMiss, disabled, setDisabled, disabledRef };
 }

--- a/app/src/lib/hooks/useTransformFlow.ts
+++ b/app/src/lib/hooks/useTransformFlow.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { DEFAULT_SETTINGS } from '../settings';
 import { flog } from '../log';
 import {
   INITIAL_TRANSFORM_FLOW_STATE,
@@ -16,6 +17,8 @@ interface UseTransformFlowProps {
   accessibilityGranted: boolean | null;
   /** The configured transform hotkey (one of TransformKey), or null=disabled. */
   transformHoldKey: string | null;
+  /** Selected microphone device id (same contract as start_native_recording). */
+  microphone?: string;
 }
 
 /**
@@ -36,8 +39,13 @@ export function useTransformFlow({
   initialized,
   accessibilityGranted,
   transformHoldKey,
+  microphone,
 }: UseTransformFlowProps) {
   const stateRef = useRef<TransformFlowState>(INITIAL_TRANSFORM_FLOW_STATE);
+  const microphoneRef = useRef(microphone);
+  useEffect(() => {
+    microphoneRef.current = microphone;
+  }, [microphone]);
 
   useEffect(() => {
     if (!enabled || !initialized || !accessibilityGranted || !transformHoldKey) return;
@@ -45,6 +53,11 @@ export function useTransformFlow({
     let cancelled = false;
     let unlistenPressed: (() => void) | null = null;
     let unlistenReleased: (() => void) | null = null;
+
+    const deviceNameArg = () => {
+      const mic = microphoneRef.current;
+      return mic && mic !== DEFAULT_SETTINGS.microphone ? mic : null;
+    };
 
     const dispatch = (input: TransformFlowInput) => {
       const step = reduceTransformFlow(stateRef.current, input);
@@ -54,7 +67,11 @@ export function useTransformFlow({
         return;
       }
       if (step.command) {
-        invoke(step.command).catch((e) => {
+        const args =
+          step.command === 'start_transform_capture'
+            ? { deviceName: deviceNameArg() }
+            : undefined;
+        invoke(step.command, args).catch((e) => {
           flog.warn('transform-flow', 'command failed', { command: step.command, error: String(e) });
         });
       }
@@ -63,6 +80,11 @@ export function useTransformFlow({
     const setup = async () => {
       // A (re)start of the listener resets the reducer — a hold that lost its
       // release event (listener torn down mid-hold) must not wedge the next press.
+      // If we were mid-hold, cancel the backend so Listening + live mic is not
+      // left running with no release coming (C2 finding 5).
+      if (stateRef.current.holding) {
+        invoke('cancel_transform').catch(() => {});
+      }
       stateRef.current = INITIAL_TRANSFORM_FLOW_STATE;
 
       unlistenPressed = await listen('transform-key-pressed', () => {
@@ -92,6 +114,12 @@ export function useTransformFlow({
       unlistenPressed?.();
       unlistenReleased?.();
       invoke('stop_transform_listener').catch(() => {});
+      // Mid-hold cleanup: backend is Listening with a live mic and no release
+      // will arrive after the listener stops — cancel so we do not wedge.
+      if (stateRef.current.holding) {
+        invoke('cancel_transform').catch(() => {});
+        stateRef.current = INITIAL_TRANSFORM_FLOW_STATE;
+      }
     };
   }, [enabled, initialized, accessibilityGranted, transformHoldKey]);
 }

--- a/app/src/lib/hooks/useTransformFlow.ts
+++ b/app/src/lib/hooks/useTransformFlow.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { flog } from '../log';
+import {
+  INITIAL_TRANSFORM_FLOW_STATE,
+  reduceTransformFlow,
+  type TransformFlowInput,
+  type TransformFlowState,
+} from '../transformFlow';
+
+interface UseTransformFlowProps {
+  /** transformHoldKey configured AND hotkeys armed. */
+  enabled: boolean;
+  initialized: boolean;
+  accessibilityGranted: boolean | null;
+  /** The configured transform hotkey (one of TransformKey), or null=disabled. */
+  transformHoldKey: string | null;
+}
+
+/**
+ * Main-window driver for the AX-selection transform flow (issue #312 PR-C2).
+ *
+ * Mirrors `useHoldDownToggle`'s listen-and-call-command pattern: it starts the
+ * independent transform rdev listener, subscribes to `transform-key-pressed` /
+ * `transform-key-released`, and turns that press/release stream into the flow
+ * commands via the pure `reduceTransformFlow` reducer (double-press ignore,
+ * short-tap cancel, and missing-release tolerance — see that module).
+ *
+ * Always call this hook (gate its *effects* on `enabled`, per the Rules of
+ * Hooks) — same discipline as the dictation hotkey hooks. The popover window
+ * drives Approve/Retry/Cancel/Undo separately (`useTransformReviewDriver`).
+ */
+export function useTransformFlow({
+  enabled,
+  initialized,
+  accessibilityGranted,
+  transformHoldKey,
+}: UseTransformFlowProps) {
+  const stateRef = useRef<TransformFlowState>(INITIAL_TRANSFORM_FLOW_STATE);
+
+  useEffect(() => {
+    if (!enabled || !initialized || !accessibilityGranted || !transformHoldKey) return;
+
+    let cancelled = false;
+    let unlistenPressed: (() => void) | null = null;
+    let unlistenReleased: (() => void) | null = null;
+
+    const dispatch = (input: TransformFlowInput) => {
+      const step = reduceTransformFlow(stateRef.current, input);
+      stateRef.current = step.state;
+      if (step.ignored) {
+        flog.info('transform-flow', 'input ignored', { reason: step.ignored, input: input.type });
+        return;
+      }
+      if (step.command) {
+        invoke(step.command).catch((e) => {
+          flog.warn('transform-flow', 'command failed', { command: step.command, error: String(e) });
+        });
+      }
+    };
+
+    const setup = async () => {
+      // A (re)start of the listener resets the reducer — a hold that lost its
+      // release event (listener torn down mid-hold) must not wedge the next press.
+      stateRef.current = INITIAL_TRANSFORM_FLOW_STATE;
+
+      unlistenPressed = await listen('transform-key-pressed', () => {
+        dispatch({ type: 'pressed', now: Date.now() });
+      });
+      if (cancelled) { unlistenPressed(); return; }
+
+      unlistenReleased = await listen('transform-key-released', () => {
+        dispatch({ type: 'released', now: Date.now() });
+      });
+      if (cancelled) { unlistenPressed(); unlistenReleased(); return; }
+
+      try {
+        await invoke('start_transform_listener', { hotkey: transformHoldKey });
+        if (cancelled) {
+          invoke('stop_transform_listener').catch(() => {});
+        }
+      } catch (err) {
+        flog.warn('transform-flow', 'failed to start transform listener', { error: String(err) });
+      }
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      unlistenPressed?.();
+      unlistenReleased?.();
+      invoke('stop_transform_listener').catch(() => {});
+    };
+  }, [enabled, initialized, accessibilityGranted, transformHoldKey]);
+}

--- a/app/src/lib/hooks/useTransformReviewDriver.test.tsx
+++ b/app/src/lib/hooks/useTransformReviewDriver.test.tsx
@@ -1,0 +1,135 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TransformReviewContent } from '../transformReview';
+
+type Listener = (event: { payload: unknown }) => void;
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listeners: {} as Record<string, Listener>,
+  unlisten: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (event: string, listener: Listener) => {
+    mocks.listeners[event] = listener;
+    return mocks.unlisten;
+  }),
+}));
+vi.mock('../log', () => ({
+  flog: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { useTransformReviewDriver, type ReviewDriverResult } from './useTransformReviewDriver';
+
+const CONTENT: TransformReviewContent = {
+  instruction: 'Make it concise',
+  original: 'the original selected text',
+  proposed: 'concise text',
+};
+
+describe('useTransformReviewDriver (real driver)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: ReviewDriverResult | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.invoke.mockReset();
+    mocks.listeners = {};
+    mocks.unlisten.mockReset();
+    current = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  function contentCalls() {
+    return mocks.invoke.mock.calls.filter((c) => c[0] === 'get_transform_review_content').length;
+  }
+
+  it('pulls review content via command when the state changes to ready', async () => {
+    mocks.invoke.mockResolvedValue(CONTENT);
+
+    function Harness() {
+      current = useTransformReviewDriver(true);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No content is broadcast in the event payload — it must be pulled.
+    expect(mocks.listeners['transform-state-changed']).toBeDefined();
+    expect(contentCalls()).toBe(0);
+
+    await act(async () => {
+      mocks.listeners['transform-state-changed']?.({ payload: { state: 'ready' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(current!.state).toBe('ready');
+    // The real (non-mock) driver fetched the text content by command.
+    expect(mocks.invoke).toHaveBeenCalledWith('get_transform_review_content');
+    expect(current!.content).toEqual(CONTENT);
+  });
+
+  it('carries the errorCode from the event on a failed state', async () => {
+    mocks.invoke.mockResolvedValue(CONTENT);
+
+    function Harness() {
+      current = useTransformReviewDriver(true);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mocks.listeners['transform-state-changed']?.({
+        payload: { state: 'failed', errorCode: 'model_not_downloaded' },
+      });
+      await Promise.resolve();
+    });
+
+    expect(current!.state).toBe('failed');
+    expect(current!.errorCode).toBe('model_not_downloaded');
+  });
+
+  it('approve/cancel/retry invoke the real transform-flow commands', async () => {
+    mocks.invoke.mockResolvedValue(CONTENT);
+
+    function Harness() {
+      current = useTransformReviewDriver(true);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    await act(async () => { current!.approve(); });
+    await act(async () => { current!.retry(); });
+    await act(async () => { current!.cancel(); });
+
+    const names = mocks.invoke.mock.calls.map((c) => c[0]);
+    expect(names).toContain('approve_transform');
+    expect(names).toContain('retry_transform_instruction');
+    expect(names).toContain('cancel_transform');
+  });
+});

--- a/app/src/lib/hooks/useTransformReviewDriver.test.tsx
+++ b/app/src/lib/hooks/useTransformReviewDriver.test.tsx
@@ -132,4 +132,29 @@ describe('useTransformReviewDriver (real driver)', () => {
     expect(names).toContain('retry_transform_instruction');
     expect(names).toContain('cancel_transform');
   });
+
+  it('undo uses undo_transform_and_close and does not chain cancel_transform', async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+
+    function Harness() {
+      current = useTransformReviewDriver(true);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      current!.undo();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const names = mocks.invoke.mock.calls.map((c) => c[0]);
+    expect(names).toContain('undo_transform_and_close');
+    expect(names).not.toContain('cancel_transform');
+    expect(names).not.toContain('undo_transform');
+  });
 });

--- a/app/src/lib/hooks/useTransformReviewDriver.ts
+++ b/app/src/lib/hooks/useTransformReviewDriver.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { DEFAULT_SETTINGS, loadSettings } from '../settings';
 import { flog } from '../log';
 import {
   EMPTY_REVIEW_CONTENT,
@@ -22,18 +23,21 @@ export interface ReviewDriverResult {
   undo: () => void;
 }
 
+function deviceNameArg(): string | null {
+  try {
+    const mic = loadSettings().microphone;
+    return mic && mic !== DEFAULT_SETTINGS.microphone ? mic : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * The real (non-mock) driver: subscribes to the `transform-state-changed`
  * event and fetches text content via `get_transform_review_content` whenever
  * the state changes. `errorCode` is carried on the event itself; instruction/
  * original/proposed text is fetched separately by command so it is never
  * broadcast as an event payload (it may be sensitive selected text).
- *
- * PR-C2 wires the real backend to emit `transform-state-changed` and to
- * populate `get_transform_review_content`; it will also add the real
- * cancel/retry/approve/undo commands. For PR-C1, `cancel` hides the popover
- * (the one native effect already wired) and `retry`/`approve`/`undo` are
- * no-ops — there is no backend transform pipeline yet to drive.
  *
  * Always call this hook (gate its *effects* on `enabled`, per the Rules of
  * Hooks) — same pattern as `useHoldDownToggle`/`useDoubleTapToggle`.
@@ -106,12 +110,15 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
   // backend owns the state machine and emits the follow-up `transform-state-
   // changed` events; these calls never carry any review text.
   const cancel = useCallback(() => {
+    // Clear local content immediately so a subsequent show cannot flash stale
+    // selection text before the next get_transform_review_content resolves.
+    setContent(EMPTY_REVIEW_CONTENT);
     invoke('cancel_transform').catch((e) => {
       flog.warn('transform-review', 'cancel_transform failed', { error: String(e) });
     });
   }, []);
   const retry = useCallback(() => {
-    invoke('retry_transform_instruction').catch((e) => {
+    invoke('retry_transform_instruction', { deviceName: deviceNameArg() }).catch((e) => {
       flog.warn('transform-review', 'retry_transform_instruction failed', { error: String(e) });
     });
   }, []);
@@ -121,17 +128,15 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
     });
   }, []);
   const undo = useCallback(() => {
-    // Undo the applied write, then tear the popover down (brief confirmation is
-    // the applied-state UI already on screen). `cancel_transform` clears the
-    // session and hides the popover once undo has run.
-    invoke('undo_transform')
-      .catch((e) => {
-        flog.warn('transform-review', 'undo_transform failed', { error: String(e) });
+    // Flow-level undo: hides + clears session on success WITHOUT a second
+    // epoch bump (chaining cancel_transform would clobber paste-fallback
+    // clipboard restore inside the 300ms window — C2 finding 4).
+    invoke('undo_transform_and_close')
+      .then(() => {
+        setContent(EMPTY_REVIEW_CONTENT);
       })
-      .finally(() => {
-        invoke('cancel_transform').catch((e) => {
-          flog.warn('transform-review', 'cancel_transform after undo failed', { error: String(e) });
-        });
+      .catch((e) => {
+        flog.warn('transform-review', 'undo_transform_and_close failed', { error: String(e) });
       });
   }, []);
 

--- a/app/src/lib/hooks/useTransformReviewDriver.ts
+++ b/app/src/lib/hooks/useTransformReviewDriver.ts
@@ -102,15 +102,38 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
     return () => window.clearInterval(id);
   }, [enabled, state]);
 
+  // PR-C2: wire the popover actions to the real transform-flow commands. The
+  // backend owns the state machine and emits the follow-up `transform-state-
+  // changed` events; these calls never carry any review text.
   const cancel = useCallback(() => {
-    invoke('hide_transform_popover').catch((e) => {
-      flog.warn('transform-review', 'hide_transform_popover failed', { error: String(e) });
+    invoke('cancel_transform').catch((e) => {
+      flog.warn('transform-review', 'cancel_transform failed', { error: String(e) });
     });
   }, []);
-  // PR-C2: wire these to real transform commands once the sidecar exists.
-  const retry = useCallback(() => {}, []);
-  const approve = useCallback(() => {}, []);
-  const undo = useCallback(() => {}, []);
+  const retry = useCallback(() => {
+    invoke('retry_transform_instruction').catch((e) => {
+      flog.warn('transform-review', 'retry_transform_instruction failed', { error: String(e) });
+    });
+  }, []);
+  const approve = useCallback(() => {
+    invoke('approve_transform').catch((e) => {
+      flog.warn('transform-review', 'approve_transform failed', { error: String(e) });
+    });
+  }, []);
+  const undo = useCallback(() => {
+    // Undo the applied write, then tear the popover down (brief confirmation is
+    // the applied-state UI already on screen). `cancel_transform` clears the
+    // session and hides the popover once undo has run.
+    invoke('undo_transform')
+      .catch((e) => {
+        flog.warn('transform-review', 'undo_transform failed', { error: String(e) });
+      })
+      .finally(() => {
+        invoke('cancel_transform').catch((e) => {
+          flog.warn('transform-review', 'cancel_transform after undo failed', { error: String(e) });
+        });
+      });
+  }, []);
 
   return { state, errorCode, content, thinkingElapsedMs, cancel, retry, approve, undo };
 }

--- a/app/src/lib/transformFlow.test.ts
+++ b/app/src/lib/transformFlow.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HOLD_MIN_MS,
+  INITIAL_TRANSFORM_FLOW_STATE,
+  reduceTransformFlow,
+  type TransformFlowState,
+} from './transformFlow';
+
+describe('reduceTransformFlow', () => {
+  it('starts a capture on the first press', () => {
+    const step = reduceTransformFlow(INITIAL_TRANSFORM_FLOW_STATE, { type: 'pressed', now: 1000 });
+    expect(step.command).toBe('start_transform_capture');
+    expect(step.state).toEqual({ holding: true, pressedAt: 1000 });
+    expect(step.ignored).toBeUndefined();
+  });
+
+  it('ignores a double-press while already holding', () => {
+    const held: TransformFlowState = { holding: true, pressedAt: 1000 };
+    const step = reduceTransformFlow(held, { type: 'pressed', now: 1050 });
+    expect(step.command).toBeNull();
+    expect(step.ignored).toBe('double_press');
+    // State is unchanged — the original hold is preserved.
+    expect(step.state).toEqual(held);
+  });
+
+  it('finishes the instruction on a normal-length release', () => {
+    const held: TransformFlowState = { holding: true, pressedAt: 1000 };
+    const step = reduceTransformFlow(held, { type: 'released', now: 1000 + HOLD_MIN_MS + 1 });
+    expect(step.command).toBe('finish_transform_instruction');
+    expect(step.state).toEqual({ holding: false, pressedAt: null });
+  });
+
+  it('cancels silently on a too-short tap', () => {
+    const held: TransformFlowState = { holding: true, pressedAt: 1000 };
+    const step = reduceTransformFlow(held, { type: 'released', now: 1000 + HOLD_MIN_MS - 1 });
+    expect(step.command).toBe('cancel_transform');
+    expect(step.state).toEqual({ holding: false, pressedAt: null });
+  });
+
+  it('exactly HOLD_MIN_MS counts as a real instruction (not a tap)', () => {
+    const held: TransformFlowState = { holding: true, pressedAt: 1000 };
+    const step = reduceTransformFlow(held, { type: 'released', now: 1000 + HOLD_MIN_MS });
+    expect(step.command).toBe('finish_transform_instruction');
+  });
+
+  it('tolerates a stray release with no active hold', () => {
+    const step = reduceTransformFlow(INITIAL_TRANSFORM_FLOW_STATE, { type: 'released', now: 5000 });
+    expect(step.command).toBeNull();
+    expect(step.ignored).toBe('stray_release');
+    expect(step.state).toEqual(INITIAL_TRANSFORM_FLOW_STATE);
+  });
+
+  it('reset recovers from a missing release, so the next press works again', () => {
+    // A hold whose release event never arrived (listener stopped mid-hold).
+    const stuck: TransformFlowState = { holding: true, pressedAt: 1000 };
+    // Without a reset, a new press would be ignored as a double-press:
+    expect(reduceTransformFlow(stuck, { type: 'pressed', now: 9000 }).ignored).toBe('double_press');
+    // The hook dispatches `reset` when the listener (re)starts.
+    const afterReset = reduceTransformFlow(stuck, { type: 'reset' });
+    expect(afterReset.state).toEqual(INITIAL_TRANSFORM_FLOW_STATE);
+    // Now the next press starts a fresh capture.
+    const step = reduceTransformFlow(afterReset.state, { type: 'pressed', now: 9100 });
+    expect(step.command).toBe('start_transform_capture');
+  });
+
+  it('a full press/release/press cycle drives start -> finish -> start', () => {
+    let state = INITIAL_TRANSFORM_FLOW_STATE;
+    let step = reduceTransformFlow(state, { type: 'pressed', now: 0 });
+    expect(step.command).toBe('start_transform_capture');
+    state = step.state;
+
+    step = reduceTransformFlow(state, { type: 'released', now: 1000 });
+    expect(step.command).toBe('finish_transform_instruction');
+    state = step.state;
+
+    step = reduceTransformFlow(state, { type: 'pressed', now: 2000 });
+    expect(step.command).toBe('start_transform_capture');
+  });
+});

--- a/app/src/lib/transformFlow.ts
+++ b/app/src/lib/transformFlow.ts
@@ -1,0 +1,91 @@
+// Pure reducer for the main-window transform hotkey driver (issue #312 PR-C2).
+//
+// The transform hotkey emits `transform-key-pressed` / `transform-key-released`
+// exactly like the dictation hold-down hotkey. This reducer turns that
+// press/release stream into the flow commands, with two edge rules the review
+// flagged:
+//
+//  - **double-press ignore**: a second `pressed` while already holding (no
+//    intervening `released`) is ignored — a key-repeat / bounce must not start
+//    a second capture. (The backend independently ignores a start while a
+//    transform is mid-flight, so a press during thinking/review is also safe.)
+//  - **missing-release tolerance**: if a `released` never arrives (e.g. the
+//    rdev listener was stopped mid-hold, per the B1 review note), the hook
+//    dispatches `reset` when the listener (re)starts, clearing the stuck
+//    `holding` so the next press works again.
+//
+// A release shorter than HOLD_MIN_MS is treated as an accidental tap: the flow
+// is cancelled silently rather than transcribing empty audio.
+
+export const HOLD_MIN_MS = 300;
+
+export interface TransformFlowState {
+  /** True between a `pressed` and its matching `released`. */
+  holding: boolean;
+  /** Timestamp (ms) of the current hold's press, or null when not holding. */
+  pressedAt: number | null;
+}
+
+export const INITIAL_TRANSFORM_FLOW_STATE: TransformFlowState = {
+  holding: false,
+  pressedAt: null,
+};
+
+export type TransformFlowInput =
+  | { type: 'pressed'; now: number }
+  | { type: 'released'; now: number }
+  | { type: 'reset' };
+
+/** The Tauri command a step wants invoked, or null for a logged no-op. */
+export type TransformFlowCommand =
+  | 'start_transform_capture'
+  | 'finish_transform_instruction'
+  | 'cancel_transform';
+
+export interface TransformFlowStep {
+  state: TransformFlowState;
+  command: TransformFlowCommand | null;
+  /** Human-readable reason a step was a no-op (for logging/tests). */
+  ignored?: 'double_press' | 'stray_release';
+}
+
+export function reduceTransformFlow(
+  state: TransformFlowState,
+  input: TransformFlowInput,
+): TransformFlowStep {
+  switch (input.type) {
+    case 'reset':
+      return { state: INITIAL_TRANSFORM_FLOW_STATE, command: null };
+
+    case 'pressed': {
+      // Double-press ignore: already holding from a prior, unreleased press.
+      if (state.holding) {
+        return { state, command: null, ignored: 'double_press' };
+      }
+      return {
+        state: { holding: true, pressedAt: input.now },
+        command: 'start_transform_capture',
+      };
+    }
+
+    case 'released': {
+      // Stray release (no active hold) — tolerated, never wedges the flow.
+      if (!state.holding) {
+        return { state, command: null, ignored: 'stray_release' };
+      }
+      const heldMs = state.pressedAt === null ? Infinity : input.now - state.pressedAt;
+      const command: TransformFlowCommand =
+        heldMs < HOLD_MIN_MS ? 'cancel_transform' : 'finish_transform_instruction';
+      return {
+        state: { holding: false, pressedAt: null },
+        command,
+      };
+    }
+
+    default: {
+      const _exhaustive: never = input;
+      void _exhaustive;
+      return { state, command: null };
+    }
+  }
+}

--- a/app/src/lib/transformReview.ts
+++ b/app/src/lib/transformReview.ts
@@ -10,18 +10,35 @@
 
 export type ReviewState = 'listening' | 'thinking' | 'ready' | 'failed' | 'applied';
 
+// Kept in sync with the Rust code producers in `transform_flow.rs`
+// (`selection_error_code` / `transform_error_code` / `apply_error_code`). Any
+// code the backend emits that is NOT listed here degrades gracefully to the
+// generic "Something went wrong" copy via `normalizeReviewErrorCode` — a
+// version-skew safety net, not a bug.
 export type ReviewErrorCode =
   | 'model_not_downloaded'
+  | 'model_unreadable'
   | 'timeout'
   | 'output_invalid'
-  | 'crashed';
+  | 'crashed'
+  | 'disabled'
+  | 'busy'
+  | 'no_instruction'
+  | 'no_selection'
+  | 'too_large'
+  | 'ax_unavailable'
+  | 'accessibility_denied'
+  | 'target_gone'
+  | 'selection_changed';
 
 const REVIEW_STATES: readonly ReviewState[] = [
   'listening', 'thinking', 'ready', 'failed', 'applied',
 ];
 
 const REVIEW_ERROR_CODES: readonly ReviewErrorCode[] = [
-  'model_not_downloaded', 'timeout', 'output_invalid', 'crashed',
+  'model_not_downloaded', 'model_unreadable', 'timeout', 'output_invalid', 'crashed',
+  'disabled', 'busy', 'no_instruction', 'no_selection', 'too_large', 'ax_unavailable',
+  'accessibility_denied', 'target_gone', 'selection_changed',
 ];
 
 export function isReviewState(v: unknown): v is ReviewState {
@@ -35,9 +52,19 @@ export function isReviewErrorCode(v: unknown): v is ReviewErrorCode {
 /** Stable copy for each error code — never render a raw error code to the user. */
 export const REVIEW_ERROR_COPY: Record<ReviewErrorCode, string> = {
   model_not_downloaded: 'Model not downloaded',
+  model_unreadable: "Model file couldn't be read",
   timeout: 'Timed out',
   output_invalid: 'Model gave no usable output',
   crashed: 'Sidecar crashed — original text untouched',
+  disabled: 'Transform temporarily disabled — try again shortly',
+  busy: 'Busy — try again in a moment',
+  no_instruction: "Didn't catch an instruction — hold the key and speak",
+  no_selection: 'Select some text first',
+  too_large: 'Selection is too large to transform',
+  ax_unavailable: "Couldn't read the selection",
+  accessibility_denied: 'Accessibility permission required',
+  target_gone: 'The target app changed — original text untouched',
+  selection_changed: 'The selection changed — nothing was overwritten',
 };
 
 /**


### PR DESCRIPTION
## Summary

Phase C2 of #312: the full flow wired end-to-end — transform hotkey → AX selection capture → anchored popover (listening) → spoken instruction ASR (cleanup-only stage config; never voice-commands/CLI) → sidecar transform → diff review → Approve/Retry/Cancel → apply with Undo. Overlay shows a minimal "transforming…" indicator; the readable diff lives in the popover.

- `transform_flow.rs` orchestrator with an exhaustive spec-by-test state machine; commands `start_transform_capture` / `finish_transform_instruction` / `retry_transform_instruction` / `approve_transform` / `cancel_transform` / `undo_transform_and_close`.
- Cancel correctness hardened across two independent review rounds: race-safe `try_transition` on every resurrection path, cooperative sidecar cancel via a per-request `CancelToken` (stored alongside the abort handle — a cancel can never be lost to or leak into a neighboring request), mic-leak recheck after capture start, cancel-during-Applying teardown safety.
- Fail closed everywhere: secure fields flash-and-abort with no content UI; sidecar crash/timeout/blank output surface as popover error states; original text untouched except through user-invoked Approve/Undo.
- Privacy: state events carry `{state, errorCode}` only; instruction/original/proposed move solely through `get_transform_review_content` pulled by the popover window; instructions never enter history or stats.

## Verification

- Full workspace suites green (this branch): 534+ lib, 14 sidecar-integration (incl. cooperative-cancel and token-scoping tests), tsc clean, 259 vitest.
- Two adversarial review rounds (initial: 9 findings; re-review: all closed, follow-ups folded into the stacked D-phase branch).

Part of #312. Stacked: `issue/312-transform-settings` (Phase D) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)