### PR TITLE
feat: transform settings, presets, saved transforms, and docs (#312 Phase D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Read these before working on a feature:
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 - **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 - **[docs/features/voice-commands.md](docs/features/voice-commands.md)** — Typed replacements, multiline snippets, safe variables, scopes, and clipboard permission
+- **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
 - **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion
 - **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
@@ -55,9 +56,16 @@ Read these before working on a feature:
 | `commands/models.rs` | Model download pipeline and existence checks |
 | `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
 | `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window commands |
-| `keyboard.rs` | Hold-down and double-tap detectors, shared rdev listener thread |
+| `commands/transform_model.rs` | Transform LLM model download/status/remove/reset |
+| `commands/transform_popover.rs` | Transform review window geometry + show/hide/focusable |
+| `keyboard.rs` | Hold-down, double-tap, and transform-hold detectors; shared rdev listener thread |
 | `audio.rs` | cpal capture, mono conversion, 16kHz resampling |
 | `transcriber/` | whisper-rs model loading and inference |
+| `selection.rs` | AX selection capture for transform (secure-field fail-closed) |
+| `transform_apply.rs` | Approve/undo write-back (only path that writes to the target app) |
+| `transform_flow.rs` | End-to-end transform orchestrator + Tauri commands |
+| `transform_presets.rs` | Built-in spoken transform presets (Shorten/Bullets/…) |
+| `llm_sidecar.rs` | Host supervisor for signed local-LLM helper (no in-process llama) |
 | `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
 | `ide_context.rs` | Memory-only bounded IDE symbol and root-relative file index |
 | `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
@@ -95,8 +103,15 @@ Read these before working on a feature:
 | `lib/hooks/useOverlaySettingsMirror.ts` | Overlay's localStorage settings snapshot + quick-control actions |
 | `lib/hooks/useRecordingControls.ts` | Overlay click/double-click disambiguation, locked mode |
 | `lib/hooks/useWaveform.ts` | Overlay audio-level listener + rAF waveform bar animation |
+| `lib/hooks/useTransformFlow.ts` | Main-window transform hold-key driver |
+| `lib/hooks/useTransformReviewDriver.ts` | Review popover state + approve/retry/cancel/undo |
+| `lib/transformSettings.ts` | Transform model + listener command wrappers |
+| `lib/transformFlow.ts` | Pure reducer for transform press/release |
+| `lib/transformReview.ts` | Review state/error types + content guards |
 | `components/onboarding/OnboardingFlow.tsx` | First-launch setup assistant (permissions + model wizard) |
-| `components/settings/SettingsPanel.tsx` | Settings UI with mode switching |
+| `components/settings/SettingsPanel.tsx` | Settings UI with mode switching (incl. Transform page) |
+| `components/settings/TransformsManager.tsx` | Saved transform CRUD UI |
+| `components/transform-review/` | Review popover UI (diff, actions, mock driver) |
 | `components/log-viewer/LogViewerApp.tsx` | Structured event viewer with Events + Metrics tabs |
 | `components/overlay/deriveVisual.ts` | Pure: overlay top-bar indicator + flash-priority derivation |
 | `components/overlay/OverlayPill.tsx` | Overlay top bar (presentational) |

--- a/app/src-tauri/src/commands/transform_model.rs
+++ b/app/src-tauri/src/commands/transform_model.rs
@@ -38,6 +38,10 @@ pub struct TransformModelStatus {
     pub path: Option<String>,
     pub size_bytes: u64,
     pub sha256: &'static str,
+    /// True once the sidecar circuit breaker has latched disabled after repeated
+    /// faults. The settings UI shows the Reset button + notice only when this is
+    /// set (#312 D1 round-2 finding 7).
+    pub runtime_disabled: bool,
 }
 
 /// A published model of exactly the pinned size is considered ready. The full
@@ -52,10 +56,22 @@ fn model_is_ready() -> Option<std::path::PathBuf> {
     }
 }
 
+/// Resolve the download lifecycle state without needing app state. Shared by
+/// the command wrapper and internal callers (e.g. `transform_flow`).
+pub(crate) fn transform_model_state() -> TransformModelState {
+    if model_is_ready().is_some() {
+        TransformModelState::Ready
+    } else if DOWNLOADING.load(Ordering::Acquire) {
+        TransformModelState::Downloading
+    } else {
+        TransformModelState::NotDownloaded
+    }
+}
+
 #[tauri::command]
