### PR TITLE
fix(transform): auto-dismiss failed review when dictation starts (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Local dictation evaluation harness** adds strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports through `murmur-eval` (#267).
 
 ### Fixed
+- A failed transform review popover (sidecar crash, blank instruction, capture error, missing model) no longer blocks dictation until manually dismissed: pressing the dictation key now auto-dismisses the failed review — which holds nothing user-approvable — and records. A ready review with a pending proposal still blocks, so unaccepted work is never destroyed implicitly (#327).
 - Disabling Murmur from the overlay no longer traps it disabled: the hover quick-settings card — which holds the "Enable Murmur" power button — now stays reachable while disabled, so the overlay's own control can turn Murmur back on. Previously the global-disable state gated off the overlay's hover-expand, leaving the tray "Disable Murmur" check item as the only way back.
 
 ## [0.19.0] - 2026-07-20

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1932,6 +1932,20 @@ pub async fn start_native_recording(
         tracing::info!(target: "pipeline", "start_native_recording: app disabled — ignoring");
         return Ok(serde_json::json!({ "type": "app_disabled", "state": "idle" }));
     }
+    // A transform review parked on FAILURE (ReviewPending with no proposed
+    // text) holds nothing user-approvable — auto-dismiss it so the dictation
+    // key just works instead of silently refusing until the user manually
+    // dismisses the failed popover (issue #327). A ready review still blocks
+    // via the transform_status guard below.
+    {
+        let fx = crate::transform_flow::TauriFlowEffects {
+            app: &app_handle,
+            state: &state,
+        };
+        if crate::transform_flow::dismiss_failed_review(&state.app_state, &fx) {
+            tracing::info!(target: "pipeline", "start_native_recording: auto-dismissed failed transform review");
+        }
+    }
     // Stop any resident local-LLM helper before recording (fail-fast no-op
     // while a transform is in flight; the is_transform_busy guard below then
     // refuses this recording).

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1108,6 +1108,39 @@ pub(crate) async fn cancel_transform(
     Ok(())
 }
 
+/// Dismiss a review parked on FAILURE — `ReviewPending` with no proposed text
+/// in the session (a ready review always has one: `run_transform`'s Ok arm
+/// stores the proposal inside the same `Thinking -> ReviewPending` transition
+/// that emits `ready`). Returns `true` if the flow was torn down to `Idle`.
+///
+/// Used by `start_native_recording` (issue #327): a failed review popover holds
+/// nothing user-approvable, so pressing the dictation key auto-dismisses it and
+/// records, instead of refusing until the user manually dismisses the popover.
+/// A ready review (proposal present) — including an apply-failure that kept its
+/// proposal so Retry/Undo stay reachable — still blocks recording as before.
+/// The `try_transition` keeps this race-safe against a concurrent retry
+/// (`ReviewPending -> Listening`): exactly one side wins.
+pub(crate) fn dismiss_failed_review(app_state: &AppState, fx: &dyn FlowEffects) -> bool {
+    let has_proposal = transform_apply::session_snapshot(app_state)
+        .map(|s| s.proposed.is_some())
+        .unwrap_or(false);
+    if has_proposal {
+        return false;
+    }
+    if !app_state.try_transition_transform_status(
+        TransformStatus::ReviewPending,
+        TransformStatus::Idle,
+    ) {
+        return false;
+    }
+    transform_apply::clear_session(app_state);
+    // `hide_popover` on the production effects also emits the content-free
+    // `transform-review-hidden` reset (item 13), same as every other
+    // backend-initiated hide.
+    fx.hide_popover();
+    true
+}
+
 /// Undo an applied transform and close the popover **without** bumping the
 /// clipboard-restore epoch a second time.
 ///
@@ -1647,6 +1680,81 @@ mod tests {
             vec![("failed".to_string(), Some("model_not_downloaded".to_string()))]
         );
         assert!(fx.popover_shown());
+    }
+
+    // ---- dismiss_failed_review (issue #327) --------------------------------
+
+    fn snapshot_for_dismiss_tests() -> TransformSnapshot {
+        TransformSnapshot {
+            bundle_id: None,
+            pid: 1,
+            text: "hello".to_string(),
+            range: Some((0, 5)),
+            bounds: None,
+            captured_at: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn dismiss_failed_review_tears_down_proposal_less_review() {
+        // A failed review: ReviewPending with a session but no proposed text
+        // (sidecar crash / no_instruction / capture error all land here).
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        transform_apply::start_session(&app_state, snapshot_for_dismiss_tests());
+        app_state.set_transform_status(TransformStatus::ReviewPending);
+
+        assert!(dismiss_failed_review(&app_state, &fx));
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+        assert!(transform_apply::session_snapshot(&app_state).is_none());
+        assert!(!fx.popover_shown());
+    }
+
+    #[test]
+    fn dismiss_failed_review_tears_down_sessionless_review() {
+        // model_not_downloaded fails before any session is started.
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        app_state.set_transform_status(TransformStatus::ReviewPending);
+
+        assert!(dismiss_failed_review(&app_state, &fx));
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+    }
+
+    #[test]
+    fn dismiss_failed_review_keeps_ready_review_blocking() {
+        // A ready review (proposal present) holds user-approvable work — it
+        // must NOT be dismissed implicitly by the dictation key.
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        transform_apply::start_session(&app_state, snapshot_for_dismiss_tests());
+        assert!(transform_apply::set_proposed_text(&app_state, "HELLO".to_string()));
+        app_state.set_transform_status(TransformStatus::ReviewPending);
+
+        assert!(!dismiss_failed_review(&app_state, &fx));
+        assert_eq!(app_state.transform_status(), TransformStatus::ReviewPending);
+        assert!(transform_apply::session_snapshot(&app_state).is_some());
+    }
+
+    #[test]
+    fn dismiss_failed_review_ignores_non_review_states() {
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        for status in [
+            TransformStatus::Idle,
+            TransformStatus::Capturing,
+            TransformStatus::Listening,
+            TransformStatus::Thinking,
+            TransformStatus::Applying,
+        ] {
+            app_state.set_transform_status(status);
+            assert!(
+                !dismiss_failed_review(&app_state, &fx),
+                "{:?} must not be dismissed",
+                status
+            );
+            assert_eq!(app_state.transform_status(), status);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #327

## Problem

After a transform pass fails (sidecar crash, blank instruction, capture error, missing model), the review popover shows the error and pins the flow at `TransformStatus::ReviewPending` (there is no `Failed` status variant — failure is `ReviewState::Failed` + no proposed text). `blocks_recording()` refuses any non-Idle status, so the dictation key silently does nothing until the user manually dismisses the popover. Found during #325 native smoke testing.

## Fix

- `transform_flow::dismiss_failed_review(app_state, fx)`: if the flow is `ReviewPending` **with no proposed text** in the session, atomically `try_transition(ReviewPending -> Idle)`, clear the session, and hide the popover (the production effects' `hide_popover` also emits the content-free `transform-review-hidden` reset, same as every backend-initiated hide). Race-safe against a concurrent retry (`ReviewPending -> Listening`) — exactly one side wins.
- `start_native_recording` calls it before its transform guard, so the dictation key auto-dismisses a failed review and records.
- A **ready** review (proposal present — including an apply-failure that kept its proposal so Retry/Undo stay reachable) still blocks: unaccepted work is never destroyed implicitly.
- `blocks_recording()` is unchanged; the existing `every_non_idle_transform_status_blocks_recording_start` invariant holds.

## Tests

4 new unit tests: proposal-less review dismissed (session + sessionless), ready review kept blocking, non-review states untouched.

- `cargo check` — clean
- `cargo test -- --test-threads=1` — 547 passed, 0 failed
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dictation now automatically dismisses failed transform reviews that contain no approvable content.
  * Ready reviews with pending proposals continue to block dictation until reviewed.
  * Prevented stale failed-review popovers from interfering with recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->