### PR TITLE
feat(diagnostics): add report import and comparison core

### DIFF
--- a/app/src/lib/__fixtures__/diagnostic-reports/benchmark-legacy.json
+++ b/app/src/lib/__fixtures__/diagnostic-reports/benchmark-legacy.json
@@ -1,0 +1,56 @@
+{
+  "createdAt": "2026-07-19T12:00:00Z",
+  "appVersion": "0.18.0",
+  "platform": "macos aarch64",
+  "preset": "quick",
+  "iterations": 3,
+  "sharedInitMs": 1400,
+  "results": [
+    {
+      "modelName": "tiny.en",
+      "label": "Whisper Tiny English",
+      "backend": "whisper.cpp",
+      "accelerator": "Metal",
+      "modelLoadMs": 230,
+      "firstInferenceMs": 450,
+      "warmMedianMs": 120,
+      "warmP95Ms": 140,
+      "realtimeFactor": 0.22,
+      "wordErrorRate": 0.11,
+      "normalizedWordErrorRate": 0.09,
+      "deliveredWordErrorRate": 0.1,
+      "deliveredNormalizedWordErrorRate": 0.08,
+      "memoryDeltaMb": 82,
+      "fixtures": [
+        {
+          "fixtureId": "short",
+          "label": "Short",
+          "audioSeconds": 5.5,
+          "warmMedianMs": 120,
+          "warmP95Ms": 140,
+          "realtimeFactor": 0.22,
+          "wordErrorRate": 0.11,
+          "wordErrors": 1,
+          "referenceWords": 12,
+          "normalizedWordErrorRate": 0.09,
+          "normalizedWordErrors": 1,
+          "normalizedReferenceWords": 12,
+          "reference": "PRIVATE_LEGACY_REFERENCE",
+          "transcript": "PRIVATE_LEGACY_TRANSCRIPT",
+          "deliveredTranscript": "PRIVATE_LEGACY_DELIVERED",
+          "deliveredWordErrorRate": 0.1,
+          "deliveredWordErrors": 1,
+          "deliveredNormalizedWordErrorRate": 0.08,
+          "deliveredNormalizedWordErrors": 1,
+          "deliveredTransformFailed": false
+        }
+      ],
+      "error": null
+    }
+  ],
+  "recommendations": {
+    "fastest": "tiny.en",
+    "mostAccurate": "tiny.en",
+    "balanced": "tiny.en"
+  }
+}

--- a/app/src/lib/__fixtures__/diagnostic-reports/benchmark-v2.json
+++ b/app/src/lib/__fixtures__/diagnostic-reports/benchmark-v2.json
@@ -1,0 +1,82 @@
+{
+  "reportVersion": 2,
+  "createdAt": "2026-07-21T12:00:00Z",
+  "appVersion": "0.19.0",
+  "platform": "macos aarch64",
+  "preset": "quick",
+  "iterations": 3,
+  "sharedInitMs": 1200,
+  "environment": {
+    "os": "macOS",
+    "osVersion": "15.5",
+    "architecture": "aarch64",
+    "hardwareModel": "Mac14,3",
+    "chip": "Apple M2",
+    "memoryMb": 16384
+  },
+  "corpus": {
+    "language": "en",
+    "fixtureIds": ["short"],
+    "fixtureCount": 1,
+    "referenceWords": 12,
+    "provenance": "Bundled synthetic fixture",
+    "limitation": "Directional local comparison only."
+  },
+  "configuration": {
+    "vadThreshold": 0.5,
+    "executionPath": "full-buffer final transcription after recording stops",
+    "transcriptTransformProfile": "default local delivery pipeline",
+    "percentileMethod": "nearest-rank over measured warm iterations",
+    "modelRunOrder": ["tiny.en"],
+    "sharedInitOrder": ["tiny.en"]
+  },
+  "results": [
+    {
+      "modelName": "tiny.en",
+      "label": "Whisper Tiny English",
+      "backend": "whisper.cpp",
+      "accelerator": "Metal",
+      "downloadSize": "75 MB",
+      "modelLoadMs": 210,
+      "firstInferenceMs": 430,
+      "warmMedianMs": 110,
+      "warmP95Ms": 130,
+      "realtimeFactor": 0.2,
+      "wordErrorRate": 0.1,
+      "normalizedWordErrorRate": 0.08,
+      "deliveredWordErrorRate": 0.09,
+      "deliveredNormalizedWordErrorRate": 0.07,
+      "memoryDeltaMb": 86,
+      "fixtures": [
+        {
+          "fixtureId": "short",
+          "label": "Short",
+          "audioSeconds": 5.5,
+          "warmMedianMs": 110,
+          "warmP95Ms": 130,
+          "realtimeFactor": 0.2,
+          "wordErrorRate": 0.1,
+          "wordErrors": 1,
+          "referenceWords": 12,
+          "normalizedWordErrorRate": 0.08,
+          "normalizedWordErrors": 1,
+          "normalizedReferenceWords": 12,
+          "reference": "PRIVATE_REFERENCE_SENTINEL",
+          "transcript": "PRIVATE_TRANSCRIPT_SENTINEL",
+          "deliveredTranscript": "PRIVATE_DELIVERED_SENTINEL",
+          "deliveredWordErrorRate": 0.09,
+          "deliveredWordErrors": 1,
+          "deliveredNormalizedWordErrorRate": 0.07,
+          "deliveredNormalizedWordErrors": 1,
+          "deliveredTransformFailed": false
+        }
+      ],
+      "error": null
+    }
+  ],
+  "recommendations": {
+    "fastest": "tiny.en",
+    "mostAccurate": "tiny.en",
+    "balanced": "tiny.en"
+  }
+}

--- a/app/src/lib/__fixtures__/diagnostic-reports/evaluation-v1-deterministic.json
+++ b/app/src/lib/__fixtures__/diagnostic-reports/evaluation-v1-deterministic.json
@@ -1,0 +1,108 @@
+{
+  "reportVersion": 1,
+  "fixtureVersion": 1,
+  "generatedAt": "2026-07-21T13:00:00Z",
+  "tier": "deterministic",
+  "privacy": {
+    "localOnly": true,
+    "historyIngestion": false,
+    "networkUsed": false,
+    "systemClipboardUsed": false,
+    "fixtureProvenanceRequired": true
+  },
+  "environment": {
+    "appVersion": "0.19.0",
+    "os": "macos",
+    "arch": "aarch64",
+    "machineLabel": "local-mac",
+    "logicalCpus": 8
+  },
+  "summary": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "aggregateRawWer": 0,
+    "aggregateNormalizedWer": 0,
+    "aggregateCer": 0,
+    "transformationMatchRate": 1,
+    "commandExactMatchRate": 1,
+    "noChangePreservationRate": 1,
+    "deliveryMatchRate": 1
+  },
+  "cases": [
+    {
+      "id": "deterministic-short",
+      "status": "passed",
+      "failures": [],
+      "provenance": {
+        "kind": "curatedSynthetic",
+        "source": "PRIVATE_PROVENANCE_SENTINEL",
+        "containsRealUserData": false,
+        "deletion": "PRIVATE_DELETION_SENTINEL"
+      },
+      "context": {
+        "bundleId": "PRIVATE_BUNDLE_SENTINEL",
+        "matchedProfile": "PRIVATE_PROFILE_SENTINEL",
+        "fixtureOnly": true
+      },
+      "model": null,
+      "recognition": {
+        "expectedRaw": "PRIVATE_EXPECTED_RAW_SENTINEL",
+        "actualRaw": "PRIVATE_ACTUAL_RAW_SENTINEL",
+        "rawWordErrors": 0,
+        "normalizedWordErrors": 0,
+        "referenceWords": 4,
+        "normalizedReferenceWords": 4,
+        "referenceCharacters": 22,
+        "characterErrors": 0,
+        "rawWer": 0,
+        "normalizedWer": 0,
+        "cer": 0,
+        "boundedAlternativeMatch": true
+      },
+      "transformation": {
+        "expectedFinal": "PRIVATE_EXPECTED_FINAL_SENTINEL",
+        "actualFinal": "PRIVATE_ACTUAL_FINAL_SENTINEL",
+        "exactMatch": true,
+        "commandExactMatch": true,
+        "noChangePreserved": true,
+        "stages": [
+          {
+            "name": "smartFormatting",
+            "outcome": "applied",
+            "changed": true,
+            "durationUs": 120,
+            "text": "PRIVATE_STAGE_TEXT_SENTINEL",
+            "expectationMatch": true
+          }
+        ]
+      },
+      "delivery": {
+        "expected": "PRIVATE_DELIVERY_EXPECTED_SENTINEL",
+        "delivered": "PRIVATE_DELIVERY_ACTUAL_SENTINEL",
+        "exactMatch": true,
+        "attempts": 1,
+        "partialCount": 0,
+        "firstPartialMs": null,
+        "firstPartialApplicability": "notApplicable",
+        "finalOnly": true
+      },
+      "latency": {
+        "rawAsrMs": 10,
+        "transformationMs": 5,
+        "finalizationMs": 1,
+        "deliveryMs": 2,
+        "totalMs": 18
+      },
+      "runtime": {
+        "incrementalCompletion": "notApplicableFinalOnly",
+        "fallbackUsed": false,
+        "fallbackStages": [],
+        "memoryBeforeMb": 100,
+        "memoryAfterMb": 102,
+        "memoryDeltaMb": 2
+      }
+    }
+  ]
+}

--- a/app/src/lib/__fixtures__/diagnostic-reports/evaluation-v1-hardware.json
+++ b/app/src/lib/__fixtures__/diagnostic-reports/evaluation-v1-hardware.json
@@ -1,0 +1,106 @@
+{
+  "reportVersion": 1,
+  "fixtureVersion": 1,
+  "generatedAt": "2026-07-21T14:00:00Z",
+  "tier": "hardware",
+  "privacy": {
+    "localOnly": true,
+    "historyIngestion": false,
+    "networkUsed": false,
+    "systemClipboardUsed": false,
+    "fixtureProvenanceRequired": true
+  },
+  "environment": {
+    "appVersion": "0.19.0",
+    "os": "macos",
+    "arch": "aarch64",
+    "machineLabel": "local-mac",
+    "logicalCpus": 8
+  },
+  "summary": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "aggregateRawWer": 0.05,
+    "aggregateNormalizedWer": 0.04,
+    "aggregateCer": 0.02,
+    "transformationMatchRate": 1,
+    "commandExactMatchRate": null,
+    "noChangePreservationRate": 1,
+    "deliveryMatchRate": 1
+  },
+  "cases": [
+    {
+      "id": "hardware-short",
+      "status": "passed",
+      "failures": [],
+      "provenance": {
+        "kind": "repositoryProjectTest",
+        "source": "Bundled hardware fixture",
+        "containsRealUserData": false,
+        "deletion": "Delete the fixture and generated local reports."
+      },
+      "context": {
+        "bundleId": null,
+        "matchedProfile": null,
+        "fixtureOnly": true
+      },
+      "model": {
+        "name": "tiny.en",
+        "backend": "whisper.cpp",
+        "accelerator": "Metal",
+        "audioPath": "PRIVATE_AUDIO_PATH_SENTINEL",
+        "sampleRateHz": 16000,
+        "channels": 1
+      },
+      "recognition": {
+        "expectedRaw": "PRIVATE_HARDWARE_EXPECTED",
+        "actualRaw": "PRIVATE_HARDWARE_ACTUAL",
+        "rawWordErrors": 1,
+        "normalizedWordErrors": 1,
+        "referenceWords": 20,
+        "normalizedReferenceWords": 20,
+        "referenceCharacters": 100,
+        "characterErrors": 2,
+        "rawWer": 0.05,
+        "normalizedWer": 0.04,
+        "cer": 0.02,
+        "boundedAlternativeMatch": true
+      },
+      "transformation": {
+        "expectedFinal": "PRIVATE_HARDWARE_FINAL",
+        "actualFinal": "PRIVATE_HARDWARE_FINAL",
+        "exactMatch": true,
+        "commandExactMatch": null,
+        "noChangePreserved": true,
+        "stages": []
+      },
+      "delivery": {
+        "expected": "PRIVATE_HARDWARE_DELIVERY",
+        "delivered": "PRIVATE_HARDWARE_DELIVERY",
+        "exactMatch": true,
+        "attempts": 1,
+        "partialCount": 0,
+        "firstPartialMs": null,
+        "firstPartialApplicability": "notApplicable",
+        "finalOnly": true
+      },
+      "latency": {
+        "rawAsrMs": 220,
+        "transformationMs": 8,
+        "finalizationMs": 1,
+        "deliveryMs": 2,
+        "totalMs": 231
+      },
+      "runtime": {
+        "incrementalCompletion": "notApplicableFinalOnly",
+        "fallbackUsed": false,
+        "fallbackStages": [],
+        "memoryBeforeMb": 120,
+        "memoryAfterMb": 130,
+        "memoryDeltaMb": 10
+      }
+    }
+  ]
+}

--- a/app/src/lib/diagnosticComparison.test.ts
+++ b/app/src/lib/diagnosticComparison.test.ts
@@ -191,4 +191,24 @@ describe('compareDiagnosticReports', () => {
       'evaluation_execution_mismatch',
     ]));
   });