-pub fn transform_model_status() -> TransformModelStatus {
+pub fn transform_model_status(state: tauri::State<'_, State>) -> TransformModelStatus {
     let ready = model_is_ready();
-    let state = if ready.is_some() {
+    let model_state = if ready.is_some() {
         TransformModelState::Ready
     } else if DOWNLOADING.load(Ordering::Acquire) {
         TransformModelState::Downloading
@@ -63,10 +79,11 @@ pub fn transform_model_status() -> TransformModelStatus {
         TransformModelState::NotDownloaded
     };
     TransformModelStatus {
-        state,
+        state: model_state,
         path: ready.map(|p| p.to_string_lossy().into_owned()),
         size_bytes: TRANSFORM_MODEL_SIZE_BYTES,
         sha256: TRANSFORM_MODEL_SHA256,
+        runtime_disabled: state.transform_runtime.runtime_disabled(),
     }
 }
 
@@ -250,10 +267,19 @@ mod tests {
 
     #[test]
     fn status_shape_carries_only_bounded_metadata() {
-        let status = transform_model_status();
+        // Build the status directly (the command needs app state); the point of
+        // this test is the serialized shape, not the live runtime.
+        let status = TransformModelStatus {
+            state: transform_model_state(),
+            path: None,
+            size_bytes: TRANSFORM_MODEL_SIZE_BYTES,
+            sha256: TRANSFORM_MODEL_SHA256,
+            runtime_disabled: false,
+        };
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("sha256"));
         assert!(json.contains("sizeBytes"));
+        assert!(json.contains("runtimeDisabled"));
         // No URL, revision, or free-form text leaks into the status payload.
         assert!(!json.contains("huggingface"));
     }

--- a/app/src-tauri/src/knowledge_store/migrations.rs
+++ b/app/src-tauri/src/knowledge_store/migrations.rs
@@ -1,6 +1,6 @@
 use rusqlite::{Connection, Transaction};
 
-pub const LATEST_SCHEMA_VERSION: u32 = 3;
+pub const LATEST_SCHEMA_VERSION: u32 = 4;
 
 pub fn migrate(connection: &mut Connection) -> Result<(), String> {
     migrate_through(connection, LATEST_SCHEMA_VERSION)
@@ -101,6 +101,61 @@ fn apply(transaction: &Transaction<'_>, version: u32) -> Result<(), String> {
                 ALTER TABLE knowledge_entries ADD COLUMN voice_command_clipboard INTEGER NOT NULL DEFAULT 0
                     CHECK(voice_command_clipboard IN (0, 1));
                 INSERT INTO knowledge_meta(key, value) VALUES ('legacy_voice_commands_migrated', 0);
+                CREATE INDEX knowledge_entries_voice_commands
+                    ON knowledge_entries(voice_command_kind, enabled, scope_kind, app_bundle_id, created_at_ms, id);
+                "#,
+            )
+            .map_err(db_error),
+        // #312 D1: allow KnowledgeKind::Transform. SQLite cannot ALTER a CHECK
+        // constraint, so rebuild knowledge_entries with the expanded kind set.
+        4 => transaction
+            .execute_batch(
+                r#"
+                CREATE TABLE knowledge_entries_v4 (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    kind TEXT NOT NULL CHECK(kind IN ('replacement_rule', 'vocabulary_term', 'snippet', 'transform')),
+                    trigger_text TEXT NOT NULL,
+                    normalized_trigger TEXT NOT NULL,
+                    content_text TEXT NOT NULL,
+                    aliases_json TEXT NOT NULL DEFAULT '[]',
+                    enabled INTEGER NOT NULL CHECK(enabled IN (0, 1)),
+                    scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'app', 'project')),
+                    app_bundle_id TEXT,
+                    project_root TEXT,
+                    provenance TEXT NOT NULL CHECK(provenance IN ('manual', 'code_scan', 'learned_correction', 'import')),
+                    created_at_ms INTEGER NOT NULL,
+                    updated_at_ms INTEGER NOT NULL,
+                    revision INTEGER NOT NULL CHECK(revision > 0),
+                    voice_command_kind TEXT
+                        CHECK(voice_command_kind IN ('text_replacement', 'snippet')),
+                    voice_command_clipboard INTEGER NOT NULL DEFAULT 0
+                        CHECK(voice_command_clipboard IN (0, 1)),
+                    CHECK(
+                        (scope_kind = 'global' AND app_bundle_id IS NULL AND project_root IS NULL)
+                        OR (scope_kind = 'app' AND app_bundle_id IS NOT NULL AND project_root IS NULL)
+                        OR (scope_kind = 'project' AND app_bundle_id IS NOT NULL AND project_root IS NOT NULL)
+                    )
+                );
+                INSERT INTO knowledge_entries_v4 (
+                    id, kind, trigger_text, normalized_trigger, content_text, aliases_json,
+                    enabled, scope_kind, app_bundle_id, project_root, provenance,
+                    created_at_ms, updated_at_ms, revision,
+                    voice_command_kind, voice_command_clipboard
+                )
+                SELECT
+                    id, kind, trigger_text, normalized_trigger, content_text, aliases_json,
+                    enabled, scope_kind, app_bundle_id, project_root, provenance,
+                    created_at_ms, updated_at_ms, revision,
+                    voice_command_kind, voice_command_clipboard
+                FROM knowledge_entries;
+                DROP TABLE knowledge_entries;
+                ALTER TABLE knowledge_entries_v4 RENAME TO knowledge_entries;
+                CREATE INDEX knowledge_entries_listing
+                    ON knowledge_entries(updated_at_ms DESC, id ASC);
+                CREATE INDEX knowledge_entries_resolution
+                    ON knowledge_entries(kind, enabled, normalized_trigger, scope_kind, app_bundle_id, project_root);
+                CREATE INDEX knowledge_entries_scope
+                    ON knowledge_entries(scope_kind, app_bundle_id, project_root);
                 CREATE INDEX knowledge_entries_voice_commands
                     ON knowledge_entries(voice_command_kind, enabled, scope_kind, app_bundle_id, created_at_ms, id);
                 "#,

--- a/app/src-tauri/src/knowledge_store/mod.rs
+++ b/app/src-tauri/src/knowledge_store/mod.rs
@@ -559,7 +559,7 @@ mod tests {
 
         let store = KnowledgeStore::default();
         let status = store.initialize(root.clone());
-        assert_eq!(status.schema_version, 3);
+        assert_eq!(status.schema_version, 4);
         assert_eq!(
             std::fs::read_dir(root.join("backups"))
                 .unwrap()

--- a/app/src-tauri/src/knowledge_store/mod.rs
+++ b/app/src-tauri/src/knowledge_store/mod.rs
@@ -616,4 +616,288 @@ mod tests {
         assert!(!message.contains("private-secret"));
         assert!(!message.contains(temp.path().to_string_lossy().as_ref()));
     }
+
+    fn transform_draft(name: &str, instruction: &str) -> KnowledgeDraft {
+        KnowledgeDraft {
+            id: None,
+            expected_revision: None,
+            payload: KnowledgePayload::Transform {
+                name: name.to_string(),
+                instruction: instruction.to_string(),
+            },
+            enabled: true,
+            scope: KnowledgeScope::Global,
+            voice_command: None,
+        }
+    }
+
+    #[test]
+    fn transform_instructions_over_the_protocol_byte_limit_are_rejected() {
+        let (_temp, store) = store();
+        let oversized = "x".repeat(5_000);
+        let error = store
+            .upsert_manual(transform_draft("too long", &oversized))
+            .unwrap_err();
+        assert!(
+            error.contains("4096") || error.to_lowercase().contains("byte"),
+            "expected a byte-limit message, got: {error}"
+        );
+
+        // A right-at-the-limit instruction (in bytes) still saves fine.
+        let at_limit = "y".repeat(murmur_local_llm_protocol::MAX_INSTRUCTION_BYTES);
+        assert!(store
+            .upsert_manual(transform_draft("right at limit", &at_limit))
+            .is_ok());
+    }
+
+    #[test]
+    fn saving_an_exact_duplicate_transform_name_is_rejected_but_editing_self_is_allowed() {
+        let (_temp, store) = store();
+        let first = store
+            .upsert_manual(transform_draft("Meeting Notes", "Rewrite as bullet notes."))
+            .unwrap();
+
+        // Same normalized name (case + whitespace-insensitive) is rejected.
+        let error = store
+            .upsert_manual(transform_draft("meeting   notes", "Something else."))
+            .unwrap_err();
+        assert!(error.contains("already exists"));
+
+        // Punctuation-only differences also collide (shares the preset normalize()).
+        let error = store
+            .upsert_manual(transform_draft("Meeting Notes!", "Something else."))
+            .unwrap_err();
+        assert!(error.contains("already exists"));
+
+        // Editing the same record with its own (unchanged) name is fine.
+        let mut draft = transform_draft("Meeting Notes", "Updated instruction.");
+        draft.id = Some(first.id.clone());
+        draft.expected_revision = Some(first.revision);
+        assert!(store.upsert_manual(draft).is_ok());
+
+        // A distinct name is unaffected.
+        assert!(store
+            .upsert_manual(transform_draft("standup summary", "Summarize as a standup update."))
+            .is_ok());
+    }
+
+    #[test]
+    fn transform_entries_export_import_round_trip_at_current_version() {
+        let (temp, store) = store();
+        let transform = store
+            .upsert_manual(transform_draft(
+                "meeting notes",
+                "Rewrite as concise meeting notes with action items.",
+            ))
+            .unwrap();
+
+        let export = temp.path().join("transform-export.json");
+        store.export_to_file(&export).unwrap();
+        let bundle: KnowledgeExport =
+            serde_json::from_slice(&std::fs::read(&export).unwrap()).unwrap();
+        assert_eq!(bundle.version, EXPORT_VERSION);
+        assert_eq!(bundle.version, 3, "store convention bumped for #312 round 2");
+        assert!(bundle
+            .entries
+            .iter()
+            .any(|entry| matches!(entry.payload, KnowledgePayload::Transform { .. })));
+
+        let revision = store.status().store_revision;
+        store.delete_all(revision).unwrap();
+        assert_eq!(store.status().record_count, 0);
+
+        let imported = store.import_from_file(&export).unwrap();
+        assert_eq!(imported.imported, 1);
+        let restored = store.get(&transform.id).unwrap();
+        assert_eq!(restored.payload, transform.payload);
+        assert_eq!(restored.provenance, KnowledgeProvenance::Import);
+    }
+
+    #[test]
+    fn import_rejects_a_newer_export_version_with_the_clean_message_not_a_serde_error() {
+        let (temp, store) = store();
+        let bundle = KnowledgeExport {
+            format: EXPORT_FORMAT.to_string(),
+            version: 4,
+            exported_at_ms: 0,
+            entries: Vec::new(),
+        };
+        let path = temp.path().join("future-version.json");
+        std::fs::write(&path, serde_json::to_vec(&bundle).unwrap()).unwrap();
+        let error = store.import_from_file(&path).unwrap_err();
+        assert_eq!(
+            error,
+            "The selected knowledge export format is not supported by this Murmur build."
+        );
+    }
+
+    #[test]
+    fn import_still_accepts_legacy_version_1_and_2_bundles() {
+        let (temp, store) = store();
+        let mut bundle = KnowledgeExport {
+            format: EXPORT_FORMAT.to_string(),
+            version: 1,
+            exported_at_ms: 0,
+            entries: vec![KnowledgeEntry {
+                id: "legacy-entry-00000001".to_string(),
+                payload: KnowledgePayload::ReplacementRule {
+                    source: "hello".to_string(),
+                    replacement: "hi".to_string(),
+                },
+                enabled: true,
+                scope: KnowledgeScope::Global,
+                provenance: KnowledgeProvenance::Manual,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+                revision: 1,
+                voice_command: None,
+            }],
+        };
+        let v1_path = temp.path().join("v1-export.json");
+        std::fs::write(&v1_path, serde_json::to_vec(&bundle).unwrap()).unwrap();
+        assert_eq!(store.import_from_file(&v1_path).unwrap().imported, 1);
+
+        bundle.version = 2;
+        bundle.entries[0].id = "legacy-entry-00000002".to_string();
+        // Distinct payload so this isn't treated as a semantic duplicate of
+        // the v1 entry already imported above (import dedupes by payload +
+        // scope + enabled + voice_command, independent of ID).
+        bundle.entries[0].payload = KnowledgePayload::ReplacementRule {
+            source: "goodbye".to_string(),
+            replacement: "bye".to_string(),
+        };
+        let v2_path = temp.path().join("v2-export.json");
+        std::fs::write(&v2_path, serde_json::to_vec(&bundle).unwrap()).unwrap();
+        assert_eq!(store.import_from_file(&v2_path).unwrap().imported, 1);
+    }
+
+    /// Data-carrying v3 -> v4 migration test (issue #312 round 2 D1 fix #4).
+    /// Migration 4 rebuilds `knowledge_entries` from scratch (SQLite cannot
+    /// ALTER a CHECK constraint) to widen the `kind` set for
+    /// `KnowledgeKind::Transform`. Seed one row of every kind that already
+    /// existed at v3 — including voice-command columns populated — then
+    /// migrate and assert every row/field survives losslessly and every
+    /// index (from v2 and v3) is recreated on the rebuilt table.
+    #[test]
+    fn schema_v3_to_v4_migration_is_lossless_and_recreates_every_index() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("knowledge");
+        std::fs::create_dir_all(root.join("backups")).unwrap();
+        std::fs::create_dir_all(root.join("quarantine")).unwrap();
+        let db = root.join("knowledge.sqlite3");
+        let mut connection = Connection::open(&db).unwrap();
+        migrations::migrate_to_for_test(&mut connection, 3).unwrap();
+
+        let now = 1_700_000_000_000_i64;
+        connection
+            .execute(
+                "INSERT INTO knowledge_entries(id, kind, trigger_text, normalized_trigger, content_text, aliases_json, enabled, scope_kind, app_bundle_id, project_root, provenance, created_at_ms, updated_at_ms, revision, voice_command_kind, voice_command_clipboard) VALUES ('replacement-1', 'replacement_rule', 'use hook', 'use hook', 'useHook', '[]', 1, 'global', NULL, NULL, 'manual', ?1, ?1, 1, NULL, 0)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO knowledge_entries(id, kind, trigger_text, normalized_trigger, content_text, aliases_json, enabled, scope_kind, app_bundle_id, project_root, provenance, created_at_ms, updated_at_ms, revision, voice_command_kind, voice_command_clipboard) VALUES ('vocab-1', 'vocabulary_term', 'Tori', 'tori', '', '[\"Tory\",\"Tori\"]', 1, 'app', 'com.editor', NULL, 'manual', ?1, ?1, 1, NULL, 0)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO knowledge_entries(id, kind, trigger_text, normalized_trigger, content_text, aliases_json, enabled, scope_kind, app_bundle_id, project_root, provenance, created_at_ms, updated_at_ms, revision, voice_command_kind, voice_command_clipboard) VALUES ('snippet-1', 'snippet', 'sign off', 'sign off', 'Regards, George', '[]', 1, 'project', 'com.editor', '/project', 'manual', ?1, ?1, 1, NULL, 0)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO knowledge_entries(id, kind, trigger_text, normalized_trigger, content_text, aliases_json, enabled, scope_kind, app_bundle_id, project_root, provenance, created_at_ms, updated_at_ms, revision, voice_command_kind, voice_command_clipboard) VALUES ('voice-1', 'replacement_rule', 'my signature', 'my signature', 'Regards, George', '[]', 1, 'global', NULL, NULL, 'manual', ?1, ?1, 1, 'text_replacement', 1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        drop(connection);
+
+        let store = KnowledgeStore::default();
+        let status = store.initialize(root.clone());
+        assert_eq!(status.availability, StoreAvailability::Ready);
+        assert_eq!(status.schema_version, 4);
+        assert_eq!(status.record_count, 4);
+
+        let replacement = store.get("replacement-1").unwrap();
+        assert_eq!(
+            replacement.payload,
+            KnowledgePayload::ReplacementRule {
+                source: "use hook".to_string(),
+                replacement: "useHook".to_string(),
+            }
+        );
+        assert_eq!(replacement.scope, KnowledgeScope::Global);
+        assert_eq!(replacement.created_at_ms, now);
+        assert_eq!(replacement.updated_at_ms, now);
+        assert!(replacement.voice_command.is_none());
+
+        let vocab = store.get("vocab-1").unwrap();
+        assert_eq!(
+            vocab.payload,
+            KnowledgePayload::VocabularyTerm {
+                written: "Tori".to_string(),
+                aliases: vec!["Tory".to_string(), "Tori".to_string()],
+            }
+        );
+        assert_eq!(
+            vocab.scope,
+            KnowledgeScope::App {
+                bundle_id: "com.editor".to_string()
+            }
+        );
+
+        let snippet = store.get("snippet-1").unwrap();
+        assert_eq!(
+            snippet.payload,
+            KnowledgePayload::Snippet {
+                trigger: "sign off".to_string(),
+                body: "Regards, George".to_string(),
+            }
+        );
+        assert_eq!(
+            snippet.scope,
+            KnowledgeScope::Project {
+                bundle_id: "com.editor".to_string(),
+                root: "/project".to_string(),
+            }
+        );
+
+        let voice = store.get("voice-1").unwrap();
+        assert_eq!(
+            voice.voice_command,
+            Some(VoiceCommandMetadata {
+                command_type: VoiceCommandKind::TextReplacement,
+                allow_clipboard_read: true,
+            })
+        );
+
+        // Migration 4 rebuilds knowledge_entries (DROP + rename), so every
+        // index defined at v2 and v3 must be recreated, not just the new
+        // columns/CHECK constraint.
+        let connection = Connection::open(&db).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='knowledge_entries' ORDER BY name",
+            )
+            .unwrap();
+        let indexes: Vec<String> = statement
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        for expected in [
+            "knowledge_entries_listing",
+            "knowledge_entries_resolution",
+            "knowledge_entries_scope",
+            "knowledge_entries_voice_commands",
+        ] {
+            assert!(
+                indexes.iter().any(|name| name == expected),
+                "missing index {expected}, have: {indexes:?}"
+            );
+        }
+    }
 }

--- a/app/src-tauri/src/knowledge_store/repository.rs
+++ b/app/src-tauri/src/knowledge_store/repository.rs
@@ -197,6 +197,9 @@ impl KnowledgeRepository {
                 draft.id.as_deref(),
             )?;
         }
+        if let KnowledgePayload::Transform { name, .. } = &draft.payload {
+            validate_transform_name_conflict_tx(&transaction, name, draft.id.as_deref())?;
+        }
         let timestamp = now_ms();
         let (trigger, content, aliases) = draft.payload.storage_parts();
         let aliases_json = serde_json::to_string(&aliases).map_err(|_| validation_error())?;
@@ -849,10 +852,21 @@ fn validate_payload(payload: &KnowledgePayload) -> Result<(), String> {
             }
         }
         KnowledgePayload::Transform { .. } => {
-            if content.is_empty() || content.chars().count() > MAX_SNIPPET_CHARS {
+            if content.is_empty() {
                 return Err(
                     "Transform instructions must be between 1 and 65,536 characters.".to_string(),
                 );
+            }
+            // The local-LLM sidecar protocol caps instruction bytes at
+            // MAX_INSTRUCTION_BYTES (4096); enforce the same bound (bytes,
+            // not chars) here so an oversized saved transform is rejected at
+            // save time instead of saving fine and always failing later with
+            // an opaque invalid_request (issue #312 round 2 D1 fix #3).
+            if content.len() > murmur_local_llm_protocol::MAX_INSTRUCTION_BYTES {
+                return Err(format!(
+                    "Transform instructions must be at most {} bytes.",
+                    murmur_local_llm_protocol::MAX_INSTRUCTION_BYTES
+                ));
             }
         }
     }
@@ -950,6 +964,40 @@ fn validate_voice_command_conflicts_tx(
             return Err(
                 "A Voice Command with that phrase already exists in this scope.".to_string(),
             );
+        }
+    }
+    Ok(())
+}
+
+/// Reject an exact duplicate saved-transform name (issue #312 round 2 D1
+/// fix #5). Uses the same normalization as preset matching and
+/// `transform_flow::resolve_saved_transform` (case- and punctuation-
+/// insensitive) so two names that would be indistinguishable when spoken
+/// cannot both be saved. Preset-name/alias shadowing is intentionally NOT
+/// rejected here — it is only a UI-level warning, since a saved transform
+/// with that name is still valid data (it is simply unreachable by voice
+/// until renamed or the preset changes).
+fn validate_transform_name_conflict_tx(
+    transaction: &rusqlite::Transaction<'_>,
+    name: &str,
+    editing_id: Option<&str>,
+) -> Result<(), String> {
+    let normalized = crate::transform_presets::normalize(name);
+    if normalized.is_empty() {
+        return Ok(());
+    }
+    for existing in entries_with_kind(transaction, KnowledgeKind::Transform)? {
+        if editing_id == Some(existing.id.as_str()) {
+            continue;
+        }
+        if let KnowledgePayload::Transform {
+            name: existing_name,
+            ..
+        } = &existing.payload
+        {
+            if crate::transform_presets::normalize(existing_name) == normalized {
+                return Err("A saved transform with that name already exists.".to_string());
+            }
         }
     }
     Ok(())
@@ -1117,7 +1165,7 @@ fn read_import(path: &Path) -> Result<KnowledgeExport, String> {
         .map_err(|_| "Murmur could not read the selected knowledge import.".to_string())?;
     let bundle: KnowledgeExport = serde_json::from_slice(&bytes)
         .map_err(|_| "The selected file is not a valid Murmur knowledge export.".to_string())?;
-    if bundle.format != EXPORT_FORMAT || !matches!(bundle.version, 1 | EXPORT_VERSION) {
+    if bundle.format != EXPORT_FORMAT || !matches!(bundle.version, 1 | 2 | 3) {
         return Err(
             "The selected knowledge export format is not supported by this Murmur build."
                 .to_string(),

--- a/app/src-tauri/src/knowledge_store/repository.rs
+++ b/app/src-tauri/src/knowledge_store/repository.rs
@@ -854,7 +854,7 @@ fn validate_payload(payload: &KnowledgePayload) -> Result<(), String> {
         KnowledgePayload::Transform { .. } => {
             if content.is_empty() {
                 return Err(
-                    "Transform instructions must be between 1 and 65,536 characters.".to_string(),
+                    "Transform instructions must be 1 to 4,096 bytes.".to_string(),
                 );
             }
             // The local-LLM sidecar protocol caps instruction bytes at

--- a/app/src-tauri/src/knowledge_store/repository.rs
+++ b/app/src-tauri/src/knowledge_store/repository.rs
@@ -762,6 +762,10 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<KnowledgeEntry> {
             trigger,
             body: content,
         },
+        "transform" => KnowledgePayload::Transform {
+            name: trigger,
+            instruction: content,
+        },
         _ => return Err(rusqlite::Error::InvalidQuery),
     };
     let scope = match scope_kind.as_str() {
@@ -842,6 +846,13 @@ fn validate_payload(payload: &KnowledgePayload) -> Result<(), String> {
         KnowledgePayload::Snippet { .. } => {
             if content.is_empty() || content.chars().count() > MAX_SNIPPET_CHARS {
                 return Err("Snippet bodies must be between 1 and 65,536 characters.".to_string());
+            }
+        }
+        KnowledgePayload::Transform { .. } => {
+            if content.is_empty() || content.chars().count() > MAX_SNIPPET_CHARS {
+                return Err(
+                    "Transform instructions must be between 1 and 65,536 characters.".to_string(),
+                );
             }
         }
     }

--- a/app/src-tauri/src/knowledge_store/types.rs
+++ b/app/src-tauri/src/knowledge_store/types.rs
@@ -11,6 +11,9 @@ pub enum KnowledgeKind {
     ReplacementRule,
     VocabularyTerm,
     Snippet,
+    /// User-defined selected-text transform (issue #312 D1): spoken name expands
+    /// to a full rewrite instruction before the local LLM runs.
+    Transform,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,6 +54,7 @@ impl KnowledgeKind {
             Self::ReplacementRule => "replacement_rule",
             Self::VocabularyTerm => "vocabulary_term",
             Self::Snippet => "snippet",
+            Self::Transform => "transform",
         }
     }
 }
@@ -147,6 +151,11 @@ pub enum KnowledgePayload {
         trigger: String,
         body: String,
     },
+    /// Named transform instruction for the selected-text flow (#312 D1).
+    Transform {
+        name: String,
+        instruction: String,
+    },
 }
 
 impl KnowledgePayload {
@@ -155,6 +164,7 @@ impl KnowledgePayload {
             Self::ReplacementRule { .. } => KnowledgeKind::ReplacementRule,
             Self::VocabularyTerm { .. } => KnowledgeKind::VocabularyTerm,
             Self::Snippet { .. } => KnowledgeKind::Snippet,
+            Self::Transform { .. } => KnowledgeKind::Transform,
         }
     }
 
@@ -168,6 +178,9 @@ impl KnowledgePayload {
                 (written.clone(), String::new(), aliases.clone())
             }
             Self::Snippet { trigger, body } => (trigger.clone(), body.clone(), Vec::new()),
+            Self::Transform { name, instruction } => {
+                (name.clone(), instruction.clone(), Vec::new())
+            }
         }
     }
 }

--- a/app/src-tauri/src/knowledge_store/types.rs
+++ b/app/src-tauri/src/knowledge_store/types.rs
@@ -1,7 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 pub const EXPORT_FORMAT: &str = "murmur-personal-knowledge";
-pub const EXPORT_VERSION: u32 = 2;
+/// Bumped 2 -> 3 for issue #312 round 2: v3 bundles can carry
+/// `KnowledgeKind::Transform` entries (the store convention is to bump this
+/// whenever the payload shape space expands). Import still accepts older
+/// bundles (version 1 and 2) since their entries are a strict subset of the
+/// current `KnowledgePayload` variants.
+pub const EXPORT_VERSION: u32 = 3;
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 100;
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub mod transcriber;
 mod transcript_transform;
 mod transform_apply;
 pub mod transform_flow;
+mod transform_presets;
 mod vad;
 mod vocab;
 mod vocabulary_alias;

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -20,6 +20,47 @@ use std::time::Duration;
 use murmur_local_llm_protocol::{ErrorCode, FinishReason};
 
 // ---------------------------------------------------------------------------
+// Per-request cooperative cancel token (#312 C2 follow-up, item 11).
+// ---------------------------------------------------------------------------
+
+/// A cooperative cancel signal scoped to exactly ONE transform request.
+///
+/// This replaces the earlier supervisor-wide `cancel_requested` flag, which was
+/// reset at each request start (`self.cancel_requested.store(false)`) and could
+/// therefore have a legitimate cancel WIPED by the next request's reset — or,
+/// symmetrically, leak a stale cancel into the next request. A fresh token is
+/// created per request in `transform_flow::run_transform` (before the spawn)
+/// and registered for the request's lifetime; canceling it can only ever affect
+/// the exact request it was created for. Cheap to clone (a shared
+/// `Arc<AtomicBool>`).
+#[derive(Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// A fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Request cooperative cancellation for this request.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Whether cancellation has been requested for this request.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+
+    /// Identity check: clones of the same token compare equal; distinct tokens
+    /// do not. Lets the in-flight slot be cleared only when it still holds our
+    /// token (a later request may already have replaced it).
+    fn is_same(&self, other: &CancelToken) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Immutable catalog pins (single source of truth, shared with the installer).
 // ---------------------------------------------------------------------------
 
@@ -544,15 +585,23 @@ mod supported {
         rss_warned: bool,
     }
 
-    /// RAII guard that clears the in-flight `busy` flag on drop. It is moved
-    /// into the `spawn_blocking` closure so `busy` is released when the blocking
-    /// work finishes on EVERY path — including when the async future is dropped
-    /// (e.g. a `tokio::time::timeout` wrapper) mid-request. A blocking task is
-    /// never cancelled, so its guard always drops.
-    struct BusyGuard(Arc<LlmSidecar>);
+    /// RAII guard that clears the in-flight `busy` flag AND the per-request
+    /// cancel slot on drop. It is moved into the `spawn_blocking` closure so
+    /// both are released when the blocking work finishes on EVERY path —
+    /// including when the async future is dropped (e.g. a `tokio::time::timeout`
+    /// wrapper) mid-request. A blocking task is never cancelled, so its guard
+    /// always drops.
+    struct BusyGuard {
+        sidecar: Arc<LlmSidecar>,
+        cancel: CancelToken,
+    }
     impl Drop for BusyGuard {
         fn drop(&mut self) {
-            self.0.busy.store(false, Ordering::Release);
+            // Clear our per-request cancel slot (only if it still holds our
+            // token) BEFORE releasing busy, so a cancel arriving after busy
+            // frees can never land on the wrong (already-finished) request.
+            self.sidecar.clear_inflight_cancel(&self.cancel);
+            self.sidecar.busy.store(false, Ordering::Release);
         }
     }
 
@@ -560,11 +609,12 @@ mod supported {
         plan: SpawnPlan,
         host_guard: OnceLock<Arc<dyn HostGuard>>,
         busy: AtomicBool,
-        /// Set by [`Self::cancel_inflight_request`] so the blocking
-        /// `run_request` loop can send a cooperative Cancel frame instead of
-        /// waiting out the full deadline (BusyGuard only drops when that work
-        /// finishes — aborting the outer tokio task alone does not clear busy).
-        cancel_requested: AtomicBool,
+        /// The in-flight request's cancel token, registered for the duration of
+        /// one `transform` call and cleared by its `BusyGuard`. Per-request (not
+        /// supervisor-wide): [`Self::cancel_inflight_request`] cancels ONLY the
+        /// token currently in flight, so a cancel can never wipe or leak into a
+        /// neighbouring request. `None` between requests → cancel is a no-op.
+        inflight_cancel: Mutex<Option<CancelToken>>,
         inner: Mutex<Inner>,
     }
 
@@ -586,7 +636,7 @@ mod supported {
                 plan,
                 host_guard: OnceLock::new(),
                 busy: AtomicBool::new(false),
-                cancel_requested: AtomicBool::new(false),
+                inflight_cancel: Mutex::new(None),
                 inner: Mutex::new(Inner {
                     child: None,
                     breaker: Breaker::default(),
@@ -619,14 +669,45 @@ mod supported {
 
         /// Request cooperative cancel of the in-flight transform (if any).
         ///
-        /// The blocking `run_request` loop observes this flag, sends a protocol
-        /// Cancel frame, and settles via the same cancel-then-kill dance used
-        /// for deadline expiry. Dropping the outer async future alone does
-        /// **not** clear `busy` — only the blocking work finishing does — so
-        /// callers that abort a `tokio::spawn` wrapper must also call this
-        /// (see `cancel_transform`).
+        /// Cancels ONLY the request currently in flight — it flips that
+        /// request's own [`CancelToken`], never a shared flag — so a cancel can
+        /// never affect the next request. The blocking `run_request` loop
+        /// observes the token, sends a protocol Cancel frame, and settles via
+        /// the same cancel-then-kill dance used for deadline expiry. Dropping
+        /// the outer async future alone does **not** clear `busy` — only the
+        /// blocking work finishing does — so callers that abort a
+        /// `tokio::spawn` wrapper must also call this (see `cancel_transform`).
+        /// A no-op when no request is in flight (`inflight_cancel` is `None`).
         pub fn cancel_inflight_request(&self) {
-            self.cancel_requested.store(true, Ordering::Release);
+            if let Some(token) = self
+                .inflight_cancel
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .as_ref()
+            {
+                token.cancel();
+            }
+        }
+
+        /// Register the in-flight request's cancel token (called once per
+        /// request, before the blocking work starts).
+        fn set_inflight_cancel(&self, token: CancelToken) {
+            *self
+                .inflight_cancel
+                .lock()
+                .unwrap_or_else(|p| p.into_inner()) = Some(token);
+        }
+
+        /// Clear the in-flight slot, but only if it still holds `token` — a
+        /// later request may already have replaced it.
+        fn clear_inflight_cancel(&self, token: &CancelToken) {
+            let mut slot = self
+                .inflight_cancel
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if slot.as_ref().map(|t| t.is_same(token)).unwrap_or(false) {
+                *slot = None;
+            }
         }
 
         /// Test-support: whether a helper process is currently resident. Not
@@ -642,6 +723,7 @@ mod supported {
             instruction: &str,
             input: &str,
             deadline: Duration,
+            cancel: CancelToken,
         ) -> Result<TransformOutput, TransformError> {
             // App-side limit enforcement (defence in depth over the helper).
             if instruction.len() > MAX_INSTRUCTION_BYTES
@@ -661,12 +743,20 @@ mod supported {
             {
                 return Err(TransformError::Busy);
             }
-            // Own the busy flag from here. Moving this guard into the blocking
-            // closure guarantees `busy` clears when the blocking work ends even
-            // if this async future is dropped at the `.await` below.
-            let busy_guard = BusyGuard(Arc::clone(self));
-            // Clear any stale cancel signal from a prior request.
-            self.cancel_requested.store(false, Ordering::Release);
+            // Register this request's cancel token so cancel_inflight_request()
+            // reaches exactly THIS request. No stale-flag reset is needed (the
+            // token is fresh per request), so a concurrent cancel can never be
+            // wiped. Cleared by the BusyGuard drop below.
+            self.set_inflight_cancel(cancel.clone());
+            // Own the busy flag + cancel slot from here. Moving this guard into
+            // the blocking closure guarantees both clear when the blocking work
+            // ends even if this async future is dropped at the `.await` below.
+            // No `.await` sits between the busy claim and this move, so there is
+            // no window where busy is held without its guard.
+            let busy_guard = BusyGuard {
+                sidecar: Arc::clone(self),
+                cancel: cancel.clone(),
+            };
 
             // Bucket sizes up front so no raw length leaves this frame.
             let instruction_bucket = size_bucket(instruction.len());
@@ -678,7 +768,7 @@ mod supported {
             let started = Instant::now();
             let join = tokio::task::spawn_blocking(move || {
                 let _busy = busy_guard;
-                this.transform_blocking(&instruction, &input, deadline)
+                this.transform_blocking(&instruction, &input, deadline, &cancel)
             })
             .await;
 
@@ -710,6 +800,7 @@ mod supported {
             instruction: &str,
             input: &str,
             deadline: Duration,
+            cancel: &CancelToken,
         ) -> Result<TransformOutput, TransformError> {
             let mut inner = self.lock();
 
@@ -754,7 +845,7 @@ mod supported {
                     input,
                     deadline,
                     &self.plan,
-                    &self.cancel_requested,
+                    cancel,
                 )
             };
 
@@ -1116,7 +1207,7 @@ mod supported {
         input: &str,
         deadline: Duration,
         plan: &SpawnPlan,
-        cancel_requested: &AtomicBool,
+        cancel: &CancelToken,
     ) -> RequestOutcome {
         let transform = HostMessage::Transform {
             protocol: PROTOCOL_NAME.to_string(),
@@ -1138,7 +1229,7 @@ mod supported {
         let deadline_at = Instant::now() + wait;
         loop {
             // User cancel (e.g. Esc / short-tap) wins over the deadline wait.
-            if cancel_requested.load(Ordering::Acquire) {
+            if cancel.is_cancelled() {
                 return cancel_and_settle(
                     child,
                     request_id,
@@ -1155,8 +1246,8 @@ mod supported {
                     CancelReason::Deadline,
                 );
             }
-            // Poll in short slices so a cancel_requested flag is observed
-            // promptly even when the helper is silent.
+            // Poll in short slices so a cancel token flip is observed promptly
+            // even when the helper is silent.
             let slice = (deadline_at - now).min(Duration::from_millis(50));
             match child.events.recv_timeout(slice) {
                 Ok(HelperEvent::Frame(frame)) => {
@@ -1335,7 +1426,6 @@ pub use supported::LlmSidecar;
 pub struct LlmSidecar {
     host_guard: OnceLock<Arc<dyn HostGuard>>,
     busy: AtomicBool,
-    cancel_requested: AtomicBool,
     _plan: SpawnPlan,
 }
 
@@ -1354,7 +1444,6 @@ impl LlmSidecar {
         Self {
             host_guard: OnceLock::new(),
             busy: AtomicBool::new(false),
-            cancel_requested: AtomicBool::new(false),
             _plan: plan,
         }
     }
@@ -1367,9 +1456,8 @@ impl LlmSidecar {
         self.busy.load(Ordering::Acquire)
     }
 
-    pub fn cancel_inflight_request(&self) {
-        self.cancel_requested.store(true, Ordering::Release);
-    }
+    /// No runtime here, so nothing is ever in flight — a no-op.
+    pub fn cancel_inflight_request(&self) {}
 
     pub fn has_live_child(&self) -> bool {
         false
@@ -1380,6 +1468,7 @@ impl LlmSidecar {
         _instruction: &str,
         _input: &str,
         _deadline: Duration,
+        _cancel: CancelToken,
     ) -> Result<TransformOutput, TransformError> {
         Err(TransformError::Unsupported)
     }
@@ -1418,6 +1507,26 @@ mod tests {
             assert!(path.to_string_lossy().contains(TRANSFORM_MODEL_SHA256));
             assert!(path.ends_with(TRANSFORM_MODEL_FILENAME));
         }
+    }
+
+    #[test]
+    fn cancel_token_is_scoped_per_instance() {
+        // The per-request cancel token is the core of item 11: two distinct
+        // tokens are independent, and clones of one share its state. This is
+        // what makes a cancel for request N unable to affect request N+1.
+        let a = CancelToken::new();
+        let b = CancelToken::new();
+        assert!(!a.is_cancelled() && !b.is_cancelled());
+
+        a.cancel();
+        assert!(a.is_cancelled(), "cancelling A must flip A");
+        assert!(!b.is_cancelled(), "cancelling A must NOT flip B (per-request)");
+
+        // A clone observes the same cancellation; identity holds across clones.
+        let a2 = a.clone();
+        assert!(a2.is_cancelled());
+        assert!(a.is_same(&a2));
+        assert!(!a.is_same(&b));
     }
 
     #[test]

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -617,6 +617,14 @@ mod supported {
             self.busy.load(Ordering::Acquire)
         }
 
+        /// True once the circuit breaker has latched disabled after repeated
+        /// faults (cleared only by `reset`). Surfaced in the model status so the
+        /// settings UI can show the Reset button + notice only when it matters
+        /// (#312 D1 round-2 finding 7).
+        pub fn runtime_disabled(&self) -> bool {
+            self.lock().breaker.disabled
+        }
+
         /// Request cooperative cancel of the in-flight transform (if any).
         ///
         /// The blocking `run_request` loop observes this flag, sends a protocol
@@ -1365,6 +1373,10 @@ impl LlmSidecar {
 
     pub fn is_transform_busy(&self) -> bool {
         self.busy.load(Ordering::Acquire)
+    }
+
+    pub fn runtime_disabled(&self) -> bool {
+        false
     }
 
     pub fn cancel_inflight_request(&self) {

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -354,7 +354,7 @@ pub struct AppState {
     /// inner `spawn_blocking` work finishes. Callers must also invoke
     /// `LlmSidecar::cancel_inflight_request` so the blocking loop sends a
     /// protocol Cancel and settles promptly (see `cancel_transform`).
-    pub transform_inflight: Mutex<Option<tokio::task::AbortHandle>>,
+    pub transform_inflight: Mutex<Option<(tokio::task::AbortHandle, crate::llm_sidecar::CancelToken)>>,
 }
 
 impl AppState {

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -362,8 +362,13 @@ pub fn decide(state: FlowState, event: FlowEvent) -> FlowDecision {
             vec![SetFocusable(true), Emit(ReviewState::Failed)],
         ),
         (S::Applying, E::UndoOk) => go(S::Idle, vec![HidePopover, ClearSession]),
+        // Undo-failure UX (item 12): stay Applied and re-emit Applied — NOT
+        // Failed — so the Undo button stays reachable and the applied text is
+        // never stranded un-undoable. The command layer carries the undo error
+        // code on this `applied` emit (spec-by-test:
+        // `decide_undo_error_keeps_applied_and_undo_reachable`).
         (S::Applying, E::UndoError) => {
-            go(S::Applied, vec![Emit(ReviewState::Failed)])
+            go(S::Applied, vec![Emit(ReviewState::Applied)])
         }
         // Cancel during Applying: tear down; ApplyingGuard must not resurrect
         // ReviewPending after the session is cleared (see cancel_transform).
@@ -555,7 +560,16 @@ pub(crate) async fn run_transform(
     let sidecar = Arc::clone(sidecar);
     let input = original;
     let instr = instruction;
-    let join = tokio::spawn(async move { sidecar.transform(&instr, &input, deadline).await });
+    // Per-request cancel token (item 11): created here, before the spawn, and
+    // handed to the sidecar for exactly this request. `transform` registers it
+    // as the in-flight token, so `cancel_transform`'s
+    // `cancel_inflight_request()` cooperatively cancels ONLY this request —
+    // never a neighbouring one. Its lifetime tracks the AbortHandle stored just
+    // below (both cleared when the request settles).
+    let cancel = crate::llm_sidecar::CancelToken::new();
+    let join = tokio::spawn(async move {
+        sidecar.transform(&instr, &input, deadline, cancel).await
+    });
     *inflight.lock_or_recover() = Some(join.abort_handle());
     let joined = join.await;
     *inflight.lock_or_recover() = None;
@@ -603,6 +617,19 @@ pub(crate) async fn run_transform(
 // Production effects: real Tauri emission + popover window commands.
 // ===========================================================================
 
+/// Content-free "the popover was hidden by the backend" signal (item 13).
+///
+/// Backend-initiated hides (short-tap cancel, linger auto-hide, audio-start
+/// teardown, secure-field/capture aborts) never go through the popover's own
+/// Cancel/Undo buttons, so the popover webview keeps whatever review content it
+/// last fetched and could flash it on the NEXT show. This bare event tells the
+/// review driver to reset its content to `EMPTY_REVIEW_CONTENT`. Privacy: the
+/// payload is empty — no state text, no error, nothing.
+fn emit_transform_hidden(app: &tauri::AppHandle) {
+    use tauri::Emitter;
+    let _ = app.emit("transform-review-hidden", ());
+}
+
 pub(crate) struct TauriFlowEffects<'a> {
     pub app: &'a tauri::AppHandle,
     pub state: &'a crate::State,
@@ -636,6 +663,9 @@ impl FlowEffects for TauriFlowEffects<'_> {
 
     fn hide_popover(&self) {
         let _ = crate::commands::transform_popover::hide_popover_internal(self.app);
+        // A backend-driven hide (e.g. secure-field / capture-error abort in
+        // core_start_capture) must reset the popover's stale content (item 13).
+        emit_transform_hidden(self.app);
     }
 
     fn set_focusable(&self, focusable: bool) {
@@ -679,6 +709,8 @@ impl FlowEffects for TauriFlowEffects<'_> {
                 transform_apply::clear_session(&state.app_state);
             }
             let _ = crate::commands::transform_popover::hide_popover_internal(&app);
+            // Linger auto-hide is backend-initiated — reset stale content (item 13).
+            emit_transform_hidden(&app);
         });
     }
 }
@@ -819,7 +851,26 @@ pub(crate) async fn start_transform_capture(
             state.app_state.set_transform_status(TransformStatus::Idle);
             transform_apply::clear_session(&state.app_state);
             let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+            emit_transform_hidden(&app_handle);
             return Err(e);
+        }
+        // Mic-leak window (item 10): `cancel_transform` is lock-free and does
+        // not take `recording_transition`, so a short-tap cancel can land
+        // between `core_start_capture` returning Listening and the mic actually
+        // coming up here. At that instant the cancel saw `is_recording() ==
+        // false` and did NOT stop anything, so without this re-check the mic
+        // would stay live with status no longer Listening. Re-verify and tear
+        // down if the flow was cancelled out from under us.
+        if state.app_state.transform_status() != TransformStatus::Listening {
+            if crate::audio::is_recording() {
+                let _ = crate::audio::stop_recording();
+            }
+            // cancel_transform already cleared the session / hid the popover;
+            // repeat the teardown idempotently so no half-state survives.
+            transform_apply::clear_session(&state.app_state);
+            let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+            emit_transform_hidden(&app_handle);
+            return Ok(());
         }
     }
     Ok(())
@@ -946,6 +997,7 @@ pub(crate) async fn retry_transform_instruction(
     if transform_apply::session_snapshot(&state.app_state).is_none() {
         state.app_state.set_transform_status(TransformStatus::Idle);
         let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+        emit_transform_hidden(&app_handle);
         return Ok(());
     }
 
@@ -966,7 +1018,19 @@ pub(crate) async fn retry_transform_instruction(
         state.app_state.set_transform_status(TransformStatus::Idle);
         transform_apply::clear_session(&state.app_state);
         let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+        emit_transform_hidden(&app_handle);
         return Err(e);
+    }
+    // Same mic-leak re-check as start_transform_capture (item 10): a cancel
+    // that raced in during audio startup must not leave the mic live.
+    if state.app_state.transform_status() != TransformStatus::Listening {
+        if crate::audio::is_recording() {
+            let _ = crate::audio::stop_recording();
+        }
+        transform_apply::clear_session(&state.app_state);
+        let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+        emit_transform_hidden(&app_handle);
+        return Ok(());
     }
     Ok(())
 }
@@ -1044,6 +1108,9 @@ pub(crate) async fn cancel_transform(
     state.app_state.set_transform_status(TransformStatus::Idle);
     transform_apply::clear_session(&state.app_state);
     let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+    // Backend-initiated hide (short-tap cancel, mid-hold cleanup, or the
+    // popover's own Cancel button all route here): reset stale content (item 13).
+    emit_transform_hidden(&app_handle);
     Ok(())
 }
 
@@ -1082,11 +1149,18 @@ pub(crate) async fn undo_transform_and_close(
             // Hide + clear WITHOUT another epoch bump (cancel would bump).
             transform_apply::clear_session(&state.app_state);
             let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
+            emit_transform_hidden(&app_handle);
             Ok(())
         }
         Err(error) => {
-            // Guard drop restores Idle; session stays applied so Undo retries.
-            fx.emit_state(ReviewState::Failed, Some(apply_error_code(error)));
+            // Undo-failure UX (item 12): the guard drop restores Idle and the
+            // session stays applied, so Undo is still valid. Emitting `failed`
+            // here would strand the user on a popover with NO Undo button and a
+            // dead Retry — the applied text would become permanently
+            // un-undoable. Instead re-emit `applied` carrying the error code so
+            // the Applied UI (Undo button) stays reachable while surfacing the
+            // failure. Privacy: state event stays {state, errorCode} only.
+            fx.emit_state(ReviewState::Applied, Some(apply_error_code(error)));
             Err(apply_error_code(error).to_string())
         }
     }
@@ -1728,6 +1802,22 @@ mod tests {
         assert!(d.actions.contains(&FlowAction::HidePopover));
         assert!(d.actions.contains(&FlowAction::ClearSession));
         assert!(!d.actions.contains(&FlowAction::CancelInflight));
+    }
+
+    #[test]
+    fn decide_undo_error_keeps_applied_and_undo_reachable() {
+        // Item 12: a failed undo must NOT drop to Failed (whose UI has no Undo
+        // button and a dead Retry) — it stays Applied and re-emits Applied so
+        // the Undo button remains reachable and the applied text is never
+        // stranded un-undoable. The command layer (undo_transform_and_close)
+        // carries the undo error code on this `applied` emit.
+        let d = decide(FlowState::Applying, FlowEvent::UndoError);
+        assert_eq!(d.next, FlowState::Applied);
+        assert!(d.actions.contains(&FlowAction::Emit(ReviewState::Applied)));
+        assert!(!d.actions.contains(&FlowAction::Emit(ReviewState::Failed)));
+        // The session is NOT cleared — Undo stays valid.
+        assert!(!d.actions.contains(&FlowAction::ClearSession));
+        assert!(!d.actions.contains(&FlowAction::HidePopover));
     }
 
     #[test]

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -901,24 +901,13 @@ fn resolve_saved_transform(state: &crate::State, spoken: &str) -> Option<String>
         ..Default::default()
     };
     let response = state.knowledge.list(request).ok()?;
-    let key = spoken
-        .trim()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase();
+    let key = crate::transform_presets::normalize(spoken);
     if key.is_empty() {
         return None;
     }
     for entry in response.entries {
         if let KnowledgePayload::Transform { name, instruction } = entry.payload {
-            let name_key = name
-                .trim()
-                .split_whitespace()
-                .collect::<Vec<_>>()
-                .join(" ")
-                .to_ascii_lowercase();
-            if name_key == key {
+            if crate::transform_presets::normalize(&name) == key {
                 return Some(instruction);
             }
         }

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -859,7 +859,10 @@ pub(crate) async fn finish_transform_instruction(
         }
     };
 
-    let instruction = transcribe_instruction(&app_handle, &state, &samples).await;
+    let instruction = match transcribe_instruction(&app_handle, &state, &samples).await {
+        Ok(raw) => Ok(expand_instruction(&state, &raw)),
+        Err(()) => Err(()),
+    };
     run_transform(
         &state.app_state,
         &fx,
@@ -871,6 +874,56 @@ pub(crate) async fn finish_transform_instruction(
     )
     .await;
     Ok(())
+}
+
+/// Expand a transcribed instruction when it names a built-in preset or a
+/// saved `KnowledgeKind::Transform`. Otherwise the raw transcript is the
+/// instruction (free-form spoken rewrite request). Never logs the text.
+fn expand_instruction(state: &crate::State, spoken: &str) -> String {
+    if let Some(preset) = crate::transform_presets::resolve_preset(spoken) {
+        return preset.to_string();
+    }
+    if let Some(saved) = resolve_saved_transform(state, spoken) {
+        return saved;
+    }
+    spoken.to_string()
+}
+
+/// Case-insensitive match of a spoken name against enabled global/app
+/// Transform knowledge entries. Returns the instruction body, not the name.
+fn resolve_saved_transform(state: &crate::State, spoken: &str) -> Option<String> {
+    use crate::knowledge_store::{KnowledgeKind, KnowledgeListRequest, KnowledgePayload};
+
+    let request = KnowledgeListRequest {
+        kind: Some(KnowledgeKind::Transform),
+        enabled: Some(true),
+        limit: Some(100),
+        ..Default::default()
+    };
+    let response = state.knowledge.list(request).ok()?;
+    let key = spoken
+        .trim()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    if key.is_empty() {
+        return None;
+    }
+    for entry in response.entries {
+        if let KnowledgePayload::Transform { name, instruction } = entry.payload {
+            let name_key = name
+                .trim()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .to_ascii_lowercase();
+            if name_key == key {
+                return Some(instruction);
+            }
+        }
+    }
+    None
 }
 
 /// Retry: re-arm listening for a NEW instruction on the SAME frozen snapshot.

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -799,7 +799,7 @@ pub(crate) async fn start_transform_capture(
         return Ok(());
     }
 
-    let model_ready = crate::commands::transform_model::transform_model_status().state
+    let model_ready = crate::commands::transform_model::transform_model_state()
         == crate::commands::transform_model::TransformModelState::Ready;
 
     let fx = TauriFlowEffects {

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1156,6 +1156,10 @@ pub(crate) async fn undo_transform_and_close(
             // the Applied UI (Undo button) stays reachable while surfacing the
             // failure. Privacy: state event stays {state, errorCode} only.
             fx.emit_state(ReviewState::Applied, Some(apply_error_code(error)));
+            // Re-arm the linger so the error window is deterministic: the
+            // approve-time timer may be about to fire (hiding the popover
+            // ~instantly) or may have no-op'd mid-undo (leaving it up forever).
+            fx.schedule_linger_hide();
             Err(apply_error_code(error).to_string())
         }
     }

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -533,7 +533,7 @@ pub(crate) async fn run_transform(
     app_state: &AppState,
     fx: &dyn FlowEffects,
     sidecar: &Arc<LlmSidecar>,
-    inflight: &std::sync::Mutex<Option<tokio::task::AbortHandle>>,
+    inflight: &std::sync::Mutex<Option<(tokio::task::AbortHandle, crate::llm_sidecar::CancelToken)>>,
     instruction: Result<String, ()>,
     original: String,
     deadline: Duration,
@@ -567,10 +567,11 @@ pub(crate) async fn run_transform(
     // never a neighbouring one. Its lifetime tracks the AbortHandle stored just
     // below (both cleared when the request settles).
     let cancel = crate::llm_sidecar::CancelToken::new();
-    let join = tokio::spawn(async move {
-        sidecar.transform(&instr, &input, deadline, cancel).await
+    let join = tokio::spawn({
+        let cancel = cancel.clone();
+        async move { sidecar.transform(&instr, &input, deadline, cancel).await }
     });
-    *inflight.lock_or_recover() = Some(join.abort_handle());
+    *inflight.lock_or_recover() = Some((join.abort_handle(), cancel));
     let joined = join.await;
     *inflight.lock_or_recover() = None;
 
@@ -1079,7 +1080,11 @@ pub(crate) async fn cancel_transform(
     // BusyGuard when it finishes, so abort alone would leave busy held up to
     // the deadline. cancel_inflight_request makes run_request send Cancel.
     state.transform_runtime.cancel_inflight_request();
-    if let Some(handle) = state.app_state.transform_inflight.lock_or_recover().take() {
+    if let Some((handle, token)) = state.app_state.transform_inflight.lock_or_recover().take() {
+        // Direct token cancel closes the pre-registration window: even if the
+        // request hasn't registered with the sidecar slot yet, its own token
+        // is already cancelled by the time the blocking loop first polls it.
+        token.cancel();
         handle.abort();
     }
     // Invalidate any pending clipboard restore from a just-finished apply/undo
@@ -1112,7 +1117,8 @@ pub(crate) async fn cancel_transform(
 /// user's prior clipboard on every paste-fallback undo.
 ///
 /// On success: hide popover + clear session (undo unreachable once hidden).
-/// On failure: keep the Applied session and emit `failed` so Undo stays available.
+/// On failure: keep the Applied session and re-emit `applied` with the error code
+/// so the popover shows the failure inline and Undo stays available.
 #[tauri::command]
 pub(crate) async fn undo_transform_and_close(
     app_handle: tauri::AppHandle,

--- a/app/src-tauri/src/transform_presets.rs
+++ b/app/src-tauri/src/transform_presets.rs
@@ -1,0 +1,131 @@
+//! Built-in spoken transform presets (issue #312 Phase D1).
+//!
+//! Pure, unit-tested name/alias → full instruction expansion. Used by
+//! `finish_transform_instruction` so a short spoken name expands to a complete
+//! rewrite prompt before the sidecar sees it. Never logs the instruction text.
+
+/// One built-in preset: canonical name, aliases, and full instruction string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransformPreset {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub instruction: &'static str,
+}
+
+/// Built-in presets shipped with #312 D1.
+pub const BUILTIN_PRESETS: &[TransformPreset] = &[
+    TransformPreset {
+        name: "Shorten",
+        aliases: &["make shorter", "shorter", "condense", "brief"],
+        instruction: "Rewrite the selected text to be shorter and more concise while preserving the original meaning, tone, and key facts. Do not add new information.",
+    },
+    TransformPreset {
+        name: "Bullets",
+        aliases: &["bullet points", "bullet list", "as bullets", "make bullets"],
+        instruction: "Rewrite the selected text as a clear bullet list. Keep each bullet one idea, preserve meaning, and do not invent facts.",
+    },
+    TransformPreset {
+        name: "Professional",
+        aliases: &["formal", "more professional", "make professional"],
+        instruction: "Rewrite the selected text in a clear, professional tone suitable for workplace communication. Preserve meaning; do not add new claims.",
+    },
+    TransformPreset {
+        name: "Fix grammar",
+        aliases: &["grammar", "fix spelling", "proofread", "correct grammar"],
+        instruction: "Fix grammar, spelling, and punctuation in the selected text. Preserve meaning and voice; do not rewrite for style beyond corrections.",
+    },
+    TransformPreset {
+        name: "Casual",
+        aliases: &["informal", "make casual", "friendlier", "more casual"],
+        instruction: "Rewrite the selected text in a friendly, casual tone. Preserve meaning and do not add new information.",
+    },
+];
+
+fn normalize(s: &str) -> String {
+    s.trim()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+/// Resolve a spoken (or typed) name to a built-in preset instruction.
+/// Case-insensitive match against canonical name and aliases. Returns
+/// `None` when no preset matches so the raw transcript is used as-is.
+pub fn resolve_preset(spoken: &str) -> Option<&'static str> {
+    let key = normalize(spoken);
+    if key.is_empty() {
+        return None;
+    }
+    for preset in BUILTIN_PRESETS {
+        if normalize(preset.name) == key {
+            return Some(preset.instruction);
+        }
+        for alias in preset.aliases {
+            if normalize(alias) == key {
+                return Some(preset.instruction);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_canonical_names_case_insensitively() {
+        assert_eq!(
+            resolve_preset("shorten"),
+            Some(BUILTIN_PRESETS[0].instruction)
+        );
+        assert_eq!(
+            resolve_preset("  BULLETS  "),
+            Some(BUILTIN_PRESETS[1].instruction)
+        );
+        assert_eq!(
+            resolve_preset("Professional"),
+            Some(BUILTIN_PRESETS[2].instruction)
+        );
+        assert_eq!(
+            resolve_preset("fix grammar"),
+            Some(BUILTIN_PRESETS[3].instruction)
+        );
+        assert_eq!(
+            resolve_preset("Casual"),
+            Some(BUILTIN_PRESETS[4].instruction)
+        );
+    }
+
+    #[test]
+    fn resolves_aliases() {
+        assert_eq!(
+            resolve_preset("make shorter"),
+            Some(BUILTIN_PRESETS[0].instruction)
+        );
+        assert_eq!(
+            resolve_preset("bullet points"),
+            Some(BUILTIN_PRESETS[1].instruction)
+        );
+        assert_eq!(
+            resolve_preset("proofread"),
+            Some(BUILTIN_PRESETS[3].instruction)
+        );
+    }
+
+    #[test]
+    fn unknown_transcript_returns_none() {
+        assert_eq!(resolve_preset("translate to french"), None);
+        assert_eq!(resolve_preset(""), None);
+        assert_eq!(resolve_preset("   "), None);
+    }
+
+    #[test]
+    fn every_preset_has_nonempty_instruction() {
+        for preset in BUILTIN_PRESETS {
+            assert!(!preset.instruction.is_empty(), "{}", preset.name);
+            assert!(!preset.name.is_empty());
+        }
+    }
+}

--- a/app/src-tauri/src/transform_presets.rs
+++ b/app/src-tauri/src/transform_presets.rs
@@ -41,12 +41,22 @@ pub const BUILTIN_PRESETS: &[TransformPreset] = &[
     },
 ];
 
-fn normalize(s: &str) -> String {
-    s.trim()
-        .split_whitespace()
+/// Normalize a spoken or typed name/key for case- and punctuation-insensitive
+/// comparison. Splits on whitespace, trims non-alphanumeric characters from
+/// each word's edges (Unicode-aware, so trailing punctuation from ASR output
+/// like "Shorten." or "Make shorter!" is stripped), lowercases per-Unicode
+/// rules, and rejoins with single spaces. Words that are pure punctuation
+/// (and thus become empty after trimming) are dropped.
+///
+/// Shared by preset resolution here and by `transform_flow::resolve_saved_transform`
+/// so both use the exact same matching rule.
+pub fn normalize(s: &str) -> String {
+    s.split_whitespace()
+        .map(|word| word.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|word| !word.is_empty())
+        .map(|word| word.chars().flat_map(char::to_lowercase).collect::<String>())
         .collect::<Vec<_>>()
         .join(" ")
-        .to_ascii_lowercase()
 }
 
 /// Resolve a spoken (or typed) name to a built-in preset instruction.
@@ -119,6 +129,43 @@ mod tests {
         assert_eq!(resolve_preset("translate to french"), None);
         assert_eq!(resolve_preset(""), None);
         assert_eq!(resolve_preset("   "), None);
+    }
+
+    /// Whisper transcripts end in terminal punctuation, so preset matching
+    /// must tolerate it (issue #312 round-2 D1 fix #1). Non-alphanumeric
+    /// edges are trimmed per word; punctuation in the middle of a name is
+    /// preserved as a word separator boundary (there is none in these cases).
+    #[test]
+    fn resolves_names_with_trailing_or_surrounding_punctuation() {
+        assert_eq!(
+            resolve_preset("Shorten."),
+            Some(BUILTIN_PRESETS[0].instruction)
+        );
+        assert_eq!(
+            resolve_preset("Make shorter!"),
+            Some(BUILTIN_PRESETS[0].instruction)
+        );
+        assert_eq!(
+            resolve_preset("  fix grammar?  "),
+            Some(BUILTIN_PRESETS[3].instruction)
+        );
+    }
+
+    #[test]
+    fn punctuation_alone_does_not_create_a_false_match() {
+        // Non-matching punctuated text still falls through (returns None) so
+        // the caller uses the raw transcript as the instruction.
+        assert_eq!(resolve_preset("translate to french."), None);
+        assert_eq!(resolve_preset("..."), None);
+        assert_eq!(resolve_preset("!?"), None);
+    }
+
+    #[test]
+    fn normalize_trims_punctuation_edges_and_lowercases() {
+        assert_eq!(normalize("Shorten."), "shorten");
+        assert_eq!(normalize("Make shorter!"), "make shorter");
+        assert_eq!(normalize("  fix grammar?  "), "fix grammar");
+        assert_eq!(normalize("..."), "");
     }
 
     #[test]

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ui_lib::llm_sidecar::{
-    model_file_digest, LlmSidecar, TestSpawnConfig, TransformError, TransformOutput,
+    model_file_digest, CancelToken, LlmSidecar, TestSpawnConfig, TransformError, TransformOutput,
 };
 
 fn helper_path() -> PathBuf {
@@ -63,8 +63,14 @@ async fn run_transform(
     sidecar: &Arc<LlmSidecar>,
     deadline: Duration,
 ) -> Result<TransformOutput, TransformError> {
+    // A fresh per-request cancel token (item 11): each request scopes its own.
     sidecar
-        .transform("Rewrite this politely.", "gimme the report", deadline)
+        .transform(
+            "Rewrite this politely.",
+            "gimme the report",
+            deadline,
+            CancelToken::new(),
+        )
         .await
 }
 
@@ -232,6 +238,7 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
             "Rewrite this politely.",
             "gimme the report",
             Duration::from_secs(30),
+            CancelToken::new(),
         )
         .await
     });
@@ -248,6 +255,8 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
     assert!(claimed, "transform never became busy");
 
     let started = std::time::Instant::now();
+    // Cancel the CURRENT in-flight request via the supervisor entry point;
+    // internally it flips only the in-flight request's per-request token.
     sidecar.cancel_inflight_request();
     let err = handle.await.unwrap().unwrap_err();
     assert_eq!(err, TransformError::Cancelled);
@@ -313,4 +322,36 @@ async fn checksum_mismatch_model_refuses_to_spawn() {
     assert_eq!(err, TransformError::ModelMismatch);
     // The helper was never launched.
     assert!(!sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn a_stale_cancel_does_not_leak_into_the_next_request() {
+    // Item 11: the cancel signal is a per-request token, not a supervisor-wide
+    // flag. A request that has already finished can have its (now-stale) token
+    // cancelled with NO effect on the next request, which carries a fresh
+    // token and must run to completion. With the old shared `cancel_requested`
+    // flag this class of leak/wipe was possible; per-request tokens rule it out.
+    let fixture = fixture_model();
+    let sidecar = sidecar("happy", &fixture);
+
+    let token_n = CancelToken::new();
+    let out = sidecar
+        .transform("instr", "input", Duration::from_secs(5), token_n.clone())
+        .await
+        .unwrap();
+    assert_eq!(out.output, "mock-output");
+
+    // Cancel the finished request's token, and hit the supervisor entry point
+    // (whose in-flight slot was cleared on completion, so it is a no-op now).
+    token_n.cancel();
+    sidecar.cancel_inflight_request();
+
+    // The NEXT request has a fresh, un-cancelled token and must succeed.
+    let token_next = CancelToken::new();
+    let out2 = sidecar
+        .transform("instr", "input", Duration::from_secs(5), token_next)
+        .await
+        .unwrap();
+    assert_eq!(out2.output, "mock-output");
+    assert!(sidecar.has_live_child());
 }

--- a/app/src/components/settings/KnowledgeEditorModal.tsx
+++ b/app/src/components/settings/KnowledgeEditorModal.tsx
@@ -7,6 +7,11 @@ import type {
   KnowledgePayload,
   KnowledgeScope,
 } from '../../lib/knowledge';
+import {
+  byteLength,
+  MAX_TRANSFORM_INSTRUCTION_BYTES,
+  presetShadowWarning,
+} from './TransformsManager';
 
 interface Props {
   entry: KnowledgeEntry | null;
@@ -98,6 +103,12 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
     }
     if (payload.kind === 'transform' && (!payload.name.trim() || !payload.instruction.trim())) {
       return 'Enter both the spoken transform name and instruction.';
+    }
+    if (payload.kind === 'transform') {
+      const bytes = byteLength(payload.instruction.trim());
+      if (bytes > MAX_TRANSFORM_INSTRUCTION_BYTES) {
+        return `Instruction is ${bytes} bytes; the limit is ${MAX_TRANSFORM_INSTRUCTION_BYTES}. Shorten it and try again.`;
+      }
     }
     if (!buildScope()) return scope.kind === 'project'
       ? 'Project scope requires an app bundle ID and project root.'
@@ -208,8 +219,30 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
               <label className="block text-xs font-medium text-on-surface">Spoken name
                 <input aria-label="Spoken name" value={payload.name} onChange={(event) => setPayload({ ...payload, name: event.target.value })} className={`${inputClass} mt-1`} maxLength={256} />
               </label>
-              <label className="block text-xs font-medium text-on-surface">Instruction
+              {(() => {
+                const warning = presetShadowWarning(payload.name);
+                return warning ? (
+                  <p className="text-xs text-amber-600 dark:text-amber-400">{warning}</p>
+                ) : null;
+              })()}
+              <label className="block text-xs font-medium text-on-surface">
+                <span className="flex items-baseline justify-between">
+                  <span>Instruction</span>
+                  <span
+                    className={
+                      byteLength(payload.instruction) > MAX_TRANSFORM_INSTRUCTION_BYTES
+                        ? 'font-normal text-red-600 dark:text-red-400'
+                        : 'font-normal text-on-surface-variant'
+                    }
+                  >
+                    {byteLength(payload.instruction)} / {MAX_TRANSFORM_INSTRUCTION_BYTES} bytes
+                  </span>
+                </span>
                 <textarea aria-label="Transform instruction" value={payload.instruction} onChange={(event) => setPayload({ ...payload, instruction: event.target.value })} className={`${inputClass} mt-1 min-h-24 resize-y`} maxLength={16_384} />
+                <span className="mt-1 block font-normal text-on-surface-variant">
+                  Presets shadow saved transforms with the same spoken name — presets always run
+                  first.
+                </span>
               </label>
             </div>
           )}

--- a/app/src/components/settings/KnowledgeEditorModal.tsx
+++ b/app/src/components/settings/KnowledgeEditorModal.tsx
@@ -74,6 +74,7 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
     if (kind === 'replacement_rule') setPayload({ kind, source: '', replacement: '' });
     if (kind === 'vocabulary_term') setPayload({ kind, written: '', aliases: [] });
     if (kind === 'snippet') setPayload({ kind, trigger: '', body: '' });
+    if (kind === 'transform') setPayload({ kind, name: '', instruction: '' });
   };
 
   const buildScope = (): KnowledgeScope | null => {
@@ -94,6 +95,9 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
     }
     if (payload.kind === 'snippet' && (!payload.trigger.trim() || !payload.body.trim())) {
       return 'Enter both the spoken trigger and snippet body.';
+    }
+    if (payload.kind === 'transform' && (!payload.name.trim() || !payload.instruction.trim())) {
+      return 'Enter both the spoken transform name and instruction.';
     }
     if (!buildScope()) return scope.kind === 'project'
       ? 'Project scope requires an app bundle ID and project root.'
@@ -164,6 +168,7 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
               <option value="replacement_rule">Replacement rule</option>
               <option value="vocabulary_term">Vocabulary term</option>
               <option value="snippet">Snippet</option>
+              <option value="transform">Transform</option>
             </select>
           </label>
 
@@ -195,6 +200,16 @@ export function KnowledgeEditorModal({ entry, profiles, onClose, onSave }: Props
               </label>
               <label className="block text-xs font-medium text-on-surface">Snippet body
                 <textarea aria-label="Snippet body" value={payload.body} onChange={(event) => setPayload({ ...payload, body: event.target.value })} className={`${inputClass} mt-1 min-h-24 resize-y font-mono`} maxLength={16_384} />
+              </label>
+            </div>
+          )}
+          {payload.kind === 'transform' && (
+            <div className="space-y-3">
+              <label className="block text-xs font-medium text-on-surface">Spoken name
+                <input aria-label="Spoken name" value={payload.name} onChange={(event) => setPayload({ ...payload, name: event.target.value })} className={`${inputClass} mt-1`} maxLength={256} />
+              </label>
+              <label className="block text-xs font-medium text-on-surface">Instruction
+                <textarea aria-label="Transform instruction" value={payload.instruction} onChange={(event) => setPayload({ ...payload, instruction: event.target.value })} className={`${inputClass} mt-1 min-h-24 resize-y`} maxLength={16_384} />
               </label>
             </div>
           )}

--- a/app/src/components/settings/KnowledgeManager.tsx
+++ b/app/src/components/settings/KnowledgeManager.tsx
@@ -30,6 +30,7 @@ const KIND_LABELS: Record<KnowledgeKind, string> = {
   replacement_rule: 'Replacement',
   vocabulary_term: 'Vocabulary',
   snippet: 'Snippet',
+  transform: 'Transform',
 };
 
 function formatUpdated(timestamp: number) {
@@ -181,7 +182,7 @@ export function KnowledgeManager({ active, profiles }: Props) {
       <div className="grid gap-2 md:grid-cols-[minmax(180px,1fr)_repeat(3,minmax(105px,auto))]">
         <input value={query} onChange={(event) => setQuery(event.target.value)} aria-label="Search personal knowledge" placeholder="Search knowledge…" className="rounded-lg border border-outline-variant/40 bg-surface-container-lowest px-3 py-2 text-xs outline-none focus:border-primary" />
         <select aria-label="Filter knowledge type" value={kind} onChange={(event) => setKind(event.target.value as KnowledgeKind | 'all')} className="rounded-lg border border-outline-variant/40 bg-surface-container-lowest px-2 py-2 text-xs">
-          <option value="all">All types</option><option value="replacement_rule">Replacements</option><option value="vocabulary_term">Vocabulary</option><option value="snippet">Snippets</option>
+          <option value="all">All types</option><option value="replacement_rule">Replacements</option><option value="vocabulary_term">Vocabulary</option><option value="snippet">Snippets</option><option value="transform">Transforms</option>
         </select>
         <select aria-label="Filter enabled state" value={enabled} onChange={(event) => setEnabled(event.target.value as typeof enabled)} className="rounded-lg border border-outline-variant/40 bg-surface-container-lowest px-2 py-2 text-xs">
           <option value="all">Any state</option><option value="enabled">Enabled</option><option value="disabled">Disabled</option>

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -23,6 +23,7 @@ vi.mock('./KnowledgeManager', () => ({ KnowledgeManager: () => <div>Knowledge ma
 vi.mock('./PerformanceLab', () => ({ PerformanceLab: () => <div>Performance lab</div> }));
 vi.mock('./VocabularyAliasesEditor', () => ({ VocabularyAliasesEditor: () => <div>Vocabulary editor</div> }));
 vi.mock('./VoiceCommandsManager', () => ({ VoiceCommandsManager: () => <div>Voice commands editor</div> }));
+vi.mock('./TransformsManager', () => ({ TransformsManager: () => <div>Transforms manager</div> }));
 vi.mock('./VocabScanStrip', () => ({ VocabScanStrip: () => <div>Vocabulary scan</div> }));
 
 describe('SettingsPanel information architecture', () => {
@@ -59,9 +60,9 @@ describe('SettingsPanel information architecture', () => {
     container.remove();
   });
 
-  it('renders exactly six ordered pages with Recording selected first', () => {
+  it('renders ordered pages with Recording selected first (includes Transform)', () => {
     expect(SETTINGS_CATEGORIES.map((category) => category.label)).toEqual([
-      'Recording', 'Transcription', 'Text & Vocabulary', 'Delivery', 'Performance', 'General',
+      'Recording', 'Transcription', 'Transform', 'Text & Vocabulary', 'Delivery', 'Performance', 'General',
     ]);
     const nav = container.querySelector('nav[aria-label="Settings pages"]') as HTMLElement;
     expect(Array.from(nav.querySelectorAll('button')).slice(1).map((button) => button.textContent)).toEqual(SETTINGS_CATEGORIES.map((category) => category.label));

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -2,6 +2,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../lib/settings';
+import type { TransformModelStatus } from '../../lib/transformSettings';
 import {
   SETTINGS_CATEGORIES,
   SettingsPanel,
@@ -25,6 +26,22 @@ vi.mock('./VocabularyAliasesEditor', () => ({ VocabularyAliasesEditor: () => <di
 vi.mock('./VoiceCommandsManager', () => ({ VoiceCommandsManager: () => <div>Voice commands editor</div> }));
 vi.mock('./TransformsManager', () => ({ TransformsManager: () => <div>Transforms manager</div> }));
 vi.mock('./VocabScanStrip', () => ({ VocabScanStrip: () => <div>Vocabulary scan</div> }));
+
+const transformMocks = vi.hoisted(() => ({
+  status: null as TransformModelStatus | null,
+  setTransformKey: vi.fn(async () => {}),
+  startTransformListener: vi.fn(async () => {}),
+}));
+vi.mock('../../lib/transformSettings', () => ({
+  TRANSFORM_MODEL_SIZE_LABEL: '1.1 GB',
+  transformModelStatus: vi.fn(async () => transformMocks.status),
+  downloadTransformModel: vi.fn(async () => {}),
+  removeTransformModel: vi.fn(async () => {}),
+  resetTransformRuntime: vi.fn(async () => {}),
+  setTransformKey: transformMocks.setTransformKey,
+  startTransformListener: transformMocks.startTransformListener,
+  stopTransformListener: vi.fn(async () => {}),
+}));
 
 describe('SettingsPanel information architecture', () => {
   let container: HTMLDivElement;
@@ -103,5 +120,88 @@ describe('effectiveAutoPaste', () => {
     expect(fileOutputDeliveryDescription({ autoPaste: false })).toBe(
       'Clipboard copying stays on; auto-paste remains off.',
     );
+  });
+});
+
+describe('SettingsPanel transform block (#312 D1 round-2 findings 6-8)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  async function renderAndOpenTransform(settingsOverrides: Partial<typeof DEFAULT_SETTINGS> = {}) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', { value: vi.fn(), configurable: true });
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { value: vi.fn(), configurable: true });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(
+      <SettingsPanel
+        isOpen
+        onClose={vi.fn()}
+        settings={{ ...DEFAULT_SETTINGS, ...settingsOverrides }}
+        onUpdateSettings={vi.fn()}
+        status="idle"
+        onResetStats={vi.fn()}
+        onViewLogs={vi.fn()}
+        onRerunSetup={vi.fn()}
+        accessibilityGranted
+        onCheckForUpdate={vi.fn(async () => {})}
+        updateStatus={{ phase: 'idle' }}
+        configureError={null}
+      />,
+    ));
+    const button = Array.from(container.querySelectorAll('nav button')).find((item) => item.textContent === 'Transform') as HTMLButtonElement;
+    await act(async () => button.click());
+    // Let the transformModelStatus() fetch effect resolve.
+    await act(async () => {});
+  }
+
+  beforeEach(() => {
+    transformMocks.status = null;
+    transformMocks.setTransformKey.mockReset();
+    transformMocks.startTransformListener.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('disables the Download button while the backend reports downloading (finding 6)', async () => {
+    transformMocks.status = { state: 'downloading', path: null, sizeBytes: 100, sha256: 'x', runtimeDisabled: false };
+    await renderAndOpenTransform();
+    const downloadButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Working…') as HTMLButtonElement;
+    expect(downloadButton).toBeTruthy();
+    expect(downloadButton.disabled).toBe(true);
+  });
+
+  it('hides the Reset runtime button and notice when the breaker is not disabled (finding 7)', async () => {
+    transformMocks.status = { state: 'ready', path: '/models/x', sizeBytes: 100, sha256: 'x', runtimeDisabled: false };
+    await renderAndOpenTransform();
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === 'Reset runtime')).toBe(false);
+    expect(container.textContent).not.toContain('disabled after repeated faults');
+  });
+
+  it('shows the Reset runtime button and notice when runtimeDisabled is set (finding 7)', async () => {
+    transformMocks.status = { state: 'ready', path: '/models/x', sizeBytes: 100, sha256: 'x', runtimeDisabled: true };
+    await renderAndOpenTransform();
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === 'Reset runtime')).toBe(true);
+    expect(container.textContent).toContain('disabled after repeated faults');
+  });
+
+  it('renders shortcut-picker errors on their own line, not the model error slot (finding 8)', async () => {
+    transformMocks.status = { state: 'ready', path: '/models/x', sizeBytes: 100, sha256: 'x', runtimeDisabled: false };
+    transformMocks.setTransformKey.mockRejectedValue(new Error('shortcut already in use'));
+    await renderAndOpenTransform({ transformHoldKey: 'alt_r' });
+
+    const combobox = container.querySelector('button[role="combobox"]') as HTMLButtonElement;
+    await act(async () => combobox.click());
+    const option = Array.from(container.querySelectorAll('li[role="option"]')).find(
+      (li) => li.textContent === 'Left Control',
+    ) as HTMLLIElement;
+    await act(async () => option.click());
+
+    const errorParagraphs = Array.from(container.querySelectorAll('p')).filter((p) => p.className.includes('text-error'));
+    expect(errorParagraphs).toHaveLength(1);
+    expect(errorParagraphs[0].textContent).toContain('shortcut already in use');
   });
 });

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -10,8 +10,10 @@ import {
   IDLE_TIMEOUT_OPTIONS,
   LANGUAGE_OPTIONS,
   RECORDING_MODE_OPTIONS,
+  TRANSFORM_KEY_OPTIONS,
   type RecordingMode,
   type Settings,
+  type TransformKey,
   vocabularyPrompt,
 } from '../../lib/settings';
 import { useVocabScan } from '../../lib/hooks/useVocabScan';
@@ -21,6 +23,17 @@ import {
   modelDownloadPercent,
   type ModelDownloadProgress,
 } from '../../lib/modelDownload';
+import {
+  downloadTransformModel,
+  removeTransformModel,
+  resetTransformRuntime,
+  setTransformKey,
+  startTransformListener,
+  stopTransformListener,
+  TRANSFORM_MODEL_SIZE_LABEL,
+  transformModelStatus,
+  type TransformModelStatus,
+} from '../../lib/transformSettings';
 import type { DictationStatus } from '../../lib/types';
 import type { UpdateStatus } from '../../lib/updater';
 import { Select } from '../ui/Select';
@@ -28,6 +41,7 @@ import { AppOverridesEditor } from './AppOverridesEditor';
 import { KnowledgeManager } from './KnowledgeManager';
 import { PerformanceLab } from './PerformanceLab';
 import { SettingsSection } from './SettingsSection';
+import { TransformsManager } from './TransformsManager';
 import { VocabScanStrip } from './VocabScanStrip';
 import { VocabularyAliasesEditor } from './VocabularyAliasesEditor';
 import { VoiceCommandsManager } from './VoiceCommandsManager';
@@ -138,6 +152,7 @@ interface SettingsPanelProps {
 export const SETTINGS_CATEGORIES = [
   { id: 'recording', label: 'Recording' },
   { id: 'transcription', label: 'Transcription' },
+  { id: 'transform', label: 'Transform' },
   { id: 'text-vocabulary', label: 'Text & Vocabulary' },
   { id: 'delivery', label: 'Delivery' },
   { id: 'performance', label: 'Performance' },
@@ -271,6 +286,106 @@ export function SettingsPanel({
     invoke<string[]>('list_audio_devices').then(setAudioDevices).catch(() => setAudioDevices([]));
   }, [isOpen]);
 
+  // ---- Transform model block (#312 D1) ------------------------------------
+  const [transformModel, setTransformModel] = useState<TransformModelStatus | null>(null);
+  const [transformModelBusy, setTransformModelBusy] = useState(false);
+  const [transformModelError, setTransformModelError] = useState<string | null>(null);
+  const [transformDownloadPct, setTransformDownloadPct] = useState<number | null>(null);
+
+  const refreshTransformModel = useCallback(async () => {
+    try {
+      setTransformModel(await transformModelStatus());
+    } catch {
+      setTransformModel(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || activeCat !== 'transform') return;
+    void refreshTransformModel();
+  }, [isOpen, activeCat, refreshTransformModel]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let unlisten: (() => void) | null = null;
+    listen<{ downloadedBytes?: number; totalBytes?: number; received?: number; total?: number }>(
+      'transform-model-download-progress',
+      (event) => {
+        const p = event.payload;
+        const received = p.downloadedBytes ?? p.received ?? 0;
+        const total = p.totalBytes ?? p.total ?? 0;
+        if (total > 0) setTransformDownloadPct(Math.min(100, Math.round((received / total) * 100)));
+        else setTransformDownloadPct(null);
+      },
+    )
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch(() => {});
+    return () => {
+      unlisten?.();
+    };
+  }, [isOpen]);
+
+  const updateTransformHoldKey = async (next: TransformKey | null) => {
+    try {
+      if (next === null) {
+        await stopTransformListener();
+        onUpdateSettings({ transformHoldKey: null });
+        return;
+      }
+      await setTransformKey(next);
+      await startTransformListener(next);
+      onUpdateSettings({ transformHoldKey: next });
+    } catch (e) {
+      setTransformModelError(String(e));
+    }
+  };
+
+  const downloadTransform = async () => {
+    setTransformModelBusy(true);
+    setTransformModelError(null);
+    setTransformDownloadPct(0);
+    try {
+      await downloadTransformModel();
+      await refreshTransformModel();
+    } catch (e) {
+      setTransformModelError(String(e));
+    } finally {
+      setTransformModelBusy(false);
+      setTransformDownloadPct(null);
+    }
+  };
+
+  const removeTransform = async () => {
+    if (!window.confirm('Remove the on-device transform model (~1.1 GB)? You can re-download it later.')) {
+      return;
+    }
+    setTransformModelBusy(true);
+    setTransformModelError(null);
+    try {
+      await removeTransformModel();
+      await refreshTransformModel();
+    } catch (e) {
+      setTransformModelError(String(e));
+    } finally {
+      setTransformModelBusy(false);
+    }
+  };
+
+  const resetTransform = async () => {
+    setTransformModelBusy(true);
+    setTransformModelError(null);
+    try {
+      await resetTransformRuntime();
+      await refreshTransformModel();
+    } catch (e) {
+      setTransformModelError(String(e));
+    } finally {
+      setTransformModelBusy(false);
+    }
+  };
+
   const isRecording = status !== 'idle';
   const isDoubleTap = settings.recordingMode === 'double_tap';
   const isBoth = settings.recordingMode === 'both';
@@ -362,6 +477,117 @@ export function SettingsPanel({
               <p className="mt-1 text-xs text-on-surface-variant">{keyHelp}</p>
             </div>
             {(isDoubleTap || isBoth) && <SettingToggle title="Hotkey Timing Feedback" description="Flash the overlay when a tap misses the double-tap window." checked={settings.hotkeyMissFeedback} onChange={() => onUpdateSettings({ hotkeyMissFeedback: !settings.hotkeyMissFeedback })} />}
+          </SettingsSection>
+
+          <SettingsSection pageId="transform" activePage={activeCat} title="Transform" subtitle="Selected-text rewrite with a local on-device model">
+            <div className="rounded-xl border border-primary/20 bg-primary/5 p-3">
+              <p className="text-sm font-medium text-on-surface">Local only · Apple Silicon</p>
+              <p className="mt-1 text-xs text-on-surface-variant">
+                Hold a dedicated shortcut, speak an instruction, and review a proposed rewrite before
+                anything is written. The model stays on-device ({TRANSFORM_MODEL_SIZE_LABEL} download).
+                Never auto-applies.
+              </p>
+            </div>
+            <SettingToggle
+              title="Enable Transform Shortcut"
+              description="Hold the transform key while text is selected to capture a rewrite instruction."
+              checked={settings.transformHoldKey !== null}
+              onChange={() => {
+                void updateTransformHoldKey(
+                  settings.transformHoldKey === null ? 'alt_r' : null,
+                );
+              }}
+            />
+            {settings.transformHoldKey !== null && (
+              <div className="ml-3 space-y-2 border-l border-outline-variant/30 pl-3">
+                <label className="mb-1 block text-sm font-medium text-on-surface">Hold key</label>
+                <Select
+                  value={settings.transformHoldKey}
+                  onChange={(value) => {
+                    void updateTransformHoldKey(value as TransformKey);
+                  }}
+                  items={TRANSFORM_KEY_OPTIONS}
+                />
+                <p className="text-xs text-on-surface-variant">
+                  Dictation hold keys are rejected. Right Option / Left Control / Right Shift only.
+                </p>
+                {accessibilityGranted === false && (
+                  <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                    <span>Accessibility permission is required for transform capture and apply.</span>
+                    <button type="button" onClick={requestAccessibility} className="ml-auto underline">Grant</button>
+                  </div>
+                )}
+              </div>
+            )}
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="text-sm font-medium text-on-surface">On-device model</h2>
+              <p className="mt-1 mb-3 text-xs text-on-surface-variant">
+                Qwen2.5-1.5B Instruct (Q4_K_M), {TRANSFORM_MODEL_SIZE_LABEL}. Downloaded to
+                Application Support; verified by size and SHA-256. Apple Silicon only.
+              </p>
+              {transformModel && (
+                <p className="mb-2 text-xs text-on-surface-variant" data-testid="transform-model-status">
+                  Status:{' '}
+                  {transformModel.state === 'ready'
+                    ? 'Ready'
+                    : transformModel.state === 'downloading'
+                      ? 'Downloading…'
+                      : 'Not downloaded'}
+                </p>
+              )}
+              {transformDownloadPct !== null && (
+                <div className="mb-2">
+                  <div className="mb-1 flex justify-between text-xs text-on-surface-variant">
+                    <span>Downloading transform model</span>
+                    <span>{transformDownloadPct}%</span>
+                  </div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-surface-container-highest">
+                    <div
+                      className="h-full rounded-full bg-primary transition-all duration-200"
+                      style={{ width: `${transformDownloadPct}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+              {transformModelError && (
+                <p className="mb-2 text-xs text-error">{transformModelError}</p>
+              )}
+              <div className="flex flex-wrap gap-2">
+                {transformModel?.state !== 'ready' && (
+                  <button
+                    type="button"
+                    disabled={transformModelBusy}
+                    onClick={() => void downloadTransform()}
+                    className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary disabled:opacity-50"
+                  >
+                    {transformModelBusy ? 'Working…' : 'Download'}
+                  </button>
+                )}
+                {transformModel?.state === 'ready' && (
+                  <button
+                    type="button"
+                    disabled={transformModelBusy}
+                    onClick={() => void removeTransform()}
+                    className="rounded-lg border border-outline-variant/30 px-3 py-1.5 text-xs font-medium text-on-surface-variant disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                )}
+                <button
+                  type="button"
+                  disabled={transformModelBusy}
+                  onClick={() => void resetTransform()}
+                  className="rounded-lg border border-outline-variant/30 px-3 py-1.5 text-xs font-medium text-on-surface-variant disabled:opacity-50"
+                  title="Clear the circuit breaker if the transform runtime was disabled after repeated faults"
+                >
+                  Reset runtime
+                </button>
+              </div>
+            </div>
+            <div className="border-t border-outline-variant/20 pt-4">
+              <h2 className="mb-1 text-sm font-medium text-on-surface">Saved transforms</h2>
+              <TransformsManager active={isOpen && activeCat === 'transform'} />
+            </div>
           </SettingsSection>
 
           <SettingsSection pageId="transcription" activePage={activeCat} title="Transcription" subtitle="Model, language, and runtime lifecycle">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -290,6 +290,9 @@ export function SettingsPanel({
   const [transformModel, setTransformModel] = useState<TransformModelStatus | null>(null);
   const [transformModelBusy, setTransformModelBusy] = useState(false);
   const [transformModelError, setTransformModelError] = useState<string | null>(null);
+  // Shortcut-picker failures get their own error line, separate from the model
+  // block's error slot (#312 D1 round-2 finding 8).
+  const [transformKeyError, setTransformKeyError] = useState<string | null>(null);
   const [transformDownloadPct, setTransformDownloadPct] = useState<number | null>(null);
 
   const refreshTransformModel = useCallback(async () => {
@@ -308,12 +311,10 @@ export function SettingsPanel({
   useEffect(() => {
     if (!isOpen) return;
     let unlisten: (() => void) | null = null;
-    listen<{ downloadedBytes?: number; totalBytes?: number; received?: number; total?: number }>(
+    listen<{ received?: number; total?: number }>(
       'transform-model-download-progress',
       (event) => {
-        const p = event.payload;
-        const received = p.downloadedBytes ?? p.received ?? 0;
-        const total = p.totalBytes ?? p.total ?? 0;
+        const { received = 0, total = 0 } = event.payload;
         if (total > 0) setTransformDownloadPct(Math.min(100, Math.round((received / total) * 100)));
         else setTransformDownloadPct(null);
       },
@@ -328,6 +329,7 @@ export function SettingsPanel({
   }, [isOpen]);
 
   const updateTransformHoldKey = async (next: TransformKey | null) => {
+    setTransformKeyError(null);
     try {
       if (next === null) {
         await stopTransformListener();
@@ -338,7 +340,7 @@ export function SettingsPanel({
       await startTransformListener(next);
       onUpdateSettings({ transformHoldKey: next });
     } catch (e) {
-      setTransformModelError(String(e));
+      setTransformKeyError(String(e));
     }
   };
 
@@ -511,6 +513,9 @@ export function SettingsPanel({
                 <p className="text-xs text-on-surface-variant">
                   Dictation hold keys are rejected. Right Option / Left Control / Right Shift only.
                 </p>
+                {transformKeyError && (
+                  <p className="text-xs text-error">{transformKeyError}</p>
+                )}
                 {accessibilityGranted === false && (
                   <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
                     <span>Accessibility permission is required for transform capture and apply.</span>
@@ -556,11 +561,11 @@ export function SettingsPanel({
                 {transformModel?.state !== 'ready' && (
                   <button
                     type="button"
-                    disabled={transformModelBusy}
+                    disabled={transformModelBusy || transformModel?.state === 'downloading'}
                     onClick={() => void downloadTransform()}
                     className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary disabled:opacity-50"
                   >
-                    {transformModelBusy ? 'Working…' : 'Download'}
+                    {transformModelBusy || transformModel?.state === 'downloading' ? 'Working…' : 'Download'}
                   </button>
                 )}
                 {transformModel?.state === 'ready' && (
@@ -573,16 +578,23 @@ export function SettingsPanel({
                     Remove
                   </button>
                 )}
-                <button
-                  type="button"
-                  disabled={transformModelBusy}
-                  onClick={() => void resetTransform()}
-                  className="rounded-lg border border-outline-variant/30 px-3 py-1.5 text-xs font-medium text-on-surface-variant disabled:opacity-50"
-                  title="Clear the circuit breaker if the transform runtime was disabled after repeated faults"
-                >
-                  Reset runtime
-                </button>
+                {transformModel?.runtimeDisabled && (
+                  <button
+                    type="button"
+                    disabled={transformModelBusy}
+                    onClick={() => void resetTransform()}
+                    className="rounded-lg border border-outline-variant/30 px-3 py-1.5 text-xs font-medium text-on-surface-variant disabled:opacity-50"
+                    title="Clear the circuit breaker if the transform runtime was disabled after repeated faults"
+                  >
+                    Reset runtime
+                  </button>
+                )}
               </div>
+              {transformModel?.runtimeDisabled && (
+                <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  The transform runtime was disabled after repeated faults. Reset it to try again.
+                </p>
+              )}
             </div>
             <div className="border-t border-outline-variant/20 pt-4">
               <h2 className="mb-1 text-sm font-medium text-on-surface">Saved transforms</h2>

--- a/app/src/components/settings/TransformsManager.tsx
+++ b/app/src/components/settings/TransformsManager.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from 'react';
+import {
+  deleteKnowledge,
+  setKnowledgeEnabled,
+  upsertKnowledge,
+  type KnowledgeDraft,
+  type KnowledgeEntry,
+} from '../../lib/knowledge';
+import { useKnowledge } from '../../lib/hooks/useKnowledge';
+
+interface Props {
+  active: boolean;
+}
+
+function TransformEditor({
+  entry,
+  onClose,
+  onSaved,
+}: {
+  entry: KnowledgeEntry | null;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const [name, setName] = useState(
+    entry?.payload.kind === 'transform' ? entry.payload.name : '',
+  );
+  const [instruction, setInstruction] = useState(
+    entry?.payload.kind === 'transform' ? entry.payload.instruction : '',
+  );
+  const [enabled, setEnabled] = useState(entry?.enabled ?? true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const draft = useMemo<KnowledgeDraft>(() => ({
+    id: entry?.id,
+    expectedRevision: entry?.revision,
+    payload: { kind: 'transform', name: name.trim(), instruction: instruction.trim() },
+    enabled,
+    scope: { kind: 'global' },
+  }), [enabled, entry, instruction, name]);
+
+  const save = async () => {
+    if (!name.trim()) {
+      setError('Enter a spoken name (e.g. “meeting notes”).');
+      return;
+    }
+    if (!instruction.trim()) {
+      setError('Enter the full rewrite instruction.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await upsertKnowledge(draft);
+      await onSaved();
+      onClose();
+    } catch (cause) {
+      setError(String(cause));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-3">
+      <div>
+        <label className="mb-1 block text-xs font-medium text-on-surface">Spoken name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded-lg border border-outline-variant/30 bg-surface px-3 py-2 text-sm text-on-surface"
+          placeholder="e.g. meeting notes"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-on-surface">Instruction</label>
+        <textarea
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          rows={4}
+          className="w-full rounded-lg border border-outline-variant/30 bg-surface px-3 py-2 text-sm text-on-surface"
+          placeholder="Rewrite as concise meeting notes with action items…"
+        />
+      </div>
+      <label className="flex items-center gap-2 text-xs text-on-surface">
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Enabled
+      </label>
+      {error && <p className="text-xs text-error">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void save()}
+          className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button type="button" onClick={onClose} className="rounded-lg px-3 py-1.5 text-xs text-on-surface-variant underline">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const TRANSFORM_LIST_REQUEST = { kind: 'transform' as const, limit: 100 };
+
+/**
+ * CRUD list for user-defined selected-text transforms (issue #312 D1).
+ * Mirrors the snippets/voice-commands manager idiom via the knowledge store.
+ */
+export function TransformsManager({ active }: Props) {
+  const { entries, loading, error, refresh } = useKnowledge(TRANSFORM_LIST_REQUEST, active);
+  const [editing, setEditing] = useState<KnowledgeEntry | null | 'new'>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-on-surface-variant">
+          Speak a saved name during transform hold to expand it to the full instruction.
+          Built-ins: Shorten, Bullets, Professional, Fix grammar, Casual.
+        </p>
+        <button
+          type="button"
+          onClick={() => setEditing('new')}
+          className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary"
+        >
+          Add
+        </button>
+      </div>
+
+      {editing !== null && (
+        <TransformEditor
+          entry={editing === 'new' ? null : editing}
+          onClose={() => setEditing(null)}
+          onSaved={async () => {
+            await refresh();
+          }}
+        />
+      )}
+
+      {(error || actionError) && (
+        <p className="text-xs text-error">{error ?? actionError}</p>
+      )}
+      {loading && entries.length === 0 && (
+        <p className="text-xs text-on-surface-variant">Loading…</p>
+      )}
+      {!loading && entries.length === 0 && editing === null && (
+        <p className="text-xs text-on-surface-variant">No saved transforms yet.</p>
+      )}
+
+      <ul className="space-y-2">
+        {entries.map((entry) => {
+          const name = entry.payload.kind === 'transform' ? entry.payload.name : entry.id;
+          const instruction =
+            entry.payload.kind === 'transform' ? entry.payload.instruction : '';
+          return (
+            <li
+              key={entry.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-outline-variant/20 bg-surface-container-lowest px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-on-surface">
+                  {name}
+                  {!entry.enabled && (
+                    <span className="ml-2 text-xs font-normal text-on-surface-variant">(disabled)</span>
+                  )}
+                </p>
+                <p className="mt-0.5 line-clamp-2 text-xs text-on-surface-variant">{instruction}</p>
+              </div>
+              <div className="flex shrink-0 flex-col items-end gap-1">
+                <button
+                  type="button"
+                  className="text-xs text-on-surface-variant underline"
+                  onClick={() => setEditing(entry)}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-on-surface-variant underline"
+                  onClick={() => {
+                    void setKnowledgeEnabled(entry, !entry.enabled)
+                      .then(() => refresh())
+                      .catch((e) => setActionError(String(e)));
+                  }}
+                >
+                  {entry.enabled ? 'Disable' : 'Enable'}
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-error underline"
+                  onClick={() => {
+                    if (!window.confirm(`Delete transform “${name}”?`)) return;
+                    void deleteKnowledge(entry)
+                      .then(() => refresh())
+                      .catch((e) => setActionError(String(e)));
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/app/src/components/settings/TransformsManager.tsx
+++ b/app/src/components/settings/TransformsManager.tsx
@@ -12,6 +12,54 @@ interface Props {
   active: boolean;
 }
 
+/// Same cap the sidecar protocol and knowledge_store::validate_payload
+/// enforce (murmur_local_llm_protocol::MAX_INSTRUCTION_BYTES). Kept as a
+/// local mirror since this component cannot import Rust constants; bytes,
+/// not chars, to match the Rust-side check exactly (issue #312 round 2 D1
+/// fix #3).
+export const MAX_TRANSFORM_INSTRUCTION_BYTES = 4096;
+
+export function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+/**
+ * Mirrors `app/src-tauri/src/transform_presets.rs` BUILTIN_PRESETS (name +
+ * aliases). Used only to warn a user at save time that their chosen name is
+ * shadowed by a built-in preset — the Rust side (`transform_presets::resolve_preset`,
+ * checked before saved transforms in `transform_flow::expand_instruction`) is
+ * the sole source of truth for actual preset matching. Keep this list in
+ * sync when presets change.
+ */
+const BUILTIN_TRANSFORM_PRESET_NAMES = [
+  'Shorten', 'make shorter', 'shorter', 'condense', 'brief',
+  'Bullets', 'bullet points', 'bullet list', 'as bullets', 'make bullets',
+  'Professional', 'formal', 'more professional', 'make professional',
+  'Fix grammar', 'grammar', 'fix spelling', 'proofread', 'correct grammar',
+  'Casual', 'informal', 'make casual', 'friendlier', 'more casual',
+];
+
+/** Case- and punctuation-insensitive key, mirroring the Rust `normalize()`
+ * used for both preset and saved-transform name matching. */
+export function normalizeTransformKey(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((word) => word.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''))
+    .filter((word) => word.length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
+const NORMALIZED_PRESET_NAMES = new Set(
+  BUILTIN_TRANSFORM_PRESET_NAMES.map(normalizeTransformKey),
+);
+
+export function presetShadowWarning(name: string): string | null {
+  const key = normalizeTransformKey(name);
+  if (key.length === 0 || !NORMALIZED_PRESET_NAMES.has(key)) return null;
+  return 'This name matches a built-in preset. Speaking it will run the built-in preset instead — presets always take precedence over saved transforms with the same name.';
+}
+
 function TransformEditor({
   entry,
   onClose,
@@ -31,6 +79,10 @@ function TransformEditor({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
+  const instructionBytes = byteLength(instruction.trim());
+  const overInstructionLimit = instructionBytes > MAX_TRANSFORM_INSTRUCTION_BYTES;
+  const shadowWarning = presetShadowWarning(name);
+
   const draft = useMemo<KnowledgeDraft>(() => ({
     id: entry?.id,
     expectedRevision: entry?.revision,
@@ -46,6 +98,12 @@ function TransformEditor({
     }
     if (!instruction.trim()) {
       setError('Enter the full rewrite instruction.');
+      return;
+    }
+    if (overInstructionLimit) {
+      setError(
+        `Instruction is ${instructionBytes} bytes; the limit is ${MAX_TRANSFORM_INSTRUCTION_BYTES}. Shorten it and try again.`,
+      );
       return;
     }
     setSaving(true);
@@ -71,9 +129,19 @@ function TransformEditor({
           className="w-full rounded-lg border border-outline-variant/30 bg-surface px-3 py-2 text-sm text-on-surface"
           placeholder="e.g. meeting notes"
         />
+        {shadowWarning && (
+          <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">{shadowWarning}</p>
+        )}
       </div>
       <div>
-        <label className="mb-1 block text-xs font-medium text-on-surface">Instruction</label>
+        <div className="mb-1 flex items-baseline justify-between">
+          <label className="block text-xs font-medium text-on-surface">Instruction</label>
+          <span
+            className={`text-xs ${overInstructionLimit ? 'text-error' : 'text-on-surface-variant'}`}
+          >
+            {instructionBytes} / {MAX_TRANSFORM_INSTRUCTION_BYTES} bytes
+          </span>
+        </div>
         <textarea
           value={instruction}
           onChange={(e) => setInstruction(e.target.value)}
@@ -81,6 +149,12 @@ function TransformEditor({
           className="w-full rounded-lg border border-outline-variant/30 bg-surface px-3 py-2 text-sm text-on-surface"
           placeholder="Rewrite as concise meeting notes with action items…"
         />
+        {overInstructionLimit && (
+          <p className="mt-1 text-xs text-error">
+            Instruction exceeds the {MAX_TRANSFORM_INSTRUCTION_BYTES}-byte limit enforced by the
+            local transform model.
+          </p>
+        )}
       </div>
       <label className="flex items-center gap-2 text-xs text-on-surface">
         <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
@@ -90,7 +164,7 @@ function TransformEditor({
       <div className="flex gap-2">
         <button
           type="button"
-          disabled={saving}
+          disabled={saving || overInstructionLimit}
           onClick={() => void save()}
           className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary disabled:opacity-50"
         >
@@ -120,7 +194,9 @@ export function TransformsManager({ active }: Props) {
       <div className="flex items-center justify-between gap-2">
         <p className="text-xs text-on-surface-variant">
           Speak a saved name during transform hold to expand it to the full instruction.
-          Built-ins: Shorten, Bullets, Professional, Fix grammar, Casual.
+          Built-ins: Shorten, Bullets, Professional, Fix grammar, Casual. If a saved name
+          matches a built-in preset (or one of its aliases), the built-in preset always
+          runs instead — rename the saved transform to avoid being shadowed.
         </p>
         <button
           type="button"

--- a/app/src/components/transform-review/ReviewApplied.tsx
+++ b/app/src/components/transform-review/ReviewApplied.tsx
@@ -1,13 +1,24 @@
 interface ReviewAppliedProps {
   onUndo: () => void;
+  /** Set when the last undo attempt failed — the text stays applied and Undo stays available. */
+  errorMessage?: string | null;
 }
 
 /** Transient "applied" row: check + "Replaced" + Undo. Auto-dismisses via the driver's own timer. */
-export function ReviewApplied({ onUndo }: ReviewAppliedProps) {
+export function ReviewApplied({ onUndo, errorMessage }: ReviewAppliedProps) {
   return (
     <div className="flex items-center gap-2 px-3 pb-3 text-[12px] text-white/80">
-      <span className="text-emerald-400" aria-hidden="true">✓</span>
-      <span>Replaced</span>
+      {errorMessage ? (
+        <>
+          <span className="text-amber-400" aria-hidden="true">!</span>
+          <span className="text-amber-200/90">{errorMessage}</span>
+        </>
+      ) : (
+        <>
+          <span className="text-emerald-400" aria-hidden="true">✓</span>
+          <span>Replaced</span>
+        </>
+      )}
       <button
         type="button"
         onClick={onUndo}

--- a/app/src/components/transform-review/TransformReviewApp.tsx
+++ b/app/src/components/transform-review/TransformReviewApp.tsx
@@ -162,7 +162,7 @@ export function TransformReviewApp() {
 
       {vm.showDiff && <ReviewDiff original={driver.content.original} proposed={driver.content.proposed} />}
 
-      {vm.errorMessage && (
+      {vm.errorMessage && !vm.showUndo && (
         <div className="px-3 py-2 text-[12px] text-red-300/90">{vm.errorMessage}</div>
       )}
 

--- a/app/src/components/transform-review/TransformReviewApp.tsx
+++ b/app/src/components/transform-review/TransformReviewApp.tsx
@@ -166,7 +166,7 @@ export function TransformReviewApp() {
         <div className="px-3 py-2 text-[12px] text-red-300/90">{vm.errorMessage}</div>
       )}
 
-      {vm.showUndo && <ReviewApplied onUndo={driver.undo} />}
+      {vm.showUndo && <ReviewApplied onUndo={driver.undo} errorMessage={vm.errorMessage} />}
 
       {(vm.approveEnabled || vm.retryEnabled || vm.cancelEnabled) && (
         <ReviewActions

--- a/app/src/components/transform-review/deriveReviewState.ts
+++ b/app/src/components/transform-review/deriveReviewState.ts
@@ -107,6 +107,7 @@ export function deriveReviewState(input: ReviewStateInput): ReviewViewModel {
       return {
         ...baseViewModel(state, instruction),
         showUndo: true,
+        errorMessage: errorCode ? errorMessageFor(errorCode) : null,
       };
 
     default: {

--- a/app/src/lib/hooks/useTransformReviewDriver.test.tsx
+++ b/app/src/lib/hooks/useTransformReviewDriver.test.tsx
@@ -133,6 +133,40 @@ describe('useTransformReviewDriver (real driver)', () => {
     expect(names).toContain('cancel_transform');
   });
 
+  it('clears content on a backend-initiated transform-review-hidden signal', async () => {
+    mocks.invoke.mockResolvedValue(CONTENT);
+
+    function Harness() {
+      current = useTransformReviewDriver(true);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Populate content via a normal state change first.
+    await act(async () => {
+      mocks.listeners['transform-state-changed']?.({ payload: { state: 'ready' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(current!.content).toEqual(CONTENT);
+
+    // A backend-initiated hide (item 13) must reset the stale content so it
+    // cannot flash on the next show.
+    expect(mocks.listeners['transform-review-hidden']).toBeDefined();
+    await act(async () => {
+      mocks.listeners['transform-review-hidden']?.({ payload: null });
+      await Promise.resolve();
+    });
+
+    expect(current!.content).toEqual({ instruction: '', original: '', proposed: '' });
+    expect(current!.errorCode).toBeNull();
+  });
+
   it('undo uses undo_transform_and_close and does not chain cancel_transform', async () => {
     mocks.invoke.mockResolvedValue(undefined);
 

--- a/app/src/lib/hooks/useTransformReviewDriver.ts
+++ b/app/src/lib/hooks/useTransformReviewDriver.ts
@@ -52,6 +52,24 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
     if (!enabled) return;
     let cancelled = false;
     let unlisten: (() => void) | null = null;
+    let unlistenHidden: (() => void) | null = null;
+
+    // A backend-initiated hide (short-tap cancel, linger auto-hide, capture
+    // aborts) emits this content-free signal so we drop any stale review
+    // content — otherwise the hidden webview keeps the old diff and can flash
+    // it on the next show (item 13). Payload is intentionally empty.
+    listen('transform-review-hidden', () => {
+      if (cancelled) return;
+      setContent(EMPTY_REVIEW_CONTENT);
+      setErrorCode(null);
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else unlistenHidden = fn;
+      })
+      .catch((e) => {
+        flog.error('transform-review', 'listen(transform-review-hidden) failed', { error: String(e) });
+      });
 
     listen<unknown>('transform-state-changed', (event) => {
       if (cancelled) return;
@@ -88,6 +106,7 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
     return () => {
       cancelled = true;
       unlisten?.();
+      unlistenHidden?.();
     };
   }, [enabled]);
 

--- a/app/src/lib/hooks/useTransformReviewDriver.ts
+++ b/app/src/lib/hooks/useTransformReviewDriver.ts
@@ -62,6 +62,7 @@ export function useTransformReviewDriver(enabled: boolean): ReviewDriverResult {
       if (cancelled) return;
       setContent(EMPTY_REVIEW_CONTENT);
       setErrorCode(null);
+      setState('listening');
     })
       .then((fn) => {
         if (cancelled) fn();

--- a/app/src/lib/knowledge.ts
+++ b/app/src/lib/knowledge.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 
-export type KnowledgeKind = 'replacement_rule' | 'vocabulary_term' | 'snippet';
+export type KnowledgeKind = 'replacement_rule' | 'vocabulary_term' | 'snippet' | 'transform';
 export type KnowledgeProvenance = 'manual' | 'code_scan' | 'learned_correction' | 'import';
 export type KnowledgeAvailability = 'ready' | 'recovered' | 'reinitialized' | 'unavailable';
 export type VoiceCommandKind = 'text_replacement' | 'snippet';
@@ -18,7 +18,8 @@ export type KnowledgeScope =
 export type KnowledgePayload =
   | { kind: 'replacement_rule'; source: string; replacement: string }
   | { kind: 'vocabulary_term'; written: string; aliases: string[] }
-  | { kind: 'snippet'; trigger: string; body: string };
+  | { kind: 'snippet'; trigger: string; body: string }
+  | { kind: 'transform'; name: string; instruction: string };
 
 export interface KnowledgeEntry {
   id: string;
@@ -137,6 +138,7 @@ export function payloadTitle(payload: KnowledgePayload): string {
     case 'replacement_rule': return payload.source;
     case 'vocabulary_term': return payload.written;
     case 'snippet': return payload.trigger;
+    case 'transform': return payload.name;
   }
 }
 
@@ -145,6 +147,7 @@ export function payloadDetail(payload: KnowledgePayload): string {
     case 'replacement_rule': return payload.replacement;
     case 'vocabulary_term': return payload.aliases.join(', ') || 'No spoken aliases';
     case 'snippet': return payload.body;
+    case 'transform': return payload.instruction;
   }
 }
 

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -304,9 +304,9 @@ export const DOUBLE_TAP_KEY_OPTIONS: { value: DoubleTapKey; label: string }[] = 
   { value: 'ctrl_r', label: 'Control' },
 ];
 
-/** No settings UI consumes this yet (Phase D of issue #312) — kept alongside
- * `DOUBLE_TAP_KEY_OPTIONS` so the allow-list used by migration/validation has
- * a single source of truth ready for when the picker ships. */
+/** Allow-list of transform hold-key options, shared by the Settings Transform
+ * section's picker (issue #312 D1) and migration/validation, so both draw from
+ * a single source of truth. Kept alongside `DOUBLE_TAP_KEY_OPTIONS`. */
 export const TRANSFORM_KEY_OPTIONS: { value: TransformKey; label: string }[] = [
   { value: 'alt_r', label: 'Right Option' },
   { value: 'ctrl_l', label: 'Left Control' },

--- a/app/src/lib/transformReview.test.ts
+++ b/app/src/lib/transformReview.test.ts
@@ -38,6 +38,14 @@ describe('normalizeReviewErrorCode', () => {
     expect(normalizeReviewErrorCode('model_not_downloaded')).toBe('model_not_downloaded');
   });
 
+  it('recognizes undo-path apply error codes (item 12)', () => {
+    // The undo-failure UX re-emits `applied` carrying these codes; they must
+    // normalize through so a real undo error is not coerced to null.
+    expect(normalizeReviewErrorCode('clipboard_unavailable')).toBe('clipboard_unavailable');
+    expect(normalizeReviewErrorCode('paste_failed')).toBe('paste_failed');
+    expect(normalizeReviewErrorCode('not_applied')).toBe('not_applied');
+  });
+
   it('coerces unknown or missing error codes to null', () => {
     expect(normalizeReviewErrorCode('some_future_code')).toBeNull();
     expect(normalizeReviewErrorCode(undefined)).toBeNull();

--- a/app/src/lib/transformReview.ts
+++ b/app/src/lib/transformReview.ts
@@ -29,7 +29,10 @@ export type ReviewErrorCode =
   | 'ax_unavailable'
   | 'accessibility_denied'
   | 'target_gone'
-  | 'selection_changed';
+  | 'selection_changed'
+  | 'clipboard_unavailable'
+  | 'paste_failed'
+  | 'not_applied';
 
 const REVIEW_STATES: readonly ReviewState[] = [
   'listening', 'thinking', 'ready', 'failed', 'applied',
@@ -39,6 +42,7 @@ const REVIEW_ERROR_CODES: readonly ReviewErrorCode[] = [
   'model_not_downloaded', 'model_unreadable', 'timeout', 'output_invalid', 'crashed',
   'disabled', 'busy', 'no_instruction', 'no_selection', 'too_large', 'ax_unavailable',
   'accessibility_denied', 'target_gone', 'selection_changed',
+  'clipboard_unavailable', 'paste_failed', 'not_applied',
 ];
 
 export function isReviewState(v: unknown): v is ReviewState {
@@ -65,6 +69,9 @@ export const REVIEW_ERROR_COPY: Record<ReviewErrorCode, string> = {
   accessibility_denied: 'Accessibility permission required',
   target_gone: 'The target app changed — original text untouched',
   selection_changed: 'The selection changed — nothing was overwritten',
+  clipboard_unavailable: "Couldn't reach the clipboard — try Undo again",
+  paste_failed: "Couldn't undo the change — try Undo again",
+  not_applied: 'Nothing to undo',
 };
 
 /**

--- a/app/src/lib/transformSettings.ts
+++ b/app/src/lib/transformSettings.ts
@@ -9,11 +9,17 @@ export interface TransformModelStatus {
   path: string | null;
   sizeBytes: number;
   sha256: string;
+  /** True when the sidecar circuit breaker has disabled the runtime after
+   *  repeated faults; the Reset button + notice are only shown then (#312 D1
+   *  round-2 finding 7). */
+  runtimeDisabled: boolean;
 }
 
+/** Matches the Rust `transform-model-download-progress` event payload
+ *  (`{ received, total, phase }` in `commands/transform_model.rs`). */
 export interface TransformModelDownloadProgress {
-  downloadedBytes: number;
-  totalBytes: number;
+  received: number;
+  total: number;
 }
 
 export async function transformModelStatus(): Promise<TransformModelStatus> {

--- a/app/src/lib/transformSettings.ts
+++ b/app/src/lib/transformSettings.ts
@@ -1,0 +1,53 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { TransformKey } from './settings';
+
+/** Transform model lifecycle status from `transform_model_status`. */
+export type TransformModelState = 'notDownloaded' | 'downloading' | 'ready';
+
+export interface TransformModelStatus {
+  state: TransformModelState;
+  path: string | null;
+  sizeBytes: number;
+  sha256: string;
+}
+
+export interface TransformModelDownloadProgress {
+  downloadedBytes: number;
+  totalBytes: number;
+}
+
+export async function transformModelStatus(): Promise<TransformModelStatus> {
+  return invoke('transform_model_status');
+}
+
+export async function downloadTransformModel(): Promise<void> {
+  return invoke('download_transform_model');
+}
+
+export async function removeTransformModel(): Promise<void> {
+  return invoke('remove_transform_model');
+}
+
+export async function resetTransformRuntime(): Promise<void> {
+  return invoke('reset_transform_runtime');
+}
+
+/** Rejected if `hotkey` collides with a dictation hold key. */
+export async function setTransformKey(hotkey: TransformKey | null): Promise<void> {
+  if (hotkey === null) {
+    await invoke('stop_transform_listener');
+    return;
+  }
+  await invoke('set_transform_key', { hotkey });
+}
+
+export async function startTransformListener(hotkey: TransformKey): Promise<void> {
+  await invoke('start_transform_listener', { hotkey });
+}
+
+export async function stopTransformListener(): Promise<void> {
+  await invoke('stop_transform_listener');
+}
+
+/** ~1.1 GB pinned Qwen2.5-1.5B GGUF (exact size from the catalog pin). */
+export const TRANSFORM_MODEL_SIZE_LABEL = '~1.1 GB';

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,18 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-07-20: Selected-text transform Phase D wrap (#312)
+
+**Decision:** Ship settings + presets + docs for local selected-text transform without expanding scope into AX webview special-cases. Built-in presets (Shorten / Bullets / Professional / Fix grammar / Casual) and user-defined `KnowledgeKind::Transform` names expand in `finish_transform_instruction` before the sidecar runs. Settings owns hold-key wiring, model download/remove/reset, and saved-transform CRUD. Cursor-chat and similar webviews remain best-effort (documented limitation, not a blocker). Native smoke and issue acceptance checkboxes stay a separate pass on a built `.app`.
+
+**Rationale:** Phases A–C delivered the signed sidecar, AX capture/apply, review popover, and end-to-end flow. Phase D only exposes configuration and documents the contract; dogfood follow-ups must not grow apply semantics or link llama into the app crate.
+
+**Status:** active
+
+**References:** issue #312; ADR `2026-07-20-signed-local-llm-sidecar.md`; `docs/features/selected-text-transform.md`; branches `issue/312-transform-flow`, `issue/312-transform-settings`.
+
+---
+
 ## 2026-07-20: Overlay geometry & lifecycle contract locked (#280)
 
 **Decision:** Five locked outcomes of the overlay architecture review (issue #280; PRs #290, #299, #301):

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -125,7 +125,11 @@ The overlay runs in a separate window with no shared React context. Writes go th
 
 ## Visual States
 
-The overlay's top-bar indicator is a pure function of status + two transient flags + global-disable (`deriveVisual()`); `status` itself is driven by the `recording-status-changed` event.
+The overlay's top-bar indicator is a pure function of status + transient flags + global-disable (`deriveVisual()`); `status` itself is driven by the `recording-status-changed` event.
+
+### Transform indicators (issue #312)
+
+While a selected-text transform is in **Thinking** (sidecar running), the overlay can show a **transforming…** indicator (`deriveVisual` priority: cancelled > secure-field flash > hotkey-miss > recording > processing > transforming > idle). Secure/password fields refused by the transform capture path emit a content-free `transform-secure-field` flash via `useOverlayRuntime` — no selection text is ever read or shown.
 
 ### Idle
 Small mic SVG icon at 40% white opacity (dimmed further to 15% when globally disabled). Compact width.

--- a/docs/features/recording-modes.md
+++ b/docs/features/recording-modes.md
@@ -2,6 +2,10 @@
 
 The app supports Hold-Down, Double-Tap, and a combined Both mode, selectable in Settings. All use `rdev` for low-level keyboard event listening and require Accessibility permission.
 
+## Transform hold key (issue #312)
+
+Separate from dictation modes: a dedicated **transform hold key** (`transformHoldKey`: `alt_r` / `ctrl_l` / `shift_r`) drives the selected-text transform flow. It uses the **same shared rdev listener thread** as dictation (one thread rule), with an independent detector and `start_transform_listener` / `stop_transform_listener` / `set_transform_key` commands. Dictation hold keys are rejected for the transform shortcut so the two never share a physical key. See [selected-text-transform.md](selected-text-transform.md).
+
 ## Hold-Down Mode (default)
 
 Hold a modifier key to record, release to stop and transcribe.

--- a/docs/features/selected-text-transform.md
+++ b/docs/features/selected-text-transform.md
@@ -1,0 +1,73 @@
+# Selected-text transform
+
+Issue [#312](https://github.com/georgenijo/murmur-app/issues/312). Hold a dedicated transform shortcut while text is selected in another app, speak an instruction (“make this shorter” or a preset name), review a local LLM proposal in a non-focusable popover, then Approve to replace the selection or Undo to restore. Entirely on-device, fail-closed, never auto-applies.
+
+Binding runtime ADR: [docs/decisions/2026-07-20-signed-local-llm-sidecar.md](../decisions/2026-07-20-signed-local-llm-sidecar.md).
+
+## Flow
+
+1. User selects text in a third-party app and holds the transform key (`alt_r` / `ctrl_l` / `shift_r`).
+2. Host freezes an AX selection snapshot (secure fields refused), shows the review popover in **listening**, arms mic for the instruction only.
+3. On release (≥300ms hold): stop mic → cleanup-only ASR on the instruction → expand built-in preset or saved transform name if matched → signed local-LLM sidecar proposes a rewrite.
+4. Popover shows **thinking** then **ready** (word diff). Events carry `{ state, errorCode }` only; instruction / original / proposed text are pulled via `get_transform_review_content`.
+5. **Approve** writes through `transform_apply` (AX set-value or paste fallback with clipboard restore). **Undo** restores the frozen original. Esc / short-tap cancels at every stage.
+
+Dictation and transform are mutually exclusive (status guards both ways + sidecar busy + helper shutdown before recording).
+
+## Model storage
+
+- Catalog pin: Qwen2.5-1.5B-Instruct Q4_K_M (~1.1 GB), exact size + SHA-256 enforced at download and before spawn.
+- Path: `~/Library/Application Support/local-dictation/models/transform-llm/<sha256>/qwen2.5-1.5b-instruct-q4_k_m.gguf`
+- Download streams to a `.partial` file, hashes while streaming, fsyncs, then atomically publishes under the hash directory.
+- **Remove** deletes the hash directory (and any partial). The helper is shut down first so the file is not open.
+- **Reset runtime** clears the circuit breaker after repeated helper faults (`reset_transform_runtime`).
+- Apple Silicon + macOS only; other platforms report unsupported.
+
+## Permissions
+
+- **Accessibility** is required for: transform-key listening (rdev), AX selection capture, and AX write-back / paste-fallback frontmost checks.
+- **Microphone** is required for instruction ASR (same device as dictation settings).
+- Secure/password fields: AXSubrole checked **before** any value read; AX errors during the check fail closed. No popover content; optional overlay flash only.
+
+## Supported vs best-effort apps
+
+| Class | Examples | Expected behavior |
+|-------|----------|-------------------|
+| AX-native text | Notes, Mail compose, TextEdit, many Cocoa fields | Selection capture + AX set-value preferred; undo restores original |
+| Best-effort (paste fallback) | Many browsers, Slack, Electron shells | Capture often works; apply may paste-replace; clipboard is saved/restored with an epoch guard |
+| Documented limitation | Cursor chat / other webview editors | Best-effort only — webview accessibility is incomplete. Not a blocker for #312; file follow-ups rather than scope-creeping AX work |
+
+## Failure semantics
+
+- Any sidecar crash, timeout, protocol violation, model mismatch, or malformed output → popover **failed**, original selection **untouched**, dictation unaffected once busy clears.
+- Cancel mid-thinking sends a cooperative protocol Cancel (then kill if unresponsive); BusyGuard clears when blocking work settles — dictation can start cleanly afterward.
+- Apply/undo failures surface stable `errorCode`s (`target_gone`, `selection_changed`, `paste_failed`, …) without content in logs.
+- Instructions never enter transcription history or stats.
+
+## Sidecar removal / lifecycle
+
+- Packaged as Tauri `externalBin` (`murmur-llm-sidecar`), signed with hardened runtime + App Sandbox (split entitlements via the repository finalizer).
+- Host spawns with empty env, fixed cwd, model as inherited read-only fd 3 — no path args, no network in the helper.
+- Idle unload and RSS ceilings are enforced by the host supervisor (`llm_sidecar.rs`). Circuit breaker disables the runtime after repeated faults until explicit reset.
+- The app crate must **never** link `llama-cpp-2` (ggml ABI clash with whisper).
+
+## Settings UI
+
+Settings → **Transform**:
+
+- Enable + hold-key picker (rejects dictation keys)
+- Model status / Download / Remove / Reset runtime
+- Saved transforms CRUD (`KnowledgeKind::Transform`) plus built-in presets: Shorten, Bullets, Professional, Fix grammar, Casual
+
+## Related modules
+
+| Area | Path |
+|------|------|
+| Flow orchestrator | `src/transform_flow.rs` |
+| Apply / undo | `src/transform_apply.rs` |
+| Selection capture | `src/selection.rs` |
+| Sidecar supervisor | `src/llm_sidecar.rs` |
+| Presets | `src/transform_presets.rs` |
+| Model install | `commands/transform_model.rs` |
+| Popover window | `commands/transform_popover.rs`, `components/transform-review/` |
+| Frontend drivers | `useTransformFlow`, `useTransformReviewDriver` |

--- a/docs/features/selected-text-transform.md
+++ b/docs/features/selected-text-transform.md
@@ -14,6 +14,31 @@ Binding runtime ADR: [docs/decisions/2026-07-20-signed-local-llm-sidecar.md](../
 
 Dictation and transform are mutually exclusive (status guards both ways + sidecar busy + helper shutdown before recording).
 
+## Instruction expansion and name precedence
+
+`transform_flow::expand_instruction` resolves a spoken instruction in this
+order, stopping at the first match:
+
+1. **Built-in preset** (`transform_presets::resolve_preset`) — checked by
+   canonical name and every alias.
+2. **Saved transform** (`KnowledgeKind::Transform`, `transform_flow::resolve_saved_transform`)
+   — checked by name against enabled saved transforms.
+3. **Raw transcript** — used as a free-form rewrite instruction when nothing matched.
+
+Both lookups normalize the spoken text and the stored name with the same
+`transform_presets::normalize()`: split on whitespace, trim non-alphanumeric
+characters from each word's edges (Unicode-aware), lowercase, and rejoin —
+so ASR punctuation ("Shorten.", "Make shorter!", "  fix grammar?  ") does not
+prevent a match.
+
+**Presets always shadow saved transforms with the same normalized name.** If
+you save a transform named "shorten" (or an alias like "make shorter"), the
+built-in preset still runs when you speak that name — the saved transform is
+stored but unreachable by voice until you rename it or the built-in changes.
+The Transforms editor rejects saving two transforms with the same normalized
+name outright, and warns (without blocking) when a name collides with a
+preset name or alias.
+
 ## Model storage
 
 - Catalog pin: Qwen2.5-1.5B-Instruct Q4_K_M (~1.1 GB), exact size + SHA-256 enforced at download and before spawn.
@@ -57,7 +82,7 @@ Settings → **Transform**:
 
 - Enable + hold-key picker (rejects dictation keys)
 - Model status / Download / Remove / Reset runtime
-- Saved transforms CRUD (`KnowledgeKind::Transform`) plus built-in presets: Shorten, Bullets, Professional, Fix grammar, Casual
+- Saved transforms CRUD (`KnowledgeKind::Transform`) plus built-in presets: Shorten, Bullets, Professional, Fix grammar, Casual. Instructions are capped at `MAX_INSTRUCTION_BYTES` (4096 bytes); exact duplicate saved names are rejected, and a name colliding with a preset (name or alias) is shadowed — see [Instruction expansion and name precedence](#instruction-expansion-and-name-precedence)
 
 ## Related modules
 


### PR DESCRIPTION
## Summary

Phase D of #312 — the final code phase: user-facing configuration and docs for transform mode.

- **Settings — Transform section** (`SettingsPanel.tsx`): shortcut enable/picker (alt_r / ctrl_l / shift_r; dictation keys rejected by the commands), on-device model block (status / throttled download progress on its own event / Remove with confirm / runtime-disabled notice with Reset gated on real breaker state), dedicated error lines per control, ~1.1 GB Apple-Silicon-only copy. Boot wiring starts the transform listener when configured.
- **Built-in presets** (`transform_presets.rs`): Shorten, Bullets, Professional, Fix grammar, Casual — punctuation-tolerant, Unicode-aware spoken-name matching (real whisper transcripts like "Shorten." resolve), shared normalize used by preset and saved-transform resolution, preset-first precedence documented and warned on shadowing.
- **Saved transforms**: `KnowledgeKind::Transform {name, instruction}` — schema v4 with a data-carrying lossless migration test, export format v3 (accepts 1|2|3, clean version rejection), exact-duplicate names rejected, instructions capped at the protocol's 4,096-byte limit server-side plus live byte counters in both editors. CRUD UI follows the existing snippets idiom.
- **Instruction expansion** in `finish_transform_instruction`: preset → saved transform → raw transcript, never logged.
- **Docs**: `docs/features/selected-text-transform.md` (flow, model storage/removal, Accessibility, supported vs best-effort apps incl. the Cursor-webview caveat, failure semantics, precedence), overlay/recording-modes/CLAUDE.md updates, DECISIONS.md entry.
- Round-2 flow hardening rides along (built stacked on C2): per-request cancel token riding the abort handle, mic-leak recheck, undo-failure shown inline with deterministic linger, stale-content reset on backend hides.

## Verification

- Combined-tree suites: 567 Rust passed / 0 failed (543 lib + 24 integration), tsc clean, 263 vitest.
- Built by three parallel agents with disjoint file ownership, merged, then two adversarial review rounds over the combined diff — all findings closed and re-verified.

Closes the code side of #312; native smoke checklist remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)