### PR TITLE
docs: decide honest accelerator diagnostics metrics

### DIFF
--- a/docs/decisions/2026-07-22-accelerator-diagnostics-metrics.md
+++ b/docs/decisions/2026-07-22-accelerator-diagnostics-metrics.md
@@ -1,0 +1,120 @@
+# Honest accelerator metrics for Diagnostics
+
+- **Status:** accepted
+- **Date:** 2026-07-22
+- **Issue:** [#354](https://github.com/georgenijo/murmur-app/issues/354)
+- **Parent:** [#350](https://github.com/georgenijo/murmur-app/issues/350)
+
+## Decision
+
+Diagnostics must not display a GPU or ANE utilization percentage. Murmur's
+pinned inference runtimes do not expose the command buffers, encoders, or
+execution-plan data needed to derive one from public APIs, and Core ML does not
+provide a public production API for reporting which compute unit executed an
+operation.
+
+The production contract should ship backend identity, end-to-end timing,
+throughput where meaningful, correctly scoped memory, and an explicit
+unavailable state. Command-buffer timing, Metal counters, Metal allocation
+accounting, Metal HUD/capture, and Core ML Instruments remain developer
+diagnostics until the relevant pinned runtime exposes an integration seam and a
+production rehearsal proves the result.
+
+This spike changes no production UI, telemetry schema, dependency, sidecar
+protocol, entitlement, or signing configuration.
+
+## Production backend matrix
+
+Every backend has one disposition and exact user-facing metric names:
+
+| Backend | Exact metrics | Public source | Precision and scope | Availability, overhead, and release impact | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| Whisper / Metal | `Backend: Whisper / Metal`; `Inference duration (ms)`; `Real-time factor`; `Main-process RSS (MiB)`; `GPU utilization unavailable` | Existing Rust `Instant` timing, decoded audio duration, and `memory-stats` task RSS | Integer-millisecond request wall time; ratio against audio seconds. RSS is the main process and includes non-model memory. No percentage is inferred. | Apple Silicon, macOS 14+; negligible new cost; no entitlement, signing, or dependency change. | **SHIP** |
+| Local LLM / Metal sidecar | `Backend: Local LLM / Metal (sidecar)`; `Generation duration (ms)`; `Output throughput (tokens/s)`; `Sidecar RSS (MiB)`; `GPU utilization unavailable` | Existing `Instant` duration and protocol `output_tokens`; public task/process RSS measured by the helper | Integer-millisecond request wall time; token rate derived from returned output-token count. RSS must be measured inside the helper, not attributed to the main process. | Apple Silicon, macOS 14+; timing is already available. Helper RSS needs a reviewed RSS implementation plus protocol, tests, and split-entitlement signing rehearsal; no privilege or private API. | **SHIP** |
+| Core ML | `Backend: Core ML / automatic compute-unit selection`; `Inference duration (ms)`; `Real-time factor`; `Main-process RSS (MiB)`; `Accelerator utilization unavailable` | Existing request timing and FluidAudio `processing_time`; public Core ML model configuration; `memory-stats` RSS | Integer-millisecond wall/model timing and ratio against audio seconds. `computeUnits` is an allowed execution set, not proof that ANE or GPU executed an operation. | Apple Silicon, macOS 14+; negligible new sampling cost; no entitlement/signing change or new dependency. | **SHIP** |
+| CPU | `Backend: CPU`; `Inference duration (ms)`; `Real-time factor`; `Main-process RSS (MiB)`; `Host CPU utilization (%)` | Existing Rust `Instant`, audio duration, `memory-stats`, and public Mach `host_statistics64` | Integer-millisecond request wall time. The existing CPU value is system-wide, so it must say `Host`, not process. RSS remains main-process scoped. | Murmur's supported macOS 14+ and Linux paths; existing Diagnostics cadence; no new entitlement, signing, or dependency change. | **SHIP** |
+
+`SHIP` is the recommendation for the Diagnostics production follow-up, not an
+implementation in this evidence spike. The unavailable labels are part of the
+contract: absence must not be rendered as zero. ANE activity must never be
+presented as GPU activity.
+
+## Public API and tool matrix
+
+| Candidate | What it can honestly measure | Integration boundary | Hardware / OS and overhead | Entitlements, signing, dependencies | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| `MTLCommandBuffer.gpuStartTime` / `gpuEndTime` | `Metal command-buffer GPU elapsed time (ms)` for an accessible completed command buffer | The pinned whisper.cpp and llama.cpp runtimes own multiple internal command buffers and expose no callback. Summing buffers could overcount overlap; dividing by wall time would not be whole-device utilization. | Public API compiled against the current deployment target. Standalone M4 probe median wall delta: 0.75–1.31 µs for its owned synthetic dispatch. | No special entitlement in the probe. Production use requires maintained runtime patches; the sidecar also requires protocol and signed-helper changes. | **DEVELOPER-ONLY** |
+| Metal counter sample buffers | `Metal timestamp counter delta (ticks)` and only counters the device reports | Requires access to an encoder/pass descriptor. The standalone M4 exposed only `timestamp/GPUTimestamp`, with stage-boundary sampling only. | Hardware-dependent; runtime checks required. Standalone median wall delta: 4.31–6.71 µs. No utilization counter was available on the test host. | No special entitlement in the probe. Production use requires runtime integration and a Metal binding or native bridge. | **DEVELOPER-ONLY** |
+| `MTLDevice.currentAllocatedSize` | `Metal resource allocation (MiB)` for resources visible through that process's device | The probe tracked its explicit 64 MiB buffer exactly, but did not prove that either pinned runtime's allocations are observable. It cannot observe the helper from the main process. | Public API; unified-memory accounting is not VRAM, residency, bandwidth, or utilization. Cheap to sample but can overlap conceptually with RSS. | No special entitlement in the probe. Helper reporting would change its protocol and signed binary. | **DEVELOPER-ONLY** |
+| Metal Performance HUD, GPU capture, Xcode Instruments | Developer frame/command/counter reports | Appropriate for an engineer-controlled run, not a stable in-app data source. | Availability and counters vary by Xcode, OS, and hardware; capture can materially perturb workloads. | Developer tooling; not a shipped dependency or entitlement. | **DEVELOPER-ONLY** |
+| Core ML Instruments | Developer-only operation placement and timing evidence | Profiles a selected run; it is not a production telemetry API and does not authorize labeling normal runs as ANE or GPU. | Requires a compatible Xcode/macOS/hardware combination; profiling overhead is tool-dependent. | Developer tooling; no production integration. | **DEVELOPER-ONLY** |
+| Privileged power samplers or private frameworks | Host-level estimated power/activity, not a stable per-Murmur utilization contract | Requires privileges or undocumented interfaces and cannot be constrained honestly to Murmur's command buffers. | Host- and OS-dependent; estimates may be inaccurate. | Root/private API requirements violate the release boundary. | **DO NOT SHIP** |
+
+## Pinned-runtime inspection
+
+The conclusion is specific to the versions Murmur ships:
+
+- `whisper-rs 0.15.1` / `whisper-rs-sys 0.14.1`, vendoring whisper.cpp
+  `v1.7.6`. Its public Metal header exposes context/buffer/graph and capture
+  controls, but no command-buffer timing or counter callback.
+- `llama-cpp-2 0.1.151` / `llama-cpp-sys-2 0.1.151`, whose vendored llama.cpp
+  revision is `9e3b928fd8c9d14dbf15a8768b9fdd7e5c721d66`. Its public Metal header likewise
+  has no timing/counter callback. It runs in Murmur's separately signed,
+  sandboxed helper.
+- `fluidaudio-rs` is pinned to
+  `2d1083314104c812944b5150866d1e334db8eed7` (FluidAudio 0.14.1). Core ML's
+  public model configuration selects permitted compute units; developer
+  profiling can inspect a run, but production code cannot report honest
+  per-operation ANE/GPU utilization.
+
+A runtime patch would be more than reading a timestamp: ggml can submit several
+command buffers, and a valid request-level value needs a defined aggregation
+rule, failure behavior, concurrency behavior, and regression coverage. Such a
+patch also creates an upstream-rebase obligation. The LLM path additionally
+changes the helper protocol and must repeat the split-entitlement signing
+rehearsal.
+
+## Memory semantics
+
+The existing `Main-process RSS (MiB)` is derived from `memory-stats` and maps to
+task resident memory on macOS. It includes Rust, native runtimes, models, audio,
+UI, and shared/mapped pages attributed by the OS. It is not accelerator memory.
+
+`Metal resource allocation (MiB)` would be a different measure: Metal resource
+bytes associated with a device in one process. On Apple Silicon, CPU and GPU
+share physical memory, so it must not be called VRAM or added to RSS. The LLM
+sidecar is a separate process; its RSS and Metal allocation must be measured and
+labeled there.
+
+## Evidence and reproducibility
+
+The disposable public-API probe and three-run results are in
+[`spikes/354-metal-metrics`](../../spikes/354-metal-metrics/RESULTS.md). The
+probe proves timestamp/counter overhead and `currentAllocatedSize` behavior only
+for work it owns. It explicitly does not prove access through Murmur's pinned
+runtimes.
+
+Primary public evidence:
+
+- Apple:
+  [`MTLCommandBuffer.gpuStartTime`](https://developer.apple.com/documentation/metal/mtlcommandbuffer/gpustarttime),
+  [counter sample buffers](https://developer.apple.com/documentation/metal/sampling-gpu-data-into-counter-sample-buffers),
+  [`MTLDevice.currentAllocatedSize`](https://developer.apple.com/documentation/metal/mtldevice/currentallocatedsize),
+  [Metal Performance HUD](https://developer.apple.com/documentation/xcode/generating-performance-reports-with-metal-performance-hud),
+  [`MLModelConfiguration`](https://developer.apple.com/documentation/coreml/mlmodelconfiguration),
+  and
+  [Core ML performance reports](https://developer.apple.com/videos/play/wwdc2022/10027/?time=1040).
+- Pinned upstream headers:
+  [whisper.cpp v1.7.6 `ggml-metal.h`](https://github.com/ggml-org/whisper.cpp/blob/v1.7.6/ggml/include/ggml-metal.h)
+  and
+  [llama.cpp pinned `ggml-metal.h`](https://github.com/ggml-org/llama.cpp/blob/9e3b928fd8c9d14dbf15a8768b9fdd7e5c721d66/ggml/include/ggml-metal.h).
+
+## Follow-up boundary
+
+Issue #350 can implement the four fallback rows without inventing accelerator
+percentages. This spike does not open another production issue for Metal
+timestamps, counters, or allocation: the standalone probe proved the public
+APIs themselves, but not access through the pinned runtimes. A future issue is
+justified only after an upstream callback or a disposable runtime patch proves
+same-process visibility and defines the multi-command-buffer aggregation
+contract.

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,18 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-07-22: Diagnostics accelerator metrics stay honest (#354)
+
+**Decision:** Diagnostics will not display GPU or ANE utilization percentages. The production follow-up may ship exact backend identity, request timing, real-time factor or token throughput, correctly scoped RSS, the existing explicitly host-wide CPU percentage, and `GPU utilization unavailable` / `Accelerator utilization unavailable`. Public Metal timestamps, counters, and allocation accounting remain developer-only until Murmur's pinned runtime exposes an integration seam and a production rehearsal proves it.
+
+**Rationale:** Public Metal instrumentation measures command buffers, encoders, and resources the caller can access; Murmur's pinned whisper.cpp and llama.cpp runtimes own those objects internally, while Core ML exposes allowed compute-unit selection rather than production execution attribution. The standalone public-API probe proves behavior only for work it owns and cannot justify fabricated percentages or claims about the pinned runtimes.
+
+**Status:** active
+
+**References:** issue #354; parent #350; ADR [`2026-07-22-accelerator-diagnostics-metrics.md`](2026-07-22-accelerator-diagnostics-metrics.md); disposable probe `spikes/354-metal-metrics`.
+
+---
+
 ## 2026-07-20: Selected-text transform Phase D wrap (#312)
 
 **Decision:** Ship settings + presets + docs for local selected-text transform without expanding scope into AX webview special-cases. Built-in presets (Shorten / Bullets / Professional / Fix grammar / Casual) and user-defined `KnowledgeKind::Transform` names expand in `finish_transform_instruction` before the sidecar runs. Settings owns hold-key wiring, model download/remove/reset, and saved-transform CRUD. Cursor-chat and similar webviews remain best-effort (documented limitation, not a blocker). Native smoke and issue acceptance checkboxes stay a separate pass on a built `.app`.

--- a/spikes/354-metal-metrics/RESULTS.md
+++ b/spikes/354-metal-metrics/RESULTS.md
@@ -1,0 +1,91 @@
+# Issue 354 public Metal API probe
+
+This is a disposable, standalone probe. It owns its `MTLDevice`, command queue,
+command buffers, encoders, and buffers. It does not load Murmur, whisper.cpp,
+llama.cpp, FluidAudio, or Core ML.
+
+Accordingly, these results prove behavior only for work and allocations created
+by the probe. They do **not** prove that Murmur can observe work or allocations
+made through its pinned runtimes.
+
+## Reproduce
+
+Run on macOS with the Xcode command-line tools:
+
+```bash
+xcrun swiftc -warnings-as-errors -O -framework Metal \
+  metal_metrics_probe.swift \
+  -o /tmp/murmur-metal-metrics-probe-354
+/tmp/murmur-metal-metrics-probe-354
+```
+
+The probe uses only the public Metal framework. It does not request root,
+entitlements, private frameworks, or privileged sampling tools.
+
+## Test host
+
+- Hardware: Apple M4, unified memory
+- Architecture: arm64
+- OS: macOS 26.5.1 (Build 25F80)
+- Sample size: 20 warmups, then 300 interleaved dispatches per mode
+- Workload: a public Metal compute kernel over 262,144 `UInt32` values
+
+## Repeated results
+
+Three consecutive runs produced:
+
+| Measurement | Run 1 | Run 2 | Run 3 |
+| --- | ---: | ---: | ---: |
+| Baseline median wall duration (ms) | 0.1913 | 0.1850 | 0.1937 |
+| Command-buffer timestamp median wall delta (µs) | 1.31 | 1.27 | 0.75 |
+| Command-buffer timestamp median wall overhead | 0.69% | 0.69% | 0.39% |
+| `Metal command-buffer GPU elapsed time (ms)`, median | 0.01317 | 0.01294 | 0.01317 |
+| Counter sample buffer median wall delta (µs) | 4.31 | 5.48 | 6.71 |
+| Counter sample buffer median wall overhead | 2.25% | 2.96% | 3.46% |
+| `Metal timestamp counter delta (ticks)`, median | 13,166 | 13,083 | 13,167 |
+
+The host exposed one counter set, `timestamp`, containing only
+`GPUTimestamp`. Stage-boundary sampling was supported; draw, dispatch, tile,
+and blit boundary sampling were not. Runtime capability checks are therefore
+mandatory, and this host supplies no public utilization counter from which an
+honest GPU percentage could be calculated.
+
+The measured overhead is a microbenchmark result for a very small synthetic
+dispatch. It is not an inference-overhead estimate. Run-to-run scheduler noise
+is larger than the command-buffer timestamp delta at the tail, so the useful
+conclusion is that both public mechanisms worked for an owned command buffer,
+not that they have a universal fixed overhead.
+
+## `currentAllocatedSize`
+
+Each run reported the same values:
+
+| Point | Bytes |
+| --- | ---: |
+| Before allocation | 1,540,096 |
+| After requesting a 64 MiB Metal buffer | 68,648,960 |
+| Immediate after release | 1,540,096 |
+| After an empty command-buffer drain | 1,540,096 |
+
+The observed increase was exactly 67,108,864 bytes, the requested buffer size.
+This proves that `MTLDevice.currentAllocatedSize` tracked an explicit buffer
+owned by this process on this host.
+
+It does not prove visibility into allocations made by Murmur's pinned
+whisper.cpp runtime or by its separate llama.cpp helper. On Apple Silicon this
+is unified-memory Metal resource allocation, not dedicated VRAM, current
+resident GPU memory, bandwidth, or utilization. It can overlap conceptually
+with process RSS and must not be added to RSS as if the values were disjoint.
+
+## Evidence boundary
+
+- `gpuStartTime` / `gpuEndTime` measure the scheduled GPU interval for a
+  command buffer the caller can access. They do not produce utilization.
+- Counter sample buffers require access to the encoder or pass descriptor. The
+  counters and sampling points available vary by device.
+- `currentAllocatedSize` describes resources allocated through a Metal device.
+  It does not identify which model or backend owns them.
+- The probe cannot cross a process boundary. The local-LLM helper would need to
+  measure and report its own data, changing its protocol and signed-helper
+  implementation.
+- No result in this file establishes access through Murmur's pinned runtimes.

--- a/spikes/354-metal-metrics/metal_metrics_probe.swift
+++ b/spikes/354-metal-metrics/metal_metrics_probe.swift
@@ -1,0 +1,440 @@
+import Foundation
+import Metal
+
+private let warmupIterations = 20
+private let measuredIterations = 300
+private let elementCount = 256 * 1024
+private let allocationProbeBytes = 64 * 1024 * 1024
+
+private enum ProbeError: Error, CustomStringConvertible {
+    case metalUnavailable
+    case commandQueueUnavailable
+    case libraryUnavailable(String)
+    case functionUnavailable
+    case pipelineUnavailable(String)
+    case bufferUnavailable
+    case commandBufferUnavailable
+    case encoderUnavailable
+    case commandBufferFailed(String)
+    case counterBufferUnavailable(String)
+    case counterDataUnavailable
+
+    var description: String {
+        switch self {
+        case .metalUnavailable:
+            return "Metal is unavailable"
+        case .commandQueueUnavailable:
+            return "Metal command queue creation failed"
+        case let .libraryUnavailable(message):
+            return "Metal library creation failed: \(message)"
+        case .functionUnavailable:
+            return "Probe kernel lookup failed"
+        case let .pipelineUnavailable(message):
+            return "Compute pipeline creation failed: \(message)"
+        case .bufferUnavailable:
+            return "Metal buffer allocation failed"
+        case .commandBufferUnavailable:
+            return "Metal command buffer creation failed"
+        case .encoderUnavailable:
+            return "Metal compute encoder creation failed"
+        case let .commandBufferFailed(message):
+            return "Metal command buffer failed: \(message)"
+        case let .counterBufferUnavailable(message):
+            return "Metal counter sample buffer creation failed: \(message)"
+        case .counterDataUnavailable:
+            return "Metal timestamp counter results were unavailable"
+        }
+    }
+}
+
+private enum InstrumentationMode: String, CaseIterable {
+    case baseline
+    case commandBufferTimestamps = "command_buffer_timestamps"
+    case counterSampleBuffer = "counter_sample_buffer"
+}
+
+private struct RunSample {
+    let wallMilliseconds: Double
+        let gpuMilliseconds: Double?
+    let counterDeltaTicks: UInt64?
+}
+
+private struct Distribution: Codable {
+    let median: Double
+    let p95: Double
+    let minimum: Double
+    let maximum: Double
+}
+
+private struct ModeResult: Codable {
+    let exactMetricName: String
+    let wallMilliseconds: Distribution
+    let medianWallDeltaMicrosecondsVersusBaseline: Double
+    let medianWallOverheadPercentVersusBaseline: Double
+    let gpuElapsedMilliseconds: Distribution?
+    let timestampCounterDeltaTicks: Distribution?
+}
+
+private struct SamplingPointSupport: Codable {
+    let name: String
+    let supported: Bool
+}
+
+private struct CounterSetDescription: Codable {
+    let name: String
+    let counters: [String]
+}
+
+private struct AllocationResult: Codable {
+    let exactMetricName: String
+    let requestedBytes: UInt64
+    let beforeBytes: UInt64
+    let afterAllocationBytes: UInt64
+    let immediateAfterReleaseBytes: UInt64
+    let afterReleaseAndDrainBytes: UInt64
+}
+
+private struct ProbeReport: Codable {
+    let probeBoundary: String
+    let deviceName: String
+    let operatingSystem: String
+    let architecture: String
+    let unifiedMemory: Bool
+    let warmupIterations: Int
+    let measuredIterationsPerMode: Int
+    let elementsPerDispatch: Int
+    let counterSets: [CounterSetDescription]
+    let samplingPoints: [SamplingPointSupport]
+    let results: [String: ModeResult]
+    let allocation: AllocationResult
+}
+
+private final class MetalProbe {
+    private let device: MTLDevice
+    private let queue: MTLCommandQueue
+    private let pipeline: MTLComputePipelineState
+    private let workBuffer: MTLBuffer
+    private let timestampCounterBuffer: MTLCounterSampleBuffer?
+
+    init() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw ProbeError.metalUnavailable
+        }
+        guard let queue = device.makeCommandQueue() else {
+            throw ProbeError.commandQueueUnavailable
+        }
+
+        let source = """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        kernel void probe_add_one(
+            device uint *values [[buffer(0)]],
+            uint index [[thread_position_in_grid]]
+        ) {
+            values[index] += 1;
+        }
+        """
+        let library: MTLLibrary
+        do {
+            library = try device.makeLibrary(source: source, options: nil)
+        } catch {
+            throw ProbeError.libraryUnavailable(String(describing: error))
+        }
+        guard let function = library.makeFunction(name: "probe_add_one") else {
+            throw ProbeError.functionUnavailable
+        }
+        do {
+            pipeline = try device.makeComputePipelineState(function: function)
+        } catch {
+            throw ProbeError.pipelineUnavailable(String(describing: error))
+        }
+        guard let workBuffer = device.makeBuffer(
+            length: elementCount * MemoryLayout<UInt32>.stride,
+            options: .storageModeShared
+        ) else {
+            throw ProbeError.bufferUnavailable
+        }
+
+        self.device = device
+        self.queue = queue
+        self.workBuffer = workBuffer
+        self.timestampCounterBuffer = try Self.makeTimestampCounterBuffer(device: device)
+    }
+
+    var metalDevice: MTLDevice {
+        device
+    }
+
+    var counterBufferAvailable: Bool {
+        timestampCounterBuffer != nil
+    }
+
+    private static func makeTimestampCounterBuffer(
+        device: MTLDevice
+    ) throws -> MTLCounterSampleBuffer? {
+        guard device.supportsCounterSampling(.atStageBoundary) else {
+            return nil
+        }
+        guard let timestampSet = device.counterSets?.first(where: {
+            $0.name == MTLCommonCounterSet.timestamp.rawValue
+        }) else {
+            return nil
+        }
+
+        let descriptor = MTLCounterSampleBufferDescriptor()
+        descriptor.counterSet = timestampSet
+        descriptor.label = "Issue 354 timestamp probe"
+        descriptor.storageMode = .shared
+        descriptor.sampleCount = 2
+        do {
+            return try device.makeCounterSampleBuffer(descriptor: descriptor)
+        } catch {
+            throw ProbeError.counterBufferUnavailable(String(describing: error))
+        }
+    }
+
+    func run(mode: InstrumentationMode) throws -> RunSample {
+        let wallStarted = DispatchTime.now().uptimeNanoseconds
+        guard let commandBuffer = queue.makeCommandBuffer() else {
+            throw ProbeError.commandBufferUnavailable
+        }
+
+        let encoder: MTLComputeCommandEncoder?
+        if mode == .counterSampleBuffer, let timestampCounterBuffer {
+            let descriptor = MTLComputePassDescriptor()
+            guard let attachment = descriptor.sampleBufferAttachments[0] else {
+                throw ProbeError.encoderUnavailable
+            }
+            attachment.sampleBuffer = timestampCounterBuffer
+            attachment.startOfEncoderSampleIndex = 0
+            attachment.endOfEncoderSampleIndex = 1
+            encoder = commandBuffer.makeComputeCommandEncoder(descriptor: descriptor)
+        } else {
+            encoder = commandBuffer.makeComputeCommandEncoder()
+        }
+        guard let encoder else {
+            throw ProbeError.encoderUnavailable
+        }
+
+        encoder.setComputePipelineState(pipeline)
+        encoder.setBuffer(workBuffer, offset: 0, index: 0)
+        let threadsPerGrid = MTLSize(width: elementCount, height: 1, depth: 1)
+        let width = min(pipeline.maxTotalThreadsPerThreadgroup, 256)
+        let threadsPerThreadgroup = MTLSize(width: width, height: 1, depth: 1)
+        encoder.dispatchThreads(threadsPerGrid, threadsPerThreadgroup: threadsPerThreadgroup)
+        encoder.endEncoding()
+
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        guard commandBuffer.status == .completed else {
+            throw ProbeError.commandBufferFailed(
+                commandBuffer.error.map(String.init(describing:)) ?? "\(commandBuffer.status.rawValue)"
+            )
+        }
+
+    let gpuMilliseconds: Double?
+        if mode == .commandBufferTimestamps {
+            gpuMilliseconds = (commandBuffer.gpuEndTime - commandBuffer.gpuStartTime) * 1_000
+        } else {
+            gpuMilliseconds = nil
+        }
+
+        let counterDeltaTicks: UInt64?
+        if mode == .counterSampleBuffer, let timestampCounterBuffer {
+            guard let data = try timestampCounterBuffer.resolveCounterRange(0..<2) else {
+                throw ProbeError.counterDataUnavailable
+            }
+            let requiredBytes = 2 * MemoryLayout<MTLCounterResultTimestamp>.stride
+            guard data.count >= requiredBytes else {
+                throw ProbeError.counterDataUnavailable
+            }
+            counterDeltaTicks = data.withUnsafeBytes { rawBuffer in
+                let samples = rawBuffer.bindMemory(to: MTLCounterResultTimestamp.self)
+                let start = samples[0].timestamp
+                let end = samples[1].timestamp
+                guard start != MTLCounterErrorValue,
+                      end != MTLCounterErrorValue,
+                      end >= start else {
+                    return nil
+                }
+                return end - start
+            }
+            if counterDeltaTicks == nil {
+                throw ProbeError.counterDataUnavailable
+            }
+        } else {
+            counterDeltaTicks = nil
+        }
+
+        let wallEnded = DispatchTime.now().uptimeNanoseconds
+        let wallMilliseconds = Double(wallEnded - wallStarted) / 1_000_000
+        return RunSample(
+            wallMilliseconds: wallMilliseconds,
+            gpuMilliseconds: gpuMilliseconds,
+            counterDeltaTicks: counterDeltaTicks
+        )
+    }
+
+    func allocationProbe() throws -> AllocationResult {
+        let before = UInt64(device.currentAllocatedSize)
+        var allocation: MTLBuffer? = device.makeBuffer(
+            length: allocationProbeBytes,
+            options: .storageModeShared
+        )
+        guard allocation != nil else {
+            throw ProbeError.bufferUnavailable
+        }
+        let afterAllocation = UInt64(device.currentAllocatedSize)
+        allocation = nil
+        let immediateAfterRelease = UInt64(device.currentAllocatedSize)
+        guard let drain = queue.makeCommandBuffer() else {
+            throw ProbeError.commandBufferUnavailable
+        }
+        drain.commit()
+        drain.waitUntilCompleted()
+        guard drain.status == .completed else {
+            throw ProbeError.commandBufferFailed(
+                drain.error.map(String.init(describing:)) ?? "\(drain.status.rawValue)"
+            )
+        }
+        autoreleasepool {}
+        let afterReleaseAndDrain = UInt64(device.currentAllocatedSize)
+
+        return AllocationResult(
+            exactMetricName: "Metal resource allocation (bytes)",
+            requestedBytes: UInt64(allocationProbeBytes),
+            beforeBytes: before,
+            afterAllocationBytes: afterAllocation,
+            immediateAfterReleaseBytes: immediateAfterRelease,
+            afterReleaseAndDrainBytes: afterReleaseAndDrain
+        )
+    }
+}
+
+private func distribution(_ values: [Double]) -> Distribution {
+    let sorted = values.sorted()
+    let medianIndex = sorted.count / 2
+    let median: Double
+    if sorted.count.isMultiple(of: 2) {
+        median = (sorted[medianIndex - 1] + sorted[medianIndex]) / 2
+    } else {
+        median = sorted[medianIndex]
+    }
+    let p95Index = min(sorted.count - 1, Int(ceil(Double(sorted.count) * 0.95)) - 1)
+    return Distribution(
+        median: median,
+        p95: sorted[p95Index],
+        minimum: sorted[0],
+        maximum: sorted[sorted.count - 1]
+    )
+}
+
+private func architectureName() -> String {
+    #if arch(arm64)
+    return "arm64"
+    #elseif arch(x86_64)
+    return "x86_64"
+    #else
+    return "unknown"
+    #endif
+}
+
+private func runProbe() throws -> ProbeReport {
+    let probe = try MetalProbe()
+
+    for _ in 0..<warmupIterations {
+        _ = try probe.run(mode: .baseline)
+    }
+
+    var samples = Dictionary(
+        uniqueKeysWithValues: InstrumentationMode.allCases.map { ($0, [RunSample]()) }
+    )
+    let measuredModes = probe.counterBufferAvailable
+        ? InstrumentationMode.allCases
+        : [.baseline, .commandBufferTimestamps]
+
+    for iteration in 0..<measuredIterations {
+        let offset = iteration % measuredModes.count
+        let orderedModes = Array(measuredModes[offset...] + measuredModes[..<offset])
+        for mode in orderedModes {
+            samples[mode, default: []].append(try probe.run(mode: mode))
+        }
+    }
+
+    let baselineDistribution = distribution(
+        samples[.baseline, default: []].map(\.wallMilliseconds)
+    )
+    var results: [String: ModeResult] = [:]
+    for mode in measuredModes {
+        let modeSamples = samples[mode, default: []]
+        let wall = distribution(modeSamples.map(\.wallMilliseconds))
+        let medianDeltaMicroseconds = (wall.median - baselineDistribution.median) * 1_000
+        let overheadPercent = baselineDistribution.median > 0
+            ? (wall.median - baselineDistribution.median) / baselineDistribution.median * 100
+            : 0
+        let gpuValues = modeSamples.compactMap(\.gpuMilliseconds)
+        let counterValues = modeSamples.compactMap(\.counterDeltaTicks).map { Double($0) }
+        let exactMetricName: String
+        switch mode {
+        case .baseline:
+            exactMetricName = "Probe command-buffer wall duration (ms)"
+        case .commandBufferTimestamps:
+            exactMetricName = "Metal command-buffer GPU elapsed time (ms)"
+        case .counterSampleBuffer:
+            exactMetricName = "Metal timestamp counter delta (ticks)"
+        }
+        results[mode.rawValue] = ModeResult(
+            exactMetricName: exactMetricName,
+            wallMilliseconds: wall,
+            medianWallDeltaMicrosecondsVersusBaseline: medianDeltaMicroseconds,
+            medianWallOverheadPercentVersusBaseline: overheadPercent,
+            gpuElapsedMilliseconds: gpuValues.isEmpty ? nil : distribution(gpuValues),
+            timestampCounterDeltaTicks: counterValues.isEmpty ? nil : distribution(counterValues)
+        )
+    }
+
+    let device = probe.metalDevice
+    let counterSets = (device.counterSets ?? []).map {
+        CounterSetDescription(name: $0.name, counters: $0.counters.map(\.name))
+    }
+    let samplingPoints: [(String, MTLCounterSamplingPoint)] = [
+        ("stage_boundary", .atStageBoundary),
+        ("draw_boundary", .atDrawBoundary),
+        ("dispatch_boundary", .atDispatchBoundary),
+        ("tile_dispatch_boundary", .atTileDispatchBoundary),
+        ("blit_boundary", .atBlitBoundary),
+    ]
+
+    return ProbeReport(
+        probeBoundary: "Standalone public Metal API probe; not Murmur runtime instrumentation",
+        deviceName: device.name,
+        operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+        architecture: architectureName(),
+        unifiedMemory: device.hasUnifiedMemory,
+        warmupIterations: warmupIterations,
+        measuredIterationsPerMode: measuredIterations,
+        elementsPerDispatch: elementCount,
+        counterSets: counterSets,
+        samplingPoints: samplingPoints.map {
+            SamplingPointSupport(name: $0.0, supported: device.supportsCounterSampling($0.1))
+        },
+        results: results,
+        allocation: try probe.allocationProbe()
+    )
+}
+
+do {
+    let report = try runProbe()
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(report)
+    guard let output = String(data: data, encoding: .utf8) else {
+        throw ProbeError.counterDataUnavailable
+    }
+    print(output)
+} catch {
+    FileHandle.standardError.write(Data("metal_metrics_probe: \(error)\n".utf8))
+    exit(1)
+}


### PR DESCRIPTION
## Summary

- record a backend-by-backend Diagnostics contract with exact metric names and one disposition per backend
- reject fabricated GPU/ANE utilization percentages; keep Metal command-buffer timing, counters, allocation accounting, HUD/capture, and Core ML profiling developer-only until a pinned-runtime seam is proven
- add a disposable public Metal API probe plus three-run Apple M4/macOS 26.5.1 measurements

## Evidence

The standalone probe observed:

- `MTLCommandBuffer` timestamp median wall delta: 0.75–1.31 microseconds for its owned synthetic dispatch
- counter sample-buffer median wall delta: 4.31–6.71 microseconds
- only `timestamp/GPUTimestamp` and stage-boundary sampling on the test M4; no utilization counter
- an exact 67,108,864-byte `currentAllocatedSize` increase for an explicit 64 MiB buffer, returning to baseline after release

These results do **not** prove access through Murmur's pinned whisper.cpp, llama.cpp, FluidAudio, or Core ML runtimes. No production UI, telemetry schema, dependency, sidecar protocol, entitlement, or signing change is included. No additional production issue is filed because same-process visibility through the pinned runtimes was not proven; #350 owns the honest fallback contract.

## Validation

- `xcrun swiftc -warnings-as-errors -O -framework Metal spikes/354-metal-metrics/metal_metrics_probe.swift -o /tmp/murmur-metal-metrics-probe-354`
- `/tmp/murmur-metal-metrics-probe-354`
- `cargo check`
- `cargo test -- --test-threads=1` (561 passed, 5 ignored in the main suite; integration suites passed)
- `npx tsc --noEmit`
- `git diff --check origin/main...HEAD`

Native UI smoke is not applicable because this spike changes no production runtime or UI.

Closes #354