+
+  it('blocks recommendations for failed or incomplete evaluation results', () => {
+    const baseline = imported(evaluationDeterministic);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'evaluation') throw new Error('evaluation fixture expected');
+    candidate.cases[0].status = 'failed';
+    candidate.cases[0].complete = false;
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison).toMatchObject({
+      status: 'blocked',
+      deltasAllowed: false,
+      recommendationAllowed: false,
+      metrics: [],
+    });
+    expect(comparison.issues).toContainEqual(expect.objectContaining({
+      code: 'evaluation_result_incomplete',
+      severity: 'blocker',
+    }));
+  });
 });

--- a/app/src/lib/diagnosticComparison.test.ts
+++ b/app/src/lib/diagnosticComparison.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import benchmarkLegacy from './__fixtures__/diagnostic-reports/benchmark-legacy.json';
+import benchmarkV2 from './__fixtures__/diagnostic-reports/benchmark-v2.json';
+import evaluationDeterministic from './__fixtures__/diagnostic-reports/evaluation-v1-deterministic.json';
+import evaluationHardware from './__fixtures__/diagnostic-reports/evaluation-v1-hardware.json';
+import { compareDiagnosticReports } from './diagnosticComparison';
+import { parseDiagnosticReportJson } from './diagnosticReports';
+import type { NormalizedDiagnosticReport } from './diagnosticReports';
+
+function imported(value: unknown): NormalizedDiagnosticReport {
+  const contents = JSON.stringify(value);
+  const result = parseDiagnosticReportJson(
+    contents,
+    new TextEncoder().encode(contents).byteLength,
+  );
+  if (!result.ok) throw new Error(result.error.code);
+  return result.report;
+}
+
+describe('compareDiagnosticReports', () => {
+  it('computes like-for-like benchmark absolute and percentage deltas', () => {
+    const baseline = imported(benchmarkV2);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'benchmark') throw new Error('benchmark fixture expected');
+    candidate.sharedInitMs = 900;
+    candidate.models[0].warmMedianMs = 99;
+    candidate.models[0].fixtures[0].wordErrorRate = 0.08;
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison.status).toBe('compatible');
+    expect(comparison.deltasAllowed).toBe(true);
+    expect(comparison.recommendationAllowed).toBe(true);
+    expect(comparison.metrics.find((entry) => entry.key === 'benchmark.sharedInitMs'))
+      .toMatchObject({
+        baseline: 1200,
+        candidate: 900,
+        absoluteDelta: -300,
+        percentageDelta: -25,
+      });
+    expect(comparison.metrics.find((entry) => entry.label === 'Warm median'))
+      .toMatchObject({ baseline: 110, candidate: 99, absoluteDelta: -11 });
+  });
+
+  it('returns no percentage delta when the baseline is zero', () => {
+    const baseline = imported(evaluationDeterministic);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'evaluation') throw new Error('evaluation fixture expected');
+    candidate.summary.aggregateRawWer = 0.1;
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison.metrics.find((entry) => entry.key === 'evaluation.summary.aggregateRawWer'))
+      .toMatchObject({
+        baseline: 0,
+        candidate: 0.1,
+        absoluteDelta: 0.1,
+        percentageDelta: null,
+      });
+  });
+
+  it('blocks benchmark deltas when corpus, configuration, or model identity differs', () => {
+    const baseline = imported(benchmarkV2);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'benchmark') throw new Error('benchmark fixture expected');
+    if (!candidate.corpus || !candidate.configuration) throw new Error('v2 fixture expected');
+    candidate.corpus.fixtureIds = ['different'];
+    candidate.configuration.vadThreshold = 0.6;
+    candidate.models[0].backend = 'different-backend';
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison.status).toBe('blocked');
+    expect(comparison.deltasAllowed).toBe(false);
+    expect(comparison.recommendationAllowed).toBe(false);
+    expect(comparison.metrics).toEqual([]);
+    expect(comparison.issues.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'corpus_mismatch',
+      'configuration_mismatch',
+      'model_set_mismatch',
+    ]));
+  });
+
+  it('blocks incomplete results and per-model fixture mismatches', () => {
+    const baseline = imported(benchmarkV2);
+    const failed = structuredClone(baseline);
+    if (failed.kind !== 'benchmark') throw new Error('benchmark fixture expected');
+    failed.models[0].succeeded = false;
+    expect(compareDiagnosticReports(baseline, failed).issues).toContainEqual(
+      expect.objectContaining({ code: 'benchmark_result_incomplete', severity: 'blocker' }),
+    );
+
+    const missingFixture = structuredClone(baseline);
+    if (missingFixture.kind !== 'benchmark') throw new Error('benchmark fixture expected');
+    missingFixture.models[0].fixtures = [];
+    expect(compareDiagnosticReports(baseline, missingFixture).issues).toContainEqual(
+      expect.objectContaining({ code: 'corpus_mismatch', field: 'models.fixtures' }),
+    );
+  });
+
+  it('imports legacy benchmarks but blocks unproven comparisons', () => {
+    const baseline = imported(benchmarkLegacy);
+    const candidate = structuredClone(baseline);
+    const comparison = compareDiagnosticReports(baseline, candidate);
+
+    expect(comparison).toMatchObject({
+      status: 'blocked',
+      deltasAllowed: false,
+      recommendationAllowed: false,
+      metrics: [],
+    });
+    expect(comparison.issues).toContainEqual(expect.objectContaining({
+      code: 'legacy_context_missing',
+      severity: 'blocker',
+    }));
+  });
+
+  it('keeps machine and app-version differences visible and disables recommendations', () => {
+    const baseline = imported(benchmarkV2);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'benchmark' || !candidate.environment) {
+      throw new Error('v2 benchmark fixture expected');
+    }
+    candidate.appVersion = '0.20.0';
+    candidate.environment.chip = 'Apple M3';
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison.status).toBe('warning');
+    expect(comparison.deltasAllowed).toBe(true);
+    expect(comparison.recommendationAllowed).toBe(false);
+    expect(comparison.metrics.length).toBeGreaterThan(0);
+    expect(comparison.issues.map((entry) => entry.code)).toEqual([
+      'app_version_mismatch',
+      'machine_mismatch',
+    ]);
+  });
+
+  it('blocks benchmark-to-evaluation comparisons without producing metrics', () => {
+    const comparison = compareDiagnosticReports(
+      imported(benchmarkV2),
+      imported(evaluationDeterministic),
+    );
+    expect(comparison).toEqual({
+      status: 'blocked',
+      issues: [{
+        code: 'report_type_mismatch',
+        severity: 'blocker',
+        field: 'kind',
+        message: 'Benchmark and evaluation reports use different metric semantics.',
+      }],
+      deltasAllowed: false,
+      recommendationAllowed: false,
+      metrics: [],
+    });
+  });
+
+  it('compares evaluation summaries, cases, latencies, and stage durations', () => {
+    const baseline = imported(evaluationDeterministic);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'evaluation') throw new Error('evaluation fixture expected');
+    candidate.cases[0].latency.totalMs = 15;
+    candidate.cases[0].transformation.stages[0].durationUs = 90;
+
+    const comparison = compareDiagnosticReports(baseline, candidate);
+    expect(comparison.status).toBe('compatible');
+    expect(comparison.metrics.find((entry) => entry.key.endsWith('.totalMs')))
+      .toMatchObject({ baseline: 18, candidate: 15, absoluteDelta: -3 });
+    expect(comparison.metrics.find((entry) => entry.unit === 'microseconds'))
+      .toMatchObject({ baseline: 120, candidate: 90, absoluteDelta: -30 });
+  });
+
+  it('blocks evaluation tier, fixture, model, and execution-semantic mismatches', () => {
+    const deterministic = imported(evaluationDeterministic);
+    const hardware = imported(evaluationHardware);
+    const tierComparison = compareDiagnosticReports(deterministic, hardware);
+    expect(tierComparison.status).toBe('blocked');
+    expect(tierComparison.issues.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'evaluation_tier_mismatch',
+      'fixture_set_mismatch',
+    ]));
+
+    const baseline = imported(evaluationHardware);
+    const candidate = structuredClone(baseline);
+    if (candidate.kind !== 'evaluation' || !candidate.cases[0].model) {
+      throw new Error('hardware evaluation fixture expected');
+    }
+    candidate.cases[0].model.accelerator = 'CPU';
+    candidate.cases[0].delivery.finalOnly = false;
+    const semanticComparison = compareDiagnosticReports(baseline, candidate);
+    expect(semanticComparison.status).toBe('blocked');
+    expect(semanticComparison.metrics).toEqual([]);
+    expect(semanticComparison.issues.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'evaluation_model_mismatch',
+      'evaluation_execution_mismatch',
+    ]));
+  });
+});

--- a/app/src/lib/diagnosticComparison.ts
+++ b/app/src/lib/diagnosticComparison.ts
@@ -23,6 +23,7 @@ export type CompatibilityIssueCode =
   | 'fixture_set_mismatch'
   | 'evaluation_model_mismatch'
   | 'evaluation_execution_mismatch'
+  | 'evaluation_result_incomplete'
   | 'machine_mismatch'
   | 'app_version_mismatch';
 
@@ -246,6 +247,15 @@ function compareEvaluationCompatibility(
       'evaluation_tier_mismatch',
       'tier',
       'Deterministic and hardware evaluation tiers cannot be compared.',
+    );
+  }
+  if (baseline.cases.some((entry) => !entry.complete || entry.status !== 'passed')
+    || candidate.cases.some((entry) => !entry.complete || entry.status !== 'passed')) {
+    blocker(
+      issues,
+      'evaluation_result_incomplete',
+      'cases.results',
+      'One or more evaluation case results are incomplete, failed, or skipped.',
     );
   }
 

