### PR TITLE
Replace legacy swarm with bounded Codex delivery loop

### DIFF
--- a/.codex/skills/murmur-feature/scripts/prepare_issue_worktree.py
+++ b/.codex/skills/murmur-feature/scripts/prepare_issue_worktree.py
@@ -1,32 +1,75 @@
 #!/usr/bin/env python3
-"""Prepare a GitHub issue worktree for Codex /feature workflow.
-
-Ports George's zsh `work <issue-number>` helper without launching Claude.
-"""
+"""Prepare a GitHub issue worktree for the Codex /feature workflow."""
 
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import re
+import shlex
 import subprocess
-import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterator
 
 
-def run(args: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.run(args, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+@dataclass(frozen=True)
+class Repository:
+    primary_root: Path
+    common_dir: Path
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: Path
+    head: str
+    branch: str | None
+
+
+def run(
+    args: list[str],
+    cwd: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     if check and proc.returncode != 0:
-        cmd = " ".join(args)
         detail = proc.stderr.strip() or proc.stdout.strip()
-        raise SystemExit(f"Command failed: {cmd}\n{detail}")
+        raise SystemExit(f"Command failed: {shlex.join(args)}\n{detail}")
     return proc
 
 
-def repo_root(start: Path) -> Path:
-    proc = run(["git", "rev-parse", "--show-toplevel"], cwd=start)
-    return Path(proc.stdout.strip())
+def absolute_git_path(start: Path, option: str) -> Path:
+    proc = run(
+        ["git", "rev-parse", "--path-format=absolute", option],
+        cwd=start,
+    )
+    return Path(proc.stdout.strip()).resolve()
+
+
+def repository(start: Path) -> Repository:
+    common_dir = absolute_git_path(start, "--git-common-dir")
+    if common_dir.name != ".git":
+        raise SystemExit(
+            f"Unsupported Git common directory {common_dir}: "
+            "the issue helper requires a non-bare repository."
+        )
+
+    primary_root = common_dir.parent.resolve()
+    if not (primary_root / ".git").is_dir():
+        raise SystemExit(
+            f"Could not derive the primary checkout from Git common directory "
+            f"{common_dir}."
+        )
+    return Repository(primary_root=primary_root, common_dir=common_dir)
 
 
 def gh_json(args: list[str], cwd: Path) -> dict:
@@ -43,38 +86,307 @@ def slugify(title: str) -> str:
     return slug or "issue"
 
 
-def local_branch_exists(root: Path, branch: str) -> bool:
-    proc = run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=root, check=False)
+def ref_oid(root: Path, ref: str) -> str | None:
+    proc = run(["git", "rev-parse", "--verify", "--quiet", ref], cwd=root, check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def remote_branch_oid(root: Path, branch: str) -> str | None:
+    ref = f"refs/heads/{branch}"
+    proc = run(
+        ["git", "ls-remote", "--exit-code", "--heads", "origin", ref],
+        cwd=root,
+        check=False,
+    )
+    if proc.returncode == 2:
+        return None
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip()
+        raise SystemExit(f"Could not inspect remote branch {ref}: {detail}")
+    line = proc.stdout.strip()
+    return line.split(maxsplit=1)[0] if line else None
+
+
+def is_ancestor(root: Path, ancestor: str, descendant: str) -> bool:
+    proc = run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=root,
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        detail = proc.stderr.strip() or proc.stdout.strip()
+        raise SystemExit(
+            f"Could not compare branch commits {ancestor} and {descendant}: {detail}"
+        )
     return proc.returncode == 0
 
 
-def worktree_exists(path: Path) -> bool:
-    return path.exists() and path.is_dir()
+def registered_worktrees(root: Path) -> list[Worktree]:
+    proc = run(["git", "worktree", "list", "--porcelain"], cwd=root)
+    records: list[Worktree] = []
+    fields: dict[str, str] = {}
+
+    def append_record() -> None:
+        if not fields:
+            return
+        path = fields.get("worktree")
+        head = fields.get("HEAD")
+        if path is None or head is None:
+            raise SystemExit("Could not parse `git worktree list --porcelain` output.")
+        records.append(
+            Worktree(
+                path=Path(path).resolve(),
+                head=head,
+                branch=fields.get("branch"),
+            )
+        )
+        fields.clear()
+
+    for line in proc.stdout.splitlines():
+        if not line:
+            append_record()
+            continue
+        key, _, value = line.partition(" ")
+        fields[key] = value
+    append_record()
+    return records
+
+
+def dirty_status(path: Path) -> str:
+    proc = run(
+        [
+            "git",
+            "--no-optional-locks",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ],
+        cwd=path,
+    )
+    return proc.stdout.strip()
+
+
+def validate_target(
+    target: Path,
+    expected_branch_ref: str,
+    worktrees: list[Worktree],
+) -> Worktree | None:
+    registered = next((item for item in worktrees if item.path == target), None)
+    if target.exists() and registered is None:
+        raise SystemExit(
+            f"Refusing to reuse {target}: the path exists but is not a registered "
+            "worktree for this repository."
+        )
+    if registered is None:
+        return None
+    if not target.is_dir():
+        raise SystemExit(
+            f"Refusing to reuse {target}: Git registers it as a worktree, but the "
+            "directory is missing."
+        )
+    if registered.branch != expected_branch_ref:
+        actual = registered.branch or "detached HEAD"
+        raise SystemExit(
+            f"Refusing to reuse {target}: expected {expected_branch_ref}, found {actual}."
+        )
+    status = dirty_status(target)
+    if status:
+        raise SystemExit(
+            f"Refusing to reuse dirty worktree {target}. Preserve or commit its "
+            f"changes first:\n{status}"
+        )
+    return registered
+
+
+def validate_branch_location(
+    target: Path,
+    expected_branch_ref: str,
+    worktrees: list[Worktree],
+) -> None:
+    elsewhere = next(
+        (
+            item
+            for item in worktrees
+            if item.branch == expected_branch_ref and item.path != target
+        ),
+        None,
+    )
+    if elsewhere is not None:
+        raise SystemExit(
+            f"Refusing to create {target}: {expected_branch_ref} is already checked "
+            f"out at {elsewhere.path}."
+        )
+
+
+def validate_local_remote_relationship(
+    root: Path,
+    branch: str,
+    local_oid: str | None,
+    remote_oid: str | None,
+    *,
+    dry_run: bool,
+) -> str:
+    if local_oid is None or remote_oid is None or local_oid == remote_oid:
+        return "equal-or-single"
+
+    remote_available = (
+        run(["git", "cat-file", "-e", f"{remote_oid}^{{commit}}"], cwd=root, check=False)
+        .returncode
+        == 0
+    )
+    if not remote_available:
+        if dry_run:
+            return "unknown-until-fetch"
+        raise SystemExit(
+            f"Remote branch origin/{branch} points to {remote_oid}, which is not "
+            "available locally. Rerun without --no-fetch or fetch that branch first."
+        )
+
+    if is_ancestor(root, remote_oid, local_oid):
+        return "local-ahead"
+    if is_ancestor(root, local_oid, remote_oid):
+        raise SystemExit(
+            f"Refusing to reuse local branch {branch}: origin/{branch} is ahead "
+            f"({local_oid} -> {remote_oid}). Reconcile it explicitly first."
+        )
+    raise SystemExit(
+        f"Refusing to reuse local branch {branch}: it has diverged from "
+        f"origin/{branch} (local {local_oid}, remote {remote_oid})."
+    )
+
+
+@contextmanager
+def creation_lock(common_dir: Path) -> Iterator[None]:
+    lock_path = common_dir / "codex-prepare-issue-worktree.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def decide_or_create_worktree(
+    repo: Repository,
+    target: Path,
+    branch: str,
+    default_branch: str,
+    *,
+    dry_run: bool,
+    no_fetch: bool,
+) -> str:
+    root = repo.primary_root
+    branch_ref = f"refs/heads/{branch}"
+    worktrees = registered_worktrees(root)
+    reused = validate_target(target, branch_ref, worktrees)
+    validate_branch_location(target, branch_ref, worktrees)
+
+    local_oid = ref_oid(root, branch_ref)
+    remote_oid = remote_branch_oid(root, branch)
+    relationship = validate_local_remote_relationship(
+        root,
+        branch,
+        local_oid,
+        remote_oid,
+        dry_run=dry_run,
+    )
+
+    if reused is not None:
+        if local_oid is None:
+            raise SystemExit(
+                f"Registered worktree {target} is on {branch_ref}, but that local "
+                "branch ref is missing."
+            )
+        if relationship == "unknown-until-fetch":
+            return "would fetch before deciding whether the clean worktree can be reused"
+        suffix = " (local branch is ahead of origin)" if relationship == "local-ahead" else ""
+        return f"reused existing clean worktree{suffix}"
+
+    if local_oid is not None:
+        if dry_run:
+            if relationship == "unknown-until-fetch":
+                return "would fetch before deciding whether the local branch can be reused"
+            suffix = " (local branch is ahead of origin)" if relationship == "local-ahead" else ""
+            return f"would create worktree from existing local branch{suffix}"
+        run(["git", "worktree", "add", str(target), branch], cwd=root)
+        return "created worktree from existing local branch"
+
+    if remote_oid is not None:
+        tracking_ref = f"refs/remotes/origin/{branch}"
+        tracking_oid = ref_oid(root, tracking_ref)
+        if dry_run:
+            return "would create worktree tracking existing remote branch"
+        if no_fetch and tracking_oid != remote_oid:
+            raise SystemExit(
+                f"Remote branch origin/{branch} exists at {remote_oid}, but the "
+                "matching remote-tracking ref is unavailable because --no-fetch "
+                "was used. Fetch it or rerun without --no-fetch."
+            )
+        if tracking_oid != remote_oid:
+            raise SystemExit(
+                f"Remote branch origin/{branch} exists at {remote_oid}, but the "
+                f"local remote-tracking ref is {tracking_oid or 'missing'}."
+            )
+        run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                "--track",
+                str(target),
+                f"origin/{branch}",
+            ],
+            cwd=root,
+        )
+        return "created worktree tracking existing remote branch"
+
+    base_ref = f"refs/remotes/origin/{default_branch}"
+    if ref_oid(root, base_ref) is None:
+        raise SystemExit(
+            f"Cannot create {branch}: origin/{default_branch} is unavailable locally."
+        )
+    if dry_run:
+        return "would create worktree and branch from origin/default"
+    run(
+        [
+            "git",
+            "worktree",
+            "add",
+            str(target),
+            "-b",
+            branch,
+            f"origin/{default_branch}",
+        ],
+        cwd=root,
+    )
+    return "created worktree and branch from origin/default"
 
 
 def load_prompt(root: Path) -> str:
     prompt_path = root / "prompts" / "PROMPT.md"
