### PR TITLE
fix(transform): dictation keypress during 'thinking' no longer destroys the ready review (#333)

### DIFF
--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -922,23 +922,40 @@ pub(crate) async fn finish_transform_instruction(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, crate::State>,
 ) -> Result<(), String> {
-    let _transition = state.app_state.recording_transition.lock().await;
-
-    // Tolerate a stray release: only proceed from Listening.
-    if state.app_state.transform_status() != TransformStatus::Listening {
-        return Ok(());
-    }
-
-    let samples = crate::audio::stop_recording().unwrap_or_default();
-
     let fx = TauriFlowEffects {
         app: &app_handle,
         state: &state,
     };
-    if !enter_thinking(&state.app_state, &fx) {
-        // Lost the race to a concurrent cancel.
-        return Ok(());
-    }
+
+    // Hold `recording_transition` ONLY for the audio-stop + state transition,
+    // never across the whisper transcription or the sidecar await (issue
+    // #333). The FIFO-fair mutex means anything parked on it resumes the
+    // moment we release; pre-fix, a dictation keypress made during a long
+    // Thinking phase queued here for up to ~20s+, resumed after the review
+    // reached `ready`, and destroyed it via the parked-review auto-dismiss —
+    // silently, seconds after the physical press. With the lock released
+    // before the heavy work, that press acquires the mutex immediately,
+    // observes `Thinking` via the `blocks_recording()` guard, and is refused
+    // with `busy_transforming` — the pre-#327 behavior — so the review
+    // survives. Concurrency during Thinking is gated by `TransformStatus`,
+    // not by this mutex: every work-starting entry point refuses while the
+    // status is non-Idle.
+    let samples = {
+        let _transition = state.app_state.recording_transition.lock().await;
+
+        // Tolerate a stray release: only proceed from Listening.
+        if state.app_state.transform_status() != TransformStatus::Listening {
+            return Ok(());
+        }
+
+        let samples = crate::audio::stop_recording().unwrap_or_default();
+
+        if !enter_thinking(&state.app_state, &fx) {
+            // Lost the race to a concurrent cancel.
+            return Ok(());
+        }
+        samples
+    };
 
     let original = match transform_apply::session_snapshot(&state.app_state) {
         Some(session) => session.snapshot.text,


### PR DESCRIPTION
## Summary

Fixes #333: `finish_transform_instruction` held the FIFO-fair `recording_transition` tokio mutex across the whisper instruction-transcription **and** the sidecar await (up to `DEFAULT_TRANSFORM_DEADLINE` = 20s). `start_native_recording` parks on that mutex at its very first statement — before the "active transform blocks recording" guard — so a dictation keypress made while a transform was still *thinking* queued, resumed the moment the transform released the lock, observed the freshly-set `ReviewPending`, and destroyed the ready review via `dismiss_review_for_recording`. Silently, seconds after the physical press. In hold-down mode the matching release also queued, adding a stray ~0-length recording.

**Fix (the issue's preferred option):** the lock is now scoped to the audio-stop + `Listening → Thinking` transition only and released before the heavy awaits. A press during Thinking acquires the mutex immediately, hits the `blocks_recording()` guard, and is refused with `busy_transforming` — the pre-#327 behavior — so the review survives. Concurrency during Thinking is gated by `TransformStatus`, which every work-starting entry point checks. Ordering inside the lock is unchanged (status check → stop audio → enter_thinking), so the mic-leak and cancel-race semantics are untouched. This also removes the full-pipeline serialization behind one 20s call (#340 item 4).

## Tier: needs-live-smoke — DO NOT MERGE until a human runs the checklist

The defect is a cross-task lock-ordering race with real rdev/audio/sidecar timing; it has no headless regression test (the command layer is pinned to the Wry runtime). Unit suites only prove no regression: `cargo test -- --test-threads=1` 550 passed, `tsc` clean, `vitest` 272 passed.

### Live smoke checklist (built .app, real model)

- [ ] **The #333 repro, fixed:** select a long paragraph in Notes → hold right Option, say "make this shorter", release → while the popover still says **thinking**, double-tap left Shift (dictation). Expected: overlay flashes the transform-busy refusal immediately; when the sidecar finishes, the **ready review appears and stays**; Approve works. No dictation recording starts, no ~0-length "no speech" flash.
- [ ] Same during **listening** (hold, speak, don't release; double-tap Shift with the other hand): dictation refused, transform continues.
- [ ] Press dictation with a **ready** review parked (no transform in flight): review is auto-dismissed and recording starts (the #327/#329 behavior, unchanged).
- [ ] Esc / short-tap cancel mid-thinking still cancels promptly; a dictation press right after cancel starts recording cleanly.
- [ ] Approve → paste-fallback app (Brave): apply works; Undo restores; clipboard restored.
- [ ] Hold-down dictation mode: press-and-hold during thinking → on release, no stray recording artifacts.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)