--- a/app/src/lib/diagnosticComparison.ts
+++ b/app/src/lib/diagnosticComparison.ts
@@ -1,0 +1,572 @@
+import type {
+  NormalizedBenchmarkModel,
+  NormalizedBenchmarkReport,
+  NormalizedDiagnosticReport,
+  NormalizedEvaluationCase,
+  NormalizedEvaluationReport,
+} from './diagnosticReports';
+
+export type CompatibilitySeverity = 'warning' | 'blocker';
+export type CompatibilityStatus = 'compatible' | 'warning' | 'blocked';
+
+export type CompatibilityIssueCode =
+  | 'report_type_mismatch'
+  | 'schema_mismatch'
+  | 'legacy_context_missing'
+  | 'preset_mismatch'
+  | 'iteration_mismatch'
+  | 'corpus_mismatch'
+  | 'configuration_mismatch'
+  | 'model_set_mismatch'
+  | 'benchmark_result_incomplete'
+  | 'evaluation_tier_mismatch'
+  | 'fixture_set_mismatch'
+  | 'evaluation_model_mismatch'
+  | 'evaluation_execution_mismatch'
+  | 'machine_mismatch'
+  | 'app_version_mismatch';
+
+export interface CompatibilityIssue {
+  code: CompatibilityIssueCode;
+  severity: CompatibilitySeverity;
+  field: string;
+  message: string;
+}
+
+export type ComparisonMetricUnit = 'ms' | 'microseconds' | 'ratio' | 'count' | 'mb';
+export type MetricDirection = 'lower_is_better' | 'higher_is_better' | 'neutral';
+
+export interface ComparisonMetric {
+  key: string;
+  scope: string;
+  label: string;
+  unit: ComparisonMetricUnit;
+  direction: MetricDirection;
+  baseline: number;
+  candidate: number;
+  absoluteDelta: number;
+  percentageDelta: number | null;
+}
+
+export interface DiagnosticComparison {
+  status: CompatibilityStatus;
+  issues: CompatibilityIssue[];
+  deltasAllowed: boolean;
+  recommendationAllowed: boolean;
+  metrics: ComparisonMetric[];
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return sameStrings([...left].sort(), [...right].sort());
+}
+
+function benchmarkModelIdentity(model: NormalizedBenchmarkModel): string {
+  return `${model.modelName}\u0000${model.backend}\u0000${model.accelerator}`;
+}
+
+function evaluationModelIdentity(entry: NormalizedEvaluationCase): string {
+  if (!entry.model) return 'none';
+  return `${entry.model.name}\u0000${entry.model.backend}\u0000${entry.model.accelerator}`;
+}
+
+function addIssue(
+  issues: CompatibilityIssue[],
+  issue: CompatibilityIssue,
+): void {
+  if (!issues.some((entry) => entry.code === issue.code && entry.field === issue.field)) {
+    issues.push(issue);
+  }
+}
+
+function blocker(
+  issues: CompatibilityIssue[],
+  code: CompatibilityIssueCode,
+  field: string,
+  message: string,
+): void {
+  addIssue(issues, { code, severity: 'blocker', field, message });
+}
+
+function warning(
+  issues: CompatibilityIssue[],
+  code: CompatibilityIssueCode,
+  field: string,
+  message: string,
+): void {
+  addIssue(issues, { code, severity: 'warning', field, message });
+}
+
+function compareBenchmarkCompatibility(
+  baseline: NormalizedBenchmarkReport,
+  candidate: NormalizedBenchmarkReport,
+): CompatibilityIssue[] {
+  const issues: CompatibilityIssue[] = [];
+  if (baseline.schemaVersion !== candidate.schemaVersion) {
+    blocker(
+      issues,
+      'schema_mismatch',
+      'schemaVersion',
+      'Benchmark schema versions differ, so their semantics are not guaranteed to match.',
+    );
+  }
+  if (baseline.schemaVersion === 'legacy' || candidate.schemaVersion === 'legacy') {
+    blocker(
+      issues,
+      'legacy_context_missing',
+      'context',
+      'Legacy benchmark metadata is incomplete, so a like-for-like comparison cannot be proven.',
+    );
+  }
+  if (baseline.preset !== candidate.preset) {
+    blocker(issues, 'preset_mismatch', 'preset', 'Benchmark presets differ.');
+  }
+  if (baseline.iterations !== candidate.iterations) {
+    blocker(issues, 'iteration_mismatch', 'iterations', 'Measured iteration counts differ.');
+  }
+  if (baseline.corpus && candidate.corpus) {
+    if (baseline.corpus.language !== candidate.corpus.language
+      || baseline.corpus.fixtureCount !== candidate.corpus.fixtureCount
+      || baseline.corpus.referenceWords !== candidate.corpus.referenceWords
+      || !sameStrings(baseline.corpus.fixtureIds, candidate.corpus.fixtureIds)) {
+      blocker(
+        issues,
+        'corpus_mismatch',
+        'corpus',
+        'Benchmark corpus identities or reference counts differ.',
+      );
+    }
+  }
+  if (baseline.configuration && candidate.configuration) {
+    const left = baseline.configuration;
+    const right = candidate.configuration;
+    if (left.vadThreshold !== right.vadThreshold
+      || left.executionPath !== right.executionPath
+      || left.transcriptTransformProfile !== right.transcriptTransformProfile
+      || left.percentileMethod !== right.percentileMethod
+      || !sameStrings(left.modelRunOrder, right.modelRunOrder)
+      || !sameStrings(left.sharedInitOrder, right.sharedInitOrder)) {
+      blocker(
+        issues,
+        'configuration_mismatch',
+        'configuration',
+        'Benchmark execution, VAD, transform, percentile, or run-order configuration differs.',
+      );
+    }
+  }
+
+  const baselineModels = baseline.models.map(benchmarkModelIdentity);
+  const candidateModels = candidate.models.map(benchmarkModelIdentity);
+  if (!sameStringSet(baselineModels, candidateModels)) {
+    blocker(
+      issues,
+      'model_set_mismatch',
+      'models',
+      'Benchmark model, backend, or accelerator identities differ.',
+    );
+  } else {
+    const candidateByIdentity = new Map(
+      candidate.models.map((entry) => [benchmarkModelIdentity(entry), entry]),
+    );
+    for (const left of baseline.models) {
+      const right = candidateByIdentity.get(benchmarkModelIdentity(left));
+      if (!right) continue;
+      if (!left.succeeded || !right.succeeded) {
+        blocker(
+          issues,
+          'benchmark_result_incomplete',
+          'models.results',
+          'One or more benchmark model results are incomplete or failed.',
+        );
+      }
+      if (!sameStringSet(
+        left.fixtures.map((entry) => entry.fixtureId),
+        right.fixtures.map((entry) => entry.fixtureId),
+      )) {
+        blocker(
+          issues,
+          'corpus_mismatch',
+          'models.fixtures',
+          'Per-model benchmark fixture identities differ.',
+        );
+      }
+    }
+  }
+
+  if (baseline.appVersion !== candidate.appVersion) {
+    warning(
+      issues,
+      'app_version_mismatch',
+      'appVersion',
+      'Murmur app versions differ; implementation changes may affect the result.',
+    );
+  }
+  if (baseline.platform !== candidate.platform
+    || JSON.stringify(baseline.environment) !== JSON.stringify(candidate.environment)) {
+    warning(
+      issues,
+      'machine_mismatch',
+      'environment',
+      'Machine or operating-system metadata differs.',
+    );
+  }
+  return issues;
+}
+
+function evaluationExecutionSignature(entry: NormalizedEvaluationCase): string {
+  return JSON.stringify({
+    fixtureOnly: entry.fixtureOnly,
+    stageNames: entry.transformation.stages.map((stage) => stage.name),
+    firstPartialApplicability: entry.delivery.firstPartialApplicability,
+    finalOnly: entry.delivery.finalOnly,
+    incrementalCompletion: entry.runtime.incrementalCompletion,
+  });
+}
+
+function compareEvaluationCompatibility(
+  baseline: NormalizedEvaluationReport,
+  candidate: NormalizedEvaluationReport,
+): CompatibilityIssue[] {
+  const issues: CompatibilityIssue[] = [];
+  if (baseline.schemaVersion !== candidate.schemaVersion
+    || baseline.fixtureVersion !== candidate.fixtureVersion) {
+    blocker(
+      issues,
+      'schema_mismatch',
+      'schemaVersion',
+      'Evaluation report or fixture schema versions differ.',
+    );
+  }
+  if (baseline.tier !== candidate.tier) {
+    blocker(
+      issues,
+      'evaluation_tier_mismatch',
+      'tier',
+      'Deterministic and hardware evaluation tiers cannot be compared.',
+    );
+  }
+
+  const baselineIds = baseline.cases.map((entry) => entry.id);
+  const candidateIds = candidate.cases.map((entry) => entry.id);
+  if (!sameStringSet(baselineIds, candidateIds)) {
+    blocker(
+      issues,
+      'fixture_set_mismatch',
+      'cases',
+      'Evaluation fixture IDs differ.',
+    );
+  } else {
+    const candidateById = new Map(candidate.cases.map((entry) => [entry.id, entry]));
+    for (const left of baseline.cases) {
+      const right = candidateById.get(left.id);
+      if (!right) continue;
+      if (evaluationModelIdentity(left) !== evaluationModelIdentity(right)) {
+        blocker(
+          issues,
+          'evaluation_model_mismatch',
+          'cases.model',
+          'Evaluation model, backend, or accelerator identities differ.',
+        );
+      }
+      if (evaluationExecutionSignature(left) !== evaluationExecutionSignature(right)) {
+        blocker(
+          issues,
+          'evaluation_execution_mismatch',
+          'cases.execution',
+          'Evaluation execution or stage semantics differ.',
+        );
+      }
+    }
+  }
+
+  if (baseline.environment.appVersion !== candidate.environment.appVersion) {
+    warning(
+      issues,
+      'app_version_mismatch',
+      'appVersion',
+      'Murmur app versions differ; implementation changes may affect the result.',
+    );
+  }
+  const leftMachine = {
+    os: baseline.environment.os,
+    architecture: baseline.environment.architecture,
+    machineLabel: baseline.environment.machineLabel,
+    logicalCpus: baseline.environment.logicalCpus,
+  };
+  const rightMachine = {
+    os: candidate.environment.os,
+    architecture: candidate.environment.architecture,
+    machineLabel: candidate.environment.machineLabel,
+    logicalCpus: candidate.environment.logicalCpus,
+  };
+  if (JSON.stringify(leftMachine) !== JSON.stringify(rightMachine)) {
+    warning(
+      issues,
+      'machine_mismatch',
+      'environment',
+      'Machine or operating-system metadata differs.',
+    );
+  }
+  return issues;
+}
+
+function metric(
+  key: string,
+  scope: string,
+  label: string,
+  unit: ComparisonMetricUnit,
+  direction: MetricDirection,
+  baseline: number | null,
+  candidate: number | null,
+): ComparisonMetric | null {
+  if (baseline === null || candidate === null) return null;
+  const absoluteDelta = candidate - baseline;
+  return {
+    key,
+    scope,
+    label,
+    unit,
+    direction,
+    baseline,
+    candidate,
+    absoluteDelta,
+    percentageDelta: baseline === 0 ? null : (absoluteDelta / Math.abs(baseline)) * 100,
+  };
+}
+
+function pushMetric(
+  metrics: ComparisonMetric[],
+  value: ComparisonMetric | null,
+): void {
+  if (value) metrics.push(value);
+}
+
+function benchmarkMetrics(
+  baseline: NormalizedBenchmarkReport,
+  candidate: NormalizedBenchmarkReport,
+): ComparisonMetric[] {
+  const metrics: ComparisonMetric[] = [];
+  pushMetric(metrics, metric(
+    'benchmark.sharedInitMs',
+    'report',
+    'Shared initialization',
+    'ms',
+    'lower_is_better',
+    baseline.sharedInitMs,
+    candidate.sharedInitMs,
+  ));
+  const candidateModels = new Map(
+    candidate.models.map((entry) => [benchmarkModelIdentity(entry), entry]),
+  );
+  for (const left of baseline.models) {
+    const right = candidateModels.get(benchmarkModelIdentity(left));
+    if (!right) continue;
+    const scope = `model:${left.modelName}:${left.backend}:${left.accelerator}`;
+    const values: Array<[
+      string,
+      string,
+      ComparisonMetricUnit,
+      MetricDirection,
+      number | null,
+      number | null,
+    ]> = [
+      ['modelLoadMs', 'Model load', 'ms', 'lower_is_better', left.modelLoadMs, right.modelLoadMs],
+      ['firstInferenceMs', 'First inference', 'ms', 'lower_is_better', left.firstInferenceMs, right.firstInferenceMs],
+      ['warmMedianMs', 'Warm median', 'ms', 'lower_is_better', left.warmMedianMs, right.warmMedianMs],
+      ['warmP95Ms', 'Warm p95', 'ms', 'lower_is_better', left.warmP95Ms, right.warmP95Ms],
+      ['realtimeFactor', 'Realtime factor', 'ratio', 'lower_is_better', left.realtimeFactor, right.realtimeFactor],
+      ['wordErrorRate', 'Raw WER', 'ratio', 'lower_is_better', left.wordErrorRate, right.wordErrorRate],
+      ['normalizedWordErrorRate', 'Normalized WER', 'ratio', 'lower_is_better', left.normalizedWordErrorRate, right.normalizedWordErrorRate],
+      ['deliveredWordErrorRate', 'Delivered raw WER', 'ratio', 'lower_is_better', left.deliveredWordErrorRate, right.deliveredWordErrorRate],
+      ['deliveredNormalizedWordErrorRate', 'Delivered normalized WER', 'ratio', 'lower_is_better', left.deliveredNormalizedWordErrorRate, right.deliveredNormalizedWordErrorRate],
+      ['memoryDeltaMb', 'Observed memory delta', 'mb', 'lower_is_better', left.memoryDeltaMb, right.memoryDeltaMb],
+    ];
+    for (const [key, label, unit, direction, baselineValue, candidateValue] of values) {
+      pushMetric(metrics, metric(
+        `benchmark.${scope}.${key}`,
+        scope,
+        label,
+        unit,
+        direction,
+        baselineValue,
+        candidateValue,
+      ));
+    }
+
+    const rightFixtures = new Map(right.fixtures.map((entry) => [entry.fixtureId, entry]));
+    for (const leftFixture of left.fixtures) {
+      const rightFixture = rightFixtures.get(leftFixture.fixtureId);
+      if (!rightFixture) continue;
+      const fixtureScope = `${scope}:fixture:${leftFixture.fixtureId}`;
+      const fixtureValues: Array<[
+        string,
+        string,
+        ComparisonMetricUnit,
+        number,
+        number,
+      ]> = [
+        ['warmMedianMs', 'Warm median', 'ms', leftFixture.warmMedianMs, rightFixture.warmMedianMs],
+        ['warmP95Ms', 'Warm p95', 'ms', leftFixture.warmP95Ms, rightFixture.warmP95Ms],
+        ['realtimeFactor', 'Realtime factor', 'ratio', leftFixture.realtimeFactor, rightFixture.realtimeFactor],
+        ['wordErrorRate', 'Raw WER', 'ratio', leftFixture.wordErrorRate, rightFixture.wordErrorRate],
+        ['normalizedWordErrorRate', 'Normalized WER', 'ratio', leftFixture.normalizedWordErrorRate, rightFixture.normalizedWordErrorRate],
+        ['deliveredWordErrorRate', 'Delivered raw WER', 'ratio', leftFixture.deliveredWordErrorRate, rightFixture.deliveredWordErrorRate],
+        ['deliveredNormalizedWordErrorRate', 'Delivered normalized WER', 'ratio', leftFixture.deliveredNormalizedWordErrorRate, rightFixture.deliveredNormalizedWordErrorRate],
+      ];
+      for (const [key, label, unit, baselineValue, candidateValue] of fixtureValues) {
+        pushMetric(metrics, metric(
+          `benchmark.${fixtureScope}.${key}`,
+          fixtureScope,
+          label,
+          unit,
+          'lower_is_better',
+          baselineValue,
+          candidateValue,
+        ));
+      }
+    }
+  }
+  return metrics;
+}
+
+function evaluationMetrics(
+  baseline: NormalizedEvaluationReport,
+  candidate: NormalizedEvaluationReport,
+): ComparisonMetric[] {
+  const metrics: ComparisonMetric[] = [];
+  const summaryValues: Array<[
+    string,
+    string,
+    ComparisonMetricUnit,
+    MetricDirection,
+    number | null,
+    number | null,
+  ]> = [
+    ['passed', 'Passed cases', 'count', 'higher_is_better', baseline.summary.passed, candidate.summary.passed],
+    ['failed', 'Failed cases', 'count', 'lower_is_better', baseline.summary.failed, candidate.summary.failed],
+    ['skipped', 'Skipped cases', 'count', 'lower_is_better', baseline.summary.skipped, candidate.summary.skipped],
+    ['aggregateRawWer', 'Aggregate raw WER', 'ratio', 'lower_is_better', baseline.summary.aggregateRawWer, candidate.summary.aggregateRawWer],
+    ['aggregateNormalizedWer', 'Aggregate normalized WER', 'ratio', 'lower_is_better', baseline.summary.aggregateNormalizedWer, candidate.summary.aggregateNormalizedWer],
+    ['aggregateCer', 'Aggregate CER', 'ratio', 'lower_is_better', baseline.summary.aggregateCer, candidate.summary.aggregateCer],
+    ['transformationMatchRate', 'Transformation match rate', 'ratio', 'higher_is_better', baseline.summary.transformationMatchRate, candidate.summary.transformationMatchRate],
+    ['commandExactMatchRate', 'Command exact-match rate', 'ratio', 'higher_is_better', baseline.summary.commandExactMatchRate, candidate.summary.commandExactMatchRate],
+    ['noChangePreservationRate', 'No-change preservation rate', 'ratio', 'higher_is_better', baseline.summary.noChangePreservationRate, candidate.summary.noChangePreservationRate],
+    ['deliveryMatchRate', 'Delivery match rate', 'ratio', 'higher_is_better', baseline.summary.deliveryMatchRate, candidate.summary.deliveryMatchRate],
+  ];
+  for (const [key, label, unit, direction, baselineValue, candidateValue] of summaryValues) {
+    pushMetric(metrics, metric(
+      `evaluation.summary.${key}`,
+      'summary',
+      label,
+      unit,
+      direction,
+      baselineValue,
+      candidateValue,
+    ));
+  }
+
+  const candidateCases = new Map(candidate.cases.map((entry) => [entry.id, entry]));
+  for (const left of baseline.cases) {
+    const right = candidateCases.get(left.id);
+    if (!right) continue;
+    const scope = `case:${left.id}`;
+    const caseValues: Array<[
+      string,
+      string,
+      ComparisonMetricUnit,
+      MetricDirection,
+      number | null,
+      number | null,
+    ]> = [
+      ['rawWer', 'Raw WER', 'ratio', 'lower_is_better', left.recognition.rawWer, right.recognition.rawWer],
+      ['normalizedWer', 'Normalized WER', 'ratio', 'lower_is_better', left.recognition.normalizedWer, right.recognition.normalizedWer],
+      ['cer', 'CER', 'ratio', 'lower_is_better', left.recognition.cer, right.recognition.cer],
+      ['rawAsrMs', 'Raw ASR', 'ms', 'lower_is_better', left.latency.rawAsrMs, right.latency.rawAsrMs],
+      ['transformationMs', 'Transformation', 'ms', 'lower_is_better', left.latency.transformationMs, right.latency.transformationMs],
+      ['finalizationMs', 'Finalization', 'ms', 'lower_is_better', left.latency.finalizationMs, right.latency.finalizationMs],
+      ['deliveryMs', 'Delivery', 'ms', 'lower_is_better', left.latency.deliveryMs, right.latency.deliveryMs],
+      ['totalMs', 'Total', 'ms', 'lower_is_better', left.latency.totalMs, right.latency.totalMs],
+      ['memoryDeltaMb', 'Memory delta', 'mb', 'lower_is_better', left.runtime.memoryDeltaMb, right.runtime.memoryDeltaMb],
+    ];
+    for (const [key, label, unit, direction, baselineValue, candidateValue] of caseValues) {
+      pushMetric(metrics, metric(
+        `evaluation.${scope}.${key}`,
+        scope,
+        label,
+        unit,
+        direction,
+        baselineValue,
+        candidateValue,
+      ));
+    }
+
+    const rightStages = new Map(
+      right.transformation.stages.map((stage) => [stage.name, stage]),
+    );
+    for (const leftStage of left.transformation.stages) {
+      const rightStage = rightStages.get(leftStage.name);
+      if (!rightStage) continue;
+      pushMetric(metrics, metric(
+        `evaluation.${scope}.stage:${leftStage.name}.durationUs`,
+        `${scope}:stage:${leftStage.name}`,
+        'Stage duration',
+        'microseconds',
+        'lower_is_better',
+        leftStage.durationUs,
+        rightStage.durationUs,
+      ));
+    }
+  }
+  return metrics;
+}
+
+export function compareDiagnosticReports(
+  baseline: NormalizedDiagnosticReport,
+  candidate: NormalizedDiagnosticReport,
+): DiagnosticComparison {
+  if (baseline.kind !== candidate.kind) {
+    const issues: CompatibilityIssue[] = [{
+      code: 'report_type_mismatch',
+      severity: 'blocker',
+      field: 'kind',
+      message: 'Benchmark and evaluation reports use different metric semantics.',
+    }];
+    return {
+      status: 'blocked',
+      issues,
+      deltasAllowed: false,
+      recommendationAllowed: false,
+      metrics: [],
+    };
+  }
+
+  let issues: CompatibilityIssue[];
+  let metrics: ComparisonMetric[];
+  if (baseline.kind === 'benchmark' && candidate.kind === 'benchmark') {
+    issues = compareBenchmarkCompatibility(baseline, candidate);
+    metrics = issues.some((entry) => entry.severity === 'blocker')
+      ? []
+      : benchmarkMetrics(baseline, candidate);
+  } else if (baseline.kind === 'evaluation' && candidate.kind === 'evaluation') {
+    issues = compareEvaluationCompatibility(baseline, candidate);
+    metrics = issues.some((entry) => entry.severity === 'blocker')
+      ? []
+      : evaluationMetrics(baseline, candidate);
+  } else {
+    issues = [];
+    metrics = [];
+  }
+
+  const blocked = issues.some((entry) => entry.severity === 'blocker');
+  const warned = issues.some((entry) => entry.severity === 'warning');
+  return {
+    status: blocked ? 'blocked' : warned ? 'warning' : 'compatible',
+    issues,
+    deltasAllowed: !blocked,
+    recommendationAllowed: !blocked && !warned,
+    metrics,
+  };
+}

