### PR TITLE
test(overlay): close deriveVisual coverage gaps — cancelled vs secureField, transforming (#339)

### DIFF
--- a/app/src/components/overlay/deriveVisual.test.ts
+++ b/app/src/components/overlay/deriveVisual.test.ts
@@ -77,4 +77,51 @@ describe('deriveVisual', () => {
     const visual = deriveVisual('idle', false, false, false);
     expect(visual.indicator).toEqual({ kind: 'idle', dimmed: false });
   });
+
+  // Issue #339 gap 1: cancelled and secure-field co-asserted. Reordering
+  // secureField above cancelled must fail this test.
+  it('cancelled beats secure-field when both flash at once', () => {
+    const visual = deriveVisual('idle', true, false, false, false, true, false);
+    expect(visual.indicator).toEqual({ kind: 'cancelled' });
+
+    const everythingOn = deriveVisual('recording', true, true, true, true, true, true);
+    expect(everythingOn.indicator).toEqual({ kind: 'cancelled' });
+  });
+
+  // Issue #339 gap 2: pin `transforming` into the chain — below recording and
+  // processing, above idle. Deleting the branch or hoisting it above an active
+  // status must fail one of these.
+  it('transforming shows while otherwise idle', () => {
+    const visual = deriveVisual('idle', false, false, false, true);
+    expect(visual.indicator).toEqual({ kind: 'transforming' });
+  });
+
+  it('transforming loses to recording and processing', () => {
+    expect(deriveVisual('recording', false, false, false, true).indicator).toEqual({
+      kind: 'recording',
+    });
+    expect(deriveVisual('processing', false, false, false, true).indicator).toEqual({
+      kind: 'processing',
+    });
+  });
+
+  it('transforming loses to every flash above it in the chain', () => {
+    expect(deriveVisual('idle', true, false, false, true).indicator).toEqual({ kind: 'cancelled' });
+    expect(deriveVisual('idle', false, false, false, true, true).indicator).toEqual({
+      kind: 'secureField',
+    });
+    expect(deriveVisual('idle', false, false, false, true, false, true).indicator).toEqual({
+      kind: 'transformBusy',
+    });
+    expect(deriveVisual('idle', false, true, false, true).indicator).toEqual({
+      kind: 'hotkeyMiss',
+    });
+  });
+
+  it('transforming does not dim, show the tap-missed label, or show the waveform', () => {
+    const visual = deriveVisual('idle', false, false, true, true);
+    expect(visual.indicator).toEqual({ kind: 'transforming' });
+    expect(visual.showTapMissedLabel).toBe(false);
+    expect(visual.waveformVisible).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the two `deriveVisual.test.ts` gaps from #339 that let overlay flash-priority regressions pass silently:

1. **`cancelled` vs `secureField` co-assertion** — both flags set at once (plus an everything-on case) pinning `cancelled` as the winner. Previously, reordering `secureField` above `cancelled` passed the entire suite.
2. **`transforming` coverage** — pins it below `recording`/`processing`, below every flash (`cancelled`/`secureField`/`transformBusy`/`hotkeyMiss`), and above `idle`; also asserts it doesn't dim, doesn't show the tap-missed label, and doesn't show the waveform.

Test-only change; no production code touched.

## Proof the new tests bite (mutation runs on this branch)

- Hoist `secureField` above `cancelled` in `deriveVisual.ts` → **1 failed** | 35 passed
- Delete the `transforming` branch → **2 failed** | 34 passed
- Unmutated → **36 passed**

## Verification

- `npx vitest run` — 272 passed (34 files)
- `npx tsc --noEmit` — clean
- `cargo test -- --test-threads=1` — 550 passed

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for visual indicator priority behavior.
  * Ensured cancelled states take precedence over secure-field indicators.
  * Added validation for transforming indicators, including their precedence and associated visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->