### PR TITLE
Overlay: thinking-orb during transcription (+ disabled-state refactor)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
-        "tailwindcss": "^4.1.18"
+        "tailwindcss": "^4.1.18",
+        "thinking-orbs": "^0.1.1"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -4229,6 +4230,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thinking-orbs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.1.1.tgz",
+      "integrity": "sha512-nLvLTGJtk74K13MmP7XiRdzFiQx7UsoZAIyBZNgXyl7Q3h2mdz0r3eKn9LCsuzb3DGOVjwDvMhtnAkIqJJRVQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/tinybench": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "thinking-orbs": "^0.1.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -28,7 +28,14 @@ pub struct AppliedSurface {
 }
 
 // Private geometry constants — the ONLY place these magic numbers live.
-const PILL_IDLE_PAD: f64 = 28.0;
+//
+// PILL_IDLE_PAD is split evenly into a left and right wing around the notch when
+// the pill is idle (`pill_margin_idle = (window_w - pill_idle_w) / 2`), so the
+// idle left wing is always `PILL_IDLE_PAD / 2` points wide regardless of notch
+// size. It must stay wide enough that the top-bar indicator (a 12pt icon at 10pt
+// left padding) clears the physical notch edge — at 28.0 the wing was only 14pt
+// and the idle mic / disabled indicator rendered mostly *behind* the notch.
+const PILL_IDLE_PAD: f64 = 56.0;
 const WINDOW_EXPAND: f64 = 120.0; // active pill pad too (fills window)
 const DROPDOWN_H: f64 = 44.0;
 const FALLBACK_NOTCH_W: f64 = 80.0;
@@ -339,7 +346,7 @@ mod tests {
                 g.pill_margin_active,
                 g.dropdown_h,
             ),
-            (305.0, 32.0, 76.0, 213.0, 305.0, 46.0, 0.0, 44.0)
+            (305.0, 32.0, 76.0, 241.0, 305.0, 32.0, 0.0, 44.0)
         );
     }
 