--- a/app/src/lib/diagnosticReports.test.ts
+++ b/app/src/lib/diagnosticReports.test.ts
@@ -147,6 +147,88 @@ describe('parseDiagnosticReportJson', () => {
       ok: false,
       error: { code: 'schema_mismatch' },
     });
+    expect(parse({ ...evaluationDeterministic, summary: null })).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+  });
+
+  it('rejects benchmark results marked successful without required measurements', () => {
+    const missingMeasurement = JSON.parse(JSON.stringify(benchmarkV2));
+    missingMeasurement.results[0].warmMedianMs = null;
+    expect(parse(missingMeasurement)).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+
+    const emptyMeasurements = JSON.parse(JSON.stringify(benchmarkV2));
+    emptyMeasurements.results[0].fixtures = [];
+    expect(parse(emptyMeasurements)).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+  });
+
+  it('rejects evaluation cases marked passed without required measurements', () => {
+    const missingRecognition = JSON.parse(JSON.stringify(evaluationDeterministic));
+    missingRecognition.cases[0].recognition.rawWer = null;
+    expect(parse(missingRecognition)).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+
+    const missingDelivery = JSON.parse(JSON.stringify(evaluationDeterministic));
+    missingDelivery.cases[0].delivery.delivered = null;
+    expect(parse(missingDelivery)).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+  });
+
+  it('keeps valid failed evaluation cases importable but not complete', () => {
+    const failed = JSON.parse(JSON.stringify(evaluationHardware));
+    failed.cases[0].status = 'failed';
+    failed.cases[0].failures = ['PRIVATE_FAILURE_SENTINEL'];
+    failed.cases[0].recognition = {
+      expectedRaw: null,
+      actualRaw: null,
+      rawWordErrors: null,
+      normalizedWordErrors: null,
+      referenceWords: null,
+      normalizedReferenceWords: null,
+      referenceCharacters: null,
+      characterErrors: null,
+      rawWer: null,
+      normalizedWer: null,
+      cer: null,
+      boundedAlternativeMatch: false,
+    };
+    failed.cases[0].transformation.actualFinal = null;
+    failed.cases[0].transformation.exactMatch = false;
+    failed.cases[0].transformation.commandExactMatch = null;
+    failed.cases[0].transformation.noChangePreserved = null;
+    failed.cases[0].transformation.stages = [];
+    failed.cases[0].delivery.delivered = null;
+    failed.cases[0].delivery.exactMatch = false;
+    failed.cases[0].delivery.attempts = 0;
+    failed.summary.passed = 0;
+    failed.summary.failed = 1;
+    failed.summary.aggregateRawWer = null;
+    failed.summary.aggregateNormalizedWer = null;
+    failed.summary.aggregateCer = null;
+    failed.summary.transformationMatchRate = 0;
+    failed.summary.commandExactMatchRate = null;
+    failed.summary.noChangePreservationRate = null;
+    failed.summary.deliveryMatchRate = 0;
+
+    const result = parse(failed);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.report.kind !== 'evaluation') return;
+    expect(result.report.cases[0]).toMatchObject({
+      status: 'failed',
+      complete: false,
+    });
+    expect(JSON.stringify(result.report)).not.toContain('PRIVATE_FAILURE_SENTINEL');
   });
 
   it('enforces model, fixture, case, and stage collection bounds', () => {

--- a/app/src/lib/diagnosticReports.test.ts
+++ b/app/src/lib/diagnosticReports.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import benchmarkLegacy from './__fixtures__/diagnostic-reports/benchmark-legacy.json';
+import benchmarkV2 from './__fixtures__/diagnostic-reports/benchmark-v2.json';
+import evaluationDeterministic from './__fixtures__/diagnostic-reports/evaluation-v1-deterministic.json';
+import evaluationHardware from './__fixtures__/diagnostic-reports/evaluation-v1-hardware.json';
+import {
+  DIAGNOSTIC_REPORT_LIMITS,
+  MAX_DIAGNOSTIC_REPORT_BYTES,
+  normalizeLocalBenchmarkReport,
+  parseDiagnosticReportJson,
+} from './diagnosticReports';
+import type { BenchmarkReport } from './benchmark';
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function parse(value: unknown) {
+  const contents = json(value);
+  return parseDiagnosticReportJson(contents, new TextEncoder().encode(contents).byteLength);
+}
+
+describe('parseDiagnosticReportJson', () => {
+  it('imports benchmark legacy and v2 fixtures with explicit schema labels', () => {
+    const legacy = parse(benchmarkLegacy);
+    const versioned = parse(benchmarkV2);
+
+    expect(legacy.ok).toBe(true);
+    expect(versioned.ok).toBe(true);
+    if (!legacy.ok || !versioned.ok) return;
+    expect(legacy.report).toMatchObject({
+      kind: 'benchmark',
+      source: 'imported',
+      schemaVersion: 'legacy',
+    });
+    expect(legacy.report.privacyWarnings).toContain(
+      'Legacy benchmark reports omit environment, corpus, and execution configuration metadata.',
+    );
+    expect(versioned.report).toMatchObject({
+      kind: 'benchmark',
+      source: 'imported',
+      schemaVersion: 2,
+    });
+  });
+
+  it('imports deterministic and hardware EvaluationReportV1 fixtures', () => {
+    const deterministic = parse(evaluationDeterministic);
+    const hardware = parse(evaluationHardware);
+
+    expect(deterministic.ok).toBe(true);
+    expect(hardware.ok).toBe(true);
+    if (!deterministic.ok || !hardware.ok) return;
+    expect(deterministic.report).toMatchObject({
+      kind: 'evaluation',
+      schemaVersion: 1,
+      fixtureVersion: 1,
+      tier: 'deterministic',
+    });
+    expect(hardware.report).toMatchObject({
+      kind: 'evaluation',
+      schemaVersion: 1,
+      fixtureVersion: 1,
+      tier: 'hardware',
+    });
+    expect(deterministic.report.privacyWarnings[0]).toContain(
+      'curated fixture transcripts and per-stage text',
+    );
+  });
+
+  it('drops report text, evaluator failures, fixture context, and audio paths', () => {
+    const reports = [parse(benchmarkV2), parse(evaluationDeterministic), parse(evaluationHardware)];
+    for (const result of reports) {
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      const normalized = JSON.stringify(result.report);
+      expect(normalized).not.toContain('PRIVATE_');
+      expect(normalized).not.toContain('expectedRaw');
+      expect(normalized).not.toContain('actualRaw');
+      expect(normalized).not.toContain('audioPath');
+      expect(normalized).not.toContain('bundleId');
+      expect(normalized).not.toContain('matchedProfile');
+      expect(normalized).not.toContain('failures');
+    }
+  });
+
+  it('returns stable content-free errors for empty, malformed, and mismatched input', () => {
+    const empty = parseDiagnosticReportJson(' \n ', 3);
+    const malformed = parseDiagnosticReportJson('{"secret":"PRIVATE_PARSE_SENTINEL"', 35);
+    const mismatch = parse({ createdAt: 'PRIVATE_SCHEMA_SENTINEL', results: [] });
+
+    expect(empty).toEqual({
+      ok: false,
+      error: { code: 'empty', message: 'The selected diagnostic report is empty.' },
+    });
+    expect(malformed).toEqual({
+      ok: false,
+      error: { code: 'malformed_json', message: 'The selected file is not valid JSON.' },
+    });
+    expect(mismatch).toMatchObject({ ok: false, error: { code: 'schema_mismatch' } });
+    expect(JSON.stringify([empty, malformed, mismatch])).not.toContain('PRIVATE_');
+  });
+
+  it('rejects declared or actual input larger than the 8 MiB cap before parsing', () => {
+    expect(parseDiagnosticReportJson('{}', MAX_DIAGNOSTIC_REPORT_BYTES + 1)).toEqual({
+      ok: false,
+      error: { code: 'oversized', message: 'Diagnostic reports are limited to 8 MiB.' },
+    });
+    const oversized = `"${'x'.repeat(MAX_DIAGNOSTIC_REPORT_BYTES)}"`;
+    expect(parseDiagnosticReportJson(oversized, 1)).toMatchObject({
+      ok: false,
+      error: { code: 'oversized' },
+    });
+  });
+
+  it('rejects unknown benchmark, report, and fixture versions', () => {
+    expect(parse({ ...benchmarkV2, reportVersion: 3 })).toMatchObject({
+      ok: false,
+      error: { code: 'unsupported_version' },
+    });
+    expect(parse({ ...evaluationDeterministic, reportVersion: 2 })).toMatchObject({
+      ok: false,
+      error: { code: 'unsupported_version' },
+    });
+    expect(parse({ ...evaluationDeterministic, fixtureVersion: 2 })).toMatchObject({
+      ok: false,
+      error: { code: 'unsupported_version' },
+    });
+  });
+
+  it('rejects unknown fields, duplicate IDs, and inconsistent summaries', () => {
+    expect(parse({ ...benchmarkV2, unexpected: true })).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+    const duplicateCase = structuredClone(evaluationDeterministic);
+    duplicateCase.cases.push(structuredClone(duplicateCase.cases[0]));
+    duplicateCase.summary.total = 2;
+    duplicateCase.summary.passed = 2;
+    expect(parse(duplicateCase)).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+    expect(parse({
+      ...evaluationDeterministic,
+      summary: { ...evaluationDeterministic.summary, total: 2 },
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'schema_mismatch' },
+    });
+  });
+
+  it('enforces model, fixture, case, and stage collection bounds', () => {
+    const tooManyModels = structuredClone(benchmarkV2);
+    tooManyModels.results = Array.from(
+      { length: DIAGNOSTIC_REPORT_LIMITS.benchmarkModels + 1 },
+      (_, index) => ({
+        ...structuredClone(benchmarkV2.results[0]),
+        modelName: `model-${index}`,
+      }),
+    );
+    expect(parse(tooManyModels)).toMatchObject({
+      ok: false,
+      error: { code: 'collection_limit' },
+    });
+
+    const tooManyFixtures = structuredClone(benchmarkV2);
+    tooManyFixtures.results[0].fixtures = Array.from(
+      { length: DIAGNOSTIC_REPORT_LIMITS.benchmarkFixturesPerModel + 1 },
+      () => ({} as typeof benchmarkV2.results[0]['fixtures'][number]),
+    );
+    expect(parse(tooManyFixtures)).toMatchObject({
+      ok: false,
+      error: { code: 'collection_limit' },
+    });
+
+    const tooManyCases = structuredClone(evaluationDeterministic);
+    tooManyCases.cases = Array.from(
+      { length: DIAGNOSTIC_REPORT_LIMITS.evaluationCases + 1 },
+      () => ({} as typeof evaluationDeterministic.cases[number]),
+    );
+    expect(parse(tooManyCases)).toMatchObject({
+      ok: false,
+      error: { code: 'collection_limit' },
+    });
+
+    const tooManyStages = structuredClone(evaluationDeterministic);
+    tooManyStages.cases[0].transformation.stages = Array.from(
+      { length: DIAGNOSTIC_REPORT_LIMITS.evaluationStagesPerCase + 1 },
+      (_, index) => ({
+        ...structuredClone(evaluationDeterministic.cases[0].transformation.stages[0]),
+        name: `stage-${index}`,
+      }),
+    );
+    expect(parse(tooManyStages)).toMatchObject({
+      ok: false,
+      error: { code: 'collection_limit' },
+    });
+  });
+
+  it('normalizes an already validated local benchmark without changing storage', () => {
+    const result = normalizeLocalBenchmarkReport(benchmarkV2 as BenchmarkReport);
+    expect(result).toMatchObject({
+      ok: true,
+      report: { kind: 'benchmark', source: 'local', schemaVersion: 2 },
+    });
+  });
+});

--- a/app/src/lib/diagnosticReports.ts
+++ b/app/src/lib/diagnosticReports.ts
@@ -1,0 +1,938 @@
+import type { BenchmarkReport } from './benchmark';
+
+export const MAX_DIAGNOSTIC_REPORT_BYTES = 8 * 1024 * 1024;
+
+export const DIAGNOSTIC_REPORT_LIMITS = {
+  benchmarkModels: 64,
+  benchmarkFixturesPerModel: 512,
+  evaluationCases: 10_000,
+  evaluationStagesPerCase: 128,
+  stringsPerCollection: 512,
+} as const;
+
+export type DiagnosticReportSource = 'imported' | 'local';
+export type DiagnosticReportKind = 'benchmark' | 'evaluation';
+
+export type DiagnosticImportErrorCode =
+  | 'empty'
+  | 'oversized'
+  | 'malformed_json'
+  | 'unsupported_version'
+  | 'schema_mismatch'
+  | 'collection_limit';
+
+export interface DiagnosticImportError {
+  code: DiagnosticImportErrorCode;
+  message: string;
+}
+
+export type DiagnosticImportResult =
+  | { ok: true; report: NormalizedDiagnosticReport }
+  | { ok: false; error: DiagnosticImportError };
+
+export interface NormalizedBenchmarkFixture {
+  fixtureId: string;
+  audioSeconds: number;
+  warmMedianMs: number;
+  warmP95Ms: number;
+  realtimeFactor: number;
+  wordErrorRate: number;
+  normalizedWordErrorRate: number;
+  deliveredWordErrorRate: number;
+  deliveredNormalizedWordErrorRate: number;
+  deliveredTransformFailed: boolean;
+}
+
+export interface NormalizedBenchmarkModel {
+  modelName: string;
+  label: string;
+  backend: string;
+  accelerator: string;
+  downloadSize: string | null;
+  modelLoadMs: number | null;
+  firstInferenceMs: number | null;
+  warmMedianMs: number | null;
+  warmP95Ms: number | null;
+  realtimeFactor: number | null;
+  wordErrorRate: number | null;
+  normalizedWordErrorRate: number | null;
+  deliveredWordErrorRate: number | null;
+  deliveredNormalizedWordErrorRate: number | null;
+  memoryDeltaMb: number;
+  fixtures: NormalizedBenchmarkFixture[];
+  succeeded: boolean;
+}
+
+export interface NormalizedBenchmarkReport {
+  kind: 'benchmark';
+  source: DiagnosticReportSource;
+  schemaVersion: 'legacy' | 2;
+  createdAt: string;
+  appVersion: string;
+  platform: string;
+  preset: 'quick' | 'standard' | 'thorough';
+  iterations: number;
+  sharedInitMs: number;
+  environment: {
+    os: string;
+    osVersion: string | null;
+    architecture: string;
+    hardwareModel: string | null;
+    chip: string | null;
+    memoryMb: number | null;
+  } | null;
+  corpus: {
+    language: string;
+    fixtureIds: string[];
+    fixtureCount: number;
+    referenceWords: number;
+  } | null;
+  configuration: {
+    vadThreshold: number;
+    executionPath: string;
+    transcriptTransformProfile: string;
+    percentileMethod: string;
+    modelRunOrder: string[];
+    sharedInitOrder: string[];
+  } | null;
+  models: NormalizedBenchmarkModel[];
+  recommendations: {
+    fastest: string | null;
+    mostAccurate: string | null;
+    balanced: string | null;
+  };
+  privacyWarnings: string[];
+}
+
+export interface NormalizedEvaluationCase {
+  id: string;
+  status: 'passed' | 'failed' | 'skipped';
+  fixtureOnly: boolean;
+  model: {
+    name: string;
+    backend: string;
+    accelerator: string;
+  } | null;
+  recognition: {
+    rawWordErrors: number | null;
+    normalizedWordErrors: number | null;
+    referenceWords: number | null;
+    normalizedReferenceWords: number | null;
+    referenceCharacters: number | null;
+    characterErrors: number | null;
+    rawWer: number | null;
+    normalizedWer: number | null;
+    cer: number | null;
+    boundedAlternativeMatch: boolean;
+  };
+  transformation: {
+    exactMatch: boolean;
+    commandExactMatch: boolean | null;
+    noChangePreserved: boolean | null;
+    stages: Array<{
+      name: string;
+      outcome: string;
+      changed: boolean;
+      durationUs: number;
+      expectationMatch: boolean;
+    }>;
+  };
+  delivery: {
+    exactMatch: boolean;
+    attempts: number;
+    partialCount: number;
+    firstPartialMs: number | null;
+    firstPartialApplicability: string;
+    finalOnly: boolean;
+  };
+  latency: {
+    rawAsrMs: number;
+    transformationMs: number;
+    finalizationMs: number;
+    deliveryMs: number;
+    totalMs: number;
+  };
+  runtime: {
+    incrementalCompletion: string;
+    fallbackUsed: boolean;
+    fallbackStages: string[];
+    memoryBeforeMb: number | null;
+    memoryAfterMb: number | null;
+    memoryDeltaMb: number | null;
+  };
+}
+
+export interface NormalizedEvaluationReport {
+  kind: 'evaluation';
+  source: DiagnosticReportSource;
+  schemaVersion: 1;
+  fixtureVersion: 1;
+  createdAt: string;
+  tier: 'deterministic' | 'hardware';
+  environment: {
+    appVersion: string;
+    os: string;
+    architecture: string;
+    machineLabel: string;
+    logicalCpus: number | null;
+  };
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    aggregateRawWer: number | null;
+    aggregateNormalizedWer: number | null;
+    aggregateCer: number | null;
+    transformationMatchRate: number | null;
+    commandExactMatchRate: number | null;
+    noChangePreservationRate: number | null;
+    deliveryMatchRate: number | null;
+  };
+  cases: NormalizedEvaluationCase[];
+  privacyWarnings: string[];
+}
+
+export type NormalizedDiagnosticReport =
+  | NormalizedBenchmarkReport
+  | NormalizedEvaluationReport;
+
+type JsonRecord = Record<string, unknown>;
+
+interface ValidationContext {
+  collectionExceeded: boolean;
+}
+
+const ERROR_MESSAGES: Record<DiagnosticImportErrorCode, string> = {
+  empty: 'The selected diagnostic report is empty.',
+  oversized: 'Diagnostic reports are limited to 8 MiB.',
+  malformed_json: 'The selected file is not valid JSON.',
+  unsupported_version: 'This diagnostic report version is not supported by this Murmur build.',
+  schema_mismatch: 'The selected JSON is not a supported Murmur benchmark or evaluation report.',
+  collection_limit: 'The selected report exceeds supported diagnostic collection limits.',
+};
+
+function failure(code: DiagnosticImportErrorCode): DiagnosticImportResult {
+  return { ok: false, error: { code, message: ERROR_MESSAGES[code] } };
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: JsonRecord,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.prototype.hasOwnProperty.call(value, key))
+    && Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || isString(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0;
+}
+
+function isInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return isInteger(value) && (value as number) >= 0;
+}
+
+function isNullableNonNegativeInteger(value: unknown): value is number | null {
+  return value === null || isNonNegativeInteger(value);
+}
+
+function isNullableNonNegativeNumber(value: unknown): value is number | null {
+  return value === null || isNonNegativeNumber(value);
+}
+
+function isNullableInteger(value: unknown): value is number | null {
+  return value === null || isInteger(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return isString(value) && value.length > 0 && Number.isFinite(Date.parse(value));
+}
+
+function boundedArray<T>(
+  value: unknown,
+  maximum: number,
+  predicate: (entry: unknown, context: ValidationContext) => entry is T,
+  context: ValidationContext,
+): value is T[] {
+  if (!Array.isArray(value)) return false;
+  if (value.length > maximum) {
+    context.collectionExceeded = true;
+    return false;
+  }
+  return value.every((entry) => predicate(entry, context));
+}
+
+function boundedStrings(
+  value: unknown,
+  maximum: number,
+  context: ValidationContext,
+): value is string[] {
+  return boundedArray(value, maximum, (entry): entry is string => isString(entry), context);
+}
+
+function hasUniqueStrings(values: string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+const BENCHMARK_FIXTURE_KEYS = [
+  'fixtureId', 'label', 'audioSeconds', 'warmMedianMs', 'warmP95Ms', 'realtimeFactor',
+  'wordErrorRate', 'wordErrors', 'referenceWords', 'normalizedWordErrorRate',
+  'normalizedWordErrors', 'normalizedReferenceWords', 'reference', 'transcript',
+  'deliveredTranscript', 'deliveredWordErrorRate', 'deliveredWordErrors',
+  'deliveredNormalizedWordErrorRate', 'deliveredNormalizedWordErrors',
+  'deliveredTransformFailed',
+] as const;
+
+function isBenchmarkFixture(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, BENCHMARK_FIXTURE_KEYS)) return false;
+  return isString(value.fixtureId)
+    && isString(value.label)
+    && isNonNegativeNumber(value.audioSeconds)
+    && isNonNegativeNumber(value.warmMedianMs)
+    && isNonNegativeNumber(value.warmP95Ms)
+    && isNonNegativeNumber(value.realtimeFactor)
+    && isNonNegativeNumber(value.wordErrorRate)
+    && isNonNegativeInteger(value.wordErrors)
+    && isNonNegativeInteger(value.referenceWords)
+    && isNonNegativeNumber(value.normalizedWordErrorRate)
+    && isNonNegativeInteger(value.normalizedWordErrors)
+    && isNonNegativeInteger(value.normalizedReferenceWords)
+    && isString(value.reference)
+    && isString(value.transcript)
+    && isString(value.deliveredTranscript)
+    && isNonNegativeNumber(value.deliveredWordErrorRate)
+    && isNonNegativeInteger(value.deliveredWordErrors)
+    && isNonNegativeNumber(value.deliveredNormalizedWordErrorRate)
+    && isNonNegativeInteger(value.deliveredNormalizedWordErrors)
+    && typeof value.deliveredTransformFailed === 'boolean';
+}
+
+const BENCHMARK_MODEL_KEYS = [
+  'modelName', 'label', 'backend', 'accelerator', 'modelLoadMs', 'firstInferenceMs',
+  'warmMedianMs', 'warmP95Ms', 'realtimeFactor', 'wordErrorRate',
+  'normalizedWordErrorRate', 'deliveredWordErrorRate',
+  'deliveredNormalizedWordErrorRate', 'memoryDeltaMb', 'fixtures', 'error',
+] as const;
+
+function isBenchmarkModel(value: unknown, context: ValidationContext): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, BENCHMARK_MODEL_KEYS, ['downloadSize'])) {
+    return false;
+  }
+  if (!boundedArray(
+    value.fixtures,
+    DIAGNOSTIC_REPORT_LIMITS.benchmarkFixturesPerModel,
+    (entry): entry is JsonRecord => isBenchmarkFixture(entry),
+    context,
+  )) {
+    return false;
+  }
+  const fixtureIds = value.fixtures.map((fixture) => fixture.fixtureId as string);
+  return isString(value.modelName)
+    && isString(value.label)
+    && isString(value.backend)
+    && isString(value.accelerator)
+    && (value.downloadSize === undefined || isString(value.downloadSize))
+    && isNullableNonNegativeNumber(value.modelLoadMs)
+    && isNullableNonNegativeNumber(value.firstInferenceMs)
+    && isNullableNonNegativeNumber(value.warmMedianMs)
+    && isNullableNonNegativeNumber(value.warmP95Ms)
+    && isNullableNonNegativeNumber(value.realtimeFactor)
+    && isNullableNonNegativeNumber(value.wordErrorRate)
+    && isNullableNonNegativeNumber(value.normalizedWordErrorRate)
+    && isNullableNonNegativeNumber(value.deliveredWordErrorRate)
+    && isNullableNonNegativeNumber(value.deliveredNormalizedWordErrorRate)
+    && isNonNegativeNumber(value.memoryDeltaMb)
+    && isNullableString(value.error)
+    && hasUniqueStrings(fixtureIds);
+}
+
+function isBenchmarkEnvironment(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'os', 'osVersion', 'architecture', 'hardwareModel', 'chip', 'memoryMb',
+  ])) return false;
+  return isString(value.os)
+    && isNullableString(value.osVersion)
+    && isString(value.architecture)
+    && isNullableString(value.hardwareModel)
+    && isNullableString(value.chip)
+    && isNullableNonNegativeInteger(value.memoryMb);
+}
+
+function isBenchmarkCorpus(value: unknown, context: ValidationContext): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'language', 'fixtureIds', 'fixtureCount', 'referenceWords', 'provenance', 'limitation',
+  ])) return false;
+  if (!boundedStrings(
+    value.fixtureIds,
+    DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection,
+    context,
+  )) return false;
+  return isString(value.language)
+    && hasUniqueStrings(value.fixtureIds)
+    && isNonNegativeInteger(value.fixtureCount)
+    && value.fixtureCount === value.fixtureIds.length
+    && isNonNegativeInteger(value.referenceWords)
+    && isString(value.provenance)
+    && isString(value.limitation);
+}
+
+function isBenchmarkConfiguration(value: unknown, context: ValidationContext): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'vadThreshold', 'executionPath', 'transcriptTransformProfile', 'percentileMethod',
+    'modelRunOrder', 'sharedInitOrder',
+  ])) return false;
+  return isNonNegativeNumber(value.vadThreshold)
+    && isString(value.executionPath)
+    && isString(value.transcriptTransformProfile)
+    && isString(value.percentileMethod)
+    && boundedStrings(value.modelRunOrder, DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection, context)
+    && boundedStrings(value.sharedInitOrder, DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection, context);
+}
+
+function isRecommendations(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, ['fastest', 'mostAccurate', 'balanced'])) {
+    return false;
+  }
+  return isNullableString(value.fastest)
+    && isNullableString(value.mostAccurate)
+    && isNullableString(value.balanced);
+}
+
+const BENCHMARK_BASE_KEYS = [
+  'createdAt', 'appVersion', 'platform', 'preset', 'iterations', 'sharedInitMs',
+  'results', 'recommendations',
+] as const;
+
+function isBenchmarkReport(
+  value: JsonRecord,
+  context: ValidationContext,
+): value is JsonRecord {
+  const version = value.reportVersion;
+  const isLegacy = version === undefined;
+  const required = isLegacy
+    ? BENCHMARK_BASE_KEYS
+    : [...BENCHMARK_BASE_KEYS, 'reportVersion', 'environment', 'corpus', 'configuration'];
+  if (!hasExactKeys(value, required)) return false;
+  if (!boundedArray(
+    value.results,
+    DIAGNOSTIC_REPORT_LIMITS.benchmarkModels,
+    isBenchmarkModel,
+    context,
+  )) return false;
+  const identities = value.results.map((model) =>
+    `${String(model.modelName)}\u0000${String(model.backend)}\u0000${String(model.accelerator)}`);
+  return (isLegacy || version === 2)
+    && isIsoDate(value.createdAt)
+    && isString(value.appVersion)
+    && isString(value.platform)
+    && (value.preset === 'quick' || value.preset === 'standard' || value.preset === 'thorough')
+    && isNonNegativeInteger(value.iterations)
+    && value.iterations > 0
+    && isNonNegativeNumber(value.sharedInitMs)
+    && isRecommendations(value.recommendations)
+    && hasUniqueStrings(identities)
+    && (isLegacy || (
+      isBenchmarkEnvironment(value.environment)
+      && isBenchmarkCorpus(value.corpus, context)
+      && isBenchmarkConfiguration(value.configuration, context)
+    ));
+}
+
+function isEvaluationPrivacy(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'localOnly', 'historyIngestion', 'networkUsed', 'systemClipboardUsed',
+    'fixtureProvenanceRequired',
+  ])) return false;
+  return value.localOnly === true
+    && value.historyIngestion === false
+    && value.networkUsed === false
+    && value.systemClipboardUsed === false
+    && value.fixtureProvenanceRequired === true;
+}
+
+function isEvaluationEnvironment(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'appVersion', 'os', 'arch', 'machineLabel', 'logicalCpus',
+  ])) return false;
+  return isString(value.appVersion)
+    && isString(value.os)
+    && isString(value.arch)
+    && isString(value.machineLabel)
+    && isNullableNonNegativeInteger(value.logicalCpus);
+}
+
+const EVALUATION_SUMMARY_KEYS = [
+  'total', 'passed', 'failed', 'skipped', 'aggregateRawWer', 'aggregateNormalizedWer',
+  'aggregateCer', 'transformationMatchRate', 'commandExactMatchRate',
+  'noChangePreservationRate', 'deliveryMatchRate',
+] as const;
+
+function isEvaluationSummary(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, EVALUATION_SUMMARY_KEYS)) return false;
+  return isNonNegativeInteger(value.total)
+    && isNonNegativeInteger(value.passed)
+    && isNonNegativeInteger(value.failed)
+    && isNonNegativeInteger(value.skipped)
+    && value.total === value.passed + value.failed + value.skipped
+    && isNullableNonNegativeNumber(value.aggregateRawWer)
+    && isNullableNonNegativeNumber(value.aggregateNormalizedWer)
+    && isNullableNonNegativeNumber(value.aggregateCer)
+    && isNullableNonNegativeNumber(value.transformationMatchRate)
+    && isNullableNonNegativeNumber(value.commandExactMatchRate)
+    && isNullableNonNegativeNumber(value.noChangePreservationRate)
+    && isNullableNonNegativeNumber(value.deliveryMatchRate);
+}
+
+function isCaseProvenance(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'kind', 'source', 'containsRealUserData', 'deletion',
+  ])) return false;
+  return isString(value.kind)
+    && isString(value.source)
+    && value.containsRealUserData === false
+    && isString(value.deletion);
+}
+
+function isCaseContext(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'bundleId', 'matchedProfile', 'fixtureOnly',
+  ])) return false;
+  return isNullableString(value.bundleId)
+    && isNullableString(value.matchedProfile)
+    && typeof value.fixtureOnly === 'boolean';
+}
+
+function isEvaluationModel(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'name', 'backend', 'accelerator', 'audioPath', 'sampleRateHz', 'channels',
+  ])) return false;
+  return isString(value.name)
+    && isString(value.backend)
+    && isString(value.accelerator)
+    && isString(value.audioPath)
+    && isNonNegativeInteger(value.sampleRateHz)
+    && value.sampleRateHz > 0
+    && isNonNegativeInteger(value.channels)
+    && value.channels > 0;
+}
+
+function isRecognition(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'expectedRaw', 'actualRaw', 'rawWordErrors', 'normalizedWordErrors',
+    'referenceWords', 'normalizedReferenceWords', 'referenceCharacters',
+    'characterErrors', 'rawWer', 'normalizedWer', 'cer', 'boundedAlternativeMatch',
+  ])) return false;
+  return isNullableString(value.expectedRaw)
+    && isNullableString(value.actualRaw)
+    && isNullableNonNegativeInteger(value.rawWordErrors)
+    && isNullableNonNegativeInteger(value.normalizedWordErrors)
+    && isNullableNonNegativeInteger(value.referenceWords)
+    && isNullableNonNegativeInteger(value.normalizedReferenceWords)
+    && isNullableNonNegativeInteger(value.referenceCharacters)
+    && isNullableNonNegativeInteger(value.characterErrors)
+    && isNullableNonNegativeNumber(value.rawWer)
+    && isNullableNonNegativeNumber(value.normalizedWer)
+    && isNullableNonNegativeNumber(value.cer)
+    && typeof value.boundedAlternativeMatch === 'boolean';
+}
+
+function isStage(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'name', 'outcome', 'changed', 'durationUs', 'text', 'expectationMatch',
+  ])) return false;
+  return isString(value.name)
+    && isString(value.outcome)
+    && typeof value.changed === 'boolean'
+    && isNonNegativeInteger(value.durationUs)
+    && isString(value.text)
+    && typeof value.expectationMatch === 'boolean';
+}
+
+function isTransformation(value: unknown, context: ValidationContext): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'expectedFinal', 'actualFinal', 'exactMatch', 'commandExactMatch',
+    'noChangePreserved', 'stages',
+  ])) return false;
+  return isString(value.expectedFinal)
+    && isNullableString(value.actualFinal)
+    && typeof value.exactMatch === 'boolean'
+    && (value.commandExactMatch === null || typeof value.commandExactMatch === 'boolean')
+    && (value.noChangePreserved === null || typeof value.noChangePreserved === 'boolean')
+    && boundedArray(
+      value.stages,
+      DIAGNOSTIC_REPORT_LIMITS.evaluationStagesPerCase,
+      (entry): entry is JsonRecord => isStage(entry),
+      context,
+    );
+}
+
+function isDelivery(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'expected', 'delivered', 'exactMatch', 'attempts', 'partialCount', 'firstPartialMs',
+    'firstPartialApplicability', 'finalOnly',
+  ])) return false;
+  return isString(value.expected)
+    && isNullableString(value.delivered)
+    && typeof value.exactMatch === 'boolean'
+    && isNonNegativeInteger(value.attempts)
+    && isNonNegativeInteger(value.partialCount)
+    && isNullableNonNegativeInteger(value.firstPartialMs)
+    && isString(value.firstPartialApplicability)
+    && typeof value.finalOnly === 'boolean';
+}
+
+function isLatency(value: unknown): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'rawAsrMs', 'transformationMs', 'finalizationMs', 'deliveryMs', 'totalMs',
+  ])) return false;
+  return isNonNegativeInteger(value.rawAsrMs)
+    && isNonNegativeInteger(value.transformationMs)
+    && isNonNegativeInteger(value.finalizationMs)
+    && isNonNegativeInteger(value.deliveryMs)
+    && isNonNegativeInteger(value.totalMs);
+}
+
+function isRuntime(value: unknown, context: ValidationContext): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'incrementalCompletion', 'fallbackUsed', 'fallbackStages', 'memoryBeforeMb',
+    'memoryAfterMb', 'memoryDeltaMb',
+  ])) return false;
+  return isString(value.incrementalCompletion)
+    && typeof value.fallbackUsed === 'boolean'
+    && boundedStrings(value.fallbackStages, DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection, context)
+    && isNullableNonNegativeInteger(value.memoryBeforeMb)
+    && isNullableNonNegativeInteger(value.memoryAfterMb)
+    && isNullableInteger(value.memoryDeltaMb);
+}
+
+function isEvaluationCase(
+  value: unknown,
+  context: ValidationContext,
+): value is JsonRecord {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'id', 'status', 'failures', 'provenance', 'context', 'model', 'recognition',
+    'transformation', 'delivery', 'latency', 'runtime',
+  ])) return false;
+  return isString(value.id)
+    && (value.status === 'passed' || value.status === 'failed' || value.status === 'skipped')
+    && boundedStrings(value.failures, DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection, context)
+    && isCaseProvenance(value.provenance)
+    && isCaseContext(value.context)
+    && (value.model === null || isEvaluationModel(value.model))
+    && isRecognition(value.recognition)
+    && isTransformation(value.transformation, context)
+    && isDelivery(value.delivery)
+    && isLatency(value.latency)
+    && isRuntime(value.runtime, context);
+}
+
+function isEvaluationReport(
+  value: JsonRecord,
+  context: ValidationContext,
+): value is JsonRecord {
+  if (!hasExactKeys(value, [
+    'reportVersion', 'fixtureVersion', 'generatedAt', 'tier', 'privacy',
+    'environment', 'summary', 'cases',
+  ])) return false;
+  if (!boundedArray(
+    value.cases,
+    DIAGNOSTIC_REPORT_LIMITS.evaluationCases,
+    isEvaluationCase,
+    context,
+  )) return false;
+  const caseIds = value.cases.map((entry) => entry.id as string);
+  return value.reportVersion === 1
+    && value.fixtureVersion === 1
+    && isIsoDate(value.generatedAt)
+    && (value.tier === 'deterministic' || value.tier === 'hardware')
+    && isEvaluationPrivacy(value.privacy)
+    && isEvaluationEnvironment(value.environment)
+    && isEvaluationSummary(value.summary)
+    && value.summary.total === value.cases.length
+    && hasUniqueStrings(caseIds);
+}
+
+function normalizeBenchmark(
+  value: JsonRecord,
+  source: DiagnosticReportSource,
+): NormalizedBenchmarkReport {
+  const versioned = value.reportVersion === 2;
+  const environment = versioned ? value.environment as JsonRecord : null;
+  const corpus = versioned ? value.corpus as JsonRecord : null;
+  const configuration = versioned ? value.configuration as JsonRecord : null;
+  const recommendations = value.recommendations as JsonRecord;
+  return {
+    kind: 'benchmark',
+    source,
+    schemaVersion: versioned ? 2 : 'legacy',
+    createdAt: value.createdAt as string,
+    appVersion: value.appVersion as string,
+    platform: value.platform as string,
+    preset: value.preset as NormalizedBenchmarkReport['preset'],
+    iterations: value.iterations as number,
+    sharedInitMs: value.sharedInitMs as number,
+    environment: environment ? {
+      os: environment.os as string,
+      osVersion: environment.osVersion as string | null,
+      architecture: environment.architecture as string,
+      hardwareModel: environment.hardwareModel as string | null,
+      chip: environment.chip as string | null,
+      memoryMb: environment.memoryMb as number | null,
+    } : null,
+    corpus: corpus ? {
+      language: corpus.language as string,
+      fixtureIds: [...corpus.fixtureIds as string[]],
+      fixtureCount: corpus.fixtureCount as number,
+      referenceWords: corpus.referenceWords as number,
+    } : null,
+    configuration: configuration ? {
+      vadThreshold: configuration.vadThreshold as number,
+      executionPath: configuration.executionPath as string,
+      transcriptTransformProfile: configuration.transcriptTransformProfile as string,
+      percentileMethod: configuration.percentileMethod as string,
+      modelRunOrder: [...configuration.modelRunOrder as string[]],
+      sharedInitOrder: [...configuration.sharedInitOrder as string[]],
+    } : null,
+    models: (value.results as JsonRecord[]).map((model) => ({
+      modelName: model.modelName as string,
+      label: model.label as string,
+      backend: model.backend as string,
+      accelerator: model.accelerator as string,
+      downloadSize: model.downloadSize as string | undefined ?? null,
+      modelLoadMs: model.modelLoadMs as number | null,
+      firstInferenceMs: model.firstInferenceMs as number | null,
+      warmMedianMs: model.warmMedianMs as number | null,
+      warmP95Ms: model.warmP95Ms as number | null,
+      realtimeFactor: model.realtimeFactor as number | null,
+      wordErrorRate: model.wordErrorRate as number | null,
+      normalizedWordErrorRate: model.normalizedWordErrorRate as number | null,
+      deliveredWordErrorRate: model.deliveredWordErrorRate as number | null,
+      deliveredNormalizedWordErrorRate:
+        model.deliveredNormalizedWordErrorRate as number | null,
+      memoryDeltaMb: model.memoryDeltaMb as number,
+      fixtures: (model.fixtures as JsonRecord[]).map((fixture) => ({
+        fixtureId: fixture.fixtureId as string,
+        audioSeconds: fixture.audioSeconds as number,
+        warmMedianMs: fixture.warmMedianMs as number,
+        warmP95Ms: fixture.warmP95Ms as number,
+        realtimeFactor: fixture.realtimeFactor as number,
+        wordErrorRate: fixture.wordErrorRate as number,
+        normalizedWordErrorRate: fixture.normalizedWordErrorRate as number,
+        deliveredWordErrorRate: fixture.deliveredWordErrorRate as number,
+        deliveredNormalizedWordErrorRate:
+          fixture.deliveredNormalizedWordErrorRate as number,
+        deliveredTransformFailed: fixture.deliveredTransformFailed as boolean,
+      })),
+      succeeded: model.error === null,
+    })),
+    recommendations: {
+      fastest: recommendations.fastest as string | null,
+      mostAccurate: recommendations.mostAccurate as string | null,
+      balanced: recommendations.balanced as string | null,
+    },
+    privacyWarnings: versioned
+      ? []
+      : ['Legacy benchmark reports omit environment, corpus, and execution configuration metadata.'],
+  };
+}
+
+function normalizeEvaluation(
+  value: JsonRecord,
+  source: DiagnosticReportSource,
+): NormalizedEvaluationReport {
+  const environment = value.environment as JsonRecord;
+  const summary = value.summary as JsonRecord;
+  return {
+    kind: 'evaluation',
+    source,
+    schemaVersion: 1,
+    fixtureVersion: 1,
+    createdAt: value.generatedAt as string,
+    tier: value.tier as NormalizedEvaluationReport['tier'],
+    environment: {
+      appVersion: environment.appVersion as string,
+      os: environment.os as string,
+      architecture: environment.arch as string,
+      machineLabel: environment.machineLabel as string,
+      logicalCpus: environment.logicalCpus as number | null,
+    },
+    summary: {
+      total: summary.total as number,
+      passed: summary.passed as number,
+      failed: summary.failed as number,
+      skipped: summary.skipped as number,
+      aggregateRawWer: summary.aggregateRawWer as number | null,
+      aggregateNormalizedWer: summary.aggregateNormalizedWer as number | null,
+      aggregateCer: summary.aggregateCer as number | null,
+      transformationMatchRate: summary.transformationMatchRate as number | null,
+      commandExactMatchRate: summary.commandExactMatchRate as number | null,
+      noChangePreservationRate: summary.noChangePreservationRate as number | null,
+      deliveryMatchRate: summary.deliveryMatchRate as number | null,
+    },
+    cases: (value.cases as JsonRecord[]).map((entry) => {
+      const context = entry.context as JsonRecord;
+      const model = entry.model as JsonRecord | null;
+      const recognition = entry.recognition as JsonRecord;
+      const transformation = entry.transformation as JsonRecord;
+      const delivery = entry.delivery as JsonRecord;
+      const latency = entry.latency as JsonRecord;
+      const runtime = entry.runtime as JsonRecord;
+      return {
+        id: entry.id as string,
+        status: entry.status as NormalizedEvaluationCase['status'],
+        fixtureOnly: context.fixtureOnly as boolean,
+        model: model ? {
+          name: model.name as string,
+          backend: model.backend as string,
+          accelerator: model.accelerator as string,
+        } : null,
+        recognition: {
+          rawWordErrors: recognition.rawWordErrors as number | null,
+          normalizedWordErrors: recognition.normalizedWordErrors as number | null,
+          referenceWords: recognition.referenceWords as number | null,
+          normalizedReferenceWords: recognition.normalizedReferenceWords as number | null,
+          referenceCharacters: recognition.referenceCharacters as number | null,
+          characterErrors: recognition.characterErrors as number | null,
+          rawWer: recognition.rawWer as number | null,
+          normalizedWer: recognition.normalizedWer as number | null,
+          cer: recognition.cer as number | null,
+          boundedAlternativeMatch: recognition.boundedAlternativeMatch as boolean,
+        },
+        transformation: {
+          exactMatch: transformation.exactMatch as boolean,
+          commandExactMatch: transformation.commandExactMatch as boolean | null,
+          noChangePreserved: transformation.noChangePreserved as boolean | null,
+          stages: (transformation.stages as JsonRecord[]).map((stage) => ({
+            name: stage.name as string,
+            outcome: stage.outcome as string,
+            changed: stage.changed as boolean,
+            durationUs: stage.durationUs as number,
+            expectationMatch: stage.expectationMatch as boolean,
+          })),
+        },
+        delivery: {
+          exactMatch: delivery.exactMatch as boolean,
+          attempts: delivery.attempts as number,
+          partialCount: delivery.partialCount as number,
+          firstPartialMs: delivery.firstPartialMs as number | null,
+          firstPartialApplicability: delivery.firstPartialApplicability as string,
+          finalOnly: delivery.finalOnly as boolean,
+        },
+        latency: {
+          rawAsrMs: latency.rawAsrMs as number,
+          transformationMs: latency.transformationMs as number,
+          finalizationMs: latency.finalizationMs as number,
+          deliveryMs: latency.deliveryMs as number,
+          totalMs: latency.totalMs as number,
+        },
+        runtime: {
+          incrementalCompletion: runtime.incrementalCompletion as string,
+          fallbackUsed: runtime.fallbackUsed as boolean,
+          fallbackStages: [...runtime.fallbackStages as string[]],
+          memoryBeforeMb: runtime.memoryBeforeMb as number | null,
+          memoryAfterMb: runtime.memoryAfterMb as number | null,
+          memoryDeltaMb: runtime.memoryDeltaMb as number | null,
+        },
+      };
+    }),
+    privacyWarnings: [
+      'Evaluation reports may contain curated fixture transcripts and per-stage text; imported data stays in this session only.',
+    ],
+  };
+}
+
+function reportFamily(value: JsonRecord): DiagnosticReportKind | null {
+  if (Object.prototype.hasOwnProperty.call(value, 'createdAt')
+    || Object.prototype.hasOwnProperty.call(value, 'results')
+    || Object.prototype.hasOwnProperty.call(value, 'recommendations')) {
+    return 'benchmark';
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'generatedAt')
+    || Object.prototype.hasOwnProperty.call(value, 'fixtureVersion')
+    || Object.prototype.hasOwnProperty.call(value, 'cases')) {
+    return 'evaluation';
+  }
+  return null;
+}
+
+function hasUnsupportedVersion(value: JsonRecord, family: DiagnosticReportKind): boolean {
+  if (family === 'benchmark') {
+    return value.reportVersion !== undefined && value.reportVersion !== 2;
+  }
+  return (value.reportVersion !== undefined && value.reportVersion !== 1)
+    || (value.fixtureVersion !== undefined && value.fixtureVersion !== 1);
+}
+
+export function parseDiagnosticReportJson(
+  contents: string,
+  sourceBytes: number,
+): DiagnosticImportResult {
+  if (!Number.isSafeInteger(sourceBytes) || sourceBytes < 0) {
+    return failure('schema_mismatch');
+  }
+  if (sourceBytes > MAX_DIAGNOSTIC_REPORT_BYTES) return failure('oversized');
+  if (contents.trim().length === 0) return failure('empty');
+  if (new TextEncoder().encode(contents).byteLength > MAX_DIAGNOSTIC_REPORT_BYTES) {
+    return failure('oversized');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return failure('malformed_json');
+  }
+  if (!isRecord(parsed)) return failure('schema_mismatch');
+
+  const family = reportFamily(parsed);
+  if (!family) return failure('schema_mismatch');
+  if (hasUnsupportedVersion(parsed, family)) return failure('unsupported_version');
+
+  const context: ValidationContext = { collectionExceeded: false };
+  const valid = family === 'benchmark'
+    ? isBenchmarkReport(parsed, context)
+    : isEvaluationReport(parsed, context);
+  if (!valid) {
+    return failure(context.collectionExceeded ? 'collection_limit' : 'schema_mismatch');
+  }
+  return {
+    ok: true,
+    report: family === 'benchmark'
+      ? normalizeBenchmark(parsed, 'imported')
+      : normalizeEvaluation(parsed, 'imported'),
+  };
+}
+
+export function normalizeLocalBenchmarkReport(
+  report: BenchmarkReport,
+): DiagnosticImportResult {
+  const parsed = report as unknown;
+  if (!isRecord(parsed)) return failure('schema_mismatch');
+  const context: ValidationContext = { collectionExceeded: false };
+  if (!isBenchmarkReport(parsed, context)) {
+    return failure(context.collectionExceeded ? 'collection_limit' : 'schema_mismatch');
+  }
+  return { ok: true, report: normalizeBenchmark(parsed, 'local') };
+}