-    if prompt_path.exists():
-        return prompt_path.read_text()
-    return ""
+    return prompt_path.read_text() if prompt_path.exists() else ""
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Prepare a GitHub issue worktree for Codex.")
     parser.add_argument("issue", help="GitHub issue number, e.g. 152")
     parser.add_argument("--cwd", default=os.getcwd(), help="Directory inside the repo. Defaults to cwd.")
-    parser.add_argument("--no-fetch", action="store_true", help="Skip fetching origin/default-branch.")
-    parser.add_argument("--dry-run", action="store_true", help="Print what would happen without creating a worktree.")
+    parser.add_argument("--no-fetch", action="store_true", help="Skip fetching origin refs.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inspect and print the action without fetching, locking, or mutating Git state.",
+    )
     ns = parser.parse_args()
 
-    root = repo_root(Path(ns.cwd))
-    repo = gh_json(["repo", "view", "--json", "nameWithOwner,defaultBranchRef"], cwd=root)
-    repo_name = repo["nameWithOwner"]
-    default_branch = repo.get("defaultBranchRef", {}).get("name") or "main"
-    repo_slug = root.name
-
-    if not ns.no_fetch:
-        run(["git", "fetch", "origin", default_branch], cwd=root)
+    repo_context = repository(Path(ns.cwd))
+    root = repo_context.primary_root
+    repo_data = gh_json(["repo", "view", "--json", "nameWithOwner,defaultBranchRef"], cwd=root)
+    repo_name = repo_data["nameWithOwner"]
+    default_branch = repo_data.get("defaultBranchRef", {}).get("name") or "main"
 
     issue = gh_json(
         ["issue", "view", ns.issue, "--repo", repo_name, "--json", "title,body,url"],
@@ -83,23 +395,29 @@ def main() -> int:
     title = issue["title"]
     body = issue.get("body") or ""
     branch = f"issue/{ns.issue}-{slugify(title)}"
-    worktree_dir = root.parent / f"{repo_slug}-issue-{ns.issue}"
+    worktree_dir = root.parent / f"{root.name}-issue-{ns.issue}"
 
-    action = "reused"
-    if worktree_exists(worktree_dir):
-        action = "reused existing worktree"
-    elif local_branch_exists(root, branch):
-        if ns.dry_run:
-            action = "would create worktree from existing branch"
-        else:
-            run(["git", "worktree", "add", str(worktree_dir), branch], cwd=root)
-            action = "created worktree from existing branch"
+    if ns.dry_run:
+        action = decide_or_create_worktree(
+            repo_context,
+            worktree_dir,
+            branch,
+            default_branch,
+            dry_run=True,
+            no_fetch=True,
+        )
     else:
-        if ns.dry_run:
-            action = "would create worktree and branch"
-        else:
-            run(["git", "worktree", "add", str(worktree_dir), "-b", branch, f"origin/{default_branch}"], cwd=root)
-            action = "created worktree and branch"
+        if not ns.no_fetch:
+            run(["git", "fetch", "origin"], cwd=root)
+        with creation_lock(repo_context.common_dir):
+            action = decide_or_create_worktree(
+                repo_context,
+                worktree_dir,
+                branch,
+                default_branch,
+                dry_run=False,
+                no_fetch=ns.no_fetch,
+            )
 
     base_prompt = load_prompt(root)
     assignment = f"""{base_prompt}

--- a/.codex/skills/murmur-feature/tests/test_prepare_issue_worktree.py
+++ b/.codex/skills/murmur-feature/tests/test_prepare_issue_worktree.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ISSUE_NUMBER = "355"
+ISSUE_TITLE = (
+    "Developer workflow: replace the legacy swarm prompt with a bounded "
+    "Codex delivery loop"
+)
+ISSUE_BRANCH = (
+    "issue/355-developer-workflow-replace-the-legacy-swarm-prompt-with-a-"
+    "bounded-codex-delivery-loop"
+)
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "prepare_issue_worktree.py"
+
+
+class PrepareIssueWorktreeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.origin = self.root / "origin.git"
+        self.primary = self.root / "murmur-app"
+        self.target = self.root / f"murmur-app-issue-{ISSUE_NUMBER}"
+        self.fake_bin = self.root / "fake-bin"
+
+        self.git("init", "--bare", "-b", "main", str(self.origin), cwd=self.root)
+        self.git("init", "-b", "main", str(self.primary), cwd=self.root)
+        self.git("config", "user.name", "Murmur Test", cwd=self.primary)
+        self.git("config", "user.email", "murmur@example.invalid", cwd=self.primary)
+        (self.primary / "README.md").write_text("# fixture\n")
+        self.git("add", "README.md", cwd=self.primary)
+        self.git("commit", "-m", "initial", cwd=self.primary)
+        self.git("remote", "add", "origin", str(self.origin), cwd=self.primary)
+        self.git("push", "-u", "origin", "main", cwd=self.primary)
+
+        self.fake_bin.mkdir()
+        fake_gh = self.fake_bin / "gh"
+        fake_gh.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "repo":
+    print(json.dumps({
+        "nameWithOwner": "georgenijo/murmur-app",
+        "defaultBranchRef": {"name": "main"},
+    }))
+elif len(sys.argv) > 1 and sys.argv[1] == "issue":
+    print(json.dumps({
+        "title": %r,
+        "body": "Fixture issue body.",
+        "url": "https://example.invalid/issues/355",
+    }))
+else:
+    print("unsupported fake gh invocation", file=sys.stderr)
+    raise SystemExit(2)
+"""
+            % ISSUE_TITLE
+        )
+        fake_gh.chmod(0o755)
+        self.env = {
+            **os.environ,
+            "PATH": f"{self.fake_bin}{os.pathsep}{os.environ['PATH']}",
+        }
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def git(
+        self,
+        *args: str,
+        cwd: Path,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=check,
+        )
+
+    def helper(
+        self,
+        *extra: str,
+        cwd: Path | None = None,
+        check: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                ISSUE_NUMBER,
+                "--cwd",
+                str(cwd or self.primary),
+                *extra,
+            ],
+            cwd=self.root,
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=check,
+        )
+
+    def assert_failed_with(
+        self,
+        result: subprocess.CompletedProcess[str],
+        message: str,
+    ) -> None:
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(message, result.stderr)
+
+    def test_fresh_creation_uses_origin_main(self) -> None:
+        expected_head = self.git("rev-parse", "origin/main", cwd=self.primary).stdout.strip()
+
+        result = self.helper()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("created worktree and branch from origin/default", result.stdout)
+        self.assertEqual(
+            self.git("branch", "--show-current", cwd=self.target).stdout.strip(),
+            ISSUE_BRANCH,
+        )
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=self.target).stdout.strip(),
+            expected_head,
+        )
+
+    def test_valid_clean_worktree_is_reused(self) -> None:
+        self.helper(check=True)
+
+        result = self.helper()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("reused existing clean worktree", result.stdout)
+
+    def test_wrong_branch_worktree_is_rejected(self) -> None:
+        self.git(
+            "worktree",
+            "add",
+            "-b",
+            "issue/355-wrong",
+            str(self.target),
+            "origin/main",
+            cwd=self.primary,
+        )
+
+        result = self.helper()
+
+        self.assert_failed_with(result, "expected refs/heads/" + ISSUE_BRANCH)
+
+    def test_unrelated_existing_directory_is_rejected(self) -> None:
+        self.target.mkdir()
+        (self.target / "keep.txt").write_text("preserve me\n")
+
+        result = self.helper()
+
+        self.assert_failed_with(result, "exists but is not a registered worktree")
+        self.assertEqual((self.target / "keep.txt").read_text(), "preserve me\n")
+
+    def test_dirty_reused_worktree_is_rejected(self) -> None:
+        self.helper(check=True)
+        (self.target / "uncommitted.txt").write_text("preserve me\n")
+
+        result = self.helper()
+
+        self.assert_failed_with(result, "Refusing to reuse dirty worktree")
+        self.assertTrue((self.target / "uncommitted.txt").exists())
+
+    def test_remote_only_branch_is_tracked_without_resetting_it(self) -> None:
+        remote_head = self.git("rev-parse", "HEAD", cwd=self.primary).stdout.strip()
+        self.git(
+            "push",
+            "origin",
+            f"HEAD:refs/heads/{ISSUE_BRANCH}",
+            cwd=self.primary,
+        )
+
+        result = self.helper()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("tracking existing remote branch", result.stdout)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=self.target).stdout.strip(),
+            remote_head,
+        )
+        self.assertEqual(
+            self.git(
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+                cwd=self.target,
+            ).stdout.strip(),
+            f"origin/{ISSUE_BRANCH}",
+        )
+
+    def test_remote_ahead_local_branch_collision_stops(self) -> None:
+        self.git("branch", ISSUE_BRANCH, "HEAD", cwd=self.primary)
+        (self.primary / "remote-change.txt").write_text("remote\n")
+        self.git("add", "remote-change.txt", cwd=self.primary)
+        self.git("commit", "-m", "remote branch change", cwd=self.primary)
+        self.git(
+            "push",
+            "origin",
+            f"HEAD:refs/heads/{ISSUE_BRANCH}",
+            cwd=self.primary,
+        )
+
+        result = self.helper()
+
+        self.assert_failed_with(result, f"origin/{ISSUE_BRANCH} is ahead")
+        self.assertFalse(self.target.exists())
+
+    def test_linked_worktree_invocation_uses_primary_checkout_path(self) -> None:
+        linked = self.root / "coordinator"
+        self.git(
+            "worktree",
+            "add",
+            "-b",
+            "coordinator",
+            str(linked),
+            "origin/main",
+            cwd=self.primary,
+        )
+
+        result = self.helper(cwd=linked)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(self.target.is_dir())
+        self.assertFalse((self.root / "coordinator-issue-355").exists())
+
+    def test_dry_run_does_not_mutate_git_or_filesystem_state(self) -> None:
+        common_dir = Path(
+            self.git(
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+                cwd=self.primary,
+            ).stdout.strip()
+        )
+
+        def snapshot() -> tuple[str, str, str, str]:
+            return (
+                self.git("for-each-ref", cwd=self.primary).stdout,
+                self.git("worktree", "list", "--porcelain", cwd=self.primary).stdout,
+                self.git("status", "--porcelain=v1", cwd=self.primary).stdout,
+                self.git("stash", "list", cwd=self.primary).stdout,
+            )
+
+        before = snapshot()
+        result = self.helper("--dry-run")
+        after = snapshot()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("would create worktree and branch", result.stdout)
+        self.assertEqual(after, before)
+        self.assertFalse(self.target.exists())
+        self.assertFalse((common_dir / "codex-prepare-issue-worktree.lock").exists())
+
+    def test_concurrent_creation_is_serialized_and_reused(self) -> None:
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            ISSUE_NUMBER,
+            "--cwd",
+            str(self.primary),
+            "--no-fetch",
+        ]
+        processes = [
+            subprocess.Popen(
+                command,
+                cwd=self.root,
+                env=self.env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            for _ in range(2)
+        ]
+        results = [process.communicate(timeout=20) for process in processes]
+
+        for process, (stdout, stderr) in zip(processes, results):
+            self.assertEqual(process.returncode, 0, f"{stdout}\n{stderr}")
+        actions = "\n".join(stdout for stdout, _ in results)
+        self.assertIn("created worktree and branch", actions)
+        self.assertIn("reused existing clean worktree", actions)
+        matching = [
+            line
+            for line in self.git(
+                "worktree",
+                "list",
+                "--porcelain",
+                cwd=self.primary,
+            ).stdout.splitlines()
+            if line == f"worktree {self.target.resolve()}"
+        ]
+        self.assertEqual(len(matching), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/prompts/PROMPT_SWARM.md
+++ b/prompts/PROMPT_SWARM.md
@@ -1,121 +1,324 @@
-# Agent Swarm — Parallel Issue Implementation
+# Bounded Codex Delivery Loop
 
-You are the team lead and senior engineer for a parallel development swarm on the Murmur project. Your job is to spawn sub-agents, review their plans critically before approving, monitor implementation, and ensure clean PRs land.
+You are the lead for a resumable, dependency-aware Murmur delivery run. Coordinate
+an explicit issue manifest through planning, implementation, independent PR
+validation, and only the merge or release actions the user has authorized.
 
-You have high standards. Reject plans that add unnecessary complexity, deviate from existing patterns, or scope-creep beyond the issue. Approve only plans that are focused, idiomatic, and consistent with the codebase.
+This prompt replaces the legacy unbounded swarm. It does not authorize work by
+itself.
 
-## 1. Setup
+## 1. Safety Invariants
 
-Read `CLAUDE.md` and `CHANGELOG.md` silently to understand the project structure, patterns, and conventions. Then run:
+- Treat the primary/root checkout as read-only coordination state.
+- Never switch, pull, edit, stage, commit, merge, or delete anything in the root
+  checkout. `git fetch` may update shared refs, but must not change the root
+  branch, HEAD, index, worktree, or stashes.
+- Use fetched `origin/main`, never the root's checked-out branch, as dependency
+  and base truth.
+- Work only on issues named in the explicit run manifest. Never discover and
+  consume every open issue.
+- The lead may run at most three workers at once. Reviewers occupy worker slots;
+  they are not extra capacity.
+- Workers must not create child agents, tasks, teams, branches, or worktrees.
+- Prepare issue worktrees sequentially with
+  `.codex/skills/murmur-feature/scripts/prepare_issue_worktree.py`.
+- Preserve existing work. Never reset, force-push, delete a branch, drop a
+  stash, or remove a dirty or blocked worktree.
+- Worker implementation and test claims are untrusted until a separate reviewer
+  validates the exact final PR head in an isolated PR worktree.
+- Never use `--admin` or otherwise bypass branch protection unless the user gives
+  a direct, contemporaneous authorization for that exact action. Delegated or
+  run-level authority cannot grant admin bypass.
+
+If a required invariant cannot be satisfied, record the exact blocker and
+continue only with other dependency-ready lanes.
+
+## 2. Explicit Run Manifest
+
+Do not start without a user-supplied issue allowlist and dependency manifest.
+Keep one canonical `RUN STATE` block in the lead task and repost the full block
+after every plan decision, PR-head change, validation result, merge, pause, or
+blocker. That block is the resume checkpoint; do not keep essential state only
+in worker tasks.
+
+Start with these safe defaults:
+
+```yaml
+approval_mode: user-per-wave
+merge_mode: pr-only
+release_mode: no-release
+authorization:
+  issue_allowlist: []
+  authorized_actions: []
+  admin_bypass: forbidden
+  stop_conditions: []
+  release:
+    version: null
+    bump: null
+    min_version: unchanged
+    tag_and_publish: false
+```
+
+Maintain this table:
+
+| Issue | Depends on | Wave | File ownership | Native smoke | Status | PR | Validated head |
+|---|---|---:|---|---|---|---|---|
+
+Use explicit statuses such as `queued`, `planning`, `awaiting-wave-approval`,
+`implementing`, `local-gates-passed`, `pr-open`, `validating`, `validated`,
+`blocked`, `merged`, `closed`, or `skipped`. Record literal blocker text in the
+run state, immediately below the affected row.
+
+### Approval modes
+
+`user-per-wave` is the default. Workers submit plans only; the lead presents one
+consolidated wave plan and waits for the user before any worker edits.
+
+`delegated-controller` is valid only when the run manifest contains bounded
+prior user authorization with all of the following:
+
+- The exact issue allowlist.
+- The actions the controller may approve.
+- `admin_bypass: forbidden`.
+- Concrete stop conditions.
+- An explicit merge policy.
+- An explicit release and `min_version` policy, even when both say no change.
+
+The authorization must be present in the current run's canonical state. Do not
+infer it from words such as "overnight", from another task, from a previous run,
+or from the existence of open issues. A delegated controller may approve plans
+only for allowlisted issues and actions. It may narrow or stop the run, but it
+must never add issues, widen file ownership, relax stop conditions, authorize
+admin bypass, or invent merge/release authority.
+
+If any delegated-authorization field is absent or ambiguous, fall back to
+`user-per-wave`, `pr-only`, and `no-release` for that action.
+
+### Merge and release modes
+
+`pr-only` means open validated PRs and stop without merging.
+
+`merge-green` is valid only when the canonical manifest contains bounded prior
+user authorization for merging the allowlisted issues. Merge one PR at a time,
+in dependency order, only after independent validation of its exact current
+head. This mode never includes admin bypass.
+
+`no-release` is the default. Release work is outside the loop unless the
+manifest contains bounded prior user authorization for `authorized-release`,
+including the exact version or allowed bump, whether tag/publish is authorized,
+the `min_version` decision (`unchanged` or the exact new value), and release stop
+conditions. Never infer a critical update or forced-update policy. Run
+`prompts/PROMPT_RELEASE.md` only within those recorded bounds, and stop before
+any release action not explicitly authorized.
+
+## 3. Start or Resume
+
+### Start
+
+1. Locate the primary checkout from Git's common directory:
+
+   ```bash
+   git rev-parse --path-format=absolute --git-common-dir
+   ```
+
+   For a normal linked worktree, the primary checkout is the parent of that
+   absolute `.git` common directory.
+
+2. Capture and add this immutable root baseline to `RUN STATE`:
+   - Active branch.
+   - Exact HEAD.
+   - `git status --porcelain=v1`.
+   - `git stash list`.
+
+3. Fetch refs without changing the root checkout:
+
+   ```bash
+   git -C <primary-root> fetch origin
+   ```
+
+4. Inspect `origin/main`, open PRs for allowlisted issues, registered worktrees,
+   local branches, remote branches, and manifest dependencies. Do not check out
+   anything in the root.
+
+5. Reconcile existing state before creating anything:
+   - Reuse a matching, clean issue worktree and branch.
+   - Resume an existing PR when its head branch matches the issue lane.
+   - Reject wrong-branch, unrelated, dirty, divergent, or ambiguous state with
+     the helper's literal explanation.
+   - Never create a duplicate lane to work around a mismatch.
+
+### Resume
+
+Read the most recent complete `RUN STATE`, then independently re-inspect GitHub
+PR heads, CI, registered worktrees, branches, and `origin/main`. Treat cached
+status and validated SHAs as historical evidence, not current truth. Any PR head
+change clears `Validated head` and returns the lane to `pr-open`.
+
+### Inspect
+
+An inspect-only request may fetch and report state but must not prepare
+worktrees, install dependencies, spawn workers, approve plans, push, merge, or
+release.
+
+### Pause
+
+Stop dispatching new work, let already-running safe commands finish, update the
+canonical state, and report active tasks and exact worktree paths. Do not delete,
+stash, reset, or synthesize completion for paused lanes.
+
+## 4. Dependency and Capacity Scheduling
+
+An issue is dependency-ready only when every listed dependency has reached the
+manifest's required state on fetched `origin/main`, or an explicit non-code
+coordination condition is recorded as satisfied. An open or locally committed
+dependency is not landed.
+
+For each scheduling pass:
+
+1. Re-fetch `origin/main`.
+2. Recompute dependency readiness from the explicit manifest.
+3. Exclude `blocked`, `skipped`, active, and not-ready lanes.
+4. Respect file ownership and avoid simultaneous overlapping edits unless the
+   manifest explicitly sequences them.
+5. Fill no more than three total worker slots.
+
+Prepare at most three ready issue worktrees, one helper invocation at a time.
+Run `npm ci` only in a fresh worktree; do not overwrite dependencies or
+uncommitted data in a reused worktree.
+
+Blocked work keeps its worktree and evidence but releases its worker slot. Use a
+freed slot for another ready implementation lane or an independent PR reviewer.
+
+## 5. Plan Gate
+
+Dispatch each ready issue worker with:
+
+- Its exact issue, dependencies, file ownership, worktree, and branch.
+- Instructions to use the repo's `murmur-feature` workflow from the existing
+  worktree without running the helper.
+- A plan-only first turn covering files, implementation, tests, risks, and scope.
+- A prohibition on child agents/tasks and on editing before approval.
+- A requirement to report unexpected existing changes rather than overwrite
+  them.
+
+Collect plans and verify that they:
+
+- Address only the issue and manifest ownership.
+- Respect landed dependencies and current project patterns.
+- Include issue-specific regression evidence and proportionate native/UI checks.
+- Do not rely on another worker changing an unowned file.
+
+Under `user-per-wave`, present the consolidated plan and wait for the user.
+Under a valid `delegated-controller` manifest, the controller may approve only
+within its recorded bounds. Record every decision before sending implementation
+approval. Unapproved plans remain paused and consume no worker slot.
+
+## 6. Implement and Open PRs
+
+Approved workers implement exactly their plans in their issue worktrees. They
+must make focused commits and self-review `origin/main...HEAD`.
+
+Before opening a PR, every lane must pass:
+
 ```bash
-git pull --ff-only origin main
+cd app/src-tauri && cargo check
+cd app/src-tauri && cargo test -- --test-threads=1
+cd app && npx tsc --noEmit
+git diff --check
 ```
 
-## 2. Create the Team
+Also require:
 
-Use the `TeamCreate` tool to create a team named `"swarm"`.
+- Issue-specific tests for the changed seam.
+- Frontend/browser verification for visual webview changes.
+- Real native app smoke for native behavior or UI.
+- A precise reason when native/UI verification is not applicable.
 
-## 3. Spawn One Agent Per Issue
+Run no more than two static validation jobs simultaneously and no more than one
+native smoke simultaneously. These limits apply across issue workers and
+independent reviewers.
 
-The issues to work on are listed at the bottom of this prompt. For each issue number:
+On this Mac, native validation must preserve the CoreAudio evidence boundary. If
+CoreAudio returns its backend-specific input-config error, recovery to Ready may
+be reported, but microphone capture, transcription completion, auto-paste, or
+final-paste coverage must not be claimed.
 
-1. Fetch the issue details:
-   ```bash
-   gh issue view <number> --json title,body --repo georgenijo/murmur-app
-   ```
+Open PRs only after local gates pass. Record the PR URL and current GitHub
+`headRefOid`. Worker evidence is still provisional.
 
-2. Create a worktree and branch locally:
-   ```bash
-   git worktree add ../murmur-app-issue-<number> -b issue/<number>-<slug>
-   ```
-   (Sanitize the issue title to a lowercase hyphenated slug for the branch name.)
+## 7. Independent PR Validation
 
-3. Use the `Agent` tool to spawn a sub-agent with:
-   - `subagent_type`: `"general-purpose"`
-   - `team_name`: `"swarm"`
-   - `name`: `"issue-<number>"`
-   - `mode`: `"plan"` — sub-agents must plan before writing any code
-   - The prompt below
+Use a freed worker slot and the repo's `murmur-pr-test` workflow. The reviewer
+must not be the implementation worker and must use an isolated PR worktree for
+the exact PR head.
 
-**Sub-agent prompt template:**
+For each PR:
 
-```
-You are implementing GitHub Issue #<number>: <title>
+1. Fetch the PR and record its exact `headRefOid`.
+2. Inspect the complete diff and issue contract independently.
+3. Run issue-specific tests and all required static gates.
+4. Perform proportionate native/UI smoke without trusting worker screenshots or
+   summaries.
+5. Check GitHub CI for that exact SHA.
+6. Query review threads with `gh api graphql`; unresolved threads block
+   validation.
+7. Re-read `headRefOid`. If it changed at any point, discard the result and
+   restart validation from the new head.
+8. Only then write the SHA into `Validated head` and mark the lane `validated`.
 
-## Context
-Read these files silently before doing anything else:
-- /Users/georgenijo/Documents/code/murmur-app/CLAUDE.md — project overview, file map, patterns
-- /Users/georgenijo/Documents/code/murmur-app/CHANGELOG.md — recent changes, naming conventions
-- /Users/georgenijo/Documents/code/murmur-app/docs/reference/settings.md — if your work touches settings
+CI success on an older SHA, a worker's local checks, a mergeability label, or a
+review summary is never a substitute for exact-head independent validation.
 
-Also read any file in docs/features/ that is relevant to your work.
+## 8. Blockers and Merge Order
 
-## Your Assignment
-<issue body>
+Preserve policy and review failures literally, including messages such as:
 
-## Instructions
+- `Review Can not approve your own pull request`
+- `the base branch policy prohibits the merge`
 
-1. Your worktree is at: /Users/georgenijo/Documents/code/murmur-app-issue-<number>
-   Your branch is: issue/<number>-<slug>
-   Work only in your worktree directory.
+Do not retry with `--admin`, hide the blocker behind a generic status, or keep a
+blocked reviewer occupying a worker slot. Update the run state, retain the
+worktree/branch/PR, free the slot, and continue other dependency-ready lanes.
 
-2. Enter plan mode. Read all relevant files before planning. Write a focused plan covering:
-   - Which files you will change and why
-   - What exactly you will add or modify — no more than the issue requires
-   - How your approach follows existing patterns in the codebase
-   - Verification steps
+When `merge_mode` is `pr-only`, stop after validated PR handoff.
 
-   Submit your plan for review. Do not write any code until the lead approves.
+When a valid bounded manifest authorizes `merge-green`:
 
-3. After approval, implement exactly what was planned. No scope creep.
+1. Reconfirm the PR head equals `Validated head`.
+2. Reconfirm exact-head CI and zero unresolved review threads.
+3. Merge only the next dependency-ready PR, using the normal protected-branch
+   path and never `--admin`.
+4. Fetch `origin/main` and confirm the merge landed.
+5. Update dependent branches. Prefer merging `origin/main` into a published
+   branch; rebase only when explicitly safe and authorized. Never force-push
+   without direct user authorization.
+6. Clear prior validation for every changed dependent head and rerun affected
+   tests, CI, review-thread checks, and native/UI smoke.
+7. Only then consider the next dependency-ordered merge.
 
-4. Run verification:
-   - cd app/src-tauri && cargo check
-   - cd app/src-tauri && cargo test -- --test-threads=1
-   - cd app && npx tsc --noEmit
+Do not merge several "green" PRs from one stale snapshot.
 
-5. Commit and open a PR:
-   git push -u origin issue/<number>-<slug>
-   gh pr create --title "<issue title>" --body "Closes #<number>" --repo georgenijo/murmur-app
+## 9. Cleanup and Completion
 
-6. Send your PR URL to "swarm-lead" when done, or describe any blocker if stuck.
-```
+Remove a worktree only when all of these are true:
 
-Spawn all agents before waiting for any — maximize parallelism.
+- Its PR is merged or explicitly closed.
+- The worktree is registered and belongs to this repository.
+- Its branch and path match the recorded lane.
+- `git status --porcelain=v1` is empty.
+- No task is using it.
 
-## 4. Review Plans
+Never delete local or remote branches as part of this loop. Preserve blocked
+worktrees, stashes, uncommitted data, and ambiguous paths.
 
-When a sub-agent submits a plan for approval, review it critically as a senior engineer:
+Before declaring the manifest complete:
 
-**Approve if:**
-- It addresses exactly what the issue asks — nothing more, nothing less
-- It follows existing patterns (file structure, naming conventions, error handling, how settings are wired, how Tauri commands are structured)
-- It doesn't introduce unnecessary abstractions, new dependencies, or premature generalization
-- Verification steps are included
+1. Re-fetch and inspect every allowlisted lane.
+2. Confirm each is `merged`, `closed`, or `skipped` under the authorized policy.
+3. Re-run the root baseline commands and prove branch, HEAD, status, and stashes
+   are unchanged.
+4. Report PRs, validated SHAs, merge/release results, retained worktrees, and
+   literal blockers.
 
-**Reject with specific feedback if:**
-- It adds complexity beyond what the issue requires
-- It puts code in the wrong place (wrong file, wrong module)
-- It skips existing patterns in favor of something novel
-- It's missing verification steps
-- It touches files unrelated to the issue
-
-When rejecting, be specific: "This belongs in `injector.rs`, not a new file" or "You're adding a settings field that already exists." Give the sub-agent exactly what it needs to fix the plan.
-
-## 5. Monitor Implementation
-
-After approving a plan, the sub-agent implements and opens a PR. When it reports back:
-- Note the PR URL
-- If it reports a blocker, assess whether to unblock it or mark the issue as needing human review
-
-## 6. Report & Shutdown
-
-Once all agents have completed or hit blockers, summarize:
-- PRs opened (with URLs)
-- Any issues that need human attention
-
-Send a `shutdown_request` to each teammate, then call `TeamDelete`.
-
----
-
-## Issues to Work On
+Otherwise pause with the complete `RUN STATE` when every remaining lane has a
+concrete blocker.


### PR DESCRIPTION
## Summary
- replace the legacy unbounded swarm prompt with an explicit, dependency-aware Codex delivery loop
- add fail-closed delegated-controller, merge-green, release, min_version, concurrency, validation, and cleanup policies
- harden issue worktree preparation for linked worktrees, safe reuse, remote collisions, non-mutating dry-runs, and serialized creation
- add disposable-repository regression coverage for fresh, reused, unsafe, remote-only, linked, dry-run, and concurrent cases

## Test plan
- [x] `python3 -m py_compile .codex/skills/murmur-feature/scripts/prepare_issue_worktree.py .codex/skills/murmur-feature/tests/test_prepare_issue_worktree.py`
- [x] `python3 -m unittest discover -s .codex/skills/murmur-feature/tests -p "test_*.py" -v` (10 passed)
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] Native/browser smoke: not applicable; this changes Markdown workflow policy and a Python worktree helper only

Closes #355