### PR TITLE
fix(transform): visibility snapshot — no resurrecting a closed main window, no force-hiding an opened one (#337)

### DIFF
--- a/app/src-tauri/src/commands/transform_popover.rs
+++ b/app/src-tauri/src/commands/transform_popover.rs
@@ -402,6 +402,27 @@ pub fn set_transform_popover_focusable(app: tauri::AppHandle, focusable: bool) -
     set_focusable_internal(&app, focusable)
 }
 
+/// Pure re-hide decision for `set_focusable_internal` (issues #329 + #337).
+/// The main window must be re-hidden after `set_focus` when EITHER:
+///
+/// - the sticky pass-start snapshot says it was hidden (`Some(false)`) — the
+///   #329 guarantee: under rapid repeated presses a per-call check can catch
+///   the window transiently surfaced by a previous `set_focus` and would
+///   wrongly disable the guard; or
+/// - it is hidden RIGHT NOW (`currently_visible == Some(false)`) — the #337
+///   defect-A fix: the user closed the main window mid-pass, so focusing the
+///   popover must not resurrect it, even though the pass-start snapshot says
+///   "visible".
+///
+/// `currently_visible` is `None` when there is no main window (nothing to
+/// re-hide) and `true` on an `is_visible()` error (err on the side of not
+/// force-hiding a window the user may be using).
+fn should_rehide_main(sticky_was_visible: Option<bool>, currently_visible: Option<bool>) -> bool {
+    let sticky_hidden = sticky_was_visible.map(|was| !was).unwrap_or(false);
+    let currently_hidden = currently_visible.map(|is| !is).unwrap_or(false);
+    sticky_hidden || currently_hidden
+}
+
 /// Non-command core of `set_transform_popover_focusable` (issue #312 PR-C2).
 pub(crate) fn set_focusable_internal(app: &tauri::AppHandle, focusable: bool) -> Result<(), String> {
     match app.get_webview_window("transform-review") {
@@ -416,16 +437,13 @@ pub(crate) fn set_focusable_internal(app: &tauri::AppHandle, focusable: bool) ->
                 // window — recording "visible" and disabling the re-hide
                 // guard, which leaks the main window onto the screen. Fall
                 // back to a per-call snapshot only if no show recorded one.
-                let main_was_hidden = app
+                let sticky_was_visible = app
                     .try_state::<State>()
-                    .and_then(|s| *s.transform_main_was_visible.lock_or_recover())
-                    .map(|was_visible| !was_visible)
-                    .unwrap_or_else(|| {
-                        main_window
-                            .as_ref()
-                            .map(|w| !w.is_visible().unwrap_or(true))
-                            .unwrap_or(false)
-                    });
+                    .and_then(|s| *s.transform_main_was_visible.lock_or_recover());
+                let currently_visible = main_window
+                    .as_ref()
+                    .map(|w| w.is_visible().unwrap_or(true));
+                let main_was_hidden = should_rehide_main(sticky_was_visible, currently_visible);
 
                 let _ = window.set_focus();
 
@@ -661,5 +679,38 @@ mod tests {
             .unwrap()
             .insert("extraField".into(), serde_json::json!(1));
         assert!(serde_json::from_value::<TransformPopoverGeometry>(value).is_err());
+    }
+
+    // ---- should_rehide_main (issues #329 + #337) ---------------------------
+
+    #[test]
+    fn rehides_when_hidden_at_pass_start_even_if_transiently_surfaced_now() {
+        // The #329 guarantee: rapid repeated presses can catch the main
+        // window transiently surfaced by a previous set_focus. The sticky
+        // pass-start snapshot ("hidden") must keep the guard armed.
+        assert!(should_rehide_main(Some(false), Some(true)));
+        assert!(should_rehide_main(Some(false), Some(false)));
+    }
+
+    #[test]
+    fn rehides_when_user_closed_the_main_window_mid_pass() {
+        // Issue #337 defect A: snapshot says "visible" (it was, at pass
+        // start) but the user closed the window while the transform was
+        // thinking. Focusing the popover must not resurrect it.
+        assert!(should_rehide_main(Some(true), Some(false)));
+        // Same with no snapshot recorded at all.
+        assert!(should_rehide_main(None, Some(false)));
+    }
+
+    #[test]
+    fn does_not_rehide_a_window_that_was_and_is_visible() {
+        assert!(!should_rehide_main(Some(true), Some(true)));
+        assert!(!should_rehide_main(None, Some(true)));
+    }
+
+    #[test]
+    fn does_not_rehide_when_there_is_no_main_window() {
+        assert!(!should_rehide_main(None, None));
+        assert!(!should_rehide_main(Some(true), None));
     }
 }

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -950,7 +950,23 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                             // Listening/Thinking/Applying), a stray or racing
                             // hotkey press must not blow away the session that
                             // pass owns out from under it.
-                            let app_state = &handle.state::<crate::State>().app_state;
+                            let state = handle.state::<crate::State>();
+                            let app_state = &state.app_state;
+                            // Pass boundary (issue #337 defect B): drop the
+                            // sticky main-window visibility snapshot so the
+                            // new pass re-records it at its first popover
+                            // show. The supersede paths below never route
+                            // through hide_popover_internal (which is where
+                            // the snapshot is normally cleared), so without
+                            // this a pass could inherit the previous pass's
+                            // snapshot and force-hide a main window the user
+                            // deliberately opened between passes. Gated the
+                            // same way as the session clear: only at a real
+                            // pass boundary (Idle / ReviewPending), never
+                            // under a mid-flight pass.
+                            let clear_visibility_snapshot = || {
+                                *state.transform_main_was_visible.lock_or_recover() = None;
+                            };
                             // N2 (B2 review): every session clear must be paired
                             // with the matching status transition so the status
                             // is never left stranded at ReviewPending with no
@@ -962,6 +978,7 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                             match app_state.transform_status() {
                                 crate::state::TransformStatus::Idle => {
                                     crate::transform_apply::clear_session(app_state);
+                                    clear_visibility_snapshot();
                                 }
                                 crate::state::TransformStatus::ReviewPending => {
                                     if app_state.try_transition_transform_status(
@@ -969,6 +986,7 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                                         crate::state::TransformStatus::Idle,
                                     ) {
                                         crate::transform_apply::clear_session(app_state);
+                                        clear_visibility_snapshot();
                                     }
                                 }
                                 _ => {}


### PR DESCRIPTION
## Summary

Fixes #337 — two deterministic mis-behaviors of the sticky per-pass main-window visibility snapshot (`transform_main_was_visible`, #329):

**Defect A — closed main window resurrected.** The post-`set_focus` re-hide decision read only the sticky pass-start snapshot; if the user closed the main window while the transform was thinking, the snapshot still said "visible", the guard was disabled, and `set_focus` resurfaced the window they had just closed. The decision is now the pure `should_rehide_main(sticky, live)`: re-hide when the window was hidden at pass start (**keeps the #329 rapid-press guarantee** — a transiently-surfaced window cannot disarm the guard) **or** is hidden right now (closed mid-pass — never resurrect).

**Defect B — stale snapshot force-hides a window you just opened.** The transform-key supersede paths in `keyboard.rs` (Idle / ReviewPending→Idle pass boundary) never route through `hide_popover_internal`, so pass N+1 inherited pass N's snapshot; with a `Some(false)` left over, opening the main window between passes got it force-hidden at the next ready. The pass boundary now clears the snapshot alongside the session clear — gated identically (never under a mid-flight pass) — so each pass re-records at its first popover show.

## Tests

- `should_rehide_main` truth table pinned (4 tests): #329 transient-surface case, #337 closed-mid-pass case, visible-stays case, no-window case. Mutation check: restoring the pre-fix sticky-only semantics fails `rehides_when_user_closed_the_main_window_mid_pass`.
- Defect B's clear is listener wiring (rdev callback → State) — not unit-coverable headless; see checklist.
- Suite: `cargo test -- --test-threads=1` 557 passed · `tsc` clean · `vitest` 272 passed.

## Tier: needs-live-smoke — DO NOT MERGE until a human runs the checklist

Real AppKit window show/hide/focus behavior can't be verified headless.

### Live smoke checklist (built .app)

- [ ] **Defect A repro, fixed:** main window visible → start a transform in Notes → while *thinking*, close the main window (red button) → at *ready*, the popover focuses and the main window **stays closed**.
- [ ] **Defect B repro, fixed:** main window hidden → transform to *ready*, don't approve → open the main window from the tray → press the transform key again (supersede) → at pass 2's *ready*, the main window **stays open**.
- [ ] **#329 regression check:** main window hidden → rapid repeated transform presses (supersede spam) → the main window never visibly flashes/leaks on screen.
- [ ] Normal pass with the main window visible throughout: no unexpected hide.
- [ ] Approve/Undo/Esc paths still behave; popover focus still works for Approve.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)