--- a/app/src/lib/diagnosticReports.ts
+++ b/app/src/lib/diagnosticReports.ts
@@ -107,6 +107,7 @@ export interface NormalizedBenchmarkReport {
 export interface NormalizedEvaluationCase {
   id: string;
   status: 'passed' | 'failed' | 'skipped';
+  complete: boolean;
   fixtureOnly: boolean;
   model: {
     name: string;
@@ -349,7 +350,7 @@ function isBenchmarkModel(value: unknown, context: ValidationContext): value is 
     return false;
   }
   const fixtureIds = value.fixtures.map((fixture) => fixture.fixtureId as string);
-  return isString(value.modelName)
+  const structurallyValid = isString(value.modelName)
     && isString(value.label)
     && isString(value.backend)
     && isString(value.accelerator)
@@ -366,6 +367,22 @@ function isBenchmarkModel(value: unknown, context: ValidationContext): value is 
     && isNonNegativeNumber(value.memoryDeltaMb)
     && isNullableString(value.error)
     && hasUniqueStrings(fixtureIds);
+  if (!structurallyValid) return false;
+  return value.error !== null || hasCompleteBenchmarkMeasurements(value);
+}
+
+function hasCompleteBenchmarkMeasurements(value: JsonRecord): boolean {
+  return isNonNegativeNumber(value.modelLoadMs)
+    && isNonNegativeNumber(value.firstInferenceMs)
+    && isNonNegativeNumber(value.warmMedianMs)
+    && isNonNegativeNumber(value.warmP95Ms)
+    && isNonNegativeNumber(value.realtimeFactor)
+    && isNonNegativeNumber(value.wordErrorRate)
+    && isNonNegativeNumber(value.normalizedWordErrorRate)
+    && isNonNegativeNumber(value.deliveredWordErrorRate)
+    && isNonNegativeNumber(value.deliveredNormalizedWordErrorRate)
+    && Array.isArray(value.fixtures)
+    && value.fixtures.length > 0;
 }
 
 function isBenchmarkEnvironment(value: unknown): value is JsonRecord {
@@ -635,7 +652,7 @@ function isEvaluationCase(
     'id', 'status', 'failures', 'provenance', 'context', 'model', 'recognition',
     'transformation', 'delivery', 'latency', 'runtime',
   ])) return false;
