### PR TITLE
fix(transform): dispatch NSWindow mutation to the main thread (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Local dictation evaluation harness** adds strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports through `murmur-eval` (#267).
 
 ### Fixed
+- The selected-text transform popover no longer crashes the app on macOS 26. Its `NSWindow` level/activation and shadow treatment were mutated directly from async command context (a tokio worker); macOS 26 hard-traps on off-main `NSWindow` mutation. Those raw AppKit calls are now dispatched to the main thread via `run_on_main_thread`, matching the app's AX write paths (#325).
 - Disabling Murmur from the overlay no longer traps it disabled: the hover quick-settings card — which holds the "Enable Murmur" power button — now stays reachable while disabled, so the overlay's own control can turn Murmur back on. Previously the global-disable state gated off the overlay's hover-expand, leaving the tray "Disable Murmur" check item as the only way back.
 
 ## [0.19.0] - 2026-07-20

--- a/app/src-tauri/src/commands/native_window.rs
+++ b/app/src-tauri/src/commands/native_window.rs
@@ -15,12 +15,43 @@
 /// or thinking, and always for the overlay). `false` allows the window to
 /// activate normally (used once the popover reaches ready/failed and needs to
 /// accept keyboard shortcuts).
+///
+/// The raw `NSWindow` mutation is dispatched to the main thread via
+/// `run_on_main_thread` — AppKit hard-traps (`EXC_BREAKPOINT`, "Must only be
+/// used from the main thread") on off-main window mutation on macOS 26, and the
+/// popover show path runs in async Tauri command context (a tokio worker). This
+/// mirrors the AX dispatch in `injector`/`selection`/`transform_apply` (issue
+/// #325). Fire-and-forget: the raw work has no return value and every caller
+/// ignores it, so there is no oneshot to await.
 #[cfg(target_os = "macos")]
 pub(crate) fn set_window_level_and_activation(
     window: &tauri::WebviewWindow,
     level: isize,
     prevents_activation: bool,
 ) {
+    use tauri::Manager;
+    let window = window.clone();
+    let handle = window.app_handle().clone();
+    if let Err(e) = handle.run_on_main_thread(move || {
+        apply_window_level_and_activation_on_main(&window, level, prevents_activation);
+    }) {
+        tracing::warn!(target: "system", "set_window_level_and_activation: run_on_main_thread failed: {}", e);
+    }
+}
+
+/// Main-thread-only worker holding the raw `objc2` `NSWindow` mutation. MUST run
+/// on the main thread; the `debug_assert!` trips loudly in dev if a future
+/// caller invokes it off-main instead of going through the dispatcher above.
+#[cfg(target_os = "macos")]
+fn apply_window_level_and_activation_on_main(
+    window: &tauri::WebviewWindow,
+    level: isize,
+    prevents_activation: bool,
+) {
+    debug_assert!(
+        objc2_foundation::MainThreadMarker::new().is_some(),
+        "NSWindow mutation must run on the main thread"
+    );
     let raw = window.ns_window();
     if let Ok(ptr) = raw {
         let ns_window: &objc2_app_kit::NSWindow = unsafe { &*(ptr.cast()) };

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -159,9 +159,17 @@ fn raise_window_above_menubar(overlay: &tauri::WebviewWindow) {
         super::native_window::ABOVE_MENU_BAR_LEVEL,
         true,
     );
-    if let Ok(ptr) = overlay.ns_window() {
-        let ns_window: &objc2_app_kit::NSWindow = unsafe { &*(ptr.cast()) };
-        ns_window.setHasShadow(false);
+    // Raw NSWindow mutation must run on the main thread (macOS 26 hard-traps
+    // off-main), same as `set_window_level_and_activation` (issue #325).
+    let overlay = overlay.clone();
+    let handle = overlay.app_handle().clone();
+    if let Err(e) = handle.run_on_main_thread(move || {
+        if let Ok(ptr) = overlay.ns_window() {
+            let ns_window: &objc2_app_kit::NSWindow = unsafe { &*(ptr.cast()) };
+            ns_window.setHasShadow(false);
+        }
+    }) {
+        tracing::warn!(target: "system", "raise_window_above_menubar: run_on_main_thread failed: {}", e);
     }
 }
 

--- a/docs/features/selected-text-transform.md
+++ b/docs/features/selected-text-transform.md
@@ -84,6 +84,11 @@ Settings → **Transform**:
 - Model status / Download / Remove / Reset runtime
 - Saved transforms CRUD (`KnowledgeKind::Transform`) plus built-in presets: Shorten, Bullets, Professional, Fix grammar, Casual. Instructions are capped at `MAX_INSTRUCTION_BYTES` (4096 bytes); exact duplicate saved names are rejected, and a name colliding with a preset (name or alias) is shadowed — see [Instruction expansion and name precedence](#instruction-expansion-and-name-precedence)
 
+## Threading
+
+- The popover's `NSWindow` treatment (level, `_setPreventsActivation:`, shadow) is raw AppKit and **must** run on the main thread — macOS 26 hard-traps (`EXC_BREAKPOINT`, "Must only be used from the main thread") on off-main `NSWindow` mutation. The flow's effects run in async command context (tokio worker), so `native_window::set_window_level_and_activation` dispatches the raw calls through `run_on_main_thread`, matching the AX write paths in `selection.rs` / `injector` / `transform_apply.rs`. Tauri's own window methods (`set_size`/`set_position`/`show`/`hide`/`set_focus`) already hop to main internally.
+- Native smoke canary for this crash class: **press the transform hold key on a built `.app`** (not `?mock=1`, not `tauri dev`). It exercises the real off-main window path and reproduced #325 immediately.
+
 ## Related modules
 
 | Area | Path |


### PR DESCRIPTION
Closes #325

## Problem

Pressing the transform hold key on a built `.app` (macOS 26) instantly killed the whole app — `EXC_BREAKPOINT (SIGTRAP)`, "Must only be used from the main thread". The transform flow's effects (`TauriFlowEffects::show_popover`) run in async command context (a tokio worker) and called `native_window::set_window_level_and_activation`, which mutates the raw `NSWindow` via `objc2` (`setLevel:`, `_setPreventsActivation:`) directly off the main thread. macOS 26 hard-traps on off-main `NSWindow` mutation (older macOS only warned). The path was only ever exercised via the browser mock (`?mock=1`) until the #312 native smoke test.

## Fix

Route the raw AppKit calls through `run_on_main_thread`, mirroring the AX write paths in `selection.rs` / `injector` / `transform_apply.rs`.

- `commands/native_window.rs`: `set_window_level_and_activation` now clones the window + app handle and dispatches the raw `objc2` work to the main thread. The raw body moves into a private `apply_window_level_and_activation_on_main` worker guarded by `debug_assert!(MainThreadMarker::new().is_some())` so any future off-main caller fails loudly in dev. This one change covers the popover show + focusable paths **and** the overlay (shared helper).
- `commands/overlay.rs`: `raise_window_above_menubar`'s extra `setHasShadow(false)` raw call is dispatched to main the same way.

Tauri's own window methods (`set_size`/`set_position`/`show`/`hide`/`set_focus`) already hop to main internally — the crash backtrace showed them running there concurrently with the off-main `setLevel` — so they're unchanged. No changes to `transform_flow.rs`, the `FlowEffects` trait, or `transform_popover.rs`.

Also: CHANGELOG entry + a Threading note in the transform feature doc recording the main-thread rule and the "press the transform key on a built .app" native smoke canary.

## Verification

- `cargo check` — clean, no warnings
- `cargo test -- --test-threads=1` — 543 passed, 0 failed
- `npx tsc --noEmit` — clean
- Native canary (manual): build `.app`, press transform key — pre-fix instant SIGTRAP, post-fix popover shows; overlay still behaves (shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a macOS 26 crash affecting the selected-text transform popover.
  * Improved popover window behavior when changing its activation, level, and shadow settings.

* **Documentation**
  * Added guidance for validating the transform popover on macOS using a built application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->