### PR TITLE
Diagnostics: add persistent performance run core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Read these before working on a feature:
 - **[docs/features/voice-commands.md](docs/features/voice-commands.md)** — Typed replacements, multiline snippets, safe variables, scopes, and clipboard permission
 - **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
 - **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion
+- **[docs/features/performance-diagnostics.md](docs/features/performance-diagnostics.md)** — Versioned local run metrics, retention, correlation, scoped resources, and privacy
 - **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map

--- a/app/src-tauri/src/alloc.rs
+++ b/app/src-tauri/src/alloc.rs
@@ -116,12 +116,22 @@ pub fn memory_breakdown() -> (usize, usize) {
 
 /// Rust heap usage in megabytes (from the RustHeapZone).
 pub fn rust_heap_mb() -> u64 {
-    let (rust_bytes, _) = memory_breakdown();
-    (rust_bytes / 1_048_576) as u64
+    rust_heap_bytes() / 1_048_576
 }
 
 /// C/C++ FFI heap usage in megabytes (total zones minus Rust zone).
 pub fn ffi_heap_mb() -> u64 {
+    ffi_heap_bytes() / 1_048_576
+}
+
+/// Rust heap usage in bytes (from the RustHeapZone).
+pub fn rust_heap_bytes() -> u64 {
+    let (rust_bytes, _) = memory_breakdown();
+    rust_bytes as u64
+}
+
+/// C/C++ FFI heap usage in bytes (all malloc zones minus the Rust zone).
+pub fn ffi_heap_bytes() -> u64 {
     let (rust_bytes, total_bytes) = memory_breakdown();
-    (total_bytes.saturating_sub(rust_bytes) / 1_048_576) as u64
+    total_bytes.saturating_sub(rust_bytes) as u64
 }

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod logging;
 pub mod models;
 pub(crate) mod native_window;
 pub mod overlay;
+pub mod performance;
 pub mod permissions;
 pub mod recording;
 pub mod transform_model;

--- a/app/src-tauri/src/commands/performance.rs
+++ b/app/src-tauri/src/commands/performance.rs
@@ -1,0 +1,30 @@
+use crate::performance_metrics::{PerformanceRunListV1, PerformanceRunV1, ResourceSampleV1};
+use crate::State;
+
+#[tauri::command]
+pub fn list_performance_runs(
+    limit: Option<u32>,
+    state: tauri::State<'_, State>,
+) -> Result<PerformanceRunListV1, String> {
+    state.performance.list(limit.unwrap_or(50))
+}
+
+#[tauri::command]
+pub fn get_performance_run(
+    run_id: String,
+    state: tauri::State<'_, State>,
+) -> Result<Option<PerformanceRunV1>, String> {
+    state.performance.get(run_id.trim())
+}
+
+#[tauri::command]
+pub fn get_performance_resource_window(
+    state: tauri::State<'_, State>,
+) -> Result<Vec<ResourceSampleV1>, String> {
+    state.performance.resource_window()
+}
+
+#[tauri::command]
+pub fn clear_performance_diagnostics(state: tauri::State<'_, State>) -> Result<(), String> {
+    state.performance.clear()
+}

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1,5 +1,10 @@
 use crate::dictation_context::{self, DictationContextSnapshot, ResolverInputs, SessionOverrides};
 use crate::model_runtime::{self, PreparationReason};
+use crate::performance_metrics::{
+    AcceleratorV1, ContentFreeInputSummaryV1, ModelWarmStateV1, PerformanceStageV1,
+    PerformanceRunGuard, RunCorrelationV1, RunOutcomeV1, RuntimeBackendV1, RuntimeIdentityV1,
+    RuntimeRoleV1, StableRunErrorV1, StageOutcomeV1, StageTimingV1,
+};
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
 use crate::{audio, audio_decode, injector, keyboard, vad};
@@ -407,20 +412,47 @@ fn spawn_model_preparation(app_handle: tauri::AppHandle, model_name: String, rec
         let rss_after_mb = crate::resource_monitor::get_process_rss_mb();
         let total_ms = queued_at.elapsed().as_millis() as u64;
         match result {
-            Ok(report) => tracing::info!(
-                target: "pipeline",
-                recording_id,
-                model = model_name.as_str(),
-                backend = model_runtime::model_definition(&model_name).map(|model| model.backend.as_str()).unwrap_or("unknown"),
-                cache_hit = report.cache_hit,
-                queue_ms,
-                lock_wait_ms = report.lock_wait_ms,
-                load_ms = report.load_ms,
-                total_ms,
-                rss_before_mb,
-                rss_after_mb,
-                "model_prepare_complete"
-            ),
+            Ok(report) => {
+                let correlation = RunCorrelationV1::Dictation { recording_id };
+                let _ = state.performance.update_active(&correlation, |active| {
+                    active.runtimes = runtime_identity(
+                        &model_name,
+                        if report.cache_hit {
+                            ModelWarmStateV1::Warm
+                        } else {
+                            ModelWarmStateV1::ColdLoaded
+                        },
+                    );
+                    active.stages.retain(|stage| {
+                        !matches!(
+                            stage.stage,
+                            PerformanceStageV1::ModelQueue | PerformanceStageV1::ModelLoad
+                        )
+                    });
+                    active.stages.push(StageTimingV1::measured(
+                        PerformanceStageV1::ModelQueue,
+                        queue_ms.saturating_add(report.lock_wait_ms),
+                    ));
+                    active.stages.push(StageTimingV1::measured(
+                        PerformanceStageV1::ModelLoad,
+                        report.load_ms,
+                    ));
+                });
+                tracing::info!(
+                    target: "pipeline",
+                    recording_id,
+                    model = model_name.as_str(),
+                    backend = model_runtime::model_definition(&model_name).map(|model| model.backend.as_str()).unwrap_or("unknown"),
+                    cache_hit = report.cache_hit,
+                    queue_ms,
+                    lock_wait_ms = report.lock_wait_ms,
+                    load_ms = report.load_ms,
+                    total_ms,
+                    rss_before_mb,
+                    rss_after_mb,
+                    "model_prepare_complete"
+                )
+            }
             Err(_error) => tracing::warn!(
                 target: "pipeline",
                 recording_id,
@@ -496,13 +528,111 @@ fn spawn_idle_model_preparation(
 #[derive(Default)]
 pub(crate) struct PipelineTimings {
     pub vad_ms: u64,
+    pub model_queue_ms: u64,
     pub model_load_ms: u64,
     pub decode_ms: u64,
     pub inference_ms: u64,
+    pub transform_ms: u64,
+    pub transform_stages: Vec<StageTimingV1>,
     pub correction_ms: u64,
+    pub file_output_ms: u64,
     pub paste_ms: u64,
     pub rss_before_mb: u64,
     pub rss_after_mb: u64,
+    pub warm_state: Option<ModelWarmStateV1>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipelineTerminal {
+    Success,
+    NoSpeech,
+    Cancelled(PerformanceStageV1),
+}
+
+struct PipelineResult {
+    text: String,
+    timings: PipelineTimings,
+    terminal: PipelineTerminal,
+}
+
+fn runtime_identity(model_name: &str, warm_state: ModelWarmStateV1) -> Vec<RuntimeIdentityV1> {
+    let Ok(definition) = model_runtime::model_definition(model_name) else {
+        return Vec::new();
+    };
+    let backend = match definition.backend {
+        model_runtime::BackendKind::Whisper => RuntimeBackendV1::Whisper,
+        model_runtime::BackendKind::Parakeet => RuntimeBackendV1::Parakeet,
+        model_runtime::BackendKind::Coreml => RuntimeBackendV1::Coreml,
+    };
+    let accelerator = match model_runtime::model_accelerator(definition) {
+        "CPU" => AcceleratorV1::Cpu,
+        "Metal GPU" => AcceleratorV1::MetalGpu,
+        "Apple Neural Engine" => AcceleratorV1::AppleNeuralEngine,
+        _ => AcceleratorV1::PlatformFallback,
+    };
+    vec![RuntimeIdentityV1 {
+        role: RuntimeRoleV1::Transcription,
+        model_id: model_name.to_string(),
+        backend,
+        accelerator,
+        warm_state,
+    }]
+}
+
+fn transcript_stage_timing(
+    report: &crate::transcript_transform::StageReport,
+) -> Option<StageTimingV1> {
+    use crate::transcript_transform::{
+        StageOutcome, CLEANUP_STAGE, CLI_COMMAND_STAGE, IDE_CONTEXT_STAGE, SMART_CORRECTION_STAGE,
+        SMART_FORMATTING_STAGE, VOICE_COMMANDS_STAGE,
+    };
+
+    let stage = match report.stage {
+        CLEANUP_STAGE => PerformanceStageV1::Cleanup,
+        VOICE_COMMANDS_STAGE => PerformanceStageV1::VoiceCommands,
+        SMART_CORRECTION_STAGE => PerformanceStageV1::SmartCorrection,
+        SMART_FORMATTING_STAGE => PerformanceStageV1::SmartFormatting,
+        IDE_CONTEXT_STAGE => PerformanceStageV1::IdeContext,
+        CLI_COMMAND_STAGE => PerformanceStageV1::CliCommand,
+        _ => return None,
+    };
+    let outcome = match report.outcome {
+        StageOutcome::Applied => StageOutcomeV1::Completed,
+        StageOutcome::Skipped => StageOutcomeV1::Skipped,
+        StageOutcome::Fallback => StageOutcomeV1::Fallback,
+        StageOutcome::Failed => StageOutcomeV1::Failed,
+    };
+    Some(StageTimingV1 {
+        stage,
+        duration_ms: if report.outcome == StageOutcome::Skipped {
+            crate::performance_metrics::MeasurementV1::NotApplicable
+        } else {
+            crate::performance_metrics::MeasurementV1::measured(report.duration_us / 1_000)
+        },
+        outcome,
+    })
+}
+
+fn pipeline_stages(timings: &PipelineTimings, total_ms: u64) -> Vec<StageTimingV1> {
+    let mut stages = vec![
+        StageTimingV1::measured(PerformanceStageV1::Vad, timings.vad_ms),
+        StageTimingV1::measured(PerformanceStageV1::ModelQueue, timings.model_queue_ms),
+        StageTimingV1::measured(PerformanceStageV1::ModelLoad, timings.model_load_ms),
+        StageTimingV1::measured(PerformanceStageV1::InferenceDecode, timings.decode_ms),
+        StageTimingV1::measured(
+            PerformanceStageV1::TranscriptTransform,
+            timings.transform_ms,
+        ),
+        if timings.file_output_ms == 0 {
+            StageTimingV1::not_applicable(PerformanceStageV1::FileOutput)
+        } else {
+            StageTimingV1::measured(PerformanceStageV1::FileOutput, timings.file_output_ms)
+        },
+        StageTimingV1::measured(PerformanceStageV1::ClipboardPaste, timings.paste_ms),
+        StageTimingV1::measured(PerformanceStageV1::TotalProcessing, total_ms),
+    ];
+    stages.extend(timings.transform_stages.clone());
+    stages
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -545,8 +675,9 @@ async fn run_transcription_pipeline(
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
     recording_id: u64,
+    performance_guard: &mut PerformanceRunGuard,
     context: Arc<DictationContextSnapshot>,
-) -> Result<(String, PipelineTimings), String> {
+) -> Result<PipelineResult, String> {
     // Guard resets status to Idle on any return path (error or success),
     // but only if this recording is still the active one
     let _guard = IdleGuard::new(app_state, recording_id);
@@ -554,7 +685,6 @@ async fn run_transcription_pipeline(
     let transcription = &context.transcription;
     let transformations = &context.transformations;
     let delivery = &context.delivery;
-
     // When saving to a file, suppress auto-paste into the focused app. The
     // clipboard write inside `inject_text` is unconditional, so text remains
     // copyable regardless of these toggles.
@@ -570,12 +700,17 @@ async fn run_transcription_pipeline(
     // Checkpoint 1: cancelled before VAD?
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before VAD (recording_id={})", recording_id);
-        return Ok((String::new(), PipelineTimings::default()));
+        return Ok(PipelineResult {
+            text: String::new(),
+            timings: PipelineTimings::default(),
+            terminal: PipelineTerminal::Cancelled(PerformanceStageV1::Vad),
+        });
     }
 
     // Every backend uses one authoritative full-buffer VAD + inference pass
     // after recording stops.
     let vad_threshold = 1.0 - (transcription.vad_sensitivity as f32 / 100.0);
+    performance_guard.enter(PerformanceStageV1::Vad);
     let t_vad = std::time::Instant::now();
     let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
         Some(vad_path) if vad_path.exists() => {
@@ -591,13 +726,14 @@ async fn run_transcription_pipeline(
                 Ok(vad::VadResult::NoSpeech) => {
                     tracing::info!(target: "pipeline", "VAD detected no speech ({} samples, {:?}), skipping transcription",
                             samples.len(), t_vad.elapsed());
-                    return Ok((
-                        String::new(),
-                        PipelineTimings {
+                    return Ok(PipelineResult {
+                        text: String::new(),
+                        timings: PipelineTimings {
                             vad_ms: t_vad.elapsed().as_millis() as u64,
                             ..PipelineTimings::default()
                         },
-                    ));
+                        terminal: PipelineTerminal::NoSpeech,
+                    });
                 }
                 Ok(vad::VadResult::Speech(trimmed)) => {
                     tracing::info!(target: "pipeline", "VAD trimmed {} -> {} samples ({:.0}% speech, {:?})",
@@ -627,16 +763,18 @@ async fn run_transcription_pipeline(
 
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before transcription (recording_id={})", recording_id);
-        return Ok((
-            String::new(),
-            PipelineTimings {
+        return Ok(PipelineResult {
+            text: String::new(),
+            timings: PipelineTimings {
                 vad_ms,
                 ..PipelineTimings::default()
             },
-        ));
+            terminal: PipelineTerminal::Cancelled(PerformanceStageV1::InferenceDecode),
+        });
     }
 
     let rss_before_mb = crate::resource_monitor::get_process_rss_mb();
+    performance_guard.enter(PerformanceStageV1::InferenceDecode);
     let t_transcribe = std::time::Instant::now();
     let mut decode_ms = 0;
     let (text, load_report) = app_state.model_runtime.with_ready_backend(
@@ -665,11 +803,17 @@ async fn run_transcription_pipeline(
     tracing::info!(target: "pipeline", "transcription ({} samples): {:?}", samples_for_transcription.len(), t_transcribe.elapsed());
     let mut timings = PipelineTimings {
         vad_ms,
+        model_queue_ms: load_report.lock_wait_ms,
         model_load_ms,
         decode_ms,
         inference_ms,
         rss_before_mb,
         rss_after_mb,
+        warm_state: Some(if load_report.cache_hit {
+            ModelWarmStateV1::Warm
+        } else {
+            ModelWarmStateV1::ColdLoaded
+        }),
         ..PipelineTimings::default()
     };
 
@@ -709,12 +853,15 @@ async fn run_transcription_pipeline(
         ide_context_index: transformations.ide_context_index.clone(),
         voice_command_runtime: None,
     };
+    let transform_started = std::time::Instant::now();
+    performance_guard.enter(PerformanceStageV1::TranscriptTransform);
     let transformed = crate::transcript_transform::transform_transcript(
         text,
         &transform_context,
         transform_resources,
     )
     .map_err(|error| error.to_string())?;
+    let transform_ms = transform_started.elapsed().as_millis() as u64;
     tracing::info!(
         target: "pipeline",
         changed = transformed.was_changed(),
@@ -722,6 +869,11 @@ async fn run_transcription_pipeline(
     );
     let correction_ms =
         transformed.stage_duration_ms(crate::transcript_transform::SMART_CORRECTION_STAGE);
+    let transform_stages = transformed
+        .stages
+        .iter()
+        .filter_map(transcript_stage_timing)
+        .collect();
     let text = transformed.text;
 
     // Update last_transcription_at for idle timeout tracking
@@ -730,12 +882,20 @@ async fn run_transcription_pipeline(
     if app_state.is_cancelled(recording_id) {
         tracing::info!(target: "pipeline", "cancelled before injection (recording_id={})", recording_id);
         timings.correction_ms = correction_ms;
-        return Ok((String::new(), timings));
+        timings.transform_ms = transform_ms;
+        timings.transform_stages = transform_stages;
+        return Ok(PipelineResult {
+            text: String::new(),
+            timings,
+            terminal: PipelineTerminal::Cancelled(PerformanceStageV1::ClipboardPaste),
+        });
     }
 
     // Phase: File output (optional) -- persist audio/transcript before injection.
     // Non-fatal: a write failure is logged and surfaced to the UI, but the text
     // is already on its way to the clipboard. Uses the original (pre-VAD) samples.
+    let file_output_started = std::time::Instant::now();
+    performance_guard.enter(PerformanceStageV1::FileOutput);
     if delivery.save_audio || delivery.save_transcript {
         if let Err(e) = crate::file_output::write_dictation_outputs(
             samples,
@@ -751,9 +911,15 @@ async fn run_transcription_pipeline(
             );
         }
     }
+    let file_output_ms = if delivery.save_audio || delivery.save_transcript {
+        file_output_started.elapsed().as_millis() as u64
+    } else {
+        0
+    };
 
     // Phase: Text injection (clipboard write + optional osascript paste)
     let t_inject = std::time::Instant::now();
+    performance_guard.enter(PerformanceStageV1::ClipboardPaste);
     if !text.is_empty() {
         let text_to_inject = text.clone();
         let paste_delay_ms = delivery.paste_delay_ms;
@@ -792,8 +958,15 @@ async fn run_transcription_pipeline(
     tracing::info!(target: "pipeline", "inject (clipboard + paste): {:?}", t_inject.elapsed());
 
     timings.correction_ms = correction_ms;
+    timings.transform_ms = transform_ms;
+    timings.transform_stages = transform_stages;
+    timings.file_output_ms = file_output_ms;
     timings.paste_ms = paste_ms;
-    Ok((text, timings))
+    Ok(PipelineResult {
+        text,
+        timings,
+        terminal: PipelineTerminal::Success,
+    })
     // _guard drops here, setting status to Idle
 }
 
@@ -866,6 +1039,21 @@ pub async fn process_audio(
     let _ = app_handle.emit("recording-status-changed", "processing");
     let bundle_id = crate::frontmost::frontmost_bundle_id();
     let context = resolve_live_context(&state.app_state, &state.knowledge, bundle_id.as_deref());
+    if let Err(error) = state.performance.begin_dictation(
+        rid,
+        runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown),
+    ) {
+        tracing::warn!(
+            target: "system",
+            recording_id = rid,
+            "performance run start failed: {}",
+            error
+        );
+    }
+    let mut performance_guard = state.performance.guard(
+        RunCorrelationV1::Dictation { recording_id: rid },
+        PerformanceStageV1::CaptureFinalization,
+    );
 
     // Guard resets status to Idle if decode/parse fails before reaching the pipeline
     let mut guard = IdleGuard::new(&state.app_state, rid);
@@ -886,6 +1074,11 @@ pub async fn process_audio(
         e
     })?;
     tracing::info!(target: "pipeline", "audio parse (base64 + WAV): {:?}", t_parse.elapsed());
+    performance_guard.record(StageTimingV1::measured(
+        PerformanceStageV1::CaptureFinalization,
+        t_parse.elapsed().as_millis() as u64,
+    ));
+    performance_guard.enter(PerformanceStageV1::Vad);
 
     // Pipeline has its own guard, so disarm this one
     guard.disarm();
@@ -896,6 +1089,7 @@ pub async fn process_audio(
         &app_handle,
         &state.app_state,
         rid,
+        &mut performance_guard,
         Arc::clone(&context),
     )
     .await;
@@ -909,7 +1103,9 @@ pub async fn process_audio(
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
     }
-    let (text, timings) = pipeline_result?;
+    let pipeline = pipeline_result?;
+    let text = pipeline.text;
+    let timings = pipeline.timings;
 
     let total_ms = t_total.elapsed().as_millis() as u64;
     let audio_secs = samples.len() as f64 / 16_000.0;
@@ -942,6 +1138,22 @@ pub async fn process_audio(
         model = model_name.as_str(),
         backend = backend_name.as_str(),
         "transcription complete"
+    );
+
+    let outcome = match pipeline.terminal {
+        PipelineTerminal::Success => RunOutcomeV1::Success,
+        PipelineTerminal::NoSpeech => RunOutcomeV1::NoSpeech,
+        PipelineTerminal::Cancelled(stage) => RunOutcomeV1::Cancelled { stage },
+    };
+    let warm_state = timings.warm_state.unwrap_or(ModelWarmStateV1::Unknown);
+    let _ = performance_guard.finish(
+        outcome,
+        pipeline_stages(&timings, total_ms),
+        Some(ContentFreeInputSummaryV1::audio_with_output(
+            (audio_secs * 1_000.0).round() as u64,
+            text.len(),
+        )),
+        Some(runtime_identity(&model_name, warm_state)),
     );
 
     Ok(serde_json::json!({
@@ -1116,9 +1328,7 @@ fn stage_vocabulary_configuration(
             effective_commands.push(command.clone());
         }
     }
-    let effective_entries = entries
-        .as_deref()
-        .unwrap_or(&dictation.vocabulary_entries);
+    let effective_entries = entries.as_deref().unwrap_or(&dictation.vocabulary_entries);
     crate::vocabulary_alias::validate_entries(effective_entries, &effective_commands)?;
 
     Ok(StagedVocabularyConfiguration {
@@ -2041,7 +2251,20 @@ pub async fn start_native_recording(
     let bundle_id = crate::frontmost::frontmost_bundle_id();
     refresh_expired_ide_context(&app_handle, &state.app_state, bundle_id.as_deref());
     let context = resolve_live_context(&state.app_state, &state.knowledge, bundle_id.as_deref());
-    state.app_state.set_active_context(rid, Arc::clone(&context));
+    state
+        .app_state
+        .set_active_context(rid, Arc::clone(&context));
+    if let Err(error) = state.performance.begin_dictation(
+        rid,
+        runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown),
+    ) {
+        tracing::warn!(
+            target: "system",
+            recording_id = rid,
+            "performance run start failed: {}",
+            error
+        );
+    }
     tracing::info!(
         target: "pipeline",
         recording_id = rid,
@@ -2064,6 +2287,16 @@ pub async fn start_native_recording(
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             dictation.status = DictationStatus::Idle;
         }
+        let _ = state.performance.complete(
+            &RunCorrelationV1::Dictation { recording_id: rid },
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::CaptureFinalization,
+                error_code: StableRunErrorV1::AudioCaptureFailed,
+            },
+            Vec::new(),
+            None,
+            None,
+        );
         return Err(e);
     }
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
@@ -2110,6 +2343,10 @@ pub async fn stop_native_recording(
             }
         }
     };
+    let mut performance_guard = state.performance.guard(
+        RunCorrelationV1::Dictation { recording_id: rid },
+        PerformanceStageV1::CaptureFinalization,
+    );
     let context = match state.app_state.active_context(rid) {
         Some(context) => context,
         None => {
@@ -2143,6 +2380,10 @@ pub async fn stop_native_recording(
     // rejected start inspect Processing while inference continues.
     drop(transition);
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
+    performance_guard.record(StageTimingV1::measured(
+        PerformanceStageV1::CaptureFinalization,
+        t_total.elapsed().as_millis() as u64,
+    ));
 
     if samples.is_empty() {
         tracing::info!(target: "pipeline", "stop_native_recording: no audio captured");
@@ -2150,6 +2391,15 @@ pub async fn stop_native_recording(
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
+        let _ = performance_guard.finish(
+            RunOutcomeV1::NoSpeech,
+            vec![StageTimingV1::measured(
+                PerformanceStageV1::TotalProcessing,
+                t_total.elapsed().as_millis() as u64,
+            )],
+            Some(ContentFreeInputSummaryV1::audio(samples.len() as u64 / 16)),
+            None,
+        );
         return Ok(serde_json::json!({
             "type": "transcription",
             "text": "",
@@ -2167,6 +2417,15 @@ pub async fn stop_native_recording(
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
+        let _ = performance_guard.finish(
+            RunOutcomeV1::NoSpeech,
+            vec![StageTimingV1::measured(
+                PerformanceStageV1::TotalProcessing,
+                t_total.elapsed().as_millis() as u64,
+            )],
+            Some(ContentFreeInputSummaryV1::audio(samples.len() as u64 / 16)),
+            None,
+        );
         return Ok(serde_json::json!({
             "type": "transcription",
             "text": "",
@@ -2176,12 +2435,14 @@ pub async fn stop_native_recording(
 
     // Hand off status management to the pipeline's own guard
     guard.disarm();
+    performance_guard.enter(PerformanceStageV1::Vad);
 
     let pipeline_result = run_transcription_pipeline(
         &samples,
         &app_handle,
         &state.app_state,
         rid,
+        &mut performance_guard,
         Arc::clone(&context),
     )
     .await;
@@ -2195,13 +2456,15 @@ pub async fn stop_native_recording(
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
     }
-    let (text, timings) = match pipeline_result {
+    let pipeline = match pipeline_result {
         Ok(result) => result,
         Err(error) => {
             tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", error);
             return Err(error);
         }
     };
+    let text = pipeline.text;
+    let timings = pipeline.timings;
 
     let total_ms = t_total.elapsed().as_millis() as u64;
     let audio_secs = samples.len() as f64 / 16_000.0;
@@ -2235,6 +2498,22 @@ pub async fn stop_native_recording(
         model = model_name.as_str(),
         backend = backend_name.as_str(),
         "transcription complete"
+    );
+
+    let outcome = match pipeline.terminal {
+        PipelineTerminal::Success => RunOutcomeV1::Success,
+        PipelineTerminal::NoSpeech => RunOutcomeV1::NoSpeech,
+        PipelineTerminal::Cancelled(stage) => RunOutcomeV1::Cancelled { stage },
+    };
+    let warm_state = timings.warm_state.unwrap_or(ModelWarmStateV1::Unknown);
+    let _ = performance_guard.finish(
+        outcome,
+        pipeline_stages(&timings, total_ms),
+        Some(ContentFreeInputSummaryV1::audio_with_output(
+            (audio_secs * 1_000.0).round() as u64,
+            text.len(),
+        )),
+        Some(runtime_identity(&model_name, warm_state)),
     );
 
     // Broadcast transcription result to all windows (so the main window can update
@@ -2314,6 +2593,27 @@ pub async fn cancel_native_recording(
     let _ = app_handle.emit(
         "recording-cancelled",
         serde_json::json!({ "recordingId": rid }),
+    );
+
+    let stage = match prev_status {
+        DictationStatus::Recording => PerformanceStageV1::CaptureFinalization,
+        DictationStatus::Processing => PerformanceStageV1::InferenceDecode,
+        DictationStatus::Idle => unreachable!(),
+    };
+    let outcome = if stop_err.is_some() {
+        RunOutcomeV1::Failed {
+            stage,
+            error_code: StableRunErrorV1::AudioCaptureFailed,
+        }
+    } else {
+        RunOutcomeV1::Cancelled { stage }
+    };
+    let _ = state.performance.complete(
+        &RunCorrelationV1::Dictation { recording_id: rid },
+        outcome,
+        Vec::new(),
+        None,
+        None,
     );
 
     match stop_err {
@@ -2429,6 +2729,23 @@ pub async fn transcribe_file(
             );
         }
     }
+    let file_run_id = state.app_state.next_file_run_id();
+    if let Err(error) = state
+        .performance
+        .begin_file_transcription(file_run_id, Vec::new())
+    {
+        tracing::warn!(
+            target: "system",
+            file_run_id,
+            "performance file run start failed: {}",
+            error
+        );
+    }
+    let mut performance_guard = state.performance.guard(
+        RunCorrelationV1::FileTranscription { file_run_id },
+        PerformanceStageV1::FileDecode,
+    );
+    let total_started = std::time::Instant::now();
 
     // Log only the extension as a structured field — never the raw path, which
     // would carry the user's home dir/username into telemetry (release builds
@@ -2437,7 +2754,7 @@ pub async fn transcribe_file(
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
-    tracing::info!(target: "pipeline", ext = ext, "transcribe_file: start");
+    tracing::info!(target: "pipeline", file_run_id, ext = ext, "transcribe_file: start");
 
     // Phase: decode + downmix + resample to 16kHz mono (off the async runtime).
     let t_decode = std::time::Instant::now();
@@ -2453,6 +2770,11 @@ pub async fn transcribe_file(
     let duration_secs = samples.len() as f64 / 16_000.0;
     tracing::info!(target: "pipeline", "transcribe_file: decoded {} samples (~{:.1}s) in {:?}",
         samples.len(), duration_secs, t_decode.elapsed());
+    let file_decode_ms = t_decode.elapsed().as_millis() as u64;
+    performance_guard.record(StageTimingV1::measured(
+        PerformanceStageV1::FileDecode,
+        file_decode_ms,
+    ));
 
     // Read the settings shared with live dictation in one lock.
     let (model_name, language, vad_sensitivity, custom_vocabulary, smart_punctuation) = {
@@ -2465,8 +2787,16 @@ pub async fn transcribe_file(
             dictation.smart_punctuation,
         )
     };
+    let _ = state.performance.update_active(
+        &RunCorrelationV1::FileTranscription { file_run_id },
+        |active| {
+            active.runtimes = runtime_identity(&model_name, ModelWarmStateV1::Unknown);
+        },
+    );
 
     // Phase: VAD — skip silence, best-effort with fallback to full audio (mirrors live).
+    performance_guard.enter(PerformanceStageV1::Vad);
+    let vad_started = std::time::Instant::now();
     let vad_threshold = 1.0 - (vad_sensitivity as f32 / 100.0);
     let (samples_for_transcription, vad_trimmed) = match vad::vad_model_path() {
         Some(vad_path) if vad_path.exists() => {
@@ -2481,6 +2811,23 @@ pub async fn transcribe_file(
             match vad_result {
                 Ok(vad::VadResult::NoSpeech) => {
                     tracing::info!(target: "pipeline", "transcribe_file: VAD detected no speech");
+                    let _ = performance_guard.finish(
+                        RunOutcomeV1::NoSpeech,
+                        vec![
+                            StageTimingV1::measured(
+                                PerformanceStageV1::Vad,
+                                vad_started.elapsed().as_millis() as u64,
+                            ),
+                            StageTimingV1::measured(
+                                PerformanceStageV1::TotalProcessing,
+                                total_started.elapsed().as_millis() as u64,
+                            ),
+                        ],
+                        Some(ContentFreeInputSummaryV1::audio(
+                            (duration_secs * 1_000.0).round() as u64,
+                        )),
+                        Some(runtime_identity(&model_name, ModelWarmStateV1::Unknown)),
+                    );
                     return Ok(serde_json::json!({
                         "type": "file_transcription", "text": "", "duration": duration_secs
                     }));
@@ -2506,8 +2853,10 @@ pub async fn transcribe_file(
             (samples.clone(), false)
         }
     };
+    let vad_ms = vad_started.elapsed().as_millis() as u64;
 
     // Phase: transcription (lazy model load), mirroring run_transcription_pipeline.
+    performance_guard.enter(PerformanceStageV1::InferenceDecode);
     let t_transcribe = std::time::Instant::now();
     let sanitized = custom_vocabulary.replace('\0', "");
     let code_vocab = resolve_code_vocab_prompt(&state.app_state);
@@ -2544,13 +2893,21 @@ pub async fn transcribe_file(
         cli_formatting_mode: crate::cli_command::CliFormattingMode::Auto,
         stages: crate::transcript_transform::TranscriptStageConfig::verbatim(),
     };
-    let text = crate::transcript_transform::transform_transcript(
+    performance_guard.enter(PerformanceStageV1::TranscriptTransform);
+    let transform_started = std::time::Instant::now();
+    let transformed = crate::transcript_transform::transform_transcript(
         text,
         &transform_context,
         crate::transcript_transform::TranscriptTransformResources::empty(),
     )
-    .map_err(|error| error.to_string())?
-    .text;
+    .map_err(|error| error.to_string())?;
+    let transform_ms = transform_started.elapsed().as_millis() as u64;
+    let transform_stages = transformed
+        .stages
+        .iter()
+        .filter_map(transcript_stage_timing)
+        .collect::<Vec<_>>();
+    let text = transformed.text;
 
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
 
@@ -2561,6 +2918,7 @@ pub async fn transcribe_file(
     };
     tracing::info!(
         target: "pipeline",
+        file_run_id,
         model_load_ms,
         decode_ms,
         inference_ms = t_transcribe.elapsed().as_millis() as u64,
@@ -2570,8 +2928,38 @@ pub async fn transcribe_file(
         "file transcription complete"
     );
 
+    let warm_state = if load_report.cache_hit {
+        ModelWarmStateV1::Warm
+    } else {
+        ModelWarmStateV1::ColdLoaded
+    };
+    let mut stages = vec![
+        StageTimingV1::measured(PerformanceStageV1::FileDecode, file_decode_ms),
+        StageTimingV1::measured(PerformanceStageV1::Vad, vad_ms),
+        StageTimingV1::measured(PerformanceStageV1::ModelQueue, load_report.lock_wait_ms),
+        StageTimingV1::measured(PerformanceStageV1::ModelLoad, model_load_ms),
+        StageTimingV1::measured(PerformanceStageV1::InferenceDecode, decode_ms),
+        StageTimingV1::measured(PerformanceStageV1::TranscriptTransform, transform_ms),
+        StageTimingV1::measured(PerformanceStageV1::FileReturn, 0),
+        StageTimingV1::measured(
+            PerformanceStageV1::TotalProcessing,
+            total_started.elapsed().as_millis() as u64,
+        ),
+    ];
+    stages.extend(transform_stages);
+    let _ = performance_guard.finish(
+        RunOutcomeV1::Success,
+        stages,
+        Some(ContentFreeInputSummaryV1::audio_with_output(
+            (duration_secs * 1_000.0).round() as u64,
+            text.len(),
+        )),
+        Some(runtime_identity(&model_name, warm_state)),
+    );
+
     Ok(serde_json::json!({
         "type": "file_transcription",
+        "fileRunId": file_run_id,
         "text": text,
         "duration": duration_secs
     }))

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod keyboard;
 mod knowledge_store;
 pub mod llm_sidecar;
 mod model_runtime;
+mod performance_metrics;
 mod platform;
 mod resource_monitor;
 mod selection;
@@ -53,6 +54,16 @@ pub fn ffi_heap_mb() -> u64 {
     alloc::ffi_heap_mb()
 }
 
+#[cfg(target_os = "macos")]
+pub fn rust_heap_bytes() -> u64 {
+    alloc::rust_heap_bytes()
+}
+
+#[cfg(target_os = "macos")]
+pub fn ffi_heap_bytes() -> u64 {
+    alloc::ffi_heap_bytes()
+}
+
 #[cfg(not(target_os = "macos"))]
 pub fn rust_heap_mb() -> u64 {
     0
@@ -60,6 +71,16 @@ pub fn rust_heap_mb() -> u64 {
 
 #[cfg(not(target_os = "macos"))]
 pub fn ffi_heap_mb() -> u64 {
+    0
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn rust_heap_bytes() -> u64 {
+    0
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn ffi_heap_bytes() -> u64 {
     0
 }
 
@@ -90,6 +111,7 @@ pub(crate) struct State {
     pub(crate) benchmark: std::sync::Arc<benchmark::BenchmarkCoordinator>,
     pub(crate) knowledge: knowledge_store::KnowledgeStore,
     pub(crate) correct_and_teach: correct_and_teach::CorrectAndTeachState,
+    pub(crate) performance: performance_metrics::PerformanceMetrics,
     /// Cached notch dimensions (notch_width, menu_bar_height) from setup (main thread).
     pub(crate) notch_info: Mutex<Option<(f64, f64)>>,
     /// The selection-bounds anchor from the most recent `show_transform_popover`
@@ -195,6 +217,7 @@ pub fn run() {
             benchmark: std::sync::Arc::new(benchmark::BenchmarkCoordinator::new()),
             knowledge: knowledge_store::KnowledgeStore::default(),
             correct_and_teach: correct_and_teach::CorrectAndTeachState::default(),
+            performance: performance_metrics::PerformanceMetrics::default(),
             notch_info: Mutex::new(None),
             transform_popover_anchor: Mutex::new(None),
             transform_main_was_visible: Mutex::new(None),
@@ -264,6 +287,10 @@ pub fn run() {
             commands::logging::clear_logs,
             commands::logging::log_frontend,
             commands::logging::open_log_viewer,
+            commands::performance::list_performance_runs,
+            commands::performance::get_performance_run,
+            commands::performance::get_performance_resource_window,
+            commands::performance::clear_performance_diagnostics,
             commands::models::check_model_exists,
             commands::models::check_specific_model_exists,
             commands::models::get_model_runtime_catalog,
@@ -308,6 +335,20 @@ pub fn run() {
         })
         .setup(|app| {
             telemetry::init(app.handle().clone());
+
+            let performance_root = app.path().app_data_dir()?.join("diagnostics");
+            if let Err(error) = app
+                .state::<State>()
+                .performance
+                .initialize(performance_root, Some(app.handle().clone()))
+            {
+                tracing::warn!(
+                    target: "system",
+                    diagnostics_available = false,
+                    "performance diagnostics store unavailable: {}",
+                    error
+                );
+            }
 
             let knowledge_root = app.path().app_data_dir()?.join("knowledge");
             let knowledge_status = app.state::<State>().knowledge.initialize(knowledge_root);

--- a/app/src-tauri/src/performance_metrics/mod.rs
+++ b/app/src-tauri/src/performance_metrics/mod.rs
@@ -1,0 +1,423 @@
+mod repository;
+mod types;
+
+pub use types::*;
+
+use repository::PerformanceRepository;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tauri::Emitter;
+
+#[derive(Clone, Default)]
+pub(crate) struct PerformanceMetrics {
+    inner: Arc<Mutex<PerformanceMetricsInner>>,
+}
+
+#[derive(Default)]
+struct PerformanceMetricsInner {
+    repository: Option<PerformanceRepository>,
+    app_handle: Option<tauri::AppHandle>,
+    initialization_error: Option<String>,
+}
+
+impl PerformanceMetrics {
+    pub(crate) fn initialize(
+        &self,
+        root: PathBuf,
+        app_handle: Option<tauri::AppHandle>,
+    ) -> Result<(), String> {
+        let result = PerformanceRepository::initialize(root);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner.app_handle = app_handle;
+        match result {
+            Ok(repository) => {
+                inner.repository = Some(repository);
+                inner.initialization_error = None;
+                Ok(())
+            }
+            Err(error) => {
+                inner.repository = None;
+                inner.initialization_error = Some(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    fn repository(&self) -> Result<PerformanceRepository, String> {
+        let inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner.repository.clone().ok_or_else(|| {
+            inner
+                .initialization_error
+                .clone()
+                .unwrap_or_else(|| "The local diagnostics store is unavailable.".to_string())
+        })
+    }
+
+    pub(crate) fn begin(
+        &self,
+        kind: PerformanceRunKindV1,
+        correlation: RunCorrelationV1,
+        runtimes: Vec<RuntimeIdentityV1>,
+        input: ContentFreeInputSummaryV1,
+    ) -> Result<ActiveRunV1, String> {
+        self.repository()?.begin(kind, correlation, runtimes, input)
+    }
+
+    pub(crate) fn begin_dictation(
+        &self,
+        recording_id: u64,
+        runtimes: Vec<RuntimeIdentityV1>,
+    ) -> Result<ActiveRunV1, String> {
+        self.begin(
+            PerformanceRunKindV1::Dictation,
+            RunCorrelationV1::Dictation { recording_id },
+            runtimes,
+            ContentFreeInputSummaryV1::default(),
+        )
+    }
+
+    pub(crate) fn begin_file_transcription(
+        &self,
+        file_run_id: u64,
+        runtimes: Vec<RuntimeIdentityV1>,
+    ) -> Result<ActiveRunV1, String> {
+        self.begin(
+            PerformanceRunKindV1::FileTranscription,
+            RunCorrelationV1::FileTranscription { file_run_id },
+            runtimes,
+            ContentFreeInputSummaryV1::default(),
+        )
+    }
+
+    pub(crate) fn update_active(
+        &self,
+        correlation: &RunCorrelationV1,
+        update: impl FnOnce(&mut ActiveRunV1),
+    ) -> Result<bool, String> {
+        self.repository()?.update_active(correlation, update)
+    }
+
+    pub(crate) fn record_stage(
+        &self,
+        correlation: &RunCorrelationV1,
+        timing: StageTimingV1,
+    ) -> Result<bool, String> {
+        self.update_active(correlation, |active| {
+            active.current_stage = timing.stage;
+            if let Some(existing) = active
+                .stages
+                .iter_mut()
+                .find(|stage| stage.stage == timing.stage)
+            {
+                *existing = timing;
+            } else {
+                active.stages.push(timing);
+            }
+        })
+    }
+
+    pub(crate) fn set_current_stage(
+        &self,
+        correlation: &RunCorrelationV1,
+        stage: PerformanceStageV1,
+    ) -> Result<bool, String> {
+        self.update_active(correlation, |active| active.current_stage = stage)
+    }
+
+    pub(crate) fn complete(
+        &self,
+        correlation: &RunCorrelationV1,
+        outcome: RunOutcomeV1,
+        stages: Vec<StageTimingV1>,
+        input: Option<ContentFreeInputSummaryV1>,
+        runtimes: Option<Vec<RuntimeIdentityV1>>,
+    ) -> Result<Option<PerformanceRunV1>, String> {
+        let run = self
+            .repository()?
+            .complete(correlation, outcome, stages, input, runtimes)?;
+        if let Some(run) = &run {
+            let app_handle = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .app_handle
+                .clone();
+            if let Some(app_handle) = app_handle {
+                let _ = app_handle.emit("performance-run-completed", run);
+            }
+        }
+        Ok(run)
+    }
+
+    pub(crate) fn guard(
+        &self,
+        correlation: RunCorrelationV1,
+        stage: PerformanceStageV1,
+    ) -> PerformanceRunGuard {
+        let _ = self.set_current_stage(&correlation, stage);
+        PerformanceRunGuard {
+            metrics: self.clone(),
+            correlation,
+            current_stage: stage,
+            finished: false,
+        }
+    }
+
+    pub(crate) fn insert_resource_sample(&self, sample: &ResourceSampleV1) -> Result<(), String> {
+        self.repository()?.insert_resource_sample(sample)?;
+        let app_handle = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .app_handle
+            .clone();
+        if let Some(app_handle) = app_handle {
+            let _ = app_handle.emit("performance-resource-sample", sample);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn list(&self, limit: u32) -> Result<PerformanceRunListV1, String> {
+        Ok(PerformanceRunListV1 {
+            schema_version: PERFORMANCE_RUN_SCHEMA_VERSION,
+            runs: self.repository()?.list(limit)?,
+        })
+    }
+
+    pub(crate) fn get(&self, run_id: &str) -> Result<Option<PerformanceRunV1>, String> {
+        self.repository()?.get(run_id)
+    }
+
+    pub(crate) fn resource_window(&self) -> Result<Vec<ResourceSampleV1>, String> {
+        self.repository()?.resource_window()
+    }
+
+    pub(crate) fn clear(&self) -> Result<(), String> {
+        self.repository()?.clear()?;
+        let app_handle = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .app_handle
+            .clone();
+        if let Some(app_handle) = app_handle {
+            let _ = app_handle.emit("performance-diagnostics-cleared", ());
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct PerformanceRunGuard {
+    metrics: PerformanceMetrics,
+    correlation: RunCorrelationV1,
+    current_stage: PerformanceStageV1,
+    finished: bool,
+}
+
+impl PerformanceRunGuard {
+    pub(crate) fn enter(&mut self, stage: PerformanceStageV1) {
+        self.current_stage = stage;
+        let _ = self.metrics.set_current_stage(&self.correlation, stage);
+    }
+
+    pub(crate) fn record(&mut self, timing: StageTimingV1) {
+        self.current_stage = timing.stage;
+        let _ = self.metrics.record_stage(&self.correlation, timing);
+    }
+
+    pub(crate) fn finish(
+        mut self,
+        outcome: RunOutcomeV1,
+        stages: Vec<StageTimingV1>,
+        input: Option<ContentFreeInputSummaryV1>,
+        runtimes: Option<Vec<RuntimeIdentityV1>>,
+    ) -> Result<Option<PerformanceRunV1>, String> {
+        let run = self
+            .metrics
+            .complete(&self.correlation, outcome, stages, input, runtimes)?;
+        self.finished = true;
+        Ok(run)
+    }
+}
+
+impl Drop for PerformanceRunGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let _ = self.metrics.complete(
+            &self.correlation,
+            RunOutcomeV1::Failed {
+                stage: self.current_stage,
+                error_code: StableRunErrorV1::InternalEarlyExit,
+            },
+            Vec::new(),
+            None,
+            None,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metrics() -> (tempfile::TempDir, PerformanceMetrics) {
+        let temp = tempfile::tempdir().unwrap();
+        let metrics = PerformanceMetrics::default();
+        metrics
+            .initialize(temp.path().join("diagnostics"), None)
+            .unwrap();
+        (temp, metrics)
+    }
+
+    #[test]
+    fn guard_closes_early_exit_once() {
+        let (_temp, metrics) = metrics();
+        metrics.begin_dictation(1, Vec::new()).unwrap();
+        {
+            let mut guard = metrics.guard(
+                RunCorrelationV1::Dictation { recording_id: 1 },
+                PerformanceStageV1::Vad,
+            );
+            guard.enter(PerformanceStageV1::InferenceDecode);
+        }
+        let runs = metrics.list(10).unwrap().runs;
+        assert_eq!(runs.len(), 1);
+        assert!(matches!(
+            runs[0].outcome,
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::InferenceDecode,
+                error_code: StableRunErrorV1::InternalEarlyExit
+            }
+        ));
+    }
+
+    #[test]
+    fn guard_is_panic_safe_under_unwind() {
+        let (_temp, metrics) = metrics();
+        metrics.begin_dictation(2, Vec::new()).unwrap();
+        let clone = metrics.clone();
+        let result = std::panic::catch_unwind(move || {
+            let mut guard = clone.guard(
+                RunCorrelationV1::Dictation { recording_id: 2 },
+                PerformanceStageV1::Vad,
+            );
+            guard.enter(PerformanceStageV1::ModelLoad);
+            panic!("test unwind");
+        });
+        assert!(result.is_err());
+        let runs = metrics.list(10).unwrap().runs;
+        assert_eq!(runs.len(), 1);
+        assert!(matches!(
+            runs[0].outcome,
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::ModelLoad,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn measured_zero_is_not_unavailable_or_not_applicable() {
+        let measured = MeasurementV1::measured(0_u64);
+        assert!(matches!(measured, MeasurementV1::Measured { value: 0 }));
+        assert_ne!(measured, MeasurementV1::NotApplicable);
+        assert_ne!(
+            measured,
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples
+            }
+        );
+    }
+
+    #[test]
+    fn v1_tagged_values_have_stable_json_and_round_trip() {
+        assert_eq!(
+            serde_json::to_value(MeasurementV1::measured(0_u64)).unwrap(),
+            serde_json::json!({ "status": "measured", "value": 0 })
+        );
+        assert_eq!(
+            serde_json::to_value(RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::FileDecode,
+                error_code: StableRunErrorV1::DecodeFailed,
+            })
+            .unwrap(),
+            serde_json::json!({
+                "status": "failed",
+                "stage": "fileDecode",
+                "errorCode": "decodeFailed"
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(RunCorrelationV1::Dictation { recording_id: 9 }).unwrap(),
+            serde_json::json!({ "kind": "dictation", "recordingId": 9 })
+        );
+
+        let (_temp, metrics) = metrics();
+        metrics.begin_dictation(6, Vec::new()).unwrap();
+        let run = metrics
+            .complete(
+                &RunCorrelationV1::Dictation { recording_id: 6 },
+                RunOutcomeV1::Success,
+                Vec::new(),
+                Some(ContentFreeInputSummaryV1::audio(250)),
+                None,
+            )
+            .unwrap()
+            .unwrap();
+        let payload = serde_json::to_string(&run).unwrap();
+        let decoded: PerformanceRunV1 = serde_json::from_str(&payload).unwrap();
+        assert_eq!(decoded, run);
+        assert_eq!(decoded.schema_version, PERFORMANCE_RUN_SCHEMA_VERSION);
+        assert_eq!(decoded.stages.len(), 25);
+    }
+
+    #[test]
+    fn serialized_run_has_no_free_form_content_fields() {
+        let (_temp, metrics) = metrics();
+        metrics.begin_dictation(7, Vec::new()).unwrap();
+        metrics
+            .complete(
+                &RunCorrelationV1::Dictation { recording_id: 7 },
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::InferenceDecode,
+                    error_code: StableRunErrorV1::InferenceFailed,
+                },
+                Vec::new(),
+                Some(ContentFreeInputSummaryV1::audio(123)),
+                None,
+            )
+            .unwrap();
+        let json = serde_json::to_string(&metrics.list(10).unwrap()).unwrap();
+        for forbidden in [
+            "SECRET transcript",
+            "/Users/private/file.wav",
+            "com.private.app",
+            "private window title",
+            "private profile",
+            "clipboard secret",
+            "native stderr secret",
+        ] {
+            assert!(!json.contains(forbidden));
+        }
+        for forbidden_key in [
+            "\"text\"",
+            "\"path\"",
+            "\"bundleId\"",
+            "\"windowTitle\"",
+            "\"profileName\"",
+            "\"clipboard\"",
+            "\"stderr\"",
+            "\"errorMessage\"",
+        ] {
+            assert!(!json.contains(forbidden_key));
+        }
+    }
+}

--- a/app/src-tauri/src/performance_metrics/repository.rs
+++ b/app/src-tauri/src/performance_metrics/repository.rs
@@ -1,0 +1,901 @@
+use super::types::*;
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use std::fs;
+use std::path::PathBuf;
+
+const DB_FILE: &str = "performance.sqlite3";
+const LATEST_DB_SCHEMA_VERSION: u32 = 1;
+const MAX_COMPLETED_RUNS: usize = 200;
+const MAX_RESOURCE_SAMPLES: usize = 600;
+
+#[derive(Clone)]
+pub(crate) struct PerformanceRepository {
+    db_path: PathBuf,
+}
+
+impl PerformanceRepository {
+    pub(crate) fn initialize(root: PathBuf) -> Result<Self, String> {
+        fs::create_dir_all(&root).map_err(|_| storage_error())?;
+        let repository = Self {
+            db_path: root.join(DB_FILE),
+        };
+        let mut connection = repository.open()?;
+        migrate(&mut connection)?;
+        quick_check(&connection)?;
+        repository.recover_stale_runs(&mut connection)?;
+        Ok(repository)
+    }
+
+    fn open(&self) -> Result<Connection, String> {
+        let connection = Connection::open(&self.db_path).map_err(db_error)?;
+        connection
+            .execute_batch(
+                "PRAGMA journal_mode=WAL;
+                 PRAGMA synchronous=NORMAL;
+                 PRAGMA foreign_keys=ON;
+                 PRAGMA busy_timeout=2000;",
+            )
+            .map_err(db_error)?;
+        Ok(connection)
+    }
+
+    pub(crate) fn begin(
+        &self,
+        kind: PerformanceRunKindV1,
+        correlation: RunCorrelationV1,
+        runtimes: Vec<RuntimeIdentityV1>,
+        input: ContentFreeInputSummaryV1,
+    ) -> Result<ActiveRunV1, String> {
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let run_id: String = transaction
+            .query_row("SELECT lower(hex(randomblob(16)))", [], |row| row.get(0))
+            .map_err(db_error)?;
+        let started_at_ms = now_ms();
+        let clear_epoch = clear_epoch_tx(&transaction)?;
+        let active = ActiveRunV1 {
+            run_id,
+            kind,
+            started_at_ms,
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            correlation,
+            current_stage: initial_stage(kind),
+            runtimes,
+            stages: Vec::new(),
+            input,
+            clear_epoch,
+        };
+        insert_active(&transaction, &active)?;
+        transaction.commit().map_err(db_error)?;
+        Ok(active)
+    }
+
+    pub(crate) fn update_active(
+        &self,
+        correlation: &RunCorrelationV1,
+        update: impl FnOnce(&mut ActiveRunV1),
+    ) -> Result<bool, String> {
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let Some(mut active) = active_by_correlation_tx(&transaction, correlation)? else {
+            return Ok(false);
+        };
+        update(&mut active);
+        let payload = serde_json::to_string(&active).map_err(|_| invalid_record())?;
+        let changed = transaction
+            .execute(
+                "UPDATE active_runs SET payload_json = ?, current_stage = ?
+                 WHERE run_id = ?",
+                params![payload, stage_name(active.current_stage), active.run_id],
+            )
+            .map_err(db_error)?;
+        transaction.commit().map_err(db_error)?;
+        Ok(changed == 1)
+    }
+
+    pub(crate) fn complete(
+        &self,
+        correlation: &RunCorrelationV1,
+        outcome: RunOutcomeV1,
+        stages: Vec<StageTimingV1>,
+        input: Option<ContentFreeInputSummaryV1>,
+        runtimes: Option<Vec<RuntimeIdentityV1>>,
+    ) -> Result<Option<PerformanceRunV1>, String> {
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let Some(mut active) = active_by_correlation_tx(&transaction, correlation)? else {
+            return Ok(None);
+        };
+        if active.clear_epoch != clear_epoch_tx(&transaction)? {
+            transaction
+                .execute("DELETE FROM active_runs WHERE run_id = ?", [&active.run_id])
+                .map_err(db_error)?;
+            transaction.commit().map_err(db_error)?;
+            return Ok(None);
+        }
+
+        merge_stages(&mut active.stages, stages);
+        active.stages = canonical_stages(active.stages);
+        if let Some(input) = input {
+            active.input = input;
+        }
+        if let Some(runtimes) = runtimes {
+            if active.runtimes.is_empty()
+                || active
+                    .runtimes
+                    .iter()
+                    .all(|runtime| runtime.warm_state == ModelWarmStateV1::Unknown)
+            {
+                active.runtimes = runtimes;
+            }
+        }
+        let finished_at_ms = now_ms().max(active.started_at_ms);
+        let resources = resource_summary_tx(
+            &transaction,
+            active.kind,
+            active.started_at_ms,
+            finished_at_ms,
+        )?;
+        let run = PerformanceRunV1 {
+            schema_version: PERFORMANCE_RUN_SCHEMA_VERSION,
+            run_id: active.run_id.clone(),
+            kind: active.kind,
+            started_at_ms: active.started_at_ms,
+            finished_at_ms,
+            app_version: active.app_version,
+            correlation: active.correlation,
+            outcome,
+            runtimes: active.runtimes,
+            stages: active.stages,
+            input: active.input,
+            resources,
+            follow_ups: Vec::new(),
+        };
+        let payload = serde_json::to_string(&run).map_err(|_| invalid_record())?;
+        let (correlation_kind, correlation_id) = run.correlation.storage_parts();
+        transaction
+            .execute(
+                "INSERT OR IGNORE INTO completed_runs(
+                    run_id, record_version, kind, correlation_kind, correlation_id,
+                    started_at_ms, finished_at_ms, outcome_code, payload_json
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    run.run_id,
+                    PERFORMANCE_RUN_SCHEMA_VERSION,
+                    run.kind.as_str(),
+                    correlation_kind,
+                    to_i64(correlation_id)?,
+                    run.started_at_ms,
+                    run.finished_at_ms,
+                    run.outcome.code(),
+                    payload
+                ],
+            )
+            .map_err(db_error)?;
+        transaction
+            .execute("DELETE FROM active_runs WHERE run_id = ?", [&run.run_id])
+            .map_err(db_error)?;
+        prune_completed_tx(&transaction)?;
+        transaction.commit().map_err(db_error)?;
+        Ok(Some(run))
+    }
+
+    pub(crate) fn insert_resource_sample(&self, sample: &ResourceSampleV1) -> Result<(), String> {
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let payload = serde_json::to_string(sample).map_err(|_| invalid_record())?;
+        transaction
+            .execute(
+                "INSERT INTO resource_samples(record_version, observed_at_ms, payload_json)
+                 VALUES (?, ?, ?)",
+                params![
+                    RESOURCE_SAMPLE_SCHEMA_VERSION,
+                    sample.observed_at_ms,
+                    payload
+                ],
+            )
+            .map_err(db_error)?;
+        prune_resource_samples_tx(&transaction)?;
+        transaction.commit().map_err(db_error)?;
+        Ok(())
+    }
+
+    pub(crate) fn list(&self, limit: u32) -> Result<Vec<PerformanceRunV1>, String> {
+        let connection = self.open()?;
+        let limit = limit.clamp(1, MAX_COMPLETED_RUNS as u32);
+        let mut statement = connection
+            .prepare(
+                "SELECT record_version, payload_json FROM completed_runs
+                 ORDER BY finished_at_ms DESC, run_id DESC LIMIT ?",
+            )
+            .map_err(db_error)?;
+        let rows = statement
+            .query_map([limit], |row| {
+                Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(db_error)?;
+        let mut runs = Vec::new();
+        for row in rows {
+            let (version, payload) = row.map_err(db_error)?;
+            if version != PERFORMANCE_RUN_SCHEMA_VERSION {
+                continue;
+            }
+            runs.push(serde_json::from_str(&payload).map_err(|_| invalid_record())?);
+        }
+        Ok(runs)
+    }
+
+    pub(crate) fn get(&self, run_id: &str) -> Result<Option<PerformanceRunV1>, String> {
+        if !valid_run_id(run_id) {
+            return Err("The performance run ID is invalid.".to_string());
+        }
+        let connection = self.open()?;
+        let row = connection
+            .query_row(
+                "SELECT record_version, payload_json FROM completed_runs WHERE run_id = ?",
+                [run_id],
+                |row| Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .map_err(db_error)?;
+        match row {
+            None => Ok(None),
+            Some((version, _)) if version != PERFORMANCE_RUN_SCHEMA_VERSION => {
+                Err("This performance run uses an unsupported record version.".to_string())
+            }
+            Some((_, payload)) => serde_json::from_str(&payload)
+                .map(Some)
+                .map_err(|_| invalid_record()),
+        }
+    }
+
+    pub(crate) fn resource_window(&self) -> Result<Vec<ResourceSampleV1>, String> {
+        let connection = self.open()?;
+        resource_samples_tx(&connection, i64::MIN, i64::MAX)
+    }
+
+    pub(crate) fn clear(&self) -> Result<(), String> {
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let next_epoch = clear_epoch_tx(&transaction)?.saturating_add(1);
+        transaction
+            .execute(
+                "UPDATE performance_meta SET value = ? WHERE key = 'clear_epoch'",
+                [to_i64(next_epoch)?],
+            )
+            .map_err(db_error)?;
+        transaction
+            .execute("DELETE FROM active_runs", [])
+            .map_err(db_error)?;
+        transaction
+            .execute("DELETE FROM completed_runs", [])
+            .map_err(db_error)?;
+        transaction
+            .execute("DELETE FROM resource_samples", [])
+            .map_err(db_error)?;
+        transaction.commit().map_err(db_error)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn counts(&self) -> Result<(u64, u64, u64), String> {
+        let connection = self.open()?;
+        let active = count(&connection, "active_runs")?;
+        let completed = count(&connection, "completed_runs")?;
+        let samples = count(&connection, "resource_samples")?;
+        Ok((active, completed, samples))
+    }
+
+    fn recover_stale_runs(&self, connection: &mut Connection) -> Result<(), String> {
+        let correlations = {
+            let mut statement = connection
+                .prepare("SELECT payload_json FROM active_runs")
+                .map_err(db_error)?;
+            let rows = statement
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(db_error)?
+                .filter_map(|row| row.ok())
+                .filter_map(|json| serde_json::from_str::<ActiveRunV1>(&json).ok())
+                .map(|run| (run.correlation, run.current_stage, run.input, run.runtimes))
+                .collect::<Vec<_>>();
+            rows
+        };
+        for (correlation, stage, input, runtimes) in correlations {
+            let _ = self.complete(
+                &correlation,
+                RunOutcomeV1::Interrupted {
+                    stage,
+                    error_code: StableRunErrorV1::InterruptedByRestart,
+                },
+                Vec::new(),
+                Some(input),
+                Some(runtimes),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn migrate(connection: &mut Connection) -> Result<(), String> {
+    let current: u32 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(db_error)?;
+    if current > LATEST_DB_SCHEMA_VERSION {
+        return Err(format!(
+            "The diagnostics database uses schema version {current}, which is newer than this Murmur build supports."
+        ));
+    }
+    if current == 0 {
+        let transaction = connection.transaction().map_err(db_error)?;
+        transaction
+            .execute_batch(
+                r#"
+                CREATE TABLE performance_meta (
+                    key TEXT PRIMARY KEY NOT NULL,
+                    value INTEGER NOT NULL
+                );
+                INSERT INTO performance_meta(key, value) VALUES ('clear_epoch', 0);
+
+                CREATE TABLE active_runs (
+                    run_id TEXT PRIMARY KEY NOT NULL,
+                    kind TEXT NOT NULL,
+                    correlation_kind TEXT NOT NULL,
+                    correlation_id INTEGER NOT NULL,
+                    started_at_ms INTEGER NOT NULL,
+                    current_stage TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    UNIQUE(correlation_kind, correlation_id)
+                );
+
+                CREATE TABLE completed_runs (
+                    run_id TEXT PRIMARY KEY NOT NULL,
+                    record_version INTEGER NOT NULL,
+                    kind TEXT NOT NULL,
+                    correlation_kind TEXT NOT NULL,
+                    correlation_id INTEGER NOT NULL,
+                    started_at_ms INTEGER NOT NULL,
+                    finished_at_ms INTEGER NOT NULL,
+                    outcome_code TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+                CREATE INDEX completed_runs_finished
+                    ON completed_runs(finished_at_ms DESC, run_id DESC);
+
+                CREATE TABLE resource_samples (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    record_version INTEGER NOT NULL,
+                    observed_at_ms INTEGER NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+                CREATE INDEX resource_samples_observed
+                    ON resource_samples(observed_at_ms, id);
+                "#,
+            )
+            .map_err(db_error)?;
+        transaction
+            .pragma_update(None, "user_version", LATEST_DB_SCHEMA_VERSION)
+            .map_err(db_error)?;
+        transaction.commit().map_err(db_error)?;
+    }
+    Ok(())
+}
+
+fn insert_active(transaction: &Transaction<'_>, active: &ActiveRunV1) -> Result<(), String> {
+    let payload = serde_json::to_string(active).map_err(|_| invalid_record())?;
+    let (correlation_kind, correlation_id) = active.correlation.storage_parts();
+    transaction
+        .execute(
+            "INSERT INTO active_runs(
+                run_id, kind, correlation_kind, correlation_id, started_at_ms,
+                current_stage, payload_json
+             ) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            params![
+                active.run_id,
+                active.kind.as_str(),
+                correlation_kind,
+                to_i64(correlation_id)?,
+                active.started_at_ms,
+                stage_name(active.current_stage),
+                payload
+            ],
+        )
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn active_by_correlation_tx(
+    transaction: &Transaction<'_>,
+    correlation: &RunCorrelationV1,
+) -> Result<Option<ActiveRunV1>, String> {
+    let (kind, id) = correlation.storage_parts();
+    transaction
+        .query_row(
+            "SELECT payload_json FROM active_runs
+             WHERE correlation_kind = ? AND correlation_id = ?",
+            params![kind, to_i64(id)?],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(db_error)?
+        .map(|json| serde_json::from_str(&json).map_err(|_| invalid_record()))
+        .transpose()
+}
+
+fn clear_epoch_tx(transaction: &Transaction<'_>) -> Result<u64, String> {
+    transaction
+        .query_row(
+            "SELECT value FROM performance_meta WHERE key = 'clear_epoch'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(db_error)?
+        .try_into()
+        .map_err(|_| invalid_record())
+}
+
+fn merge_stages(existing: &mut Vec<StageTimingV1>, incoming: Vec<StageTimingV1>) {
+    for stage in incoming {
+        if let Some(slot) = existing.iter_mut().find(|entry| entry.stage == stage.stage) {
+            if !matches!(
+                stage.stage,
+                PerformanceStageV1::ModelQueue | PerformanceStageV1::ModelLoad
+            ) {
+                *slot = stage;
+            }
+        } else {
+            existing.push(stage);
+        }
+    }
+}
+
+const ALL_STAGES: &[PerformanceStageV1] = &[
+    PerformanceStageV1::CaptureFinalization,
+    PerformanceStageV1::FileDecode,
+    PerformanceStageV1::Vad,
+    PerformanceStageV1::ModelQueue,
+    PerformanceStageV1::ModelLoad,
+    PerformanceStageV1::InferenceDecode,
+    PerformanceStageV1::TranscriptTransform,
+    PerformanceStageV1::Cleanup,
+    PerformanceStageV1::VoiceCommands,
+    PerformanceStageV1::SmartCorrection,
+    PerformanceStageV1::SmartFormatting,
+    PerformanceStageV1::IdeContext,
+    PerformanceStageV1::CliCommand,
+    PerformanceStageV1::FileOutput,
+    PerformanceStageV1::ClipboardPaste,
+    PerformanceStageV1::FileReturn,
+    PerformanceStageV1::TotalProcessing,
+    PerformanceStageV1::SelectedTextCapture,
+    PerformanceStageV1::InstructionCapture,
+    PerformanceStageV1::InstructionAsr,
+    PerformanceStageV1::SidecarSpawnLoad,
+    PerformanceStageV1::Generation,
+    PerformanceStageV1::ReviewReady,
+    PerformanceStageV1::Apply,
+    PerformanceStageV1::Undo,
+];
+
+fn canonical_stages(measured: Vec<StageTimingV1>) -> Vec<StageTimingV1> {
+    ALL_STAGES
+        .iter()
+        .map(|stage| {
+            measured
+                .iter()
+                .find(|timing| timing.stage == *stage)
+                .cloned()
+                .unwrap_or_else(|| StageTimingV1::not_applicable(*stage))
+        })
+        .collect()
+}
+
+fn prune_completed_tx(transaction: &Transaction<'_>) -> Result<(), String> {
+    transaction
+        .execute(
+            "DELETE FROM completed_runs
+             WHERE run_id NOT IN (
+                 SELECT run_id FROM completed_runs
+                 ORDER BY finished_at_ms DESC, run_id DESC LIMIT ?
+             )",
+            [MAX_COMPLETED_RUNS as u32],
+        )
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn prune_resource_samples_tx(transaction: &Transaction<'_>) -> Result<(), String> {
+    transaction
+        .execute(
+            "DELETE FROM resource_samples
+             WHERE id NOT IN (
+                 SELECT id FROM resource_samples ORDER BY id DESC LIMIT ?
+             )",
+            [MAX_RESOURCE_SAMPLES as u32],
+        )
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn resource_summary_tx(
+    transaction: &Transaction<'_>,
+    kind: PerformanceRunKindV1,
+    started_at_ms: i64,
+    finished_at_ms: i64,
+) -> Result<ResourceSummaryV1, String> {
+    let samples = resource_samples_tx(transaction, started_at_ms, finished_at_ms)?;
+    if samples.is_empty() {
+        return Ok(ResourceSummaryV1::unavailable_for(kind));
+    }
+    let host_cpu = samples
+        .iter()
+        .filter_map(|sample| sample.host.cpu_percent.value().copied())
+        .collect::<Vec<_>>();
+    let main_cpu = samples
+        .iter()
+        .filter_map(|sample| sample.main_process.cpu_percent.value().copied())
+        .collect::<Vec<_>>();
+    let rss = samples
+        .iter()
+        .filter_map(|sample| sample.main_process.rss_bytes.value().copied())
+        .collect::<Vec<_>>();
+    let rust_heap = samples
+        .iter()
+        .filter_map(|sample| sample.main_process.rust_heap_bytes.value().copied())
+        .collect::<Vec<_>>();
+    let ffi_heap = samples
+        .iter()
+        .filter_map(|sample| sample.main_process.ffi_native_heap_bytes.value().copied())
+        .collect::<Vec<_>>();
+    let sidecar = if kind == PerformanceRunKindV1::SelectedTextTransform {
+        SidecarResourceSummaryV1 {
+            cpu_percent: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+            rss_bytes: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+        }
+    } else {
+        SidecarResourceSummaryV1 {
+            cpu_percent: ResourceRangeV1::not_applicable(),
+            rss_bytes: ResourceRangeV1::not_applicable(),
+        }
+    };
+    Ok(ResourceSummaryV1 {
+        sample_count: samples.len().try_into().unwrap_or(u32::MAX),
+        host: HostResourceSummaryV1 {
+            cpu_percent: range_f32(&host_cpu),
+        },
+        main_process: ProcessResourceSummaryV1 {
+            cpu_percent: range_f32(&main_cpu),
+            rss_bytes: range_u64(&rss),
+            rust_heap_bytes: range_u64(&rust_heap),
+            ffi_native_heap_bytes: range_u64(&ffi_heap),
+        },
+        sidecar_process: sidecar,
+    })
+}
+
+fn resource_samples_tx(
+    connection: &Connection,
+    started_at_ms: i64,
+    finished_at_ms: i64,
+) -> Result<Vec<ResourceSampleV1>, String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT record_version, payload_json FROM resource_samples
+             WHERE observed_at_ms BETWEEN ? AND ?
+             ORDER BY observed_at_ms ASC, id ASC",
+        )
+        .map_err(db_error)?;
+    let rows = statement
+        .query_map(params![started_at_ms, finished_at_ms], |row| {
+            Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(db_error)?;
+    let mut samples = Vec::new();
+    for row in rows {
+        let (version, payload) = row.map_err(db_error)?;
+        if version != RESOURCE_SAMPLE_SCHEMA_VERSION {
+            continue;
+        }
+        samples.push(serde_json::from_str(&payload).map_err(|_| invalid_record())?);
+    }
+    Ok(samples)
+}
+
+fn range_f32(values: &[f32]) -> ResourceRangeV1<f32> {
+    if values.is_empty() {
+        return ResourceRangeV1::unavailable(UnavailableReasonV1::NoSamples);
+    }
+    ResourceRangeV1 {
+        start: MeasurementV1::measured(values[0]),
+        average: MeasurementV1::measured(
+            values.iter().map(|value| f64::from(*value)).sum::<f64>() as f32 / values.len() as f32,
+        ),
+        peak: MeasurementV1::measured(values.iter().copied().fold(f32::NEG_INFINITY, f32::max)),
+        end: MeasurementV1::measured(values[values.len() - 1]),
+    }
+}
+
+fn range_u64(values: &[u64]) -> ResourceRangeV1<u64> {
+    if values.is_empty() {
+        return ResourceRangeV1::unavailable(UnavailableReasonV1::NoSamples);
+    }
+    ResourceRangeV1 {
+        start: MeasurementV1::measured(values[0]),
+        average: MeasurementV1::measured(
+            (values.iter().map(|value| u128::from(*value)).sum::<u128>() / values.len() as u128)
+                as u64,
+        ),
+        peak: MeasurementV1::measured(values.iter().copied().max().unwrap_or(0)),
+        end: MeasurementV1::measured(values[values.len() - 1]),
+    }
+}
+
+fn initial_stage(kind: PerformanceRunKindV1) -> PerformanceStageV1 {
+    match kind {
+        PerformanceRunKindV1::Dictation => PerformanceStageV1::CaptureFinalization,
+        PerformanceRunKindV1::FileTranscription => PerformanceStageV1::FileDecode,
+        PerformanceRunKindV1::SelectedTextTransform => PerformanceStageV1::SelectedTextCapture,
+    }
+}
+
+fn stage_name(stage: PerformanceStageV1) -> String {
+    serde_json::to_string(&stage)
+        .unwrap_or_else(|_| "\"unknown\"".to_string())
+        .trim_matches('"')
+        .to_string()
+}
+
+fn valid_run_id(run_id: &str) -> bool {
+    run_id.len() == 32 && run_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn quick_check(connection: &Connection) -> Result<(), String> {
+    let result: String = connection
+        .pragma_query_value(None, "quick_check", |row| row.get(0))
+        .map_err(db_error)?;
+    if result == "ok" {
+        Ok(())
+    } else {
+        Err("The diagnostics database failed its integrity check.".to_string())
+    }
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn to_i64(value: u64) -> Result<i64, String> {
+    value
+        .try_into()
+        .map_err(|_| "The diagnostics correlation ID is out of range.".to_string())
+}
+
+#[cfg(test)]
+fn count(connection: &Connection, table: &str) -> Result<u64, String> {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    connection
+        .query_row(&sql, [], |row| row.get::<_, i64>(0))
+        .and_then(|value| {
+            value.try_into().map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Integer,
+                    Box::new(error),
+                )
+            })
+        })
+        .map_err(db_error)
+}
+
+fn db_error(_error: rusqlite::Error) -> String {
+    "The local diagnostics database operation failed.".to_string()
+}
+
+fn storage_error() -> String {
+    "The local diagnostics storage directory is unavailable.".to_string()
+}
+
+fn invalid_record() -> String {
+    "The local diagnostics database contains an invalid record.".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repository() -> (tempfile::TempDir, PerformanceRepository) {
+        let temp = tempfile::tempdir().unwrap();
+        let repository =
+            PerformanceRepository::initialize(temp.path().join("diagnostics")).unwrap();
+        (temp, repository)
+    }
+
+    fn correlation(id: u64) -> RunCorrelationV1 {
+        RunCorrelationV1::Dictation { recording_id: id }
+    }
+
+    fn sample(at: i64, cpu: MeasurementV1<f32>) -> ResourceSampleV1 {
+        ResourceSampleV1 {
+            schema_version: RESOURCE_SAMPLE_SCHEMA_VERSION,
+            observed_at_ms: at,
+            host: HostResourceSampleV1 {
+                cpu_percent: cpu.clone(),
+            },
+            main_process: ProcessResourceSampleV1 {
+                cpu_percent: cpu,
+                rss_bytes: MeasurementV1::measured(100),
+                rust_heap_bytes: MeasurementV1::measured(20),
+                ffi_native_heap_bytes: MeasurementV1::measured(30),
+            },
+            sidecar_process: SidecarResourceSampleV1::dependency_pending(),
+        }
+    }
+
+    #[test]
+    fn completed_runs_are_capped_and_completion_is_idempotent() {
+        let (_temp, repository) = repository();
+        for id in 1..=201 {
+            repository
+                .begin(
+                    PerformanceRunKindV1::Dictation,
+                    correlation(id),
+                    Vec::new(),
+                    ContentFreeInputSummaryV1::audio(1_000),
+                )
+                .unwrap();
+            assert!(repository
+                .complete(
+                    &correlation(id),
+                    RunOutcomeV1::Success,
+                    vec![StageTimingV1::measured(
+                        PerformanceStageV1::TotalProcessing,
+                        id
+                    )],
+                    None,
+                    None,
+                )
+                .unwrap()
+                .is_some());
+        }
+        assert_eq!(repository.counts().unwrap(), (0, 200, 0));
+        assert!(repository
+            .complete(
+                &correlation(201),
+                RunOutcomeV1::Success,
+                Vec::new(),
+                None,
+                None
+            )
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn resource_window_is_capped_and_summarizes_scopes() {
+        let (_temp, repository) = repository();
+        let active = repository
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(1),
+                Vec::new(),
+                ContentFreeInputSummaryV1::audio(1_000),
+            )
+            .unwrap();
+        for index in 0..601 {
+            repository
+                .insert_resource_sample(&sample(
+                    active.started_at_ms,
+                    MeasurementV1::measured(index as f32),
+                ))
+                .unwrap();
+        }
+        let run = repository
+            .complete(
+                &correlation(1),
+                RunOutcomeV1::Success,
+                Vec::new(),
+                None,
+                None,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(repository.counts().unwrap(), (0, 1, 600));
+        assert_eq!(run.resources.sample_count, 600);
+        assert!(matches!(
+            run.resources.sidecar_process.rss_bytes.start,
+            MeasurementV1::NotApplicable
+        ));
+    }
+
+    #[test]
+    fn clear_removes_only_diagnostics_and_invalidates_active_runs() {
+        let (temp, repository) = repository();
+        let unrelated = temp.path().join("logs").join("app.log");
+        fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+        fs::write(&unrelated, "keep").unwrap();
+        repository
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(1),
+                Vec::new(),
+                ContentFreeInputSummaryV1::default(),
+            )
+            .unwrap();
+        repository
+            .insert_resource_sample(&sample(1, MeasurementV1::measured(0.0)))
+            .unwrap();
+        repository.clear().unwrap();
+        assert_eq!(repository.counts().unwrap(), (0, 0, 0));
+        assert!(repository
+            .complete(
+                &correlation(1),
+                RunOutcomeV1::Success,
+                Vec::new(),
+                None,
+                None
+            )
+            .unwrap()
+            .is_none());
+        assert_eq!(fs::read_to_string(unrelated).unwrap(), "keep");
+    }
+
+    #[test]
+    fn restart_closes_stale_run_and_allows_reused_session_correlation() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let repository = PerformanceRepository::initialize(root.clone()).unwrap();
+        repository
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(1),
+                Vec::new(),
+                ContentFreeInputSummaryV1::default(),
+            )
+            .unwrap();
+        let restarted = PerformanceRepository::initialize(root).unwrap();
+        let interrupted = restarted.list(10).unwrap();
+        assert_eq!(interrupted.len(), 1);
+        assert!(matches!(
+            interrupted[0].outcome,
+            RunOutcomeV1::Interrupted {
+                error_code: StableRunErrorV1::InterruptedByRestart,
+                ..
+            }
+        ));
+
+        restarted
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(1),
+                Vec::new(),
+                ContentFreeInputSummaryV1::default(),
+            )
+            .unwrap();
+        restarted
+            .complete(
+                &correlation(1),
+                RunOutcomeV1::Success,
+                Vec::new(),
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(restarted.list(10).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn unsupported_future_database_version_fails_without_rewriting_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        fs::create_dir_all(&root).unwrap();
+        let db = root.join(DB_FILE);
+        let connection = Connection::open(&db).unwrap();
+        connection.pragma_update(None, "user_version", 99).unwrap();
+        drop(connection);
+
+        assert!(PerformanceRepository::initialize(root).is_err());
+        let connection = Connection::open(db).unwrap();
+        let version: u32 = connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, 99);
+    }
+}

--- a/app/src-tauri/src/performance_metrics/types.rs
+++ b/app/src-tauri/src/performance_metrics/types.rs
@@ -1,0 +1,482 @@
+use serde::{Deserialize, Serialize};
+
+pub const PERFORMANCE_RUN_SCHEMA_VERSION: u32 = 1;
+pub const RESOURCE_SAMPLE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UnavailableReasonV1 {
+    UnsupportedPlatform,
+    SampleFailed,
+    NoSamples,
+    DependencyPending,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum MeasurementV1<T> {
+    Measured { value: T },
+    NotApplicable,
+    Unavailable { reason: UnavailableReasonV1 },
+}
+
+impl<T> MeasurementV1<T> {
+    pub fn measured(value: T) -> Self {
+        Self::Measured { value }
+    }
+
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            Self::Measured { value } => Some(value),
+            Self::NotApplicable | Self::Unavailable { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceRunKindV1 {
+    Dictation,
+    FileTranscription,
+    SelectedTextTransform,
+}
+
+impl PerformanceRunKindV1 {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Dictation => "dictation",
+            Self::FileTranscription => "fileTranscription",
+            Self::SelectedTextTransform => "selectedTextTransform",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum RunCorrelationV1 {
+    Dictation { recording_id: u64 },
+    FileTranscription { file_run_id: u64 },
+    SelectedTextTransform { transform_pass_id: u64 },
+}
+
+impl RunCorrelationV1 {
+    pub(crate) fn storage_parts(&self) -> (&'static str, u64) {
+        match self {
+            Self::Dictation { recording_id } => ("dictation", *recording_id),
+            Self::FileTranscription { file_run_id } => ("fileTranscription", *file_run_id),
+            Self::SelectedTextTransform { transform_pass_id } => {
+                ("selectedTextTransform", *transform_pass_id)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStageV1 {
+    CaptureFinalization,
+    FileDecode,
+    Vad,
+    ModelQueue,
+    ModelLoad,
+    InferenceDecode,
+    TranscriptTransform,
+    Cleanup,
+    VoiceCommands,
+    SmartCorrection,
+    SmartFormatting,
+    IdeContext,
+    CliCommand,
+    FileOutput,
+    ClipboardPaste,
+    FileReturn,
+    TotalProcessing,
+    SelectedTextCapture,
+    InstructionCapture,
+    InstructionAsr,
+    SidecarSpawnLoad,
+    Generation,
+    ReviewReady,
+    Apply,
+    Undo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StageOutcomeV1 {
+    Completed,
+    Skipped,
+    Fallback,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageTimingV1 {
+    pub stage: PerformanceStageV1,
+    pub duration_ms: MeasurementV1<u64>,
+    pub outcome: StageOutcomeV1,
+}
+
+impl StageTimingV1 {
+    pub fn measured(stage: PerformanceStageV1, duration_ms: u64) -> Self {
+        Self {
+            stage,
+            duration_ms: MeasurementV1::measured(duration_ms),
+            outcome: StageOutcomeV1::Completed,
+        }
+    }
+
+    pub fn not_applicable(stage: PerformanceStageV1) -> Self {
+        Self {
+            stage,
+            duration_ms: MeasurementV1::NotApplicable,
+            outcome: StageOutcomeV1::Skipped,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RuntimeRoleV1 {
+    Transcription,
+    InstructionAsr,
+    Generation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RuntimeBackendV1 {
+    Whisper,
+    Parakeet,
+    Coreml,
+    LlamaCpp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AcceleratorV1 {
+    Cpu,
+    MetalGpu,
+    AppleNeuralEngine,
+    PlatformFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ModelWarmStateV1 {
+    Warm,
+    ColdLoaded,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeIdentityV1 {
+    pub role: RuntimeRoleV1,
+    pub model_id: String,
+    pub backend: RuntimeBackendV1,
+    pub accelerator: AcceleratorV1,
+    pub warm_state: ModelWarmStateV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SizeBucketV1 {
+    Empty,
+    Tiny,
+    Small,
+    Medium,
+    Large,
+    ExtraLarge,
+}
+
+pub fn size_bucket(bytes: usize) -> SizeBucketV1 {
+    match bytes {
+        0 => SizeBucketV1::Empty,
+        1..=64 => SizeBucketV1::Tiny,
+        65..=512 => SizeBucketV1::Small,
+        513..=4_096 => SizeBucketV1::Medium,
+        4_097..=32_768 => SizeBucketV1::Large,
+        _ => SizeBucketV1::ExtraLarge,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentFreeInputSummaryV1 {
+    pub audio_duration_ms: MeasurementV1<u64>,
+    pub input_size_bucket: MeasurementV1<SizeBucketV1>,
+    pub output_size_bucket: MeasurementV1<SizeBucketV1>,
+    pub output_token_count: MeasurementV1<u64>,
+}
+
+impl ContentFreeInputSummaryV1 {
+    pub fn audio(audio_duration_ms: u64) -> Self {
+        Self {
+            audio_duration_ms: MeasurementV1::measured(audio_duration_ms),
+            input_size_bucket: MeasurementV1::NotApplicable,
+            output_size_bucket: MeasurementV1::NotApplicable,
+            output_token_count: MeasurementV1::NotApplicable,
+        }
+    }
+
+    pub fn audio_with_output(audio_duration_ms: u64, output_bytes: usize) -> Self {
+        Self {
+            output_size_bucket: MeasurementV1::measured(size_bucket(output_bytes)),
+            ..Self::audio(audio_duration_ms)
+        }
+    }
+}
+
+impl Default for ContentFreeInputSummaryV1 {
+    fn default() -> Self {
+        Self {
+            audio_duration_ms: MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples,
+            },
+            input_size_bucket: MeasurementV1::NotApplicable,
+            output_size_bucket: MeasurementV1::NotApplicable,
+            output_token_count: MeasurementV1::NotApplicable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceRangeV1<T> {
+    pub start: MeasurementV1<T>,
+    pub average: MeasurementV1<T>,
+    pub peak: MeasurementV1<T>,
+    pub end: MeasurementV1<T>,
+}
+
+impl<T> ResourceRangeV1<T> {
+    pub fn unavailable(reason: UnavailableReasonV1) -> Self {
+        Self {
+            start: MeasurementV1::Unavailable { reason },
+            average: MeasurementV1::Unavailable { reason },
+            peak: MeasurementV1::Unavailable { reason },
+            end: MeasurementV1::Unavailable { reason },
+        }
+    }
+
+    pub fn not_applicable() -> Self {
+        Self {
+            start: MeasurementV1::NotApplicable,
+            average: MeasurementV1::NotApplicable,
+            peak: MeasurementV1::NotApplicable,
+            end: MeasurementV1::NotApplicable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostResourceSampleV1 {
+    pub cpu_percent: MeasurementV1<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessResourceSampleV1 {
+    pub cpu_percent: MeasurementV1<f32>,
+    pub rss_bytes: MeasurementV1<u64>,
+    pub rust_heap_bytes: MeasurementV1<u64>,
+    pub ffi_native_heap_bytes: MeasurementV1<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SidecarResourceSampleV1 {
+    pub cpu_percent: MeasurementV1<f32>,
+    pub rss_bytes: MeasurementV1<u64>,
+}
+
+impl SidecarResourceSampleV1 {
+    pub fn dependency_pending() -> Self {
+        Self {
+            cpu_percent: MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::DependencyPending,
+            },
+            rss_bytes: MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::DependencyPending,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSampleV1 {
+    pub schema_version: u32,
+    pub observed_at_ms: i64,
+    pub host: HostResourceSampleV1,
+    pub main_process: ProcessResourceSampleV1,
+    pub sidecar_process: SidecarResourceSampleV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostResourceSummaryV1 {
+    pub cpu_percent: ResourceRangeV1<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessResourceSummaryV1 {
+    pub cpu_percent: ResourceRangeV1<f32>,
+    pub rss_bytes: ResourceRangeV1<u64>,
+    pub rust_heap_bytes: ResourceRangeV1<u64>,
+    pub ffi_native_heap_bytes: ResourceRangeV1<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SidecarResourceSummaryV1 {
+    pub cpu_percent: ResourceRangeV1<f32>,
+    pub rss_bytes: ResourceRangeV1<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSummaryV1 {
+    pub sample_count: u32,
+    pub host: HostResourceSummaryV1,
+    pub main_process: ProcessResourceSummaryV1,
+    pub sidecar_process: SidecarResourceSummaryV1,
+}
+
+impl ResourceSummaryV1 {
+    pub fn unavailable_for(kind: PerformanceRunKindV1) -> Self {
+        let no_samples = UnavailableReasonV1::NoSamples;
+        let sidecar = if kind == PerformanceRunKindV1::SelectedTextTransform {
+            SidecarResourceSummaryV1 {
+                cpu_percent: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+                rss_bytes: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+            }
+        } else {
+            SidecarResourceSummaryV1 {
+                cpu_percent: ResourceRangeV1::not_applicable(),
+                rss_bytes: ResourceRangeV1::not_applicable(),
+            }
+        };
+        Self {
+            sample_count: 0,
+            host: HostResourceSummaryV1 {
+                cpu_percent: ResourceRangeV1::unavailable(no_samples),
+            },
+            main_process: ProcessResourceSummaryV1 {
+                cpu_percent: ResourceRangeV1::unavailable(no_samples),
+                rss_bytes: ResourceRangeV1::unavailable(no_samples),
+                rust_heap_bytes: ResourceRangeV1::unavailable(no_samples),
+                ffi_native_heap_bytes: ResourceRangeV1::unavailable(no_samples),
+            },
+            sidecar_process: sidecar,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StableRunErrorV1 {
+    AudioCaptureFailed,
+    DecodeFailed,
+    VadFailed,
+    ModelFailed,
+    InferenceFailed,
+    TransformStageFailed,
+    DeliveryFailed,
+    InternalEarlyExit,
+    InterruptedByRestart,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum RunOutcomeV1 {
+    Success,
+    NoSpeech,
+    Cancelled {
+        stage: PerformanceStageV1,
+    },
+    TimedOut {
+        stage: PerformanceStageV1,
+    },
+    Failed {
+        stage: PerformanceStageV1,
+        error_code: StableRunErrorV1,
+    },
+    Interrupted {
+        stage: PerformanceStageV1,
+        error_code: StableRunErrorV1,
+    },
+}
+
+impl RunOutcomeV1 {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::NoSpeech => "noSpeech",
+            Self::Cancelled { .. } => "cancelled",
+            Self::TimedOut { .. } => "timedOut",
+            Self::Failed { .. } => "failed",
+            Self::Interrupted { .. } => "interrupted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransformFollowUpKindV1 {
+    Apply,
+    Undo,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformFollowUpV1 {
+    pub kind: TransformFollowUpKindV1,
+    pub at_ms: i64,
+    pub duration_ms: MeasurementV1<u64>,
+    pub outcome: StageOutcomeV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceRunV1 {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub kind: PerformanceRunKindV1,
+    pub started_at_ms: i64,
+    pub finished_at_ms: i64,
+    pub app_version: String,
+    pub correlation: RunCorrelationV1,
+    pub outcome: RunOutcomeV1,
+    pub runtimes: Vec<RuntimeIdentityV1>,
+    pub stages: Vec<StageTimingV1>,
+    pub input: ContentFreeInputSummaryV1,
+    pub resources: ResourceSummaryV1,
+    pub follow_ups: Vec<TransformFollowUpV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ActiveRunV1 {
+    pub run_id: String,
+    pub kind: PerformanceRunKindV1,
+    pub started_at_ms: i64,
+    pub app_version: String,
+    pub correlation: RunCorrelationV1,
+    pub current_stage: PerformanceStageV1,
+    pub runtimes: Vec<RuntimeIdentityV1>,
+    pub stages: Vec<StageTimingV1>,
+    pub input: ContentFreeInputSummaryV1,
+    pub clear_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceRunListV1 {
+    pub schema_version: u32,
+    pub runs: Vec<PerformanceRunV1>,
+}

--- a/app/src-tauri/src/platform/linux.rs
+++ b/app/src-tauri/src/platform/linux.rs
@@ -43,7 +43,7 @@ fn snapshot() -> Option<CpuTicks> {
 
 static PREVIOUS: Mutex<Option<CpuTicks>> = Mutex::new(None);
 
-pub(super) fn cpu_percent() -> f32 {
+pub(super) fn cpu_percent() -> Option<f32> {
     update_cpu_percent(&mut PREVIOUS.lock_or_recover(), snapshot())
 }
 

--- a/app/src-tauri/src/platform/macos.rs
+++ b/app/src-tauri/src/platform/macos.rs
@@ -43,7 +43,7 @@ fn snapshot() -> Option<CpuTicks> {
 
 static PREVIOUS: Mutex<Option<CpuTicks>> = Mutex::new(None);
 
-pub(super) fn cpu_percent() -> f32 {
+pub(super) fn cpu_percent() -> Option<f32> {
     let current = snapshot();
     update_cpu_percent(&mut PREVIOUS.lock_or_recover(), current)
 }

--- a/app/src-tauri/src/platform/mod.rs
+++ b/app/src-tauri/src/platform/mod.rs
@@ -11,7 +11,7 @@
 )]
 mod current;
 
-pub(crate) fn cpu_percent() -> f32 {
+pub(crate) fn cpu_percent() -> Option<f32> {
     current::cpu_percent()
 }
 
@@ -41,13 +41,11 @@ pub(super) fn cpu_percent_between(previous: CpuTicks, current: CpuTicks) -> f32 
 pub(super) fn update_cpu_percent(
     previous: &mut Option<CpuTicks>,
     current: Option<CpuTicks>,
-) -> f32 {
+) -> Option<f32> {
     let Some(current) = current else {
-        return 0.0;
+        return None;
     };
-    let percent = previous
-        .map(|sample| cpu_percent_between(sample, current))
-        .unwrap_or(0.0);
+    let percent = previous.map(|sample| cpu_percent_between(sample, current));
     *previous = Some(current);
     percent
 }
@@ -76,11 +74,24 @@ mod tests {
         let baseline = CpuTicks::new(1_000, 4_000);
         let mut previous = Some(baseline);
 
-        assert_eq!(update_cpu_percent(&mut previous, None), 0.0);
+        assert_eq!(update_cpu_percent(&mut previous, None), None);
         assert_eq!(previous, Some(baseline));
         assert_eq!(
             update_cpu_percent(&mut previous, Some(CpuTicks::new(1_025, 4_075))),
-            25.0
+            Some(25.0)
+        );
+    }
+
+    #[test]
+    fn first_sample_is_unavailable_instead_of_zero() {
+        let mut previous = None;
+        assert_eq!(
+            update_cpu_percent(&mut previous, Some(CpuTicks::new(1_000, 4_000))),
+            None
+        );
+        assert_eq!(
+            update_cpu_percent(&mut previous, Some(CpuTicks::new(1_025, 4_075))),
+            Some(25.0)
         );
     }
 }

--- a/app/src-tauri/src/platform/unsupported.rs
+++ b/app/src-tauri/src/platform/unsupported.rs
@@ -1,3 +1,3 @@
-pub(super) fn cpu_percent() -> f32 {
-    0.0
+pub(super) fn cpu_percent() -> Option<f32> {
+    None
 }

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -1,21 +1,97 @@
 use crate::model_runtime::UnloadReason;
-use serde::Serialize;
 use std::sync::Mutex;
 
-#[derive(Debug, Clone, Serialize)]
-pub struct ResourceUsage {
-    pub cpu_percent: f32,
-    pub memory_mb: u64,
-    pub rss_mb: u64,
-    pub rust_heap_mb: u64,
-    pub ffi_heap_mb: u64,
+/// Get process RSS in bytes via `memory-stats` (task_info on macOS).
+pub fn get_process_rss_bytes() -> Option<u64> {
+    memory_stats::memory_stats().map(|statistics| statistics.physical_mem as u64)
 }
 
-/// Get process RSS in megabytes via `memory-stats` (task_info on macOS).
+/// Legacy internal helper retained for existing model/benchmark logs.
 pub fn get_process_rss_mb() -> u64 {
-    memory_stats::memory_stats()
-        .map(|s| s.physical_mem as u64 / 1_048_576)
-        .unwrap_or(0)
+    get_process_rss_bytes().unwrap_or(0) / 1_048_576
+}
+
+struct ProcessCpuSampler {
+    system: sysinfo::System,
+    primed: bool,
+}
+
+impl ProcessCpuSampler {
+    fn new() -> Self {
+        Self {
+            system: sysinfo::System::new(),
+            primed: false,
+        }
+    }
+
+    fn sample(&mut self) -> Option<f32> {
+        use sysinfo::{Pid, ProcessesToUpdate};
+
+        let pid = Pid::from_u32(std::process::id());
+        self.system
+            .refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+        let value = self.system.process(pid).map(|process| process.cpu_usage());
+        if value.is_some() && !self.primed {
+            self.primed = true;
+            return None;
+        }
+        value
+    }
+}
+
+static PROCESS_CPU: std::sync::OnceLock<Mutex<ProcessCpuSampler>> = std::sync::OnceLock::new();
+
+fn measured_or_unavailable<T>(value: Option<T>) -> crate::performance_metrics::MeasurementV1<T> {
+    value.map_or(
+        crate::performance_metrics::MeasurementV1::Unavailable {
+            reason: crate::performance_metrics::UnavailableReasonV1::SampleFailed,
+        },
+        crate::performance_metrics::MeasurementV1::measured,
+    )
+}
+
+pub fn sample_resources() -> crate::performance_metrics::ResourceSampleV1 {
+    use crate::performance_metrics::{
+        HostResourceSampleV1, MeasurementV1, ProcessResourceSampleV1, ResourceSampleV1,
+        SidecarResourceSampleV1, UnavailableReasonV1, RESOURCE_SAMPLE_SCHEMA_VERSION,
+    };
+
+    let process_cpu = PROCESS_CPU
+        .get_or_init(|| Mutex::new(ProcessCpuSampler::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .sample();
+    let rust_heap = if cfg!(target_os = "macos") {
+        MeasurementV1::measured(crate::rust_heap_bytes())
+    } else {
+        MeasurementV1::Unavailable {
+            reason: UnavailableReasonV1::UnsupportedPlatform,
+        }
+    };
+    let ffi_native_heap = if cfg!(target_os = "macos") {
+        MeasurementV1::measured(crate::ffi_heap_bytes())
+    } else {
+        MeasurementV1::Unavailable {
+            reason: UnavailableReasonV1::UnsupportedPlatform,
+        }
+    };
+
+    ResourceSampleV1 {
+        schema_version: RESOURCE_SAMPLE_SCHEMA_VERSION,
+        observed_at_ms: chrono::Utc::now().timestamp_millis(),
+        host: HostResourceSampleV1 {
+            cpu_percent: measured_or_unavailable(crate::platform::cpu_percent()),
+        },
+        main_process: ProcessResourceSampleV1 {
+            cpu_percent: measured_or_unavailable(process_cpu),
+            rss_bytes: measured_or_unavailable(get_process_rss_bytes()),
+            rust_heap_bytes: rust_heap,
+            ffi_native_heap_bytes: ffi_native_heap,
+        },
+        // Phase A reserves the typed sidecar scope but does not inspect the
+        // #332-owned transform runtime or llm_sidecar internals.
+        sidecar_process: SidecarResourceSampleV1::dependency_pending(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -100,25 +176,42 @@ fn check_idle_timeout() {
 // ---------------------------------------------------------------------------
 
 pub fn start_heartbeat(app_handle: tauri::AppHandle) {
+    use tauri::Manager;
+
     set_idle_timeout(app_handle.clone());
 
     tauri::async_runtime::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        let mut ticks = 0_u64;
         loop {
             interval.tick().await;
+            ticks = ticks.saturating_add(1);
 
-            let rss = get_process_rss_mb();
-            let rust = crate::rust_heap_mb();
-            let ffi = crate::ffi_heap_mb();
-            tracing::info!(
-                target: "system",
-                rss_mb = rss,
-                rust_heap_mb = rust,
-                ffi_heap_mb = ffi,
-                "heartbeat"
-            );
+            let sample = sample_resources();
+            let state = app_handle.state::<crate::State>();
+            if let Err(error) = state.performance.insert_resource_sample(&sample) {
+                tracing::warn!(
+                    target: "system",
+                    diagnostics_available = false,
+                    "performance resource sample not persisted: {}",
+                    error
+                );
+            }
 
-            check_idle_timeout();
+            if ticks % 60 == 0 {
+                let rss = get_process_rss_mb();
+                let rust = crate::rust_heap_mb();
+                let ffi = crate::ffi_heap_mb();
+                tracing::info!(
+                    target: "system",
+                    rss_mb = rss,
+                    rust_heap_mb = rust,
+                    ffi_heap_mb = ffi,
+                    "heartbeat"
+                );
+
+                check_idle_timeout();
+            }
         }
     });
 }
@@ -128,15 +221,8 @@ pub fn start_heartbeat(app_handle: tauri::AppHandle) {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_resource_usage() -> ResourceUsage {
-    let rss_mb = get_process_rss_mb();
-    ResourceUsage {
-        cpu_percent: crate::platform::cpu_percent(),
-        memory_mb: rss_mb,
-        rss_mb,
-        rust_heap_mb: crate::rust_heap_mb(),
-        ffi_heap_mb: crate::ffi_heap_mb(),
-    }
+pub fn get_resource_usage() -> crate::performance_metrics::ResourceSampleV1 {
+    sample_resources()
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -302,6 +302,10 @@ pub struct AppState {
     /// Monotonically increasing opaque ID assigned to every post-recognition
     /// transformation pass (live recordings and imported files).
     pub transcript_session_id: AtomicU64,
+    /// Monotonically increasing ID assigned to each imported-file run. This is
+    /// separate from `recording_id` so diagnostics and structured events can
+    /// correlate file work without pretending it is a microphone recording.
+    pub file_run_id: AtomicU64,
     /// Monotonic revision for settings and vocabulary inputs captured by each
     /// immutable dictation context snapshot.
     pub settings_revision: AtomicU64,
@@ -365,6 +369,10 @@ impl AppState {
 
     pub fn next_transcript_session_id(&self) -> u64 {
         self.transcript_session_id.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    pub fn next_file_run_id(&self) -> u64 {
+        self.file_run_id.fetch_add(1, Ordering::SeqCst) + 1
     }
 
     pub fn bump_settings_revision(&self) -> u64 {
@@ -480,6 +488,7 @@ impl Default for AppState {
             idle_timeout_minutes: Mutex::new(5),
             recording_id: AtomicU64::new(0),
             transcript_session_id: AtomicU64::new(0),
+            file_run_id: AtomicU64::new(0),
             settings_revision: AtomicU64::new(0),
             active_context: Mutex::new(None),
             cancelled_id: AtomicU64::new(0),

--- a/app/src/components/ResourceMonitor.tsx
+++ b/app/src/components/ResourceMonitor.tsx
@@ -16,15 +16,17 @@ function loadCollapsed(): boolean {
 
 function toPolylinePoints(
   readings: ResourceReading[],
-  getValue: (r: ResourceReading) => number,
+  getValue: (r: ResourceReading) => number | null,
   maxVal: number,
 ): string {
   if (readings.length === 0) return '';
   return readings
-    .map((r, i) => {
+    .flatMap((r, i) => {
+      const value = getValue(r);
+      if (value === null) return [];
       const x = (i / (MAX_READINGS - 1)) * CHART_W;
-      const y = (1 - getValue(r) / maxVal) * CHART_H;
-      return `${x.toFixed(2)},${y.toFixed(2)}`;
+      const y = (1 - value / maxVal) * CHART_H;
+      return [`${x.toFixed(2)},${y.toFixed(2)}`];
     })
     .join(' ');
 }
@@ -36,13 +38,20 @@ export function ResourceMonitor() {
   const readings = useResourceMonitor(!isCollapsed);
 
   const latest = readings[readings.length - 1];
-  const cpuNow = latest ? latest.cpu_percent.toFixed(1) : '—';
-  const memNow = latest ? latest.memory_mb.toLocaleString() : '—';
+  const cpuNow = latest?.host_cpu_percent == null
+    ? '—'
+    : latest.host_cpu_percent.toFixed(1);
+  const memNow = latest?.rss_mb == null
+    ? '—'
+    : latest.rss_mb.toLocaleString();
 
-  const maxMem = Math.max(...readings.map(r => r.memory_mb), 1024);
+  const maxMem = Math.max(
+    ...readings.flatMap(r => r.rss_mb === null ? [] : [r.rss_mb]),
+    1024,
+  );
 
-  const cpuPoints = toPolylinePoints(readings, r => r.cpu_percent, 100);
-  const memPoints = toPolylinePoints(readings, r => r.memory_mb, maxMem);
+  const cpuPoints = toPolylinePoints(readings, r => r.host_cpu_percent, 100);
+  const memPoints = toPolylinePoints(readings, r => r.rss_mb, maxMem);
 
   const toggle = () => {
     const next = !isCollapsed;
@@ -64,12 +73,12 @@ export function ResourceMonitor() {
           Resources
         </span>
         <div className="flex items-center gap-3">
-          <span className="text-xs text-stone-500 dark:text-stone-400">
-            <span className="text-stone-600 dark:text-stone-300 font-medium">CPU</span>
-            {' '}{cpuNow}%
+            <span className="text-xs text-stone-500 dark:text-stone-400">
+              <span className="text-stone-600 dark:text-stone-300 font-medium">Host CPU</span>
+            {' '}{cpuNow}{cpuNow === '—' ? '' : '%'}
           </span>
           <span className="text-xs text-stone-500 dark:text-stone-400">
-            <span className="text-amber-600 dark:text-amber-400 font-medium">MEM</span>
+            <span className="text-amber-600 dark:text-amber-400 font-medium">Murmur RSS</span>
             {' '}{memNow} MB
           </span>
           <svg
@@ -130,11 +139,11 @@ export function ResourceMonitor() {
           <div className="flex gap-3 mt-1">
             <span className="flex items-center gap-1 text-xs text-stone-500 dark:text-stone-400">
               <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: 'var(--cpu-stroke)' }} />
-              CPU %
+              Host CPU %
             </span>
             <span className="flex items-center gap-1 text-xs text-stone-500 dark:text-stone-400">
               <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: 'var(--mem-stroke)' }} />
-              Memory MB
+              Murmur RSS MB
             </span>
           </div>
         </div>

--- a/app/src/components/log-viewer/MetricsView.tsx
+++ b/app/src/components/log-viewer/MetricsView.tsx
@@ -312,7 +312,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 // --- Main Component ---
 
-function SimpleStatCard({ label, value, color, unit = 'MB' }: { label: string; value: number; color: string; unit?: string }) {
+function SimpleStatCard({ label, value, color, unit = 'MB' }: { label: string; value: number | string; color: string; unit?: string }) {
   return (
     <div className="min-w-0 flex-1 rounded-xl bg-surface-container-lowest p-3 shadow-sm">
       <div className="flex items-center gap-2 mb-1">
@@ -438,41 +438,62 @@ export function MetricsView({ events, resourceReadings }: MetricsViewProps) {
         </>
       )}
 
-      {/* System metrics — fed by 1s resource monitor polling */}
+      {/* Scoped resources — hydrated from persistence, then fed by the live 1s stream */}
       {resourceReadings.length > 0 && (() => {
         const latestReading = resourceReadings[resourceReadings.length - 1];
-        const rssValues = resourceReadings.map(r => r.rss_mb);
-        const heapValues = resourceReadings.map(r => r.rust_heap_mb);
-        const ffiValues = resourceReadings.map(r => r.ffi_heap_mb);
-        const cpuValues = resourceReadings.map(r => Math.round(r.cpu_percent));
+        const rssValues = resourceReadings.flatMap(r => r.rss_mb === null ? [] : [r.rss_mb]);
+        const heapValues = resourceReadings.flatMap(r => r.rust_heap_mb === null ? [] : [r.rust_heap_mb]);
+        const ffiValues = resourceReadings.flatMap(r => r.ffi_heap_mb === null ? [] : [r.ffi_heap_mb]);
+        const hostCpuValues = resourceReadings.flatMap(
+          r => r.host_cpu_percent === null ? [] : [Math.round(r.host_cpu_percent)],
+        );
+        const processCpuValues = resourceReadings.flatMap(
+          r => r.process_cpu_percent === null ? [] : [Math.round(r.process_cpu_percent)],
+        );
         return (
           <>
-            <SectionLabel>System</SectionLabel>
+            <SectionLabel>Scoped resources</SectionLabel>
             <div className="flex gap-3">
-              <SimpleStatCard label="RSS" value={latestReading.rss_mb} color={MEMORY_COLOR} />
-              <SimpleStatCard label="Rust Heap" value={latestReading.rust_heap_mb} color={HEAP_COLOR} />
-              <SimpleStatCard label="FFI Heap" value={latestReading.ffi_heap_mb} color={EXTERNAL_COLOR} />
-              <SimpleStatCard label="CPU" value={Math.round(latestReading.cpu_percent)} color={CPU_COLOR} unit="%" />
+              <SimpleStatCard label="Murmur RSS" value={latestReading.rss_mb ?? '—'} color={MEMORY_COLOR} />
+              <SimpleStatCard label="Rust Heap" value={latestReading.rust_heap_mb ?? '—'} color={HEAP_COLOR} />
+              <SimpleStatCard label="FFI / Native Heap" value={latestReading.ffi_heap_mb ?? '—'} color={EXTERNAL_COLOR} />
+              <SimpleStatCard
+                label="Murmur CPU"
+                value={latestReading.process_cpu_percent === null ? '—' : Math.round(latestReading.process_cpu_percent)}
+                color={CPU_COLOR}
+                unit="% core"
+              />
+              <SimpleStatCard
+                label="Host CPU"
+                value={latestReading.host_cpu_percent === null ? '—' : Math.round(latestReading.host_cpu_percent)}
+                color={CPU_COLOR}
+                unit="%"
+              />
             </div>
             <LiveChart
-              label={"RSS — Physical RAM Used"}
+              label={"Murmur RSS — main-process physical memory"}
               height={160}
               series={[{ key: 'rss', color: MEMORY_COLOR, values: rssValues }]}
             />
             <LiveChart
-              label={"Rust Heap — malloc zone tracked"}
+              label={"Rust Heap — Murmur malloc zone"}
               height={160}
               series={[{ key: 'heap', color: HEAP_COLOR, values: heapValues }]}
             />
             <LiveChart
-              label={"FFI Heap — whisper.cpp / C libs"}
+              label={"FFI / Native Heap — non-Rust malloc zones"}
               height={160}
               series={[{ key: 'ffi', color: EXTERNAL_COLOR, values: ffiValues }]}
             />
             <LiveChart
-              label={"CPU — System Usage"}
+              label={"Murmur CPU — 100% equals one logical core"}
               height={160}
-              series={[{ key: 'cpu', color: CPU_COLOR, values: cpuValues }]}
+              series={[{ key: 'process-cpu', color: CPU_COLOR, values: processCpuValues }]}
+            />
+            <LiveChart
+              label={"Host CPU — system-wide usage"}
+              height={160}
+              series={[{ key: 'host-cpu', color: CPU_COLOR, values: hostCpuValues }]}
             />
           </>
         );

--- a/app/src/lib/hooks/useResourceMonitor.ts
+++ b/app/src/lib/hooks/useResourceMonitor.ts
@@ -1,15 +1,36 @@
 import { useState, useEffect } from 'react';
-import { invoke } from '@tauri-apps/api/core';
+import {
+  getPerformanceResourceWindow,
+  measuredValue,
+  onPerformanceResourceSample,
+  type ResourceSampleV1,
+} from '../performance';
 
 export interface ResourceReading {
-  cpu_percent: number;
-  memory_mb: number;
-  rss_mb: number;
-  rust_heap_mb: number;
-  ffi_heap_mb: number;
+  observed_at_ms: number;
+  host_cpu_percent: number | null;
+  process_cpu_percent: number | null;
+  rss_mb: number | null;
+  rust_heap_mb: number | null;
+  ffi_heap_mb: number | null;
 }
 
 const MAX_READINGS = 60;
+
+function toMb(bytes: number | null): number | null {
+  return bytes === null ? null : Math.round(bytes / 1_048_576);
+}
+
+function toReading(sample: ResourceSampleV1): ResourceReading {
+  return {
+    observed_at_ms: sample.observedAtMs,
+    host_cpu_percent: measuredValue(sample.host.cpuPercent),
+    process_cpu_percent: measuredValue(sample.mainProcess.cpuPercent),
+    rss_mb: toMb(measuredValue(sample.mainProcess.rssBytes)),
+    rust_heap_mb: toMb(measuredValue(sample.mainProcess.rustHeapBytes)),
+    ffi_heap_mb: toMb(measuredValue(sample.mainProcess.ffiNativeHeapBytes)),
+  };
+}
 
 export function useResourceMonitor(enabled: boolean): ResourceReading[] {
   const [readings, setReadings] = useState<ResourceReading[]>([]);
@@ -17,24 +38,34 @@ export function useResourceMonitor(enabled: boolean): ResourceReading[] {
   useEffect(() => {
     if (!enabled) return;
 
-    // Clear stale readings when re-enabled so the chart starts fresh.
-    setReadings([]);
-
-    const fetchUsage = async () => {
+    let cancelled = false;
+    const append = (sample: ResourceSampleV1) => {
+      if (cancelled) return;
+      const reading = toReading(sample);
+      setReadings(prev => {
+        const withoutDuplicate = prev.filter(
+          existing => existing.observed_at_ms !== reading.observed_at_ms,
+        );
+        const next = [...withoutDuplicate, reading]
+          .sort((left, right) => left.observed_at_ms - right.observed_at_ms);
+        return next.length > MAX_READINGS ? next.slice(-MAX_READINGS) : next;
+      });
+    };
+    const hydrate = async () => {
       try {
-        const usage = await invoke<ResourceReading>('get_resource_usage');
-        setReadings(prev => {
-          const next = [...prev, usage];
-          return next.length > MAX_READINGS ? next.slice(-MAX_READINGS) : next;
-        });
+        const window = await getPerformanceResourceWindow();
+        if (!cancelled) setReadings(window.slice(-MAX_READINGS).map(toReading));
       } catch (e) {
         if (import.meta.env.DEV) console.debug('[useResourceMonitor]', e);
       }
     };
 
-    fetchUsage();
-    const id = setInterval(fetchUsage, 1000);
-    return () => clearInterval(id);
+    void hydrate();
+    const unlisten = onPerformanceResourceSample(append);
+    return () => {
+      cancelled = true;
+      void unlisten.then(stop => stop());
+    };
   }, [enabled]);
 
   return readings;

--- a/app/src/lib/performance.test.ts
+++ b/app/src/lib/performance.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMeasurementV1,
+  isPerformanceRunV1,
+  isResourceSampleV1,
+  measuredValue,
+  PERFORMANCE_STAGES_V1,
+  type MeasurementV1,
+} from './performance';
+
+describe('performance contracts', () => {
+  it('keeps measured zero distinct from unavailable and not-applicable', () => {
+    const measured: MeasurementV1<number> = { status: 'measured', value: 0 };
+    expect(isMeasurementV1(measured, (value): value is number => typeof value === 'number')).toBe(true);
+    expect(measuredValue(measured)).toBe(0);
+    expect(measuredValue({ status: 'notApplicable' })).toBeNull();
+    expect(measuredValue({ status: 'unavailable', reason: 'noSamples' })).toBeNull();
+  });
+
+  it('rejects unknown resource schema versions and zero sentinels', () => {
+    const sample = {
+      schemaVersion: 1,
+      observedAtMs: 1,
+      host: { cpuPercent: { status: 'unavailable', reason: 'sampleFailed' } },
+      mainProcess: {
+        cpuPercent: { status: 'measured', value: 0 },
+        rssBytes: { status: 'measured', value: 0 },
+        rustHeapBytes: { status: 'notApplicable' },
+        ffiNativeHeapBytes: { status: 'unavailable', reason: 'unsupportedPlatform' },
+      },
+      sidecarProcess: {
+        cpuPercent: { status: 'unavailable', reason: 'dependencyPending' },
+        rssBytes: { status: 'unavailable', reason: 'dependencyPending' },
+      },
+    };
+    expect(isResourceSampleV1(sample)).toBe(true);
+    expect(isResourceSampleV1({ ...sample, schemaVersion: 2 })).toBe(false);
+    expect(isResourceSampleV1({
+      ...sample,
+      host: { cpuPercent: 0 },
+    })).toBe(false);
+  });
+
+  it('requires correlation to match the run kind', () => {
+    const unavailable = { status: 'unavailable', reason: 'noSamples' };
+    const notApplicable = { status: 'notApplicable' };
+    const range = {
+      start: unavailable,
+      average: unavailable,
+      peak: unavailable,
+      end: unavailable,
+    };
+    const base = {
+      schemaVersion: 1,
+      runId: '0123456789abcdef0123456789abcdef',
+      kind: 'dictation',
+      startedAtMs: 1,
+      finishedAtMs: 2,
+      appVersion: '1.0.0',
+      correlation: { kind: 'dictation', recordingId: 4 },
+      outcome: { status: 'success' },
+      runtimes: [],
+      stages: PERFORMANCE_STAGES_V1.map(stage => ({
+        stage,
+        durationMs: notApplicable,
+        outcome: 'skipped',
+      })),
+      input: {
+        audioDurationMs: { status: 'measured', value: 100 },
+        inputSizeBucket: notApplicable,
+        outputSizeBucket: { status: 'measured', value: 'small' },
+        outputTokenCount: notApplicable,
+      },
+      resources: {
+        sampleCount: 0,
+        host: { cpuPercent: range },
+        mainProcess: {
+          cpuPercent: range,
+          rssBytes: range,
+          rustHeapBytes: range,
+          ffiNativeHeapBytes: range,
+        },
+        sidecarProcess: {
+          cpuPercent: {
+            start: notApplicable,
+            average: notApplicable,
+            peak: notApplicable,
+            end: notApplicable,
+          },
+          rssBytes: {
+            start: notApplicable,
+            average: notApplicable,
+            peak: notApplicable,
+            end: notApplicable,
+          },
+        },
+      },
+      followUps: [],
+    };
+    expect(isPerformanceRunV1(base)).toBe(true);
+    expect(isPerformanceRunV1({
+      ...base,
+      correlation: { kind: 'fileTranscription', fileRunId: 4 },
+    })).toBe(false);
+  });
+});

--- a/app/src/lib/performance.ts
+++ b/app/src/lib/performance.ts
@@ -1,0 +1,407 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export type UnavailableReasonV1 =
+  | 'unsupportedPlatform'
+  | 'sampleFailed'
+  | 'noSamples'
+  | 'dependencyPending';
+
+export type MeasurementV1<T> =
+  | { status: 'measured'; value: T }
+  | { status: 'notApplicable' }
+  | { status: 'unavailable'; reason: UnavailableReasonV1 };
+
+export type PerformanceRunKindV1 =
+  | 'dictation'
+  | 'fileTranscription'
+  | 'selectedTextTransform';
+
+export type RunCorrelationV1 =
+  | { kind: 'dictation'; recordingId: number }
+  | { kind: 'fileTranscription'; fileRunId: number }
+  | { kind: 'selectedTextTransform'; transformPassId: number };
+
+export type PerformanceStageV1 =
+  | 'captureFinalization'
+  | 'fileDecode'
+  | 'vad'
+  | 'modelQueue'
+  | 'modelLoad'
+  | 'inferenceDecode'
+  | 'transcriptTransform'
+  | 'cleanup'
+  | 'voiceCommands'
+  | 'smartCorrection'
+  | 'smartFormatting'
+  | 'ideContext'
+  | 'cliCommand'
+  | 'fileOutput'
+  | 'clipboardPaste'
+  | 'fileReturn'
+  | 'totalProcessing'
+  | 'selectedTextCapture'
+  | 'instructionCapture'
+  | 'instructionAsr'
+  | 'sidecarSpawnLoad'
+  | 'generation'
+  | 'reviewReady'
+  | 'apply'
+  | 'undo';
+
+export type StageOutcomeV1 = 'completed' | 'skipped' | 'fallback' | 'failed';
+
+export interface StageTimingV1 {
+  stage: PerformanceStageV1;
+  durationMs: MeasurementV1<number>;
+  outcome: StageOutcomeV1;
+}
+
+export interface RuntimeIdentityV1 {
+  role: 'transcription' | 'instructionAsr' | 'generation';
+  modelId: string;
+  backend: 'whisper' | 'parakeet' | 'coreml' | 'llamaCpp';
+  accelerator: 'cpu' | 'metalGpu' | 'appleNeuralEngine' | 'platformFallback';
+  warmState: 'warm' | 'coldLoaded' | 'unknown';
+}
+
+export type SizeBucketV1 =
+  | 'empty'
+  | 'tiny'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'extraLarge';
+
+export interface ContentFreeInputSummaryV1 {
+  audioDurationMs: MeasurementV1<number>;
+  inputSizeBucket: MeasurementV1<SizeBucketV1>;
+  outputSizeBucket: MeasurementV1<SizeBucketV1>;
+  outputTokenCount: MeasurementV1<number>;
+}
+
+export interface ResourceRangeV1<T> {
+  start: MeasurementV1<T>;
+  average: MeasurementV1<T>;
+  peak: MeasurementV1<T>;
+  end: MeasurementV1<T>;
+}
+
+export interface ResourceSampleV1 {
+  schemaVersion: 1;
+  observedAtMs: number;
+  host: {
+    cpuPercent: MeasurementV1<number>;
+  };
+  mainProcess: {
+    cpuPercent: MeasurementV1<number>;
+    rssBytes: MeasurementV1<number>;
+    rustHeapBytes: MeasurementV1<number>;
+    ffiNativeHeapBytes: MeasurementV1<number>;
+  };
+  sidecarProcess: {
+    cpuPercent: MeasurementV1<number>;
+    rssBytes: MeasurementV1<number>;
+  };
+}
+
+export interface ResourceSummaryV1 {
+  sampleCount: number;
+  host: { cpuPercent: ResourceRangeV1<number> };
+  mainProcess: {
+    cpuPercent: ResourceRangeV1<number>;
+    rssBytes: ResourceRangeV1<number>;
+    rustHeapBytes: ResourceRangeV1<number>;
+    ffiNativeHeapBytes: ResourceRangeV1<number>;
+  };
+  sidecarProcess: {
+    cpuPercent: ResourceRangeV1<number>;
+    rssBytes: ResourceRangeV1<number>;
+  };
+}
+
+export type RunOutcomeV1 =
+  | { status: 'success' }
+  | { status: 'noSpeech' }
+  | { status: 'cancelled'; stage: PerformanceStageV1 }
+  | { status: 'timedOut'; stage: PerformanceStageV1 }
+  | {
+      status: 'failed' | 'interrupted';
+      stage: PerformanceStageV1;
+      errorCode:
+        | 'audioCaptureFailed'
+        | 'decodeFailed'
+        | 'vadFailed'
+        | 'modelFailed'
+        | 'inferenceFailed'
+        | 'transformStageFailed'
+        | 'deliveryFailed'
+        | 'internalEarlyExit'
+        | 'interruptedByRestart';
+    };
+
+export interface PerformanceRunV1 {
+  schemaVersion: 1;
+  runId: string;
+  kind: PerformanceRunKindV1;
+  startedAtMs: number;
+  finishedAtMs: number;
+  appVersion: string;
+  correlation: RunCorrelationV1;
+  outcome: RunOutcomeV1;
+  runtimes: RuntimeIdentityV1[];
+  stages: StageTimingV1[];
+  input: ContentFreeInputSummaryV1;
+  resources: ResourceSummaryV1;
+  followUps: Array<{
+    kind: 'apply' | 'undo';
+    atMs: number;
+    durationMs: MeasurementV1<number>;
+    outcome: StageOutcomeV1;
+  }>;
+}
+
+export interface PerformanceRunListV1 {
+  schemaVersion: 1;
+  runs: PerformanceRunV1[];
+}
+
+const unavailableReasons = new Set<UnavailableReasonV1>([
+  'unsupportedPlatform',
+  'sampleFailed',
+  'noSamples',
+  'dependencyPending',
+]);
+export const PERFORMANCE_STAGES_V1: readonly PerformanceStageV1[] = [
+  'captureFinalization', 'fileDecode', 'vad', 'modelQueue', 'modelLoad',
+  'inferenceDecode', 'transcriptTransform', 'cleanup', 'voiceCommands',
+  'smartCorrection', 'smartFormatting', 'ideContext', 'cliCommand',
+  'fileOutput', 'clipboardPaste', 'fileReturn', 'totalProcessing',
+  'selectedTextCapture', 'instructionCapture', 'instructionAsr',
+  'sidecarSpawnLoad', 'generation', 'reviewReady', 'apply', 'undo',
+] as const;
+const performanceStages = new Set<PerformanceStageV1>(PERFORMANCE_STAGES_V1);
+const sizeBuckets = new Set<SizeBucketV1>([
+  'empty', 'tiny', 'small', 'medium', 'large', 'extraLarge',
+]);
+const stageOutcomes = new Set<StageOutcomeV1>([
+  'completed', 'skipped', 'fallback', 'failed',
+]);
+const stableErrors = new Set([
+  'audioCaptureFailed', 'decodeFailed', 'vadFailed', 'modelFailed',
+  'inferenceFailed', 'transformStageFailed', 'deliveryFailed',
+  'internalEarlyExit', 'interruptedByRestart',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function isMeasurementV1<T>(
+  value: unknown,
+  isValue: (candidate: unknown) => candidate is T,
+): value is MeasurementV1<T> {
+  if (!isRecord(value) || typeof value.status !== 'string') return false;
+  if (value.status === 'measured') return isValue(value.value);
+  if (value.status === 'notApplicable') return !('value' in value);
+  return value.status === 'unavailable'
+    && typeof value.reason === 'string'
+    && unavailableReasons.has(value.reason as UnavailableReasonV1);
+}
+
+export function measuredValue<T>(measurement: MeasurementV1<T>): T | null {
+  return measurement.status === 'measured' ? measurement.value : null;
+}
+
+export function isResourceSampleV1(value: unknown): value is ResourceSampleV1 {
+  if (!isRecord(value)
+    || value.schemaVersion !== 1
+    || !isFiniteNumber(value.observedAtMs)
+    || !isRecord(value.host)
+    || !isRecord(value.mainProcess)
+    || !isRecord(value.sidecarProcess)) {
+    return false;
+  }
+  const numberMeasurement = (candidate: unknown): candidate is MeasurementV1<number> =>
+    isMeasurementV1(candidate, isFiniteNumber);
+  return numberMeasurement(value.host.cpuPercent)
+    && numberMeasurement(value.mainProcess.cpuPercent)
+    && numberMeasurement(value.mainProcess.rssBytes)
+    && numberMeasurement(value.mainProcess.rustHeapBytes)
+    && numberMeasurement(value.mainProcess.ffiNativeHeapBytes)
+    && numberMeasurement(value.sidecarProcess.cpuPercent)
+    && numberMeasurement(value.sidecarProcess.rssBytes);
+}
+
+function isStage(value: unknown): value is PerformanceStageV1 {
+  return typeof value === 'string'
+    && performanceStages.has(value as PerformanceStageV1);
+}
+
+function isStageTiming(value: unknown): value is StageTimingV1 {
+  return isRecord(value)
+    && isStage(value.stage)
+    && isMeasurementV1(value.durationMs, isFiniteNumber)
+    && typeof value.outcome === 'string'
+    && stageOutcomes.has(value.outcome as StageOutcomeV1);
+}
+
+function isRuntime(value: unknown): value is RuntimeIdentityV1 {
+  return isRecord(value)
+    && ['transcription', 'instructionAsr', 'generation'].includes(String(value.role))
+    && typeof value.modelId === 'string'
+    && ['whisper', 'parakeet', 'coreml', 'llamaCpp'].includes(String(value.backend))
+    && ['cpu', 'metalGpu', 'appleNeuralEngine', 'platformFallback'].includes(String(value.accelerator))
+    && ['warm', 'coldLoaded', 'unknown'].includes(String(value.warmState));
+}
+
+function isInputSummary(value: unknown): value is ContentFreeInputSummaryV1 {
+  return isRecord(value)
+    && isMeasurementV1(value.audioDurationMs, isFiniteNumber)
+    && isMeasurementV1(
+      value.inputSizeBucket,
+      (candidate): candidate is SizeBucketV1 =>
+        typeof candidate === 'string' && sizeBuckets.has(candidate as SizeBucketV1),
+    )
+    && isMeasurementV1(
+      value.outputSizeBucket,
+      (candidate): candidate is SizeBucketV1 =>
+        typeof candidate === 'string' && sizeBuckets.has(candidate as SizeBucketV1),
+    )
+    && isMeasurementV1(value.outputTokenCount, isFiniteNumber);
+}
+
+function isResourceRange(value: unknown): value is ResourceRangeV1<number> {
+  return isRecord(value)
+    && isMeasurementV1(value.start, isFiniteNumber)
+    && isMeasurementV1(value.average, isFiniteNumber)
+    && isMeasurementV1(value.peak, isFiniteNumber)
+    && isMeasurementV1(value.end, isFiniteNumber);
+}
+
+function isResourceSummary(value: unknown): value is ResourceSummaryV1 {
+  return isRecord(value)
+    && isFiniteNumber(value.sampleCount)
+    && isRecord(value.host)
+    && isResourceRange(value.host.cpuPercent)
+    && isRecord(value.mainProcess)
+    && isResourceRange(value.mainProcess.cpuPercent)
+    && isResourceRange(value.mainProcess.rssBytes)
+    && isResourceRange(value.mainProcess.rustHeapBytes)
+    && isResourceRange(value.mainProcess.ffiNativeHeapBytes)
+    && isRecord(value.sidecarProcess)
+    && isResourceRange(value.sidecarProcess.cpuPercent)
+    && isResourceRange(value.sidecarProcess.rssBytes);
+}
+
+function isRunOutcome(value: unknown): value is RunOutcomeV1 {
+  if (!isRecord(value) || typeof value.status !== 'string') return false;
+  if (value.status === 'success' || value.status === 'noSpeech') return true;
+  if (value.status === 'cancelled' || value.status === 'timedOut') {
+    return isStage(value.stage);
+  }
+  return (value.status === 'failed' || value.status === 'interrupted')
+    && isStage(value.stage)
+    && typeof value.errorCode === 'string'
+    && stableErrors.has(value.errorCode);
+}
+
+function isFollowUp(value: unknown): boolean {
+  return isRecord(value)
+    && (value.kind === 'apply' || value.kind === 'undo')
+    && isFiniteNumber(value.atMs)
+    && isMeasurementV1(value.durationMs, isFiniteNumber)
+    && typeof value.outcome === 'string'
+    && stageOutcomes.has(value.outcome as StageOutcomeV1);
+}
+
+export function isPerformanceRunV1(value: unknown): value is PerformanceRunV1 {
+  if (!isRecord(value)
+    || value.schemaVersion !== 1
+    || typeof value.runId !== 'string'
+    || !/^[a-f0-9]{32}$/.test(value.runId)
+    || !['dictation', 'fileTranscription', 'selectedTextTransform'].includes(String(value.kind))
+    || !isFiniteNumber(value.startedAtMs)
+    || !isFiniteNumber(value.finishedAtMs)
+    || typeof value.appVersion !== 'string'
+    || !isRecord(value.correlation)
+    || !isRunOutcome(value.outcome)
+    || !Array.isArray(value.runtimes)
+    || !Array.isArray(value.stages)
+    || !isInputSummary(value.input)
+    || !isResourceSummary(value.resources)
+    || !Array.isArray(value.followUps)
+    || !value.runtimes.every(isRuntime)
+    || !value.stages.every(isStageTiming)
+    || !value.followUps.every(isFollowUp)) {
+    return false;
+  }
+  const stages = new Set(value.stages.map(stage => isRecord(stage) ? stage.stage : undefined));
+  if (stages.size !== PERFORMANCE_STAGES_V1.length
+    || !PERFORMANCE_STAGES_V1.every(stage => stages.has(stage))) {
+    return false;
+  }
+  const correlationMatches =
+    (value.kind === 'dictation'
+      && value.correlation.kind === 'dictation'
+      && isFiniteNumber(value.correlation.recordingId))
+    || (value.kind === 'fileTranscription'
+      && value.correlation.kind === 'fileTranscription'
+      && isFiniteNumber(value.correlation.fileRunId))
+    || (value.kind === 'selectedTextTransform'
+      && value.correlation.kind === 'selectedTextTransform'
+      && isFiniteNumber(value.correlation.transformPassId));
+  return correlationMatches;
+}
+
+export async function listPerformanceRuns(limit = 50): Promise<PerformanceRunListV1> {
+  const value = await invoke<unknown>('list_performance_runs', { limit });
+  if (!isRecord(value)
+    || value.schemaVersion !== 1
+    || !Array.isArray(value.runs)
+    || !value.runs.every(isPerformanceRunV1)) {
+    throw new Error('Murmur returned an unsupported performance-run schema.');
+  }
+  return value as unknown as PerformanceRunListV1;
+}
+
+export async function getPerformanceRun(runId: string): Promise<PerformanceRunV1 | null> {
+  const value = await invoke<unknown>('get_performance_run', { runId });
+  if (value === null) return null;
+  if (!isPerformanceRunV1(value)) {
+    throw new Error('Murmur returned an unsupported performance-run schema.');
+  }
+  return value;
+}
+
+export async function getPerformanceResourceWindow(): Promise<ResourceSampleV1[]> {
+  const value = await invoke<unknown>('get_performance_resource_window');
+  if (!Array.isArray(value) || !value.every(isResourceSampleV1)) {
+    throw new Error('Murmur returned an unsupported resource-sample schema.');
+  }
+  return value;
+}
+
+export async function clearPerformanceDiagnostics(): Promise<void> {
+  await invoke('clear_performance_diagnostics');
+}
+
+export function onPerformanceRunCompleted(
+  callback: (run: PerformanceRunV1) => void,
+): Promise<UnlistenFn> {
+  return listen<unknown>('performance-run-completed', (event) => {
+    if (isPerformanceRunV1(event.payload)) callback(event.payload);
+  });
+}
+
+export function onPerformanceResourceSample(
+  callback: (sample: ResourceSampleV1) => void,
+): Promise<UnlistenFn> {
+  return listen<unknown>('performance-resource-sample', (event) => {
+    if (isResourceSampleV1(event.payload)) callback(event.payload);
+  });
+}

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -100,7 +100,11 @@ Rows with structured data are expandable — click to reveal a `<pre>` block wit
 
 ### Metrics Tab
 
-Visualizes transcription performance data extracted from pipeline events where `summary === 'transcription complete'`.
+Visualizes transcription performance data extracted from pipeline events where
+`summary === 'transcription complete'`. Its resource compatibility charts now
+hydrate from the typed persistent resource window and subscribe to typed live
+samples. The durable Runs table and waterfall are intentionally deferred to
+#352; see [Performance diagnostics data](performance-diagnostics.md).
 
 **Four timing series:**
 
@@ -120,6 +124,15 @@ Visualizes transcription performance data extracted from pipeline events where `
 Y-axis auto-scales with "nice" round numbers and three tick marks. X-axis shows transcription index (1-based). Each data point has a dot marker.
 
 The metrics view shows the last 20 transcriptions. The series legend is toggleable — click a series label to show/hide it (at least one must remain visible).
+
+Resource labels are scope-explicit:
+
+- Host CPU is whole-system utilization.
+- Murmur CPU is main-process utilization where 100% equals one logical core.
+- Murmur RSS is main-process physical resident memory.
+- Rust heap and FFI/native heap are separate malloc-zone measurements and are
+  not presented as additive RSS components.
+- Unavailable readings render as unavailable, never as zero.
 
 ### Event Store (`useEventStore`)
 

--- a/docs/features/performance-diagnostics.md
+++ b/docs/features/performance-diagnostics.md
@@ -1,0 +1,124 @@
+# Performance diagnostics data
+
+Issue [#351](https://github.com/georgenijo/murmur-app/issues/351) defines the
+versioned, local data layer used by the Diagnostics performance workspace.
+Phase A covers dictation and imported-file runs. Selected-text transform and
+sidecar correlation remain reserved until #332 supplies the canonical
+`transform_pass_id` and one typed trace source.
+
+## Storage and retention
+
+The Rust-owned SQLite database lives at:
+
+```text
+~/Library/Application Support/com.localdictation/diagnostics/performance.sqlite3
+```
+
+It is separate from logs, transcription history, settings, personal knowledge,
+and Performance Lab/evaluation reports. The store keeps:
+
+- the newest 200 completed runs;
+- active content-free lifecycle rows so early exits and restart interruption can
+  close a run exactly once;
+- the newest 600 one-second resource samples (a ten-minute window).
+
+Completion and pruning share one transaction. On startup, a stale active row is
+closed as `interrupted` with the stable `interruptedByRestart` code. Clearing
+performance diagnostics removes only these runs and resource samples. It also
+advances a clear epoch so an operation that began before Clear cannot reinsert
+its old diagnostics when it eventually finishes.
+
+The database currently uses SQLite `user_version = 1`; run and resource JSON
+records also carry `schemaVersion: 1`. A database created by a newer Murmur
+build is preserved and treated as unavailable rather than rewritten. Unknown
+record versions are not decoded as V1.
+
+## Run contract
+
+`PerformanceRunV1` contains:
+
+- an opaque random `runId`;
+- kind (`dictation`, `fileTranscription`, or reserved
+  `selectedTextTransform`);
+- start/finish UTC timestamps and exactly one terminal outcome;
+- the existing `recordingId`, a dedicated `fileRunId`, or the future canonical
+  `transformPassId`;
+- catalog-backed model, backend, accelerator, and warm/cold state;
+- typed stage measurements;
+- content-free audio duration or bounded size/token fields;
+- scoped resource summaries.
+
+Every measurement is one of:
+
+- `measured { value }` — including a legitimate measured zero;
+- `notApplicable` — the stage or scope does not apply to this run;
+- `unavailable { reason }` — measurement was expected but unsupported, failed,
+  had no samples, or awaits an explicit dependency.
+
+The contract never uses numeric zero as a missing-data sentinel.
+
+### Dictation stages
+
+- capture finalization/resampling;
+- VAD;
+- model queue/lock wait and model load;
+- inference/decode;
+- aggregate deterministic transcript transformation and the existing
+  content-free cleanup, Voice Commands, Smart Correction, Smart Formatting,
+  IDE context, and CLI stage outcomes;
+- optional file output;
+- clipboard/paste;
+- total post-stop processing.
+
+### File stages
+
+- decode/downmix/resample;
+- VAD;
+- model queue/load and inference/decode;
+- the authoritative verbatim transcript-transform entry point;
+- file return;
+- total command processing.
+
+The selected-text capture, instruction-ASR, sidecar-load, generation,
+review-ready, apply, and undo stage names are reserved in V1 but Phase A does
+not emit them.
+
+## Resource scopes
+
+| Field | Scope and unit |
+| --- | --- |
+| Host CPU | Whole-host utilization, normalized to 0–100 percent |
+| Main-process CPU | Murmur process utilization; 100 percent equals one logical core and multithreaded work may exceed 100 |
+| Main-process RSS | Physical resident memory in bytes |
+| Rust heap | Bytes in Murmur's dedicated Rust malloc zone on macOS |
+| FFI/native heap | Bytes in all other malloc zones; not an RSS component and not a complete GPU/unified-memory measurement |
+| Sidecar CPU/RSS | Reserved as unavailable in Phase A; non-transform run summaries mark the scope not applicable |
+
+The first host/process CPU observation needs a prior counter baseline and is
+therefore unavailable rather than reported as zero. Rust/FFI heap breakdown is
+unavailable on unsupported platforms. Accelerator identity is recorded, but
+GPU or ANE utilization is not estimated.
+
+## Privacy
+
+Persistent diagnostics never contain transcript or instruction text,
+selected/proposed/replaced text, clipboard contents, paths or filenames, bundle
+IDs, window titles, project/profile names, raw stderr, or free-form native error
+messages. Errors are stable enums. Text-related sizes are bounded buckets.
+There is no network upload or remote telemetry.
+
+## Commands and events
+
+| API | Purpose |
+| --- | --- |
+| `list_performance_runs` | Read newest supported V1 runs, bounded to 200 |
+| `get_performance_run` | Read one V1 run by opaque ID |
+| `get_performance_resource_window` | Read the persistent ten-minute sample window |
+| `clear_performance_diagnostics` | Clear only the diagnostics database |
+| `performance-run-completed` | Live typed completion event |
+| `performance-resource-sample` | Live typed one-second sample event |
+
+The TypeScript guards reject unsupported schemas before UI code consumes them.
+The current resource cards use these samples and label host CPU, Murmur CPU,
+Murmur RSS, Rust heap, and FFI/native heap explicitly. The Runs table and
+waterfall remain #352, not this data-layer issue.


### PR DESCRIPTION
## Summary

- add the versioned, privacy-safe `PerformanceRunV1` and resource-sample contracts in Rust and TypeScript
- persist active/completed runs and one-second resource samples in bounded SQLite storage, including restart recovery, clear epochs, retention, and typed list/detail/clear/live APIs
- correlate dictation and imported-file lifecycles with existing recording IDs and dedicated file-run IDs, including typed stages, terminal outcomes, model/runtime identity, and content-free input summaries
- report explicit host CPU, Murmur CPU/RSS, Rust heap, and FFI/native heap scopes; keep the existing diagnostics UI layout with truthful labels
- reserve selected-text transform, follow-up, and sidecar fields as unavailable/not-applicable without touching #332-owned transform tracing or `llm_sidecar.rs`

Part of #351.

Transform-pass and sidecar integration remains deferred until #332 provides the canonical `transform_pass_id` and trace seam.

## Validation

- `cargo check`
- `cargo test -- --test-threads=1` — 572 passed, 5 ignored; integration suites passed
- `npx tsc --noEmit`
- `npm test -- --run` — 275 passed
- `git diff --check`
- isolated native dev bundle built and launched as `com.localdictation.dev`; its separate schema-v1 SQLite resource window advanced by two samples in two seconds and contained measured host CPU, Murmur CPU/RSS, Rust heap, and FFI/native heap with sidecar fields `dependencyPending`

The Tauri packaging command produced the `.app`, DMG, and updater archive, then exited non-zero because this environment has the updater public key but no `TAURI_SIGNING_PRIVATE_KEY`. UI automation stopped after the isolated dev window became unavailable; the existing release `Murmur.app` process was not automated or terminated.