-  return isString(value.id)
+  const structurallyValid = isString(value.id)
     && (value.status === 'passed' || value.status === 'failed' || value.status === 'skipped')
     && boundedStrings(value.failures, DIAGNOSTIC_REPORT_LIMITS.stringsPerCollection, context)
     && isCaseProvenance(value.provenance)
@@ -646,6 +663,45 @@ function isEvaluationCase(
     && isDelivery(value.delivery)
     && isLatency(value.latency)
     && isRuntime(value.runtime, context);
+  if (!structurallyValid) return false;
+  return hasConsistentEvaluationOutcome(value);
+}
+
+function hasCompleteRecognition(value: JsonRecord): boolean {
+  return isString(value.expectedRaw)
+    && isString(value.actualRaw)
+    && isNonNegativeInteger(value.rawWordErrors)
+    && isNonNegativeInteger(value.normalizedWordErrors)
+    && isNonNegativeInteger(value.referenceWords)
+    && value.referenceWords > 0
+    && isNonNegativeInteger(value.normalizedReferenceWords)
+    && value.normalizedReferenceWords > 0
+    && isNonNegativeInteger(value.referenceCharacters)
+    && value.referenceCharacters > 0
+    && isNonNegativeInteger(value.characterErrors)
+    && isNonNegativeNumber(value.rawWer)
+    && isNonNegativeNumber(value.normalizedWer)
+    && isNonNegativeNumber(value.cer)
+    && value.boundedAlternativeMatch === true;
+}
+
+function hasConsistentEvaluationOutcome(value: JsonRecord): boolean {
+  const failures = value.failures as string[];
+  if (value.status !== 'passed') return failures.length > 0;
+  const transformation = value.transformation as JsonRecord;
+  const delivery = value.delivery as JsonRecord;
+  return failures.length === 0
+    && hasCompleteRecognition(value.recognition as JsonRecord)
+    && isString(transformation.actualFinal)
+    && transformation.exactMatch === true
+    && transformation.commandExactMatch !== false
+    && transformation.noChangePreserved !== false
+    && (transformation.stages as JsonRecord[])
+      .every((stage) => stage.expectationMatch === true)
+    && isString(delivery.delivered)
+    && delivery.exactMatch === true
+    && isNonNegativeInteger(delivery.attempts)
+    && delivery.attempts > 0;
 }
 
 function isEvaluationReport(
@@ -662,15 +718,27 @@ function isEvaluationReport(
     isEvaluationCase,
     context,
   )) return false;
