### PR TITLE
feat(diagnostics): complete transform performance correlation

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -556,6 +556,14 @@ struct PipelineResult {
 }
 
 fn runtime_identity(model_name: &str, warm_state: ModelWarmStateV1) -> Vec<RuntimeIdentityV1> {
+    runtime_identity_for_role(model_name, warm_state, RuntimeRoleV1::Transcription)
+}
+
+pub(crate) fn runtime_identity_for_role(
+    model_name: &str,
+    warm_state: ModelWarmStateV1,
+    role: RuntimeRoleV1,
+) -> Vec<RuntimeIdentityV1> {
     let Ok(definition) = model_runtime::model_definition(model_name) else {
         return Vec::new();
     };
@@ -571,7 +579,7 @@ fn runtime_identity(model_name: &str, warm_state: ModelWarmStateV1) -> Vec<Runti
         _ => AcceleratorV1::PlatformFallback,
     };
     vec![RuntimeIdentityV1 {
-        role: RuntimeRoleV1::Transcription,
+        role,
         model_id: model_name.to_string(),
         backend,
         accelerator,

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -13,7 +13,7 @@
 //! enums are recorded.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -96,6 +96,27 @@ pub struct TransformOutput {
     pub output: String,
     pub finish_reason: FinishReason,
     pub output_tokens: u32,
+}
+
+/// Content-free timing metadata returned only by the correlated transform
+/// entry point. `None` means that phase was never entered, not a synthetic
+/// numeric zero.
+pub struct CorrelatedTransformOutcome {
+    pub result: Result<TransformOutput, TransformError>,
+    pub spawn_load_ms: Option<u64>,
+    pub generation_ms: Option<u64>,
+    pub cache_hit: Option<bool>,
+}
+
+impl CorrelatedTransformOutcome {
+    fn before_runtime(error: TransformError) -> Self {
+        Self {
+            result: Err(error),
+            spawn_load_ms: None,
+            generation_ms: None,
+            cache_hit: None,
+        }
+    }
 }
 
 /// Stable supervisor error enum. Mirrors the protocol `ErrorCode` and adds
@@ -579,6 +600,33 @@ mod supported {
         _model_file: std::fs::File,
     }
 
+    struct SpawnPidGuard<'a> {
+        resident_pid: &'a AtomicU32,
+        keep: bool,
+    }
+
+    impl<'a> SpawnPidGuard<'a> {
+        fn new(resident_pid: &'a AtomicU32, pid: u32) -> Self {
+            resident_pid.store(pid, Ordering::Release);
+            Self {
+                resident_pid,
+                keep: false,
+            }
+        }
+
+        fn keep(mut self) {
+            self.keep = true;
+        }
+    }
+
+    impl Drop for SpawnPidGuard<'_> {
+        fn drop(&mut self) {
+            if !self.keep {
+                self.resident_pid.store(0, Ordering::Release);
+            }
+        }
+    }
+
     struct Inner {
         child: Option<Child>,
         breaker: Breaker,
@@ -612,6 +660,11 @@ mod supported {
         plan: SpawnPlan,
         host_guard: OnceLock<Arc<dyn HostGuard>>,
         busy: AtomicBool,
+        /// PID of the resident helper, including while its startup handshake
+        /// is loading the model. Kept atomic because `transform_blocking`
+        /// holds `inner` across the request while the resource sampler must
+        /// remain non-blocking.
+        resident_pid: AtomicU32,
         /// The in-flight request's cancel token, registered for the duration of
         /// one `transform` call and cleared by its `BusyGuard`. Per-request (not
         /// supervisor-wide): [`Self::cancel_inflight_request`] cancels ONLY the
@@ -639,6 +692,7 @@ mod supported {
                 plan,
                 host_guard: OnceLock::new(),
                 busy: AtomicBool::new(false),
+                resident_pid: AtomicU32::new(0),
                 inflight_cancel: Mutex::new(None),
                 inner: Mutex::new(Inner {
                     child: None,
@@ -724,7 +778,23 @@ mod supported {
         /// Test-support: whether a helper process is currently resident. Not
         /// part of any stable external API.
         pub fn has_live_child(&self) -> bool {
-            self.lock().child.is_some()
+            self.resident_pid().is_some()
+        }
+
+        /// Non-blocking resource-attribution seam. PID 0 is never a child PID.
+        pub fn resident_pid(&self) -> Option<u32> {
+            match self.resident_pid.load(Ordering::Acquire) {
+                0 => None,
+                pid => Some(pid),
+            }
+        }
+
+        fn take_child(&self, inner: &mut Inner) -> Option<Child> {
+            let child = inner.child.take();
+            if child.is_some() {
+                self.resident_pid.store(0, Ordering::Release);
+            }
+            child
         }
 
         /// Async transform facade. Serializes to one in-flight request via a
@@ -738,6 +808,7 @@ mod supported {
         ) -> Result<TransformOutput, TransformError> {
             self.transform_inner(instruction, input, deadline, cancel, None)
                 .await
+                .result
         }
 
         /// Correlated transform entry point for the selected-text flow. The
@@ -749,7 +820,7 @@ mod supported {
             input: &str,
             deadline: Duration,
             cancel: CancelToken,
-        ) -> Result<TransformOutput, TransformError> {
+        ) -> CorrelatedTransformOutcome {
             self.transform_inner(
                 instruction,
                 input,
@@ -767,7 +838,7 @@ mod supported {
             deadline: Duration,
             cancel: CancelToken,
             transform_pass_id: Option<u64>,
-        ) -> Result<TransformOutput, TransformError> {
+        ) -> CorrelatedTransformOutcome {
             // App-side limit enforcement (defence in depth over the helper).
             if instruction.len() > MAX_INSTRUCTION_BYTES
                 || input.len() > MAX_INPUT_BYTES
@@ -776,7 +847,7 @@ mod supported {
                 || deadline.is_zero()
                 || deadline > Duration::from_millis(MAX_DEADLINE_MS)
             {
-                return Err(TransformError::InvalidRequest);
+                return CorrelatedTransformOutcome::before_runtime(TransformError::InvalidRequest);
             }
 
             if self
@@ -784,7 +855,7 @@ mod supported {
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                 .is_err()
             {
-                return Err(TransformError::Busy);
+                return CorrelatedTransformOutcome::before_runtime(TransformError::Busy);
             }
             // Register this request's cancel token so cancel_inflight_request()
             // reaches exactly THIS request. No stale-flag reset is needed (the
@@ -815,14 +886,14 @@ mod supported {
             })
             .await;
 
-            let result = match join {
-                Ok(r) => r,
-                Err(_) => Err(TransformError::Internal),
+            let outcome = match join {
+                Ok(outcome) => outcome,
+                Err(_) => CorrelatedTransformOutcome::before_runtime(TransformError::Internal),
             };
 
             // Telemetry: enums, durations, buckets, token counts only.
             let elapsed_ms = started.elapsed().as_millis() as u64;
-            let (outcome, output_tokens) = match &result {
+            let (result_code, output_tokens) = match &outcome.result {
                 Ok(out) => ("ok", out.output_tokens),
                 Err(err) => (err.as_str(), 0),
             };
@@ -830,7 +901,7 @@ mod supported {
                 tracing::info!(
                     target: "pipeline",
                     transform_pass_id,
-                    outcome,
+                    outcome = result_code,
                     duration_ms = elapsed_ms,
                     instruction_bucket,
                     input_bucket,
@@ -840,7 +911,7 @@ mod supported {
             } else {
                 tracing::info!(
                     target: "pipeline",
-                    outcome,
+                    outcome = result_code,
                     duration_ms = elapsed_ms,
                     instruction_bucket,
                     input_bucket,
@@ -848,7 +919,7 @@ mod supported {
                     "llm_transform"
                 );
             }
-            result
+            outcome
         }
 
         fn transform_blocking(
@@ -857,18 +928,40 @@ mod supported {
             input: &str,
             deadline: Duration,
             cancel: &CancelToken,
-        ) -> Result<TransformOutput, TransformError> {
+        ) -> CorrelatedTransformOutcome {
             let mut inner = self.lock();
+            let cache_hit = inner.child.is_some();
+            let load_started = Instant::now();
 
             if inner.breaker.is_disabled(Instant::now()) {
-                return Err(TransformError::Disabled);
+                return CorrelatedTransformOutcome {
+                    result: Err(TransformError::Disabled),
+                    spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
+                    generation_ms: None,
+                    cache_hit: Some(cache_hit),
+                };
             }
             if let Some(_reason) = self.guard().heavy_runtime_active() {
-                return Err(TransformError::HeavyRuntimeActive);
+                return CorrelatedTransformOutcome {
+                    result: Err(TransformError::HeavyRuntimeActive),
+                    spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
+                    generation_ms: None,
+                    cache_hit: Some(cache_hit),
+                };
             }
 
             // Verify the model exists before touching the helper.
-            let model_path = self.plan.model_path()?;
+            let model_path = match self.plan.model_path() {
+                Ok(path) => path,
+                Err(error) => {
+                    return CorrelatedTransformOutcome {
+                        result: Err(error),
+                        spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
+                        generation_ms: None,
+                        cache_hit: Some(cache_hit),
+                    };
+                }
+            };
 
             // Lazy spawn. Release the ASR model first so only one heavy runtime
             // is ever resident (mutual exclusion, ADR "Lifecycle and resources").
@@ -882,16 +975,28 @@ mod supported {
                         // the user can re-download. Not a helper fault → no breaker
                         // trip; the file is gone so this cannot loop.
                         self.plan.cleanup_bad_model();
-                        return Err(TransformError::ModelMismatch);
+                        return CorrelatedTransformOutcome {
+                            result: Err(TransformError::ModelMismatch),
+                            spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
+                            generation_ms: None,
+                            cache_hit: Some(cache_hit),
+                        };
                     }
                     Err(err) => {
                         inner.breaker.record_failure(Instant::now());
-                        return Err(err);
+                        return CorrelatedTransformOutcome {
+                            result: Err(err),
+                            spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
+                            generation_ms: None,
+                            cache_hit: Some(cache_hit),
+                        };
                     }
                 }
             }
+            let spawn_load_ms = load_started.elapsed().as_millis() as u64;
 
             let request_id = unique_id("req");
+            let generation_started = Instant::now();
             let outcome = {
                 let child = inner.child.as_mut().expect("child present");
                 run_request(
@@ -905,7 +1010,7 @@ mod supported {
                 )
             };
 
-            match outcome {
+            let result = match outcome {
                 RequestOutcome::Ok(out) => {
                     inner.last_activity = Instant::now();
                     Ok(out)
@@ -928,7 +1033,7 @@ mod supported {
                     Err(TransformError::Timeout)
                 }
                 RequestOutcome::TimedOutKilled => {
-                    kill_child(inner.child.take());
+                    kill_child(self.take_child(&mut inner));
                     Err(TransformError::Timeout)
                 }
                 RequestOutcome::CancelledKeepChild => {
@@ -937,24 +1042,30 @@ mod supported {
                     Err(TransformError::Cancelled)
                 }
                 RequestOutcome::CancelledKilled => {
-                    kill_child(inner.child.take());
+                    kill_child(self.take_child(&mut inner));
                     Err(TransformError::Cancelled)
                 }
                 RequestOutcome::Crashed => {
-                    kill_child(inner.child.take());
+                    kill_child(self.take_child(&mut inner));
                     inner.breaker.record_failure(Instant::now());
                     Err(TransformError::Crashed)
                 }
                 RequestOutcome::Protocol => {
-                    kill_child(inner.child.take());
+                    kill_child(self.take_child(&mut inner));
                     inner.breaker.record_failure(Instant::now());
                     Err(TransformError::Protocol)
                 }
                 RequestOutcome::OutputInvalid => {
-                    kill_child(inner.child.take());
+                    kill_child(self.take_child(&mut inner));
                     inner.breaker.record_failure(Instant::now());
                     Err(TransformError::OutputInvalid)
                 }
+            };
+            CorrelatedTransformOutcome {
+                result,
+                spawn_load_ms: Some(spawn_load_ms),
+                generation_ms: Some(generation_started.elapsed().as_millis() as u64),
+                cache_hit: Some(cache_hit),
             }
         }
 
@@ -1021,8 +1132,21 @@ mod supported {
 
             let mut proc = command.spawn().map_err(|_| TransformError::SpawnFailed)?;
             let pid = proc.id();
-            let mut stdin = proc.stdin.take().ok_or(TransformError::SpawnFailed)?;
-            let stdout = proc.stdout.take().ok_or(TransformError::SpawnFailed)?;
+            let pid_guard = SpawnPidGuard::new(&self.resident_pid, pid);
+            let mut stdin = match proc.stdin.take() {
+                Some(stdin) => stdin,
+                None => {
+                    kill_and_reap(&mut proc);
+                    return Err(TransformError::SpawnFailed);
+                }
+            };
+            let stdout = match proc.stdout.take() {
+                Some(stdout) => stdout,
+                None => {
+                    kill_and_reap(&mut proc);
+                    return Err(TransformError::SpawnFailed);
+                }
+            };
 
             // Reader thread: classifies frames, protocol violations, and EOF.
             let (tx, rx) = std::sync::mpsc::channel::<HelperEvent>();
@@ -1089,14 +1213,16 @@ mod supported {
                             kill_and_reap(&mut proc);
                             return Err(TransformError::HandshakeFailed);
                         }
-                        return Ok(Child {
+                        let child = Child {
                             proc,
                             stdin,
                             events: rx,
                             session_nonce,
                             pid,
                             _model_file: model_file,
-                        });
+                        };
+                        pid_guard.keep();
+                        return Ok(child);
                     }
                     Ok(_) | Err(RecvTimeoutError::Disconnected) => {
                         kill_and_reap(&mut proc);
@@ -1151,9 +1277,9 @@ mod supported {
                 }
 
                 if kill {
-                    (inner.child.take(), true)
+                    (self.take_child(&mut inner), true)
                 } else if inner.last_activity.elapsed() >= self.plan.idle_after() {
-                    (inner.child.take(), false)
+                    (self.take_child(&mut inner), false)
                 } else {
                     return;
                 }
@@ -1174,7 +1300,7 @@ mod supported {
             let child = match self.inner.try_lock() {
                 Ok(mut inner) => {
                     inner.breaker.reset();
-                    inner.child.take()
+                    self.take_child(&mut inner)
                 }
                 Err(_) => return,
             };
@@ -1188,7 +1314,7 @@ mod supported {
         /// transform is in flight — the guard never blocks behind a ≤31s request.
         pub fn shutdown(&self) {
             let child = match self.inner.try_lock() {
-                Ok(mut inner) => inner.child.take(),
+                Ok(mut inner) => self.take_child(&mut inner),
                 Err(_) => return,
             };
             shutdown_child(child, self.plan.cancel_grace());
@@ -1482,6 +1608,7 @@ pub use supported::LlmSidecar;
 pub struct LlmSidecar {
     host_guard: OnceLock<Arc<dyn HostGuard>>,
     busy: AtomicBool,
+    resident_pid: AtomicU32,
     _plan: SpawnPlan,
 }
 
@@ -1500,6 +1627,7 @@ impl LlmSidecar {
         Self {
             host_guard: OnceLock::new(),
             busy: AtomicBool::new(false),
+            resident_pid: AtomicU32::new(0),
             _plan: plan,
         }
     }
@@ -1523,6 +1651,10 @@ impl LlmSidecar {
         false
     }
 
+    pub fn resident_pid(&self) -> Option<u32> {
+        None
+    }
+
     pub async fn transform(
         self: &Arc<Self>,
         _instruction: &str,
@@ -1540,8 +1672,8 @@ impl LlmSidecar {
         _input: &str,
         _deadline: Duration,
         _cancel: CancelToken,
-    ) -> Result<TransformOutput, TransformError> {
-        Err(TransformError::Unsupported)
+    ) -> CorrelatedTransformOutcome {
+        CorrelatedTransformOutcome::before_runtime(TransformError::Unsupported)
     }
 
     pub fn maintenance_tick(&self) {}

--- a/app/src-tauri/src/performance_metrics/mod.rs
+++ b/app/src-tauri/src/performance_metrics/mod.rs
@@ -95,6 +95,19 @@ impl PerformanceMetrics {
         )
     }
 
+    pub(crate) fn begin_selected_text_transform(
+        &self,
+        transform_pass_id: u64,
+        runtimes: Vec<RuntimeIdentityV1>,
+    ) -> Result<ActiveRunV1, String> {
+        self.begin(
+            PerformanceRunKindV1::SelectedTextTransform,
+            RunCorrelationV1::SelectedTextTransform { transform_pass_id },
+            runtimes,
+            ContentFreeInputSummaryV1::default(),
+        )
+    }
+
     pub(crate) fn update_active(
         &self,
         correlation: &RunCorrelationV1,
@@ -183,6 +196,17 @@ impl PerformanceMetrics {
         Ok(())
     }
 
+    pub(crate) fn append_transform_follow_up(
+        &self,
+        transform_pass_id: u64,
+        follow_up: TransformFollowUpV1,
+    ) -> Result<Option<PerformanceRunV1>, String> {
+        self.repository()?.append_transform_follow_up(
+            &RunCorrelationV1::SelectedTextTransform { transform_pass_id },
+            follow_up,
+        )
+    }
+
     pub(crate) fn list(&self, limit: u32) -> Result<PerformanceRunListV1, String> {
         Ok(PerformanceRunListV1 {
             schema_version: PERFORMANCE_RUN_SCHEMA_VERSION,
@@ -229,6 +253,12 @@ impl PerformanceRunGuard {
     pub(crate) fn record(&mut self, timing: StageTimingV1) {
         self.current_stage = timing.stage;
         let _ = self.metrics.record_stage(&self.correlation, timing);
+    }
+
+    /// Leave a deliberately long-lived run active across command boundaries.
+    /// The next command creates its own panic guard for the same correlation.
+    pub(crate) fn defer(mut self) {
+        self.finished = true;
     }
 
     pub(crate) fn finish(
@@ -320,6 +350,34 @@ mod tests {
             RunOutcomeV1::Failed {
                 stage: PerformanceStageV1::ModelLoad,
                 ..
+            }
+        ));
+    }
+
+    #[test]
+    fn deferred_transform_run_is_closed_by_the_next_command_guard() {
+        let (_temp, metrics) = metrics();
+        let correlation = RunCorrelationV1::SelectedTextTransform {
+            transform_pass_id: 8,
+        };
+        metrics
+            .begin_selected_text_transform(8, Vec::new())
+            .unwrap();
+        metrics
+            .guard(correlation.clone(), PerformanceStageV1::SelectedTextCapture)
+            .defer();
+        assert!(metrics.list(10).unwrap().runs.is_empty());
+
+        let mut next_command = metrics.guard(correlation, PerformanceStageV1::InstructionCapture);
+        next_command.enter(PerformanceStageV1::InstructionAsr);
+        drop(next_command);
+        let runs = metrics.list(10).unwrap().runs;
+        assert_eq!(runs.len(), 1);
+        assert!(matches!(
+            runs[0].outcome,
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::InstructionAsr,
+                error_code: StableRunErrorV1::InternalEarlyExit,
             }
         ));
     }

--- a/app/src-tauri/src/performance_metrics/repository.rs
+++ b/app/src-tauri/src/performance_metrics/repository.rs
@@ -7,6 +7,7 @@ const DB_FILE: &str = "performance.sqlite3";
 const LATEST_DB_SCHEMA_VERSION: u32 = 1;
 const MAX_COMPLETED_RUNS: usize = 200;
 const MAX_RESOURCE_SAMPLES: usize = 600;
+const MAX_TRANSFORM_FOLLOW_UPS: usize = 8;
 
 #[derive(Clone)]
 pub(crate) struct PerformanceRepository {
@@ -198,6 +199,58 @@ impl PerformanceRepository {
         prune_resource_samples_tx(&transaction)?;
         transaction.commit().map_err(db_error)?;
         Ok(())
+    }
+
+    pub(crate) fn append_transform_follow_up(
+        &self,
+        correlation: &RunCorrelationV1,
+        follow_up: TransformFollowUpV1,
+    ) -> Result<Option<PerformanceRunV1>, String> {
+        if !matches!(correlation, RunCorrelationV1::SelectedTextTransform { .. }) {
+            return Ok(None);
+        }
+        let mut connection = self.open()?;
+        let transaction = connection.transaction().map_err(db_error)?;
+        let (kind, id) = correlation.storage_parts();
+        let row = transaction
+            .query_row(
+                "SELECT run_id, record_version, payload_json
+                 FROM completed_runs
+                 WHERE correlation_kind = ? AND correlation_id = ?
+                 ORDER BY finished_at_ms DESC, rowid DESC LIMIT 1",
+                params![kind, to_i64(id)?],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, u32>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(db_error)?;
+        let Some((run_id, version, payload)) = row else {
+            return Ok(None);
+        };
+        if version != PERFORMANCE_RUN_SCHEMA_VERSION {
+            return Ok(None);
+        }
+        let mut run: PerformanceRunV1 =
+            serde_json::from_str(&payload).map_err(|_| invalid_record())?;
+        run.follow_ups.push(follow_up);
+        if run.follow_ups.len() > MAX_TRANSFORM_FOLLOW_UPS {
+            let overflow = run.follow_ups.len() - MAX_TRANSFORM_FOLLOW_UPS;
+            run.follow_ups.drain(0..overflow);
+        }
+        let payload = serde_json::to_string(&run).map_err(|_| invalid_record())?;
+        transaction
+            .execute(
+                "UPDATE completed_runs SET payload_json = ? WHERE run_id = ?",
+                params![payload, run_id],
+            )
+            .map_err(db_error)?;
+        transaction.commit().map_err(db_error)?;
+        Ok(Some(run))
     }
 
     pub(crate) fn list(&self, limit: u32) -> Result<Vec<PerformanceRunV1>, String> {
@@ -546,9 +599,17 @@ fn resource_summary_tx(
         .filter_map(|sample| sample.main_process.ffi_native_heap_bytes.value().copied())
         .collect::<Vec<_>>();
     let sidecar = if kind == PerformanceRunKindV1::SelectedTextTransform {
+        let sidecar_cpu = samples
+            .iter()
+            .filter_map(|sample| sample.sidecar_process.cpu_percent.value().copied())
+            .collect::<Vec<_>>();
+        let sidecar_rss = samples
+            .iter()
+            .filter_map(|sample| sample.sidecar_process.rss_bytes.value().copied())
+            .collect::<Vec<_>>();
         SidecarResourceSummaryV1 {
-            cpu_percent: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
-            rss_bytes: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+            cpu_percent: range_f32(&sidecar_cpu),
+            rss_bytes: range_u64(&sidecar_rss),
         }
     } else {
         SidecarResourceSummaryV1 {
@@ -725,7 +786,15 @@ mod tests {
                 rust_heap_bytes: MeasurementV1::measured(20),
                 ffi_native_heap_bytes: MeasurementV1::measured(30),
             },
-            sidecar_process: SidecarResourceSampleV1::dependency_pending(),
+            sidecar_process: SidecarResourceSampleV1::unavailable(
+                UnavailableReasonV1::DependencyPending,
+            ),
+        }
+    }
+
+    fn transform_correlation(id: u64) -> RunCorrelationV1 {
+        RunCorrelationV1::SelectedTextTransform {
+            transform_pass_id: id,
         }
     }
 
@@ -803,6 +872,80 @@ mod tests {
             run.resources.sidecar_process.rss_bytes.start,
             MeasurementV1::NotApplicable
         ));
+    }
+
+    #[test]
+    fn transform_summarizes_measured_sidecar_and_bounds_follow_ups() {
+        let (_temp, repository) = repository();
+        let correlation = transform_correlation(41);
+        let active = repository
+            .begin(
+                PerformanceRunKindV1::SelectedTextTransform,
+                correlation.clone(),
+                vec![RuntimeIdentityV1 {
+                    role: RuntimeRoleV1::Generation,
+                    model_id: "catalog-model".to_string(),
+                    backend: RuntimeBackendV1::LlamaCpp,
+                    accelerator: AcceleratorV1::MetalGpu,
+                    warm_state: ModelWarmStateV1::Warm,
+                }],
+                ContentFreeInputSummaryV1::default(),
+            )
+            .unwrap();
+        let mut resource = sample(active.started_at_ms, MeasurementV1::measured(1.0));
+        resource.sidecar_process = SidecarResourceSampleV1 {
+            cpu_percent: MeasurementV1::measured(25.0),
+            rss_bytes: MeasurementV1::measured(456),
+        };
+        repository.insert_resource_sample(&resource).unwrap();
+        let run = repository
+            .complete(
+                &correlation,
+                RunOutcomeV1::Success,
+                vec![StageTimingV1::measured(PerformanceStageV1::Generation, 12)],
+                None,
+                None,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            run.resources.sidecar_process.rss_bytes.peak,
+            MeasurementV1::measured(456)
+        );
+
+        for index in 0..10 {
+            repository
+                .append_transform_follow_up(
+                    &correlation,
+                    TransformFollowUpV1 {
+                        kind: if index % 2 == 0 {
+                            TransformFollowUpKindV1::Apply
+                        } else {
+                            TransformFollowUpKindV1::Undo
+                        },
+                        at_ms: index,
+                        duration_ms: MeasurementV1::measured(index as u64),
+                        outcome: StageOutcomeV1::Completed,
+                    },
+                )
+                .unwrap();
+        }
+        let updated = repository.get(&run.run_id).unwrap().unwrap();
+        assert_eq!(updated.follow_ups.len(), MAX_TRANSFORM_FOLLOW_UPS);
+        assert_eq!(updated.follow_ups[0].at_ms, 2);
+        repository.clear().unwrap();
+        assert!(repository
+            .append_transform_follow_up(
+                &correlation,
+                TransformFollowUpV1 {
+                    kind: TransformFollowUpKindV1::Apply,
+                    at_ms: 11,
+                    duration_ms: MeasurementV1::measured(1),
+                    outcome: StageOutcomeV1::Completed,
+                },
+            )
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/app/src-tauri/src/performance_metrics/types.rs
+++ b/app/src-tauri/src/performance_metrics/types.rs
@@ -294,14 +294,10 @@ pub struct SidecarResourceSampleV1 {
 }
 
 impl SidecarResourceSampleV1 {
-    pub fn dependency_pending() -> Self {
+    pub fn unavailable(reason: UnavailableReasonV1) -> Self {
         Self {
-            cpu_percent: MeasurementV1::Unavailable {
-                reason: UnavailableReasonV1::DependencyPending,
-            },
-            rss_bytes: MeasurementV1::Unavailable {
-                reason: UnavailableReasonV1::DependencyPending,
-            },
+            cpu_percent: MeasurementV1::Unavailable { reason },
+            rss_bytes: MeasurementV1::Unavailable { reason },
         }
     }
 }
@@ -352,8 +348,8 @@ impl ResourceSummaryV1 {
         let no_samples = UnavailableReasonV1::NoSamples;
         let sidecar = if kind == PerformanceRunKindV1::SelectedTextTransform {
             SidecarResourceSummaryV1 {
-                cpu_percent: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
-                rss_bytes: ResourceRangeV1::unavailable(UnavailableReasonV1::DependencyPending),
+                cpu_percent: ResourceRangeV1::unavailable(no_samples),
+                rss_bytes: ResourceRangeV1::unavailable(no_samples),
             }
         } else {
             SidecarResourceSummaryV1 {

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -13,33 +13,37 @@ pub fn get_process_rss_mb() -> u64 {
 
 struct ProcessCpuSampler {
     system: sysinfo::System,
+    pid: sysinfo::Pid,
     primed: bool,
 }
 
 impl ProcessCpuSampler {
-    fn new() -> Self {
+    fn new(pid: u32) -> Self {
         Self {
             system: sysinfo::System::new(),
+            pid: sysinfo::Pid::from_u32(pid),
             primed: false,
         }
     }
 
-    fn sample(&mut self) -> Option<f32> {
-        use sysinfo::{Pid, ProcessesToUpdate};
-
-        let pid = Pid::from_u32(std::process::id());
+    fn sample(&mut self) -> (Option<f32>, Option<u64>) {
+        use sysinfo::ProcessesToUpdate;
         self.system
-            .refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
-        let value = self.system.process(pid).map(|process| process.cpu_usage());
-        if value.is_some() && !self.primed {
+            .refresh_processes(ProcessesToUpdate::Some(&[self.pid]), true);
+        let process = self.system.process(self.pid);
+        let cpu = process.map(|process| process.cpu_usage());
+        let rss = process.map(|process| process.memory());
+        if cpu.is_some() && !self.primed {
             self.primed = true;
-            return None;
+            return (None, rss);
         }
-        value
+        (cpu, rss)
     }
 }
 
 static PROCESS_CPU: std::sync::OnceLock<Mutex<ProcessCpuSampler>> = std::sync::OnceLock::new();
+static SIDECAR_CPU: std::sync::OnceLock<Mutex<Option<ProcessCpuSampler>>> =
+    std::sync::OnceLock::new();
 
 fn measured_or_unavailable<T>(value: Option<T>) -> crate::performance_metrics::MeasurementV1<T> {
     value.map_or(
@@ -50,17 +54,68 @@ fn measured_or_unavailable<T>(value: Option<T>) -> crate::performance_metrics::M
     )
 }
 
-pub fn sample_resources() -> crate::performance_metrics::ResourceSampleV1 {
+fn sample_sidecar(
+    sidecar: &crate::llm_sidecar::LlmSidecar,
+) -> crate::performance_metrics::SidecarResourceSampleV1 {
+    use crate::performance_metrics::{SidecarResourceSampleV1, UnavailableReasonV1};
+
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    {
+        let _ = sidecar;
+        return SidecarResourceSampleV1::unavailable(UnavailableReasonV1::UnsupportedPlatform);
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        let Some(pid) = sidecar.resident_pid() else {
+            return SidecarResourceSampleV1::unavailable(UnavailableReasonV1::NoSamples);
+        };
+        sample_sidecar_pid(pid)
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn sample_sidecar_pid(pid: u32) -> crate::performance_metrics::SidecarResourceSampleV1 {
+    use crate::performance_metrics::{MeasurementV1, SidecarResourceSampleV1, UnavailableReasonV1};
+
+    let mut slot = SIDECAR_CPU
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if slot.as_ref().map(|sampler| sampler.pid.as_u32()) != Some(pid) {
+        *slot = Some(ProcessCpuSampler::new(pid));
+    }
+    let (cpu, rss) = slot.as_mut().expect("sidecar sampler initialized").sample();
+    SidecarResourceSampleV1 {
+        cpu_percent: cpu.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::SampleFailed,
+            },
+            MeasurementV1::measured,
+        ),
+        rss_bytes: rss.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::SampleFailed,
+            },
+            MeasurementV1::measured,
+        ),
+    }
+}
+
+pub fn sample_resources(
+    sidecar: &crate::llm_sidecar::LlmSidecar,
+) -> crate::performance_metrics::ResourceSampleV1 {
     use crate::performance_metrics::{
         HostResourceSampleV1, MeasurementV1, ProcessResourceSampleV1, ResourceSampleV1,
-        SidecarResourceSampleV1, UnavailableReasonV1, RESOURCE_SAMPLE_SCHEMA_VERSION,
+        UnavailableReasonV1, RESOURCE_SAMPLE_SCHEMA_VERSION,
     };
 
     let process_cpu = PROCESS_CPU
-        .get_or_init(|| Mutex::new(ProcessCpuSampler::new()))
+        .get_or_init(|| Mutex::new(ProcessCpuSampler::new(std::process::id())))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .sample();
+        .sample()
+        .0;
     let rust_heap = if cfg!(target_os = "macos") {
         MeasurementV1::measured(crate::rust_heap_bytes())
     } else {
@@ -88,9 +143,7 @@ pub fn sample_resources() -> crate::performance_metrics::ResourceSampleV1 {
             rust_heap_bytes: rust_heap,
             ffi_native_heap_bytes: ffi_native_heap,
         },
-        // Phase A reserves the typed sidecar scope but does not inspect the
-        // #332-owned transform runtime or llm_sidecar internals.
-        sidecar_process: SidecarResourceSampleV1::dependency_pending(),
+        sidecar_process: sample_sidecar(sidecar),
     }
 }
 
@@ -187,8 +240,8 @@ pub fn start_heartbeat(app_handle: tauri::AppHandle) {
             interval.tick().await;
             ticks = ticks.saturating_add(1);
 
-            let sample = sample_resources();
             let state = app_handle.state::<crate::State>();
+            let sample = sample_resources(&state.transform_runtime);
             if let Err(error) = state.performance.insert_resource_sample(&sample) {
                 tracing::warn!(
                     target: "system",
@@ -221,21 +274,68 @@ pub fn start_heartbeat(app_handle: tauri::AppHandle) {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_resource_usage() -> crate::performance_metrics::ResourceSampleV1 {
-    sample_resources()
+pub fn get_resource_usage(
+    state: tauri::State<'_, crate::State>,
+) -> crate::performance_metrics::ResourceSampleV1 {
+    sample_resources(&state.transform_runtime)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::performance_metrics::{MeasurementV1, UnavailableReasonV1};
     use crate::state::DictationStatus;
 
     #[test]
     fn idle_release_requires_expired_idle_status() {
         let expired = Some(std::time::Duration::from_secs(5 * 60));
         assert!(should_release_model(5, DictationStatus::Idle, expired));
-        assert!(!should_release_model(5, DictationStatus::Recording, expired));
-        assert!(!should_release_model(5, DictationStatus::Processing, expired));
+        assert!(!should_release_model(
+            5,
+            DictationStatus::Recording,
+            expired
+        ));
+        assert!(!should_release_model(
+            5,
+            DictationStatus::Processing,
+            expired
+        ));
+    }
+
+    #[test]
+    fn nonresident_sidecar_is_never_reported_as_zero() {
+        let sidecar = crate::llm_sidecar::LlmSidecar::new();
+        let sample = sample_resources(&sidecar);
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        let expected = UnavailableReasonV1::NoSamples;
+        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        let expected = UnavailableReasonV1::UnsupportedPlatform;
+        assert_eq!(
+            sample.sidecar_process.cpu_percent,
+            MeasurementV1::Unavailable { reason: expected }
+        );
+        assert_eq!(
+            sample.sidecar_process.rss_bytes,
+            MeasurementV1::Unavailable { reason: expected }
+        );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    fn pid_sampler_reads_real_rss_and_primes_cpu_without_a_zero_sentinel() {
+        let first = sample_sidecar_pid(std::process::id());
+        assert!(matches!(
+            first.rss_bytes,
+            MeasurementV1::Measured { value } if value > 0
+        ));
+        assert_eq!(
+            first.cpu_percent,
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::SampleFailed
+            }
+        );
+        let second = sample_sidecar_pid(std::process::id());
+        assert!(matches!(second.cpu_percent, MeasurementV1::Measured { .. }));
     }
 
     #[test]

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -49,6 +49,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::llm_sidecar::{LlmSidecar, TransformError};
+use crate::performance_metrics::{
+    AcceleratorV1, ContentFreeInputSummaryV1, MeasurementV1, ModelWarmStateV1, PerformanceStageV1,
+    RunCorrelationV1, RunOutcomeV1, RuntimeBackendV1, RuntimeIdentityV1, RuntimeRoleV1,
+    StableRunErrorV1, StageOutcomeV1, StageTimingV1, TransformFollowUpKindV1, TransformFollowUpV1,
+    UnavailableReasonV1,
+};
 use crate::selection::{SelectionError, TransformSnapshot};
 use crate::state::{AppState, DictationStatus, TransformStatus};
 use crate::transform_apply::{self, ApplyError};
@@ -65,6 +71,176 @@ pub const DEFAULT_TRANSFORM_DEADLINE: Duration = Duration::from_millis(20_000);
 
 /// How long the "applied" confirmation lingers before the popover auto-hides.
 pub const APPLIED_LINGER_MS: u64 = 4_000;
+
+fn transform_correlation(transform_pass_id: u64) -> RunCorrelationV1 {
+    RunCorrelationV1::SelectedTextTransform { transform_pass_id }
+}
+
+fn performance_stage_for_transform_status(status: TransformStatus) -> PerformanceStageV1 {
+    match status {
+        TransformStatus::Capturing => PerformanceStageV1::SelectedTextCapture,
+        TransformStatus::Listening => PerformanceStageV1::InstructionCapture,
+        TransformStatus::Thinking => PerformanceStageV1::Generation,
+        TransformStatus::ReviewPending | TransformStatus::Idle => PerformanceStageV1::ReviewReady,
+        TransformStatus::Applying => PerformanceStageV1::Apply,
+    }
+}
+
+fn generation_runtime(warm_state: ModelWarmStateV1) -> RuntimeIdentityV1 {
+    RuntimeIdentityV1 {
+        role: RuntimeRoleV1::Generation,
+        model_id: crate::llm_sidecar::TRANSFORM_MODEL_ID.to_string(),
+        backend: RuntimeBackendV1::LlamaCpp,
+        accelerator: AcceleratorV1::MetalGpu,
+        warm_state,
+    }
+}
+
+fn begin_transform_performance(
+    state: &crate::State,
+    transform_pass_id: u64,
+) -> Option<crate::performance_metrics::PerformanceRunGuard> {
+    let model_name = state
+        .app_state
+        .dictation
+        .lock_or_recover()
+        .model_name
+        .clone();
+    let mut runtimes = crate::commands::recording::runtime_identity_for_role(
+        &model_name,
+        ModelWarmStateV1::Unknown,
+        RuntimeRoleV1::InstructionAsr,
+    );
+    runtimes.push(generation_runtime(ModelWarmStateV1::Unknown));
+    if state
+        .performance
+        .begin_selected_text_transform(transform_pass_id, runtimes)
+        .is_err()
+    {
+        tracing::warn!(
+            target: "system",
+            diagnostics_available = false,
+            transform_pass_id,
+            "transform performance run could not start"
+        );
+        return None;
+    }
+    sample_transform_resources(state);
+    Some(state.performance.guard(
+        transform_correlation(transform_pass_id),
+        PerformanceStageV1::SelectedTextCapture,
+    ))
+}
+
+fn sample_transform_resources(state: &crate::State) {
+    let sample = crate::resource_monitor::sample_resources(&state.transform_runtime);
+    let _ = state.performance.insert_resource_sample(&sample);
+}
+
+fn stage_timing(
+    stage: PerformanceStageV1,
+    duration_ms: MeasurementV1<u64>,
+    outcome: StageOutcomeV1,
+) -> StageTimingV1 {
+    StageTimingV1 {
+        stage,
+        duration_ms,
+        outcome,
+    }
+}
+
+fn record_transform_stage(state: &crate::State, transform_pass_id: u64, timing: StageTimingV1) {
+    let _ = state
+        .performance
+        .record_stage(&transform_correlation(transform_pass_id), timing);
+}
+
+fn update_transform_runtime(
+    state: &crate::State,
+    transform_pass_id: u64,
+    runtime: RuntimeIdentityV1,
+) {
+    let _ = state
+        .performance
+        .update_active(&transform_correlation(transform_pass_id), |active| {
+            if let Some(existing) = active
+                .runtimes
+                .iter_mut()
+                .find(|existing| existing.role == runtime.role)
+            {
+                *existing = runtime;
+            } else {
+                active.runtimes.push(runtime);
+            }
+        });
+}
+
+fn transform_input_summary(
+    audio_duration_ms: Option<u64>,
+    input_bytes: Option<usize>,
+    output: Option<(usize, u32)>,
+) -> ContentFreeInputSummaryV1 {
+    ContentFreeInputSummaryV1 {
+        audio_duration_ms: audio_duration_ms.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples,
+            },
+            MeasurementV1::measured,
+        ),
+        input_size_bucket: input_bytes.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples,
+            },
+            |bytes| MeasurementV1::measured(crate::performance_metrics::size_bucket(bytes)),
+        ),
+        output_size_bucket: output.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples,
+            },
+            |(bytes, _)| MeasurementV1::measured(crate::performance_metrics::size_bucket(bytes)),
+        ),
+        output_token_count: output.map_or(
+            MeasurementV1::Unavailable {
+                reason: UnavailableReasonV1::NoSamples,
+            },
+            |(_, tokens)| MeasurementV1::measured(u64::from(tokens)),
+        ),
+    }
+}
+
+fn complete_transform_performance(
+    state: &crate::State,
+    transform_pass_id: u64,
+    outcome: RunOutcomeV1,
+    input: Option<ContentFreeInputSummaryV1>,
+) {
+    sample_transform_resources(state);
+    let _ = state.performance.complete(
+        &transform_correlation(transform_pass_id),
+        outcome,
+        Vec::new(),
+        input,
+        None,
+    );
+}
+
+fn append_transform_follow_up(
+    state: &crate::State,
+    transform_pass_id: u64,
+    kind: TransformFollowUpKindV1,
+    duration_ms: u64,
+    outcome: StageOutcomeV1,
+) {
+    let _ = state.performance.append_transform_follow_up(
+        transform_pass_id,
+        TransformFollowUpV1 {
+            kind,
+            at_ms: chrono::Utc::now().timestamp_millis(),
+            duration_ms: MeasurementV1::measured(duration_ms),
+            outcome,
+        },
+    );
+}
 
 // ===========================================================================
 // Review state + error-code vocabulary (the ONLY strings that cross to the UI).
@@ -440,6 +616,28 @@ pub(crate) enum StartOutcome {
     Aborted,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct SidecarRunMetrics {
+    spawn_load_ms: Option<u64>,
+    generation_ms: Option<u64>,
+    cache_hit: Option<bool>,
+}
+
+pub(crate) enum TransformRunReport {
+    Ready {
+        metrics: SidecarRunMetrics,
+        output_bytes: usize,
+        output_tokens: u32,
+        review_ready_ms: u64,
+    },
+    Failed {
+        metrics: Option<SidecarRunMetrics>,
+        timed_out: bool,
+        stage: PerformanceStageV1,
+    },
+    Cancelled,
+}
+
 /// Core of `start_transform_capture` (see the command). Assumes the caller has
 /// already atomically claimed `TransformStatus::Capturing` under the dictation
 /// lock. Generic over the capture future so tests inject a fake snapshot
@@ -578,7 +776,7 @@ pub(crate) async fn run_transform(
     instruction: Result<String, ()>,
     original: String,
     deadline: Duration,
-) {
+) -> TransformRunReport {
     let transform_pass_id = app_state.active_transform_pass_id().unwrap_or(0);
     let instruction = match instruction {
         Ok(text) if !text.trim().is_empty() => text,
@@ -598,13 +796,17 @@ pub(crate) async fn run_transform(
                     );
                 }
             }
-            return;
+            return TransformRunReport::Failed {
+                metrics: None,
+                timed_out: false,
+                stage: PerformanceStageV1::InstructionAsr,
+            };
         }
     };
     // Cancel during transcription can clear the session before we get here —
     // do not spawn the sidecar on a dead session.
     if !transform_apply::set_instruction(app_state, instruction.clone()) {
-        return;
+        return TransformRunReport::Cancelled;
     }
 
     let sidecar = Arc::clone(sidecar);
@@ -621,7 +823,13 @@ pub(crate) async fn run_transform(
         let cancel = cancel.clone();
         async move {
             if transform_pass_id == 0 {
-                sidecar.transform(&instr, &input, deadline, cancel).await
+                let result = sidecar.transform(&instr, &input, deadline, cancel).await;
+                crate::llm_sidecar::CorrelatedTransformOutcome {
+                    result,
+                    spawn_load_ms: None,
+                    generation_ms: None,
+                    cache_hit: None,
+                }
             } else {
                 sidecar
                     .transform_for_pass(transform_pass_id, &instr, &input, deadline, cancel)
@@ -635,7 +843,7 @@ pub(crate) async fn run_transform(
 
     match joined {
         // Aborted by `cancel_transform`, which already tore the flow down.
-        Err(err) if err.is_cancelled() => {}
+        Err(err) if err.is_cancelled() => TransformRunReport::Cancelled,
         Err(_) => {
             if app_state.try_transition_transform_status(
                 TransformStatus::Thinking,
@@ -652,43 +860,134 @@ pub(crate) async fn run_transform(
                     );
                 }
             }
-        }
-        Ok(Ok(output)) => {
-            if !app_state.try_transition_transform_status(
-                TransformStatus::Thinking,
-                TransformStatus::ReviewPending,
-            ) {
-                return;
-            }
-            transform_apply::set_proposed_text(app_state, output.output);
-            fx.set_expanded(true);
-            fx.set_focusable(true);
-            fx.emit_state(ReviewState::Ready, None);
-            if transform_pass_id != 0 {
-                crate::transform_trace::resolution(transform_pass_id, "ready", "sidecar", None);
+            TransformRunReport::Failed {
+                metrics: None,
+                timed_out: false,
+                stage: PerformanceStageV1::Generation,
             }
         }
-        // Cooperative cancel from the sidecar: cancel_transform already tore
-        // the flow down — do not force ReviewPending.
-        Ok(Err(TransformError::Cancelled)) => {}
-        Ok(Err(error)) => {
-            if app_state.try_transition_transform_status(
-                TransformStatus::Thinking,
-                TransformStatus::ReviewPending,
-            ) {
-                let error_code = transform_error_code(error);
-                fx.set_focusable(true);
-                fx.emit_state(ReviewState::Failed, Some(error_code));
-                if transform_pass_id != 0 {
-                    crate::transform_trace::resolution(
-                        transform_pass_id,
-                        "failed",
-                        "sidecar",
-                        Some(error_code),
-                    );
+        Ok(outcome) => {
+            let metrics = SidecarRunMetrics {
+                spawn_load_ms: outcome.spawn_load_ms,
+                generation_ms: outcome.generation_ms,
+                cache_hit: outcome.cache_hit,
+            };
+            match outcome.result {
+                Ok(output) => {
+                    if !app_state.try_transition_transform_status(
+                        TransformStatus::Thinking,
+                        TransformStatus::ReviewPending,
+                    ) {
+                        return TransformRunReport::Cancelled;
+                    }
+                    let output_bytes = output.output.len();
+                    let output_tokens = output.output_tokens;
+                    let review_ready_started = std::time::Instant::now();
+                    transform_apply::set_proposed_text(app_state, output.output);
+                    fx.set_expanded(true);
+                    fx.set_focusable(true);
+                    fx.emit_state(ReviewState::Ready, None);
+                    if transform_pass_id != 0 {
+                        crate::transform_trace::resolution(
+                            transform_pass_id,
+                            "ready",
+                            "sidecar",
+                            None,
+                        );
+                    }
+                    TransformRunReport::Ready {
+                        metrics,
+                        output_bytes,
+                        output_tokens,
+                        review_ready_ms: review_ready_started.elapsed().as_millis() as u64,
+                    }
+                }
+                // Cooperative cancel from the sidecar: cancel_transform already
+                // tore the flow down — do not force ReviewPending.
+                Err(TransformError::Cancelled) => TransformRunReport::Cancelled,
+                Err(error) => {
+                    if app_state.try_transition_transform_status(
+                        TransformStatus::Thinking,
+                        TransformStatus::ReviewPending,
+                    ) {
+                        let error_code = transform_error_code(error);
+                        fx.set_focusable(true);
+                        fx.emit_state(ReviewState::Failed, Some(error_code));
+                        if transform_pass_id != 0 {
+                            crate::transform_trace::resolution(
+                                transform_pass_id,
+                                "failed",
+                                "sidecar",
+                                Some(error_code),
+                            );
+                        }
+                    }
+                    let stage = if metrics.generation_ms.is_some() {
+                        PerformanceStageV1::Generation
+                    } else {
+                        PerformanceStageV1::SidecarSpawnLoad
+                    };
+                    TransformRunReport::Failed {
+                        metrics: Some(metrics),
+                        timed_out: error == TransformError::Timeout,
+                        stage,
+                    }
                 }
             }
         }
+    }
+}
+
+fn record_sidecar_metrics(
+    state: &crate::State,
+    transform_pass_id: u64,
+    metrics: SidecarRunMetrics,
+    succeeded: bool,
+) -> PerformanceStageV1 {
+    let warm_state = match metrics.cache_hit {
+        Some(true) => ModelWarmStateV1::Warm,
+        Some(false) => ModelWarmStateV1::ColdLoaded,
+        None => ModelWarmStateV1::Unknown,
+    };
+    update_transform_runtime(state, transform_pass_id, generation_runtime(warm_state));
+
+    let load_outcome = if succeeded || metrics.generation_ms.is_some() {
+        StageOutcomeV1::Completed
+    } else {
+        StageOutcomeV1::Failed
+    };
+    record_transform_stage(
+        state,
+        transform_pass_id,
+        stage_timing(
+            PerformanceStageV1::SidecarSpawnLoad,
+            metrics.spawn_load_ms.map_or(
+                MeasurementV1::Unavailable {
+                    reason: UnavailableReasonV1::NoSamples,
+                },
+                MeasurementV1::measured,
+            ),
+            load_outcome,
+        ),
+    );
+
+    if let Some(generation_ms) = metrics.generation_ms {
+        record_transform_stage(
+            state,
+            transform_pass_id,
+            stage_timing(
+                PerformanceStageV1::Generation,
+                MeasurementV1::measured(generation_ms),
+                if succeeded {
+                    StageOutcomeV1::Completed
+                } else {
+                    StageOutcomeV1::Failed
+                },
+            ),
+        );
+        PerformanceStageV1::Generation
+    } else {
+        PerformanceStageV1::SidecarSpawnLoad
     }
 }
 
@@ -871,6 +1170,15 @@ async fn transcribe_instruction(
             None,
             0,
         );
+        record_transform_stage(
+            state,
+            transform_pass_id,
+            stage_timing(
+                PerformanceStageV1::InstructionAsr,
+                MeasurementV1::measured(started.elapsed().as_millis() as u64),
+                StageOutcomeV1::Failed,
+            ),
+        );
         return Err(InstructionFailure::AudioEmpty);
     }
     let (model_name, language, smart_punctuation) = {
@@ -888,7 +1196,7 @@ async fn transcribe_instruction(
         crate::model_runtime::PreparationReason::Pipeline,
         |backend| backend.transcribe(samples, &language, None, smart_punctuation),
     );
-    let (raw, _load_report) = match raw {
+    let (raw, load_report) = match raw {
         Ok(pair) => pair,
         Err(e) => {
             let _ = e;
@@ -899,9 +1207,32 @@ async fn transcribe_instruction(
                 None,
                 started.elapsed().as_millis() as u64,
             );
+            record_transform_stage(
+                state,
+                transform_pass_id,
+                stage_timing(
+                    PerformanceStageV1::InstructionAsr,
+                    MeasurementV1::measured(started.elapsed().as_millis() as u64),
+                    StageOutcomeV1::Failed,
+                ),
+            );
             return Err(InstructionFailure::TranscriptionError);
         }
     };
+    if let Some(runtime) = crate::commands::recording::runtime_identity_for_role(
+        &model_name,
+        if load_report.cache_hit {
+            ModelWarmStateV1::Warm
+        } else {
+            ModelWarmStateV1::ColdLoaded
+        },
+        RuntimeRoleV1::InstructionAsr,
+    )
+    .into_iter()
+    .next()
+    {
+        update_transform_runtime(state, transform_pass_id, runtime);
+    }
 
     let context = crate::transcript_transform::TranscriptContext {
         session_id: state.app_state.next_transcript_session_id(),
@@ -924,6 +1255,15 @@ async fn transcribe_instruction(
                 None,
                 started.elapsed().as_millis() as u64,
             );
+            record_transform_stage(
+                state,
+                transform_pass_id,
+                stage_timing(
+                    PerformanceStageV1::InstructionAsr,
+                    MeasurementV1::measured(started.elapsed().as_millis() as u64),
+                    StageOutcomeV1::Failed,
+                ),
+            );
             return Err(InstructionFailure::TranscriptionError);
         }
     };
@@ -937,6 +1277,15 @@ async fn transcribe_instruction(
             None,
             started.elapsed().as_millis() as u64,
         );
+        record_transform_stage(
+            state,
+            transform_pass_id,
+            stage_timing(
+                PerformanceStageV1::InstructionAsr,
+                MeasurementV1::measured(started.elapsed().as_millis() as u64),
+                StageOutcomeV1::Failed,
+            ),
+        );
         Err(InstructionFailure::TranscriptBlank)
     } else {
         crate::transform_trace::instruction(
@@ -945,6 +1294,15 @@ async fn transcribe_instruction(
             "ok",
             Some(crate::selection::length_bucket(trimmed.len())),
             started.elapsed().as_millis() as u64,
+        );
+        record_transform_stage(
+            state,
+            transform_pass_id,
+            stage_timing(
+                PerformanceStageV1::InstructionAsr,
+                MeasurementV1::measured(started.elapsed().as_millis() as u64),
+                StageOutcomeV1::Completed,
+            ),
         );
         Ok(trimmed)
     }
@@ -1020,6 +1378,7 @@ pub(crate) async fn start_transform_capture(
         let _ = app_handle.emit("transform-busy", ());
         return Ok(());
     }
+    let mut performance_guard = begin_transform_performance(&state, transform_pass_id);
 
     let model_ready = crate::commands::transform_model::transform_model_state()
         == crate::commands::transform_model::TransformModelState::Ready;
@@ -1040,6 +1399,7 @@ pub(crate) async fn start_transform_capture(
     // Aborted arm below tears the mic down; nothing is ever transcribed from
     // an aborted pass.
     if model_ready {
+        let audio_start_started = std::time::Instant::now();
         if let Err(e) = crate::audio::start_recording(Some(app_handle.clone()), device_name) {
             crate::transform_trace::audio(transform_pass_id, "armed", "error", 0, 0);
             crate::transform_trace::resolution(
@@ -1049,6 +1409,24 @@ pub(crate) async fn start_transform_capture(
                 Some("audio_start_failed"),
             );
             state.app_state.set_transform_status(TransformStatus::Idle);
+            record_transform_stage(
+                &state,
+                transform_pass_id,
+                stage_timing(
+                    PerformanceStageV1::InstructionCapture,
+                    MeasurementV1::measured(audio_start_started.elapsed().as_millis() as u64),
+                    StageOutcomeV1::Failed,
+                ),
+            );
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::InstructionCapture,
+                    error_code: StableRunErrorV1::AudioCaptureFailed,
+                },
+                None,
+            );
             transform_apply::clear_session(&state.app_state);
             let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
             emit_transform_hidden(&app_handle);
@@ -1058,15 +1436,41 @@ pub(crate) async fn start_transform_capture(
         crate::transform_trace::audio(transform_pass_id, "armed", "ok", 0, 0);
     }
 
-    let outcome = core_start_capture(
-        &state.app_state,
-        &fx,
-        model_ready,
-        crate::selection::capture_selection(&app_handle, transform_pass_id),
-    )
+    let capture_started = std::time::Instant::now();
+    let capture_result = if model_ready {
+        Some(crate::selection::capture_selection(&app_handle, transform_pass_id).await)
+    } else {
+        None
+    };
+    let capture_succeeded = capture_result.as_ref().is_some_and(|result| result.is_ok());
+    record_transform_stage(
+        &state,
+        transform_pass_id,
+        stage_timing(
+            PerformanceStageV1::SelectedTextCapture,
+            MeasurementV1::measured(capture_started.elapsed().as_millis() as u64),
+            if capture_succeeded {
+                StageOutcomeV1::Completed
+            } else {
+                StageOutcomeV1::Failed
+            },
+        ),
+    );
+    let outcome = core_start_capture(&state.app_state, &fx, model_ready, async move {
+        capture_result.expect("capture future is polled only when the model is ready")
+    })
     .await;
 
     if outcome != StartOutcome::Listening {
+        complete_transform_performance(
+            &state,
+            transform_pass_id,
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::SelectedTextCapture,
+                error_code: StableRunErrorV1::TransformStageFailed,
+            },
+            None,
+        );
         // Capture aborted (secure field, capture error, model-not-ready
         // failed popover, or a cancel racing the capture) — the pre-armed mic
         // must not stay live.
@@ -1084,6 +1488,9 @@ pub(crate) async fn start_transform_capture(
             state.app_state.clear_transform_pass(transform_pass_id);
         }
         return Ok(());
+    }
+    if let Some(guard) = performance_guard.as_mut() {
+        guard.enter(PerformanceStageV1::InstructionCapture);
     }
 
     {
@@ -1112,6 +1519,9 @@ pub(crate) async fn start_transform_capture(
             emit_transform_hidden(&app_handle);
             return Ok(());
         }
+    }
+    if let Some(guard) = performance_guard {
+        guard.defer();
     }
     Ok(())
 }
@@ -1142,7 +1552,7 @@ pub(crate) async fn finish_transform_instruction(
     // survives. Concurrency during Thinking is gated by `TransformStatus`,
     // not by this mutex: every work-starting entry point refuses while the
     // status is non-Idle.
-    let samples = {
+    let (samples, mut performance_guard) = {
         let _transition = state.app_state.recording_transition.lock().await;
 
         // Tolerate a stray release: only proceed from Listening.
@@ -1152,6 +1562,10 @@ pub(crate) async fn finish_transform_instruction(
             return Ok(());
         }
 
+        let mut guard = state.performance.guard(
+            transform_correlation(transform_pass_id),
+            PerformanceStageV1::InstructionCapture,
+        );
         let samples = crate::audio::stop_recording().unwrap_or_default();
         crate::transform_trace::audio(
             transform_pass_id,
@@ -1160,12 +1574,29 @@ pub(crate) async fn finish_transform_instruction(
             samples.len(),
             samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64,
         );
+        let audio_duration_ms =
+            samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64;
+        record_transform_stage(
+            &state,
+            transform_pass_id,
+            stage_timing(
+                PerformanceStageV1::InstructionCapture,
+                MeasurementV1::measured(audio_duration_ms),
+                if samples.is_empty() {
+                    StageOutcomeV1::Failed
+                } else {
+                    StageOutcomeV1::Completed
+                },
+            ),
+        );
 
         if !enter_thinking(&state.app_state, &fx) {
             // Lost the race to a concurrent cancel.
+            guard.defer();
             return Ok(());
         }
-        samples
+        guard.enter(PerformanceStageV1::InstructionAsr);
+        (samples, Some(guard))
     };
 
     let original = match transform_apply::session_snapshot(&state.app_state) {
@@ -1178,6 +1609,15 @@ pub(crate) async fn finish_transform_instruction(
                 "failed",
                 "instruction",
                 Some("no_session"),
+            );
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::InstructionCapture,
+                    error_code: StableRunErrorV1::InternalEarlyExit,
+                },
+                None,
             );
             state.app_state.clear_transform_pass(transform_pass_id);
             return Ok(());
@@ -1192,7 +1632,12 @@ pub(crate) async fn finish_transform_instruction(
             Ok(raw) => Ok(expand_instruction(&state, &raw)),
             Err(_) => Err(()),
         };
-    run_transform(
+    let audio_duration_ms = samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64;
+    let input_bytes = original.len();
+    if let Some(guard) = performance_guard.as_mut() {
+        guard.enter(PerformanceStageV1::SidecarSpawnLoad);
+    }
+    let report = run_transform(
         &state.app_state,
         &fx,
         &state.transform_runtime,
@@ -1202,6 +1647,85 @@ pub(crate) async fn finish_transform_instruction(
         DEFAULT_TRANSFORM_DEADLINE,
     )
     .await;
+    match report {
+        TransformRunReport::Ready {
+            metrics,
+            output_bytes,
+            output_tokens,
+            review_ready_ms,
+        } => {
+            record_sidecar_metrics(&state, transform_pass_id, metrics, true);
+            record_transform_stage(
+                &state,
+                transform_pass_id,
+                StageTimingV1::measured(PerformanceStageV1::ReviewReady, review_ready_ms),
+            );
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                RunOutcomeV1::Success,
+                Some(transform_input_summary(
+                    Some(audio_duration_ms),
+                    Some(input_bytes),
+                    Some((output_bytes, output_tokens)),
+                )),
+            );
+        }
+        TransformRunReport::Failed {
+            metrics: Some(metrics),
+            timed_out,
+            ..
+        } => {
+            let terminal_stage = record_sidecar_metrics(&state, transform_pass_id, metrics, false);
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                if timed_out {
+                    RunOutcomeV1::TimedOut {
+                        stage: terminal_stage,
+                    }
+                } else {
+                    RunOutcomeV1::Failed {
+                        stage: terminal_stage,
+                        error_code: StableRunErrorV1::TransformStageFailed,
+                    }
+                },
+                Some(transform_input_summary(
+                    Some(audio_duration_ms),
+                    Some(input_bytes),
+                    None,
+                )),
+            );
+        }
+        TransformRunReport::Failed {
+            metrics: None,
+            stage,
+            ..
+        } => {
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                RunOutcomeV1::Failed {
+                    stage,
+                    error_code: if stage == PerformanceStageV1::InstructionAsr {
+                        StableRunErrorV1::InferenceFailed
+                    } else {
+                        StableRunErrorV1::InternalEarlyExit
+                    },
+                },
+                Some(transform_input_summary(
+                    Some(audio_duration_ms),
+                    Some(input_bytes),
+                    None,
+                )),
+            );
+        }
+        TransformRunReport::Cancelled => {
+            if let Some(guard) = performance_guard {
+                guard.defer();
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1336,6 +1860,7 @@ pub(crate) async fn approve_transform(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, crate::State>,
 ) -> Result<(), String> {
+    let performance_started = std::time::Instant::now();
     let transform_pass_id = transform_apply::session_snapshot(&state.app_state)
         .map(|session| session.transform_pass_id)
         .or_else(|| state.app_state.active_transform_pass_id())
@@ -1353,6 +1878,13 @@ pub(crate) async fn approve_transform(
         None => {
             fx.emit_state(ReviewState::Failed, Some("busy"));
             if transform_pass_id != 0 {
+                append_transform_follow_up(
+                    &state,
+                    transform_pass_id,
+                    TransformFollowUpKindV1::Apply,
+                    performance_started.elapsed().as_millis() as u64,
+                    StageOutcomeV1::Failed,
+                );
                 crate::transform_trace::resolution(
                     transform_pass_id,
                     "failed",
@@ -1370,6 +1902,13 @@ pub(crate) async fn approve_transform(
             fx.emit_state(ReviewState::Applied, None);
             fx.schedule_linger_hide();
             if transform_pass_id != 0 {
+                append_transform_follow_up(
+                    &state,
+                    transform_pass_id,
+                    TransformFollowUpKindV1::Apply,
+                    performance_started.elapsed().as_millis() as u64,
+                    StageOutcomeV1::Completed,
+                );
                 crate::transform_trace::effect(transform_pass_id, "apply", via.as_str(), None);
                 crate::transform_trace::resolution(transform_pass_id, "applied", "apply", None);
             }
@@ -1381,6 +1920,13 @@ pub(crate) async fn approve_transform(
             let error_code = apply_error_code(error);
             fx.emit_state(ReviewState::Failed, Some(error_code));
             if transform_pass_id != 0 {
+                append_transform_follow_up(
+                    &state,
+                    transform_pass_id,
+                    TransformFollowUpKindV1::Apply,
+                    performance_started.elapsed().as_millis() as u64,
+                    StageOutcomeV1::Failed,
+                );
                 crate::transform_trace::effect(
                     transform_pass_id,
                     "apply",
@@ -1416,6 +1962,12 @@ pub(crate) async fn cancel_transform(
     }
     let transform_pass_id = active_pass_id.unwrap_or(0);
     let prev = state.app_state.transform_status();
+    let _performance_guard = (transform_pass_id != 0).then(|| {
+        state.performance.guard(
+            transform_correlation(transform_pass_id),
+            performance_stage_for_transform_status(prev),
+        )
+    });
 
     // Cooperative cancel first: the blocking spawn_blocking work only clears
     // BusyGuard when it finishes, so abort alone would leave busy held up to
@@ -1450,6 +2002,19 @@ pub(crate) async fn cancel_transform(
             samples.len(),
             samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64,
         );
+        if transform_pass_id != 0 {
+            record_transform_stage(
+                &state,
+                transform_pass_id,
+                stage_timing(
+                    PerformanceStageV1::InstructionCapture,
+                    MeasurementV1::measured(
+                        samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64,
+                    ),
+                    StageOutcomeV1::Completed,
+                ),
+            );
+        }
     }
 
     // Force Idle even from Applying — ApplyingGuard drop will no-op once status
@@ -1461,6 +2026,13 @@ pub(crate) async fn cancel_transform(
     // popover's own Cancel button all route here): reset stale content (item 13).
     emit_transform_hidden(&app_handle);
     if transform_pass_id != 0 {
+        let stage = performance_stage_for_transform_status(prev);
+        complete_transform_performance(
+            &state,
+            transform_pass_id,
+            RunOutcomeV1::Cancelled { stage },
+            None,
+        );
         crate::transform_trace::resolution(transform_pass_id, "cancelled", prev.as_str(), None);
         state.app_state.clear_transform_pass(transform_pass_id);
     }
@@ -1550,6 +2122,7 @@ pub(crate) async fn undo_transform_and_close(
     app_handle: tauri::AppHandle,
     state: tauri::State<'_, crate::State>,
 ) -> Result<(), String> {
+    let performance_started = std::time::Instant::now();
     let transform_pass_id = transform_apply::session_snapshot(&state.app_state)
         .map(|session| session.transform_pass_id)
         .or_else(|| state.app_state.active_transform_pass_id())
@@ -1564,6 +2137,15 @@ pub(crate) async fn undo_transform_and_close(
             Some(guard) => guard,
             None => {
                 fx.emit_state(ReviewState::Failed, Some("busy"));
+                if transform_pass_id != 0 {
+                    append_transform_follow_up(
+                        &state,
+                        transform_pass_id,
+                        TransformFollowUpKindV1::Undo,
+                        performance_started.elapsed().as_millis() as u64,
+                        StageOutcomeV1::Failed,
+                    );
+                }
                 return Err("busy".to_string());
             }
         };
@@ -1576,6 +2158,13 @@ pub(crate) async fn undo_transform_and_close(
             let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
             emit_transform_hidden(&app_handle);
             if transform_pass_id != 0 {
+                append_transform_follow_up(
+                    &state,
+                    transform_pass_id,
+                    TransformFollowUpKindV1::Undo,
+                    performance_started.elapsed().as_millis() as u64,
+                    StageOutcomeV1::Completed,
+                );
                 crate::transform_trace::effect(transform_pass_id, "undo", "ok", None);
                 crate::transform_trace::resolution(transform_pass_id, "undone", "undo", None);
                 state.app_state.clear_transform_pass(transform_pass_id);
@@ -1596,6 +2185,13 @@ pub(crate) async fn undo_transform_and_close(
             // ~instantly) or may have no-op'd mid-undo (leaving it up forever).
             fx.schedule_linger_hide();
             if transform_pass_id != 0 {
+                append_transform_follow_up(
+                    &state,
+                    transform_pass_id,
+                    TransformFollowUpKindV1::Undo,
+                    performance_started.elapsed().as_millis() as u64,
+                    StageOutcomeV1::Failed,
+                );
                 crate::transform_trace::effect(
                     transform_pass_id,
                     "undo",

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -86,6 +86,40 @@ async fn successful_transform_round_trip() {
 }
 
 #[tokio::test]
+async fn correlated_transform_reports_cold_then_warm_phase_timings() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("happy", &fixture);
+    let cold = sidecar
+        .transform_for_pass(
+            77,
+            "Rewrite this politely.",
+            "gimme the report",
+            Duration::from_secs(5),
+            CancelToken::new(),
+        )
+        .await;
+    assert!(cold.result.is_ok());
+    assert_eq!(cold.cache_hit, Some(false));
+    assert!(cold.spawn_load_ms.is_some());
+    assert!(cold.generation_ms.is_some());
+    assert!(sidecar.resident_pid().is_some());
+
+    let warm = sidecar
+        .transform_for_pass(
+            78,
+            "Rewrite this politely.",
+            "gimme the report",
+            Duration::from_secs(5),
+            CancelToken::new(),
+        )
+        .await;
+    assert!(warm.result.is_ok());
+    assert_eq!(warm.cache_hit, Some(true));
+    assert!(warm.spawn_load_ms.is_some());
+    assert!(warm.generation_ms.is_some());
+}
+
+#[tokio::test]
 async fn timeout_cancels_then_kills_and_reports_timeout() {
     let fixture = fixture_model();
     let sidecar = sidecar("slow_ignore_cancel", &fixture);

--- a/docs/features/performance-diagnostics.md
+++ b/docs/features/performance-diagnostics.md
@@ -2,9 +2,9 @@
 
 Issue [#351](https://github.com/georgenijo/murmur-app/issues/351) defines the
 versioned, local data layer used by the Diagnostics performance workspace.
-Phase A covers dictation and imported-file runs. Selected-text transform and
-sidecar correlation remain reserved until #332 supplies the canonical
-`transform_pass_id` and one typed trace source.
+Dictation, imported-file, and selected-text transform runs share this contract.
+Transform metrics reuse #332's canonical `transform_pass_id`; the existing
+content-free transform trace remains the only structured trace source.
 
 ## Storage and retention
 
@@ -18,6 +18,7 @@ It is separate from logs, transcription history, settings, personal knowledge,
 and Performance Lab/evaluation reports. The store keeps:
 
 - the newest 200 completed runs;
+- at most eight apply/undo follow-up attempts per completed transform run;
 - active content-free lifecycle rows so early exits and restart interruption can
   close a run exactly once;
 - the newest 600 one-second resource samples (a ten-minute window).
@@ -38,10 +39,9 @@ record versions are not decoded as V1.
 `PerformanceRunV1` contains:
 
 - an opaque random `runId`;
-- kind (`dictation`, `fileTranscription`, or reserved
-  `selectedTextTransform`);
+- kind (`dictation`, `fileTranscription`, or `selectedTextTransform`);
 - start/finish UTC timestamps and exactly one terminal outcome;
-- the existing `recordingId`, a dedicated `fileRunId`, or the future canonical
+- the existing `recordingId`, a dedicated `fileRunId`, or the canonical
   `transformPassId`;
 - catalog-backed model, backend, accelerator, and warm/cold state;
 - typed stage measurements;
@@ -79,9 +79,20 @@ The contract never uses numeric zero as a missing-data sentinel.
 - file return;
 - total command processing.
 
-The selected-text capture, instruction-ASR, sidecar-load, generation,
-review-ready, apply, and undo stage names are reserved in V1 but Phase A does
-not emit them.
+### Selected-text transform stages
+
+- selected-text capture;
+- instruction audio capture and cleanup-only ASR;
+- sidecar spawn/model-load and generation as separate timings;
+- review-ready completion or a stable terminal failure, cancellation, or
+  timeout.
+
+The run starts only after the canonical pass wins the transform pipeline claim.
+It closes at review-ready or the first terminal outcome. Apply and Undo happen
+after that completion, so their measured duration and completed/failed outcome
+are appended as bounded correlated follow-up records rather than changing the
+run's single terminal outcome. Retry keeps #332's same pass ID and does not
+create a competing trace identity.
 
 ## Resource scopes
 
@@ -92,12 +103,19 @@ not emit them.
 | Main-process RSS | Physical resident memory in bytes |
 | Rust heap | Bytes in Murmur's dedicated Rust malloc zone on macOS |
 | FFI/native heap | Bytes in all other malloc zones; not an RSS component and not a complete GPU/unified-memory measurement |
-| Sidecar CPU/RSS | Reserved as unavailable in Phase A; non-transform run summaries mark the scope not applicable |
+| Sidecar CPU/RSS | Signed local-LLM helper process only; sampled by its atomic resident PID, including model handshake |
 
 The first host/process CPU observation needs a prior counter baseline and is
 therefore unavailable rather than reported as zero. Rust/FFI heap breakdown is
 unavailable on unsupported platforms. Accelerator identity is recorded, but
 GPU or ANE utilization is not estimated.
+
+Only one transform request can own the helper at a time. Resource samples in
+the transform run's wall-clock interval are therefore attributable to that
+pass; an idle/nonresident helper yields `unavailable { reason: noSamples }`.
+Non-transform run summaries mark the sidecar scope `notApplicable`. A vanished
+PID or failed process read is `sampleFailed`, and unsupported platforms report
+`unsupportedPlatform`.
 
 ## Privacy
 

--- a/docs/features/selected-text-transform.md
+++ b/docs/features/selected-text-transform.md
@@ -90,6 +90,14 @@ their actual `from`, requested `to`, and whether the atomic transition won.
 Pass resolution uses stable outcomes (`ready`, `failed`, `cancelled`, `applied`,
 `undone`) plus stable stage/error codes.
 
+The persistent `PerformanceRunV1` uses that same pass ID. A successfully
+claimed pass records selected-text capture, instruction capture/ASR,
+sidecar spawn/load, generation, and review-ready or terminal failure. The base
+run completes once; later Apply/Undo attempts append bounded, content-free
+follow-up duration/outcome records. Sidecar CPU/RSS samples use the helper's
+resident PID and are summarized only for the transform run's wall-clock
+interval. No second transform tracing path is introduced.
+
 Transform diagnostics are content-free. They may contain IDs, enum values,
 numeric AX outcomes, booleans, sample/token counts, timings, apply/capture
 routes, and length buckets. They never contain selected text, instruction or


### PR DESCRIPTION
## Summary
- reuse the canonical transform_pass_id to persist selected-text capture, instruction capture/ASR, sidecar spawn/load, generation, and review-ready or terminal outcomes in PerformanceRunV1
- append bounded apply/undo follow-up outcomes without changing the base run terminal result or duplicating #332 transform tracing
- sample the real helper PID for sidecar CPU/RSS, including cold model handshake, while keeping nonresident/unsupported/sample-failure states explicit
- preserve the 200-run/600-sample caps, clear epoch, stable content-free errors, and panic-safe cross-command lifecycle guards

## Validation
- cargo check
- cargo test -- --test-threads=1 (600 unit tests plus integration suites; 0 failures)
- npx tsc --noEmit
- npm test (38 files, 305 tests)
- npm run build
- git diff --check
- isolated Local Dictation Dev.app build and startup under com.localdictation.dev; diagnostics store initialized and sampled
- correlated mock-helper integration proves cold/warm spawn-load and generation timings plus resident PID lifecycle

The debug app and bundles were produced successfully. Tauri then reported the expected missing TAURI_SIGNING_PRIVATE_KEY for updater signing. The existing root release process PID 40360 was not signaled, replaced, or automated.

Closes #351