### PR TITLE
fix(transform): parked reviews no longer wedge file transcription; benchmarks respect transform status (#338)

### DIFF
--- a/app/src-tauri/src/commands/benchmark.rs
+++ b/app/src-tauri/src/commands/benchmark.rs
@@ -42,8 +42,30 @@ pub async fn run_benchmark(
     request: BenchmarkRequest,
 ) -> Result<BenchmarkReport, String> {
     let coordinator = state.benchmark.clone();
+    // Auto-dismiss a parked transform review, refuse on an active transform
+    // (issue #338 — this path previously ignored the transform status
+    // entirely and would run a benchmark right over a parked review). The
+    // in-lock guard below stays as a race guard.
+    {
+        let fx = crate::transform_flow::TauriFlowEffects {
+            app: &app_handle,
+            state: &state,
+        };
+        crate::transform_flow::clear_parked_review_for_pipeline_work(
+            &state.app_state,
+            &fx,
+            "run_benchmark",
+            "Wait for the transform to finish before benchmarking",
+        )?;
+    }
     {
         let dictation = state.app_state.dictation.lock_or_recover();
+        // An ACTIVE transform (Capturing/Listening/Thinking/Applying) holds
+        // the shared Whisper backend / mic / AX surface — refuse, matching
+        // every other work-starting entry point (issue #338).
+        if state.app_state.transform_status().blocks_recording() {
+            return Err("Wait for the transform to finish before benchmarking".to_string());
+        }
         if dictation.status != DictationStatus::Idle {
             return Err("Stop recording before running a benchmark".to_string());
         }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -812,6 +812,21 @@ pub async fn process_audio(
     audio_data: String,
     state: tauri::State<'_, State>,
 ) -> Result<serde_json::Value, String> {
+    // Auto-dismiss a parked transform review, refuse on an active transform
+    // (issue #338 — same policy as start_native_recording). The in-lock
+    // transform guard below stays as a race guard.
+    {
+        let fx = crate::transform_flow::TauriFlowEffects {
+            app: &app_handle,
+            state: &state,
+        };
+        crate::transform_flow::clear_parked_review_for_pipeline_work(
+            &state.app_state,
+            &fx,
+            "process_audio",
+            "Cannot process audio while a transform is in progress.",
+        )?;
+    }
     // Only one heavy inference runtime may be resident: stop any local-LLM
     // helper before recording. Fail-fast no-op while a transform is in flight —
     // the is_transform_busy guard below then refuses this recording.
@@ -2363,6 +2378,29 @@ pub async fn transcribe_file(
         .swap(true, Ordering::SeqCst)
     {
         return Err("Already transcribing a file.".to_string());
+    }
+    // Auto-dismiss a parked transform review, refuse on an active transform
+    // (issue #338 — same policy as start_native_recording; a parked review
+    // never finishes on its own, so "wait for the transform" would never
+    // resolve). The in-lock transform guard below stays as a race guard.
+    // Note: file_transcribing was claimed above, so release it on refusal.
+    {
+        let fx = crate::transform_flow::TauriFlowEffects {
+            app: &app_handle,
+            state: &state,
+        };
+        if let Err(refusal) = crate::transform_flow::clear_parked_review_for_pipeline_work(
+            &state.app_state,
+            &fx,
+            "transcribe_file",
+            "Wait for the transform to finish before transcribing a file.",
+        ) {
+            state
+                .app_state
+                .file_transcribing
+                .store(false, Ordering::SeqCst);
+            return Err(refusal);
+        }
     }
     // Only one heavy inference runtime may be resident: stop any local-LLM
     // helper before running the file transcription (fail-fast no-op while a

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1151,6 +1151,33 @@ pub(crate) fn dismiss_review_for_recording(app_state: &AppState, fx: &dyn FlowEf
     true
 }
 
+/// Entry-point prologue for pipeline work other than a dictation recording —
+/// file transcription, the legacy base64 `process_audio` path, and benchmarks
+/// (issue #338). Auto-dismisses a parked (ready/failed) review exactly like
+/// `start_native_recording` does — a parked review never completes on its
+/// own, so refusing with "wait for the transform to finish" would deadlock
+/// the user — then refuses with `refusal` if an ACTIVE transform phase
+/// (Capturing/Listening/Thinking/Applying) still holds the shared pipeline.
+///
+/// Callers may re-check `blocks_recording()` under their own dictation lock
+/// afterwards as a race guard; this prologue is the part every work-starting
+/// entry point must share so parked reviews are handled consistently.
+pub(crate) fn clear_parked_review_for_pipeline_work(
+    app_state: &AppState,
+    fx: &dyn FlowEffects,
+    entry: &'static str,
+    refusal: &str,
+) -> Result<(), String> {
+    if dismiss_review_for_recording(app_state, fx) {
+        tracing::info!(target: "pipeline", entry = entry, "auto-dismissed parked transform review");
+    }
+    if app_state.transform_status().blocks_recording() {
+        tracing::warn!(target: "pipeline", entry = entry, "blocked — transform in progress");
+        return Err(refusal.to_string());
+    }
+    Ok(())
+}
+
 /// Undo an applied transform and close the popover **without** bumping the
 /// clipboard-restore epoch a second time.
 ///
@@ -1768,6 +1795,58 @@ mod tests {
             );
             assert_eq!(app_state.transform_status(), status);
         }
+    }
+
+    // ---- clear_parked_review_for_pipeline_work (issue #338) ----------------
+
+    #[test]
+    fn pipeline_work_dismisses_parked_review_and_proceeds() {
+        // Issue #338: a parked (ready/failed) review never completes on its
+        // own — file transcription / process_audio / benchmarks must dismiss
+        // it and proceed, not refuse with "wait for the transform to finish".
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        transform_apply::start_session(&app_state, snapshot_for_dismiss_tests());
+        assert!(transform_apply::set_proposed_text(&app_state, "HELLO".to_string()));
+        app_state.set_transform_status(TransformStatus::ReviewPending);
+
+        let result =
+            clear_parked_review_for_pipeline_work(&app_state, &fx, "test_entry", "blocked");
+        assert_eq!(result, Ok(()));
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
+        assert!(transform_apply::session_snapshot(&app_state).is_none());
+        assert!(!fx.popover_shown());
+    }
+
+    #[test]
+    fn pipeline_work_refused_while_a_transform_phase_is_active() {
+        // Issue #338 (benchmark side): an ACTIVE transform must refuse the
+        // work — the benchmark path previously ignored transform status
+        // entirely and ran right over it.
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        for status in [
+            TransformStatus::Capturing,
+            TransformStatus::Listening,
+            TransformStatus::Thinking,
+            TransformStatus::Applying,
+        ] {
+            app_state.set_transform_status(status);
+            let result =
+                clear_parked_review_for_pipeline_work(&app_state, &fx, "test_entry", "blocked");
+            assert_eq!(result, Err("blocked".to_string()), "{:?} must refuse", status);
+            assert_eq!(app_state.transform_status(), status, "{:?} must survive", status);
+        }
+    }
+
+    #[test]
+    fn pipeline_work_is_a_noop_when_transform_is_idle() {
+        let app_state = AppState::default();
+        let fx = RecordingFlowEffects::new();
+        let result =
+            clear_parked_review_for_pipeline_work(&app_state, &fx, "test_entry", "blocked");
+        assert_eq!(result, Ok(()));
+        assert_eq!(app_state.transform_status(), TransformStatus::Idle);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #338: a parked (ready/failed) transform review — which never completes on its own — hard-blocked file transcription and the legacy `process_audio` path with "wait for the transform to finish" (which would never come), while Performance-Lab benchmarks ignored the transform status entirely and ran right over parked reviews and active transforms.

All work-starting entry points now share one prologue, `transform_flow::clear_parked_review_for_pipeline_work`:

1. **Auto-dismiss a parked `ReviewPending` review** — exactly the `start_native_recording` policy from #327/#329 (race-safe `try_transition`, session cleared, popover hidden with the content-free reset event).
2. **Refuse on an ACTIVE transform phase** (Capturing/Listening/Thinking/Applying) with the entry point's message.

Wiring:
- `transcribe_file` — prologue before the pipeline; releases its already-claimed `file_transcribing` flag if the prologue refuses. In-lock transform guard kept as a race guard.
- `process_audio` — prologue before the pipeline; in-lock guard kept.
- `run_benchmark` — prologue plus a new in-lock active-transform guard ("Wait for the transform to finish before benchmarking").

## Regression proof (mutations reproduce pre-fix behavior; run on this branch)

| Pre-fix behavior restored by mutation | Result |
|---|---|
| No dismissal — parked review blocks (transcribe_file/process_audio pre-fix) | `pipeline_work_dismisses_parked_review_and_proceeds` **FAILED** |
| No transform guard at all (benchmark pre-fix) | `pipeline_work_refused_while_a_transform_phase_is_active` **FAILED** |
| Unmutated | 3/3 pass |

## Verification

- `cargo test -- --test-threads=1` — 553 passed (3 new tests)
- `npx tsc --noEmit` — clean; `npx vitest run` — 272 passed

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)