+  if (!isEvaluationSummary(value.summary)) return false;
   const caseIds = value.cases.map((entry) => entry.id as string);
+  const tierModelsAreConsistent = value.cases.every((entry) =>
+    value.tier === 'deterministic' ? entry.model === null : entry.model !== null);
+  const summary = value.summary as JsonRecord;
+  const passedSummaryIsComplete = summary.passed === 0 || (
+    isNonNegativeNumber(summary.aggregateRawWer)
+    && isNonNegativeNumber(summary.aggregateNormalizedWer)
+    && isNonNegativeNumber(summary.aggregateCer)
+    && isNonNegativeNumber(summary.transformationMatchRate)
+    && isNonNegativeNumber(summary.deliveryMatchRate)
+  );
   return value.reportVersion === 1
     && value.fixtureVersion === 1
     && isIsoDate(value.generatedAt)
     && (value.tier === 'deterministic' || value.tier === 'hardware')
     && isEvaluationPrivacy(value.privacy)
     && isEvaluationEnvironment(value.environment)
-    && isEvaluationSummary(value.summary)
     && value.summary.total === value.cases.length
+    && tierModelsAreConsistent
+    && passedSummaryIsComplete
     && hasUniqueStrings(caseIds);
 }
 
@@ -745,7 +813,7 @@ function normalizeBenchmark(
           fixture.deliveredNormalizedWordErrorRate as number,
         deliveredTransformFailed: fixture.deliveredTransformFailed as boolean,
       })),
-      succeeded: model.error === null,
+      succeeded: model.error === null && hasCompleteBenchmarkMeasurements(model),
     })),
     recommendations: {
       fastest: recommendations.fastest as string | null,
@@ -802,6 +870,7 @@ function normalizeEvaluation(
       return {
         id: entry.id as string,
         status: entry.status as NormalizedEvaluationCase['status'],
+        complete: entry.status === 'passed' && hasConsistentEvaluationOutcome(entry),
         fixtureOnly: context.fixtureOnly as boolean,
         model: model ? {
           name: model.name as string,

--- a/docs/features/diagnostic-report-comparison.md
+++ b/docs/features/diagnostic-report-comparison.md
@@ -59,7 +59,10 @@ like-for-like comparison, so they cannot produce deltas or recommendations.
 Evaluation comparison is blocked when report/fixture schema, deterministic
 versus hardware tier, fixture ID set, per-case model/backend/accelerator, stage
 sequence, fixture-only mode, final-only behavior, or incremental-completion
-semantics differ.
+semantics differ. Cases marked passed must contain complete recognition,
+transformation, and delivery measurements. Failed, skipped, or incomplete case
+sets may still be imported for inspection, but cannot produce deltas or
+recommendations.
 
 Machine/OS metadata and Murmur app-version differences are visible warnings.
 They still permit side-by-side deltas, but disable recommendation eligibility.

--- a/docs/features/diagnostic-report-comparison.md
+++ b/docs/features/diagnostic-report-comparison.md
@@ -1,0 +1,81 @@
+# Diagnostic Report Import and Comparison
+
+Issue #353 is delivered in phases. The first phase defines the local parser and
+comparison contract; Diagnostics navigation and presentation follow after the
+Performance/Runs shell from #352 is stable.
+
+## Supported reports
+
+The importer accepts only these JSON contracts:
+
+- legacy Performance Lab `BenchmarkReport` objects without `reportVersion`;
+- Performance Lab `BenchmarkReport` schema version 2;
+- `murmur-eval` report version 1 with fixture version 1.
+
+Unknown versions, unknown fields, missing or incorrectly typed fields,
+non-finite or negative measurements, duplicate model/fixture/case IDs, malformed
+JSON, and inconsistent evaluation summary counts fail closed. Benchmark and
+evaluation reports are recognized separately and are never interpreted as one
+another.
+
+Imports are limited to 8 MiB. The parser also caps benchmark models, fixtures
+per model, evaluation cases, stages per case, and string collections. The
+future file picker must check the file size before reading it; the parser
+rechecks both the declared byte count and decoded UTF-8 size before parsing.
+
+Import errors use stable codes and fixed messages. They never include the
+selected path, filename, JSON contents, or a rejected field value.
+
+## In-memory representation and privacy
+
+Normalized imports are session-only. The parser has no storage or telemetry
+dependency and never receives a source path. Its normalized output includes the
+metadata and numeric/categorical measurements required for comparison, but
+deliberately drops:
+
+- benchmark reference, transcript, and delivered transcript text;
+- evaluation expected, actual, delivered, and per-stage text;
+- evaluation failure strings and provenance/deletion text;
+- evaluator bundle IDs, matched profile names, and audio paths.
+
+Evaluation imports always carry a warning that the selected source report may
+contain curated fixture transcripts and stage text. Clearing an import in the
+future UI will discard only in-session state and will not change or delete the
+source file.
+
+## Compatibility gate
+
+Compatibility is evaluated before deltas or recommendations are exposed.
+Findings are either blockers or warnings.
+
+Benchmark comparison is blocked when schema, preset, measured iteration count,
+corpus identity/counts, VAD threshold, execution path, transform profile,
+percentile method, model/shared-initialization order, or exact
+model/backend/accelerator sets differ. Failed/incomplete model results and
+different per-model fixture sets also block comparison. Legacy reports remain readable, but
+their missing environment/corpus/execution metadata prevents proving a
+like-for-like comparison, so they cannot produce deltas or recommendations.
+
+Evaluation comparison is blocked when report/fixture schema, deterministic
+versus hardware tier, fixture ID set, per-case model/backend/accelerator, stage
+sequence, fixture-only mode, final-only behavior, or incremental-completion
+semantics differ.
+
+Machine/OS metadata and Murmur app-version differences are visible warnings.
+They still permit side-by-side deltas, but disable recommendation eligibility.
+Any blocker suppresses all deltas, preventing incompatible metrics from
+entering a ranking.
+
+## Delta semantics
+
+For a compatible metric:
+
+```text
+absolute delta = candidate - baseline
+percentage delta = absolute delta / abs(baseline) * 100
+```
+
+Percentage delta is unavailable when the baseline is zero. Missing metrics stay
+unavailable rather than becoming zero. Every metric declares its unit and
+whether lower or higher values are preferable; the comparison core does not
+round values or synthesize a cross-report winner.


### PR DESCRIPTION
## Summary
- add strict, bounded parsers for legacy/v2 Performance Lab reports and EvaluationReportV1
- normalize imported data into content-minimized session objects and return stable content-free failures
- gate incompatible, failed, skipped, or incomplete results before deltas or recommendations, with checked-in fixtures and contract documentation

## Phase A scope
- parser/comparison core only
- no LogViewerApp, MetricsView, tab, navigation, picker, or dashboard-shell changes
- UI integration will follow after #352 establishes the Diagnostics shell

## Privacy and safety
- 8 MiB input cap plus bounded models, fixtures, cases, stages, and string collections
- normalized output drops transcript/stage/delivery text, evaluator failures, bundle/profile context, and audio paths
- no storage or telemetry dependency; imported data is designed to remain session-only
- unknown versions, malformed JSON, schema mismatches, duplicate identities, incomplete results, and incompatible semantics fail closed
- successful benchmark/evaluation results must carry their required measurements; failed/skipped evaluation reports remain importable but cannot produce deltas or recommendations

## Test plan
- [x] `npm test -- src/lib/diagnosticReports.test.ts src/lib/diagnosticComparison.test.ts` (22 passed)
- [x] `npm test` (294 passed)
- [x] `npx tsc --noEmit`
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` (561 unit tests passed; integration tests passed)
- [x] `git diff --check`

Part of #353