--- a/app/src/components/OverlayWidget.tsx
+++ b/app/src/components/OverlayWidget.tsx
@@ -29,6 +29,38 @@ export function OverlayWidget() {
   const hotkeyMissFeedbackRef = useRef(false);
   const statusRef = useRef<DictationStatus>('idle');
 
+  // Minimum-visible processing window. Neural-Engine transcription can finish in
+  // ~200ms, which would flash the processing indicator (the thinking orb) too
+  // briefly to perceive. Hold the *visual* status in `processing` for at least
+  // MIN_PROCESSING_MS after it begins — the real `status` the hooks below depend
+  // on is untouched. A new recording always overrides the hold immediately.
+  const MIN_PROCESSING_MS = 1000;
+  const [displayStatus, setDisplayStatus] = useState<DictationStatus>('idle');
+  const processingSinceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (status === 'processing') {
+      processingSinceRef.current = Date.now();
+      setDisplayStatus('processing');
+      return;
+    }
+    if (status === 'recording') {
+      processingSinceRef.current = null;
+      setDisplayStatus('recording');
+      return;
+    }
+    // status === 'idle': if we were showing processing, keep the orb up for the
+    // remainder of the minimum window before falling back to idle.
+    if (processingSinceRef.current !== null) {
+      const remaining = Math.max(0, MIN_PROCESSING_MS - (Date.now() - processingSinceRef.current));
+      processingSinceRef.current = null;
+      if (remaining === 0) { setDisplayStatus('idle'); return; }
+      setDisplayStatus('processing');
+      const timer = window.setTimeout(() => setDisplayStatus('idle'), remaining);
+      return () => window.clearTimeout(timer);
+    }
+    setDisplayStatus('idle');
+  }, [status]);
+
   const settingsMirror = useOverlaySettingsMirror({ setDisabled, setShowHotkeyMiss, hotkeyMissFeedbackRef });
 
   const runtime = useOverlayRuntime({
@@ -47,7 +79,7 @@ export function OverlayWidget() {
     status, statusRef, disabledRef: runtime.disabledRef, expandedRef,
   });
 
-  const visual = deriveVisual(status, runtime.showCancelled, runtime.showHotkeyMiss, runtime.disabled);
+  const visual = deriveVisual(displayStatus, runtime.showCancelled, runtime.showHotkeyMiss, runtime.disabled);
 
   // Log mount/unmount.
   useEffect(() => {
@@ -121,10 +153,16 @@ export function OverlayWidget() {
             ? geometry.pillActiveW
             : geometry.pillIdleW,
           height: topH + (expanded ? geometry.dropdownH : 0),
-          marginLeft: (expanded || visual.isActive)
-            ? geometry.pillMarginActive
-            : geometry.pillMarginIdle,
-          background: 'rgba(20, 20, 20, 0.92)',
+          // Centering offset via transform (not margin) so it animates on the
+          // compositor in lockstep with width — see OVERLAY_ISLAND_TRANSITION.
+          transform: `translateX(${
+            (expanded || visual.isActive)
+              ? geometry.pillMarginActive
+              : geometry.pillMarginIdle
+          }px)`,
+          // Subtle red-tinted charcoal when globally disabled; crossfades with the
+          // mic morph (background-color is in OVERLAY_ISLAND_TRANSITION).
+          backgroundColor: runtime.disabled ? 'rgba(34, 18, 18, 0.92)' : 'rgba(20, 20, 20, 0.92)',
           boxShadow: visual.showTapMissedLabel ? 'inset 0 -2px 0 rgba(245,158,11,0.9), 0 3px 16px rgba(245,158,11,0.22)' : 'none',
           backdropFilter: 'blur(40px)',
           WebkitBackdropFilter: 'blur(40px)',
@@ -134,7 +172,7 @@ export function OverlayWidget() {
         <OverlayPill
           geometry={geometry}
           visual={visual}
-          status={status}
+          status={displayStatus}
           barRefs={waveform.barRefs}
         />
         <OverlayDropdown

--- a/app/src/components/overlay/OverlayPill.tsx
+++ b/app/src/components/overlay/OverlayPill.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import type { OverlayGeometry } from '../../lib/overlayGeometry';
 import type { DictationStatus } from '../../lib/types';
 import { BAR_COUNT } from '../../lib/hooks/useWaveform';
+import { OVERLAY_STATE_MS, OVERLAY_ACTIVE_EASE } from '../../lib/overlayMotion';
 import type { OverlayVisual } from './deriveVisual';
+import { ThinkingOrb } from 'thinking-orbs';
 
 function formatElapsed(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -42,13 +44,17 @@ export function OverlayPill({
 
   const topH = geometry.collapsedH;
   const { indicator } = visual;
+  // The final indicator branch renders both idle and disabled from one node so
+  // the enable↔disable toggle can animate; this flag drives the morph.
+  const micDisabled = indicator.kind === 'disabled';
 
   return (
     <>
       {/* Top bar — the only draggable surface (keeps the dropdown buttons clickable) */}
       <div data-tauri-drag-region className="flex items-center" style={{ height: topH, paddingLeft: 10, paddingRight: 10 }}>
-        {/* Left side — mic icon (idle) or red dot (recording) or spinner (processing) or red X (cancelled), all same position */}
-        <div className="shrink-0 w-3 h-3 flex items-center justify-center">
+        {/* Left side — mic icon (idle) or red dot (recording) or thinking orb (processing) or red X (cancelled), all same position.
+            The processing orb needs a larger box (20px) than the 12px icons; during processing there's no timer/waveform, so growing the slot doesn't crowd anything. */}
+        <div className={`shrink-0 flex items-center justify-center ${indicator.kind === 'processing' ? 'w-5 h-5' : 'w-3 h-3'}`}>
           {indicator.kind === 'cancelled' ? (
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
               <line x1="6" y1="6" x2="18" y2="18" />
@@ -61,12 +67,39 @@ export function OverlayPill({
           ) : indicator.kind === 'recording' ? (
             <div className="w-2.5 h-2.5 rounded-full bg-red-500" style={{ animation: 'pulse 0.8s ease-in-out infinite' }} />
           ) : indicator.kind === 'processing' ? (
-            <span className="w-3 h-3 border-[1.5px] border-white/20 border-t-white/70 rounded-full animate-spin block" />
+            // Thinking-orb (MIT, thinking-orbs) — "working" state signals transcription in progress.
+            <ThinkingOrb state="working" size={20} theme="dark" aria-label="Transcribing" />
           ) : (
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: indicator.dimmed ? 0.15 : 1 }}>
+            /* Idle OR globally-disabled: ONE persistent mic node so the enable↔disable
+               toggle morphs instead of hard-swapping two SVGs. The stroke crossfades
+               white↔red and the slash draws itself in/out (pathLength-normalized
+               dashoffset). Disabled is a distinct shape (slashed red mic), not a dimmed
+               mic — at 12px an opacity change is unreadable, and this state silently
+               swallows every recording. */
+            <svg
+              width="12" height="12" viewBox="0 0 24 24" fill="none"
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              style={{
+                stroke: micDisabled ? '#ef4444' : 'rgba(255,255,255,0.4)',
+                transition: `stroke ${OVERLAY_STATE_MS}ms ${OVERLAY_ACTIVE_EASE}`,
+              }}
+              aria-label={micDisabled ? 'Murmur is disabled' : undefined}
+              role={micDisabled ? 'img' : undefined}
+            >
               <rect x="9" y="1" width="6" height="12" rx="3" />
               <path d="M5 10a7 7 0 0 0 14 0" />
               <line x1="12" y1="17" x2="12" y2="21" />
+              {/* Slash: always mounted, red, drawn in only when disabled. pathLength=1
+                  normalizes the diagonal so dashoffset 1→0 sweeps it on (and 0→1
+                  retracts it on re-enable). */}
+              <line
+                x1="3" y1="3" x2="21" y2="21" stroke="#ef4444"
+                pathLength={1} strokeDasharray={1}
+                style={{
+                  strokeDashoffset: micDisabled ? 0 : 1,
+                  transition: `stroke-dashoffset ${OVERLAY_STATE_MS}ms ${OVERLAY_ACTIVE_EASE}`,
+                }}
+              />
             </svg>
           )}
         </div>

--- a/app/src/components/overlay/deriveVisual.test.ts
+++ b/app/src/components/overlay/deriveVisual.test.ts
@@ -20,7 +20,7 @@ function expectedIndicator(
   if (showHotkeyMiss) return { kind: 'hotkeyMiss' };
   if (status === 'recording') return { kind: 'recording' };
   if (status === 'processing') return { kind: 'processing' };
-  return { kind: 'idle', dimmed: disabled };
+  return disabled ? { kind: 'disabled' } : { kind: 'idle' };
 }
 
 describe('deriveVisual', () => {
@@ -55,8 +55,27 @@ describe('deriveVisual', () => {
     expect(visual.indicator).toEqual({ kind: 'hotkeyMiss' });
   });
 
-  it('dims the idle mic icon only when disabled and otherwise idle', () => {
-    expect(deriveVisual('idle', false, false, true).indicator).toEqual({ kind: 'idle', dimmed: true });
-    expect(deriveVisual('idle', false, false, false).indicator).toEqual({ kind: 'idle', dimmed: false });
+  it('surfaces global-disable as its own indicator, not a dimmed idle mic', () => {
+    expect(deriveVisual('idle', false, false, true).indicator).toEqual({ kind: 'disabled' });
+    expect(deriveVisual('idle', false, false, false).indicator).toEqual({ kind: 'idle' });
+  });
+
+  // Regression: global-disable was previously signalled only by dropping the
+  // idle mic to 15% opacity, which is ~6% effective white on the dark pill and
+  // indistinguishable from enabled at a glance. A user clicked the notch ~20
+  // times over 20 minutes with no feedback while every start_native_recording
+  // was rejected with "app disabled — ignoring". The off state must be a
+  // distinct indicator kind so it can render a distinct shape, not an alpha.
+  it('does not represent disabled as an opacity variant of idle', () => {
+    const off = deriveVisual('idle', false, false, true).indicator;
+    expect(off.kind).not.toBe('idle');
+    expect(off).not.toHaveProperty('dimmed');
+  });
+
+  it('keeps transient flashes and active statuses ahead of disabled', () => {
+    expect(deriveVisual('idle', true, false, true).indicator).toEqual({ kind: 'cancelled' });
+    expect(deriveVisual('idle', false, true, true).indicator).toEqual({ kind: 'hotkeyMiss' });
+    expect(deriveVisual('recording', false, false, true).indicator).toEqual({ kind: 'recording' });
+    expect(deriveVisual('processing', false, false, true).indicator).toEqual({ kind: 'processing' });
   });
 });

--- a/app/src/components/overlay/deriveVisual.ts
+++ b/app/src/components/overlay/deriveVisual.ts
@@ -3,15 +3,19 @@ import type { DictationStatus } from '../../lib/types';
 /**
  * Which indicator the top-bar left slot shows. Mirrors the priority chain that
  * used to live inline as a ternary in OverlayWidget's JSX: cancelled beats a
- * hotkey-miss flash, which beats an active status, which beats idle. `dimmed`
- * only applies to the idle mic icon (the global-disable dimming effect).
+ * hotkey-miss flash, which beats an active status, which beats idle.
+ *
+ * `disabled` is its own kind rather than a flag on `idle` because global
+ * disable is a distinct state the user must be able to read at a glance, and
+ * the renderer owes it a distinct shape — not an alpha applied to the idle mic.
  */
 export type OverlayIndicator =
   | { kind: 'cancelled' }
   | { kind: 'hotkeyMiss' }
   | { kind: 'recording' }
   | { kind: 'processing' }
-  | { kind: 'idle'; dimmed: boolean };
+  | { kind: 'disabled' }
+  | { kind: 'idle' };
 
 export interface OverlayVisual {
   /** Which icon/badge the top-bar left slot renders. */
@@ -31,12 +35,17 @@ export interface OverlayVisual {
  * as the original ternary chain in OverlayWidget.tsx did:
  *
  *   showCancelled ? X : showHotkeyMiss ? ! : status==='recording' ? dot
- *     : status==='processing' ? spinner : mic (dimmed if disabled)
+ *     : status==='processing' ? spinner : disabled ? slashed mic : mic
  *
- * Priority: cancelled > hotkey-miss > recording > processing > idle. (Since
- * `status` is a single enum value, recording and processing can never both be
- * true, so their relative order does not change behavior — only idle's
- * position at the end, after both, matters.)
+ * Priority: cancelled > hotkey-miss > recording > processing > disabled > idle.
+ * (Since `status` is a single enum value, recording and processing can never
+ * both be true, so their relative order does not change behavior — only the
+ * disabled/idle pair's position at the end, after both, matters.)
+ *
+ * Global disable sits below the transient flashes and the active statuses on
+ * purpose: a cancelled or hotkey-miss flash is a response to something the user
+ * just did and must not be swallowed, and a recording already in flight when
+ * disable lands should keep showing its true state until it settles.
  */
 export function deriveVisual(
   status: DictationStatus,
@@ -52,7 +61,9 @@ export function deriveVisual(
         ? { kind: 'recording' }
         : status === 'processing'
           ? { kind: 'processing' }
-          : { kind: 'idle', dimmed: disabled };
+          : disabled
+            ? { kind: 'disabled' }
+            : { kind: 'idle' };
 
   return {
     indicator,

--- a/app/src/components/overlay/overlay-geometry.fixture.json
+++ b/app/src/components/overlay/overlay-geometry.fixture.json
@@ -1,4 +1,4 @@
 {
-  "notched":  { "windowW":305,"collapsedH":32,"expandedH":76,"pillIdleW":213,"pillActiveW":305,"pillMarginIdle":46,"pillMarginActive":0,"dropdownH":44 },
-  "fallback": { "windowW":200,"collapsedH":37,"expandedH":81,"pillIdleW":108,"pillActiveW":200,"pillMarginIdle":46,"pillMarginActive":0,"dropdownH":44 }
+  "notched":  { "windowW":305,"collapsedH":32,"expandedH":76,"pillIdleW":241,"pillActiveW":305,"pillMarginIdle":32,"pillMarginActive":0,"dropdownH":44 },
+  "fallback": { "windowW":200,"collapsedH":37,"expandedH":81,"pillIdleW":136,"pillActiveW":200,"pillMarginIdle":32,"pillMarginActive":0,"dropdownH":44 }
 }

--- a/app/src/components/overlay/overlayGeometry.test.ts
+++ b/app/src/components/overlay/overlayGeometry.test.ts
@@ -24,14 +24,14 @@ describe('overlay geometry contract fixture', () => {
   it('locks the characterization values', () => {
     expect(fixture.notched).toEqual({
       windowW: 305, collapsedH: 32, expandedH: 76,
-      pillIdleW: 213, pillActiveW: 305,
-      pillMarginIdle: 46, pillMarginActive: 0,
+      pillIdleW: 241, pillActiveW: 305,
+      pillMarginIdle: 32, pillMarginActive: 0,
       dropdownH: 44,
     });
     expect(fixture.fallback).toEqual({
       windowW: 200, collapsedH: 37, expandedH: 81,
-      pillIdleW: 108, pillActiveW: 200,
-      pillMarginIdle: 46, pillMarginActive: 0,
+      pillIdleW: 136, pillActiveW: 200,
+      pillMarginIdle: 32, pillMarginActive: 0,
       dropdownH: 44,
     });
   });

--- a/app/src/lib/overlayMotion.ts
+++ b/app/src/lib/overlayMotion.ts
@@ -9,12 +9,29 @@
 // Values are identical to what shipped before this module existed: there is zero
 // intended visual or timing change, only a single definition point.
 
-/** Width transition duration for the island element (ms). */
+/** Width/position transition duration for the island element (ms). */
 export const OVERLAY_WIDTH_MS = 400;
 /** Height transition duration for the island element (ms). */
 export const OVERLAY_HEIGHT_MS = 360;
-/** Spring easing shared by the width and height transitions. */
+/** Spring easing (with overshoot) for the hover dropdown's height growth. */
 export const OVERLAY_SPRING = 'cubic-bezier(0.34,1.56,0.64,1)';
+/**
+ * Easing for the idle↔active width + horizontal-position change (the "in use /
+ * not in use" transition). A smooth decelerate with NO overshoot: the active
+ * pill grows to exactly the window width, so an overshooting spring would push
+ * the pill past the window frame where it is clipped — making the settle read as
+ * an abrupt cut. easeOutQuint-style deceleration lands cleanly at full width.
+ */
+export const OVERLAY_ACTIVE_EASE = 'cubic-bezier(0.22,1,0.36,1)';
+
+/**
+ * Duration (ms) for the enable↔disable state morph: the top-bar mic's stroke
+ * color crossfade (white↔red), the slashed-out line drawing in/out, and the
+ * pill's background tint. Shares `OVERLAY_ACTIVE_EASE` so the whole indicator
+ * settles with the same no-overshoot feel as the width/position change. Without
+ * it the disable toggle swapped two separate SVG nodes instantly, a hard cut.
+ */
+export const OVERLAY_STATE_MS = 260;
 
 /** Sustained hover (ms) required on the island before the card opens. */
 export const HOVER_OPEN_DWELL_MS = 150;
@@ -32,9 +49,16 @@ export const COLLAPSE_DELAY_MS = 300;
 export const SHRINK_DELAY_MS = OVERLAY_HEIGHT_MS + 20;
 
 /**
- * The composed `transition` string applied to the island element. Templated from
- * the tokens above so it stays byte-identical to the previous inline literal
- * (`width 400ms cubic-bezier(0.34,1.56,0.64,1), height 360ms cubic-bezier(0.34,1.56,0.64,1)`).
+ * The composed `transition` string applied to the island element. Width and
+ * horizontal position (`transform: translateX`) animate together with the
+ * non-overshoot active ease so the idle↔active change grows and slides as one
+ * smooth motion — previously `margin-left` was NOT transitioned, so the pill's
+ * left edge snapped while its width sprang, an asymmetric jump. Height keeps the
+ * playful spring for the hover dropdown, which grows into open space below the
+ * notch and benefits from the overshoot.
  */
 export const OVERLAY_ISLAND_TRANSITION =
-  `width ${OVERLAY_WIDTH_MS}ms ${OVERLAY_SPRING}, height ${OVERLAY_HEIGHT_MS}ms ${OVERLAY_SPRING}`;
+  `width ${OVERLAY_WIDTH_MS}ms ${OVERLAY_ACTIVE_EASE}, ` +
+  `transform ${OVERLAY_WIDTH_MS}ms ${OVERLAY_ACTIVE_EASE}, ` +
+  `height ${OVERLAY_HEIGHT_MS}ms ${OVERLAY_SPRING}, ` +
+  `background-color ${OVERLAY_STATE_MS}ms ${OVERLAY_ACTIVE_EASE}`;

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -49,7 +49,7 @@ Tauri's `focusable: false` configuration disables mouse events on macOS. The `sh
 
 Every overlay dimension comes from one source: `geometry_for(notch)` in `commands/overlay.rs`, which returns an `OverlayGeometry` (`windowW`, `collapsedH`, `expandedH`, `pillIdleW`, `pillActiveW`, `pillMarginIdle`, `pillMarginActive`, `dropdownH`). Rust owns every geometry number; the frontend only reads the struct — via `get_overlay_geometry` (`useOverlayGeometry`, with retry-with-backoff on the initial fetch) and the `overlay-geometry-changed` event — and never hardcodes pixels. No overlay component holds a geometry literal.
 
-- **Pill width** adjusts based on recording state and hover: `pillIdleW` (centered by a `pillMarginIdle` left margin) when idle-and-collapsed, or `pillActiveW` (fills the window, `pillMarginActive = 0`) when recording, processing, cancelled-flash, hotkey-miss-flash, or hover-expanded.
+- **Pill width** adjusts based on recording state and hover: `pillIdleW` (centered by `pillMarginIdle`, applied as a `translateX` offset) when idle-and-collapsed, or `pillActiveW` (fills the window, `pillMarginActive = 0`) when recording, processing, cancelled-flash, hotkey-miss-flash, or hover-expanded. `pillIdleW = notchW + PILL_IDLE_PAD` with `PILL_IDLE_PAD = 56`, so the idle pill keeps a `PILL_IDLE_PAD / 2 = 28pt` wing on each side of the notch — wide enough that the left-aligned top-bar indicator (idle mic / disabled slashed-mic) clears the physical notch edge instead of rendering behind it.
 - **Window width** (`windowW`) is fixed and horizontally centers the overlay at the top of the screen (y=0).
 - **Height** is `collapsedH` at rest and grows to `expandedH` (`= collapsedH + dropdownH`) while the hover dropdown is open; the window stays top-anchored so the extra height grows downward.
 - **Motion tokens** — durations and easing for the width/height transition — live in `app/src/lib/overlayMotion.ts` as the single source; see [Motion tokens](#motion-tokens) below rather than restating numbers here.
@@ -81,7 +81,7 @@ The controller runs a four-phase state machine:
 
 ### Motion tokens
 
-The transition durations/easings live in `app/src/lib/overlayMotion.ts` as the single source: `OVERLAY_WIDTH_MS`, `OVERLAY_HEIGHT_MS`, `OVERLAY_SPRING`, `HOVER_OPEN_DWELL_MS`, `COLLAPSE_DELAY_MS`. `SHRINK_DELAY_MS` is **derived** as `OVERLAY_HEIGHT_MS + 20` rather than a hand-tuned constant, so it can never drift from the height transition it guards. The island's `transition` string (`OVERLAY_ISLAND_TRANSITION`) is templated from these tokens. Read that file for current values rather than duplicating them in prose here. With `prefers-reduced-motion: reduce`, CSS transitions are removed (see `styles.css`) and the controller shrinks immediately after the leave-intent delay, avoiding both motion and a residual transparent hit area.
+The transition durations/easings live in `app/src/lib/overlayMotion.ts` as the single source: `OVERLAY_WIDTH_MS`, `OVERLAY_HEIGHT_MS`, `OVERLAY_SPRING`, `OVERLAY_ACTIVE_EASE`, `HOVER_OPEN_DWELL_MS`, `COLLAPSE_DELAY_MS`. `SHRINK_DELAY_MS` is **derived** as `OVERLAY_HEIGHT_MS + 20` rather than a hand-tuned constant, so it can never drift from the height transition it guards. The island's `transition` string (`OVERLAY_ISLAND_TRANSITION`) is templated from these tokens. The idle↔active change animates **both** `width` and horizontal position (`transform: translateX`, not `margin-left`) with `OVERLAY_ACTIVE_EASE` — a no-overshoot decelerate — so the pill grows and slides as one smooth motion that lands cleanly at the window edge; `margin-left` used to be omitted from the transition entirely, so the left edge snapped while the width sprang. Height keeps `OVERLAY_SPRING` (overshoot) for the hover dropdown, which grows into open space below the notch. Read that file for current values rather than duplicating them in prose here. With `prefers-reduced-motion: reduce`, CSS transitions are removed (see `styles.css`) and the controller shrinks immediately after the leave-intent delay, avoiding both motion and a residual transparent hit area.
 
 ## Frontend Hooks
 
@@ -98,7 +98,7 @@ The transition durations/easings live in `app/src/lib/overlayMotion.ts` as the s
 
 Pure, React-free logic lives alongside the presentational components in `app/src/components/overlay/`:
 
-- **`deriveVisual.ts`** — `(status, showCancelled, showHotkeyMiss, disabled) → OverlayVisual`. Encodes the top-bar indicator priority (cancelled > hotkey-miss > recording > processing > idle-with-disabled-dimming) exactly once; locked by an exhaustive matrix test (`deriveVisual.test.ts`) over every status × flag combination.
+- **`deriveVisual.ts`** — `(status, showCancelled, showHotkeyMiss, disabled) → OverlayVisual`. Encodes the top-bar indicator priority (cancelled > hotkey-miss > recording > processing > disabled > idle) exactly once; locked by an exhaustive matrix test (`deriveVisual.test.ts`) over every status × flag combination.
 
 Presentational components, both driven entirely by props (no hooks beyond `OverlayPill`'s own local elapsed-timer state):
 
@@ -111,7 +111,7 @@ The island **container** (sizing, hover handlers, `islandRef`) stays in `Overlay
 
 | Control | Action |
 |---------|--------|
-| Power | Toggles global disable. Calls `set_app_disabled` directly for an immediate gate. When disabled: red icon (`#ef4444`) on a red-tinted background, auto-paste dims to 35%, top-bar mic fades to 15%. Global disable is also a "Disable Murmur" check item in the tray menu; the command keeps the tray check state in sync and the main window persists tray-driven changes. |
+| Power | Toggles global disable. Calls `set_app_disabled` directly for an immediate gate. When disabled: red icon (`#ef4444`) on a red-tinted background, auto-paste dims to 35%, and the top-bar mic becomes the red slashed-mic disabled indicator. Global disable is also a "Disable Murmur" check item in the tray menu; the command keeps the tray check state in sync and the main window persists tray-driven changes. |
 | Auto-paste toggle | Reads/writes the `autoPaste` setting via `loadSettings()`/`saveSettings()`. |
 | Gear | Emits `open-settings` and shows/focuses the main window (`show_main_window`). |
 
@@ -126,7 +126,14 @@ The overlay runs in a separate window with no shared React context. Writes go th
 The overlay's top-bar indicator is a pure function of status + two transient flags + global-disable (`deriveVisual()`); `status` itself is driven by the `recording-status-changed` event.
 
 ### Idle
-Small mic SVG icon at 40% white opacity (dimmed further to 15% when globally disabled). Compact width.
+Small mic SVG icon at 40% white opacity. Compact width.
+
+### Globally disabled
+Slashed mic icon in red (`#ef4444`), the same red as the dropdown's Power control, carrying an `aria-label` of "Murmur is disabled". Compact width.
+
+The enable↔disable change **morphs** rather than hard-swapping: idle and disabled render from a single persistent mic node in `OverlayPill`, so the stroke crossfades white↔red, the slash line draws itself in/out (a `pathLength`-normalized `stroke-dashoffset` sweep), and the pill's background crossfades to a red-tinted charcoal — all over `OVERLAY_STATE_MS` with `OVERLAY_ACTIVE_EASE`. (Because both states share one node in the final indicator branch, React reuses the DOM node when only `disabled` flips, which is what lets the CSS transitions fire.)
+
+This is a **distinct indicator kind** (`{ kind: 'disabled' }`), not an opacity variant of idle. It previously rendered as the idle mic at 15% opacity — roughly 6% effective white on the dark pill, which was indistinguishable from the enabled state at 12px. Because global disable silently rejects every recording (`start_native_recording: app disabled — ignoring`), a state that swallows all input has to be legible from the collapsed pill alone, without opening the dropdown. Disable ranks below the transient flashes and active statuses in the priority chain, so a cancelled/hotkey-miss flash is never swallowed and an in-flight recording keeps showing its true state until it settles.
 
 ### Recording
 Expanded width. The red pulsing dot and elapsed timer occupy the visible left wing, while the animated 7-bar waveform occupies the right. No transcript text is displayed while recording.


### PR DESCRIPTION
## What

Two overlay changes shipped together:

### Thinking-orb during transcription
Replaces the small CSS spinner in the overlay's **processing** state with a [`ThinkingOrb`](https://github.com/Jakubantalik/thinking-orbs) (`state="working"`, MIT © Jakub Antalik). Recording keeps its live audio waveform — only the transcribing indicator changes.

- New dep: `thinking-orbs` (zero-dependency, canvas-based, auto dark/light, respects reduced-motion).
- `OverlayPill`: processing branch renders the orb; the left slot grows to 20px only in that state (no timer/waveform competes then).
- **Min-display window** (`OverlayWidget`): holds the processing *visual* for a 1s minimum so the orb is perceptible even when Neural-Engine transcription finishes in ~200ms. The real `status` the hooks depend on is untouched; a new recording overrides the hold immediately.

### Disabled-state refactor (bundled)
Distinct `disabled` indicator kind (slashed mic) instead of a dimmed idle mic, transform-based pill centering (compositor-animated in lockstep with width), and a wider idle wing (`PILL_IDLE_PAD` 28→56) so the indicator clears the physical notch. Includes matching motion/test/doc/fixture updates.

## Testing
- `npx tsc --noEmit` — clean
- `vitest run` — 196 passed (28 files), incl. updated `deriveVisual` / `overlayGeometry` tests
- `vite build` — overlay bundle builds with the new dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new animated “thinking” indicator for processing and transcription states.
  * Added a distinct disabled overlay state with a red slashed-microphone indicator.
* **Improvements**
  * Processing status remains visible briefly to provide smoother feedback.
  * Improved overlay positioning, sizing, background transitions, and idle-to-active animations.
  * Updated idle overlay geometry for better spacing.
* **Documentation**
  * Updated overlay behavior, motion, geometry, and disabled-state documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->