### PR TITLE
feat(diagnostics): import and compare local reports

### DIFF
--- a/app/src/components/log-viewer/LogViewerApp.test.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.test.tsx
@@ -53,9 +53,9 @@ describe('LogViewerApp shared diagnostics shell', () => {
     container.remove();
   });
 
-  it('replaces Metrics with Events, Performance, and Runs tabs', async () => {
+  it('keeps Events, Performance, and Runs and adds an accessible Reports panel', async () => {
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
-    expect(tabs.map(tab => tab.textContent)).toEqual(['Events', 'Performance', 'Runs']);
+    expect(tabs.map(tab => tab.textContent)).toEqual(['Events', 'Performance', 'Runs', 'Reports']);
     expect(container.textContent).not.toContain('Metrics');
 
     await act(async () => (tabs[1] as HTMLButtonElement).click());
@@ -65,5 +65,10 @@ describe('LogViewerApp shared diagnostics shell', () => {
     await act(async () => (tabs[2] as HTMLButtonElement).click());
     expect(container.querySelector('#diagnostics-panel-runs')).not.toBeNull();
     expect(tabs[2].getAttribute('aria-selected')).toBe('true');
+
+    await act(async () => (tabs[3] as HTMLButtonElement).click());
+    expect(container.querySelector('#diagnostics-panel-reports')).not.toBeNull();
+    expect(tabs[3].getAttribute('aria-selected')).toBe('true');
+    expect(container.textContent).toContain('Report comparison');
   });
 });

--- a/app/src/components/log-viewer/LogViewerApp.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.tsx
@@ -7,6 +7,7 @@ import { LevelFilter } from './LevelFilter';
 import { EventRow } from './EventRow';
 import { PerformanceView } from './PerformanceView';
 import { RunsView } from './RunsView';
+import { ReportCompareView } from './ReportCompareView';
 import { LEVELS, STREAMS, type StreamName, type LevelName } from '../../lib/events';
 import {
   CORRELATION_FIELD_LABELS,
@@ -16,8 +17,8 @@ import {
   type CorrelationFilter,
 } from '../../lib/eventFilters';
 
-type Tab = 'events' | 'performance' | 'runs';
-const TABS: Tab[] = ['events', 'performance', 'runs'];
+type Tab = 'events' | 'performance' | 'runs' | 'reports';
+const TABS: Tab[] = ['events', 'performance', 'runs', 'reports'];
 
 export function LogViewerApp() {
   const { events, clear } = useEventStore();
@@ -234,6 +235,15 @@ export function LogViewerApp() {
           />
         </div>
       )}
+      <div
+        role="tabpanel"
+        id="diagnostics-panel-reports"
+        aria-labelledby="diagnostics-tab-reports"
+        hidden={tab !== 'reports'}
+        className="flex-1 overflow-y-auto"
+      >
+        <ReportCompareView />
+      </div>
     </div>
   );
 }

--- a/app/src/components/log-viewer/ReportCompareView.test.tsx
+++ b/app/src/components/log-viewer/ReportCompareView.test.tsx
@@ -1,0 +1,164 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import benchmarkV2 from '../../lib/__fixtures__/diagnostic-reports/benchmark-v2.json';
+import evaluationDeterministic from '../../lib/__fixtures__/diagnostic-reports/evaluation-v1-deterministic.json';
+import { MAX_DIAGNOSTIC_REPORT_BYTES } from '../../lib/diagnosticReports';
+import { ReportCompareView } from './ReportCompareView';
+
+function jsonFile(value: unknown): File {
+  const contents = JSON.stringify(value);
+  const file = new File([contents], 'private-source-name.json', { type: 'application/json' });
+  Object.defineProperty(file, 'text', { value: async () => contents });
+  return file;
+}
+
+describe('ReportCompareView', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(<ReportCompareView />));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    localStorage.clear();
+  });
+
+  async function importFile(file: File) {
+    const input = container.querySelector('[data-testid="diagnostic-report-input"]') as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [file],
+    });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+  }
+
+  it('imports compatible benchmark reports and shows side-by-side deltas', async () => {
+    const candidate = structuredClone(benchmarkV2);
+    candidate.createdAt = '2026-07-21T14:00:00Z';
+    candidate.sharedInitMs = 900;
+
+    await importFile(jsonFile(benchmarkV2));
+    await importFile(jsonFile(candidate));
+
+    expect(container.textContent).toContain('compatible');
+    expect(container.textContent).toContain('Shared initialization');
+    expect(container.textContent).toContain('1,200 ms');
+    expect(container.textContent).toContain('900 ms');
+    expect(container.textContent).toContain('-300 ms');
+    expect(container.textContent).toContain('-25%');
+    expect(container.textContent).toContain('Eligible.');
+    expect(container.textContent).toContain('Fastest');
+    expect(container.textContent).not.toContain('private-source-name.json');
+  });
+
+  it('imports evaluation reports with the curated-text privacy warning', async () => {
+    await importFile(jsonFile(evaluationDeterministic));
+
+    expect(container.textContent).toContain('Evaluation · v1 · fixtures v1');
+    expect(container.textContent).toContain('curated fixture transcripts and per-stage text');
+    expect(container.textContent).toContain('Fixture-only deterministic run');
+  });
+
+  it('fails closed for malformed, oversized, and incomplete reports', async () => {
+    const malformedContents = '{"private":"PRIVATE_PARSE_SENTINEL"';
+    const malformed = new File([malformedContents], 'secret.json');
+    Object.defineProperty(malformed, 'text', { value: async () => malformedContents });
+    await importFile(malformed);
+    expect(container.querySelector('[role="alert"]')?.textContent)
+      .toBe('The selected file is not valid JSON.');
+    expect(container.textContent).not.toContain('PRIVATE_PARSE_SENTINEL');
+    expect(container.textContent).not.toContain('secret.json');
+
+    const text = vi.fn(async () => {
+      throw new Error('oversized files must not be read');
+    });
+    const oversized = {
+      size: MAX_DIAGNOSTIC_REPORT_BYTES + 1,
+      text,
+    } as unknown as File;
+    await importFile(oversized);
+    expect(container.querySelector('[role="alert"]')?.textContent)
+      .toBe('Diagnostic reports are limited to 8 MiB.');
+    expect(text).not.toHaveBeenCalled();
+
+    const incomplete = structuredClone(benchmarkV2);
+    incomplete.results[0].warmMedianMs = null as unknown as number;
+    await importFile(jsonFile(incomplete));
+    expect(container.querySelector('[role="alert"]')?.textContent)
+      .toBe('The selected JSON is not a supported Murmur benchmark or evaluation report.');
+    expect(container.textContent).toContain('No diagnostic reports available');
+  });
+
+  it('blocks deltas and recommendations for a valid failed benchmark result', async () => {
+    const failed = JSON.parse(JSON.stringify(benchmarkV2));
+    failed.createdAt = '2026-07-21T14:30:00Z';
+    failed.results[0].error = 'PRIVATE_FAILURE_SENTINEL';
+    failed.results[0].modelLoadMs = null;
+    failed.results[0].firstInferenceMs = null;
+    failed.results[0].warmMedianMs = null;
+    failed.results[0].warmP95Ms = null;
+    failed.results[0].realtimeFactor = null;
+    failed.results[0].wordErrorRate = null;
+    failed.results[0].normalizedWordErrorRate = null;
+    failed.results[0].deliveredWordErrorRate = null;
+    failed.results[0].deliveredNormalizedWordErrorRate = null;
+    failed.results[0].fixtures = [];
+
+    await importFile(jsonFile(benchmarkV2));
+    await importFile(jsonFile(failed));
+
+    expect(container.textContent).toContain('One or more benchmark model results are incomplete or failed.');
+    expect(container.textContent).toContain('Deltas and recommendations are unavailable');
+    expect(container.textContent).toContain('Not eligible.');
+    expect(container.textContent).not.toContain('Shared initialization');
+    expect(container.textContent).not.toContain('PRIVATE_FAILURE_SENTINEL');
+  });
+
+  it('clears imported session state without deleting saved Performance Lab history', async () => {
+    localStorage.setItem('murmur-benchmark-reports', JSON.stringify([benchmarkV2]));
+    await act(async () => {
+      root.unmount();
+      root = createRoot(container);
+      root.render(<ReportCompareView />);
+    });
+    await importFile(jsonFile({ ...benchmarkV2, createdAt: '2026-07-21T15:00:00Z' }));
+
+    const clear = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Clear imports') as HTMLButtonElement;
+    await act(async () => clear.click());
+
+    expect(localStorage.getItem('murmur-benchmark-reports')).not.toBeNull();
+    expect(container.textContent).toContain('saved Performance Lab history were not changed');
+    const badges = Array.from(container.querySelectorAll('span'))
+      .map(element => element.textContent?.trim());
+    expect(badges).toContain('local');
+    expect(badges).not.toContain('imported');
+  });
+
+  it('uses compact responsive grids and a bounded horizontal metric region', async () => {
+    const candidate = structuredClone(benchmarkV2);
+    candidate.createdAt = '2026-07-21T16:00:00Z';
+    await importFile(jsonFile(benchmarkV2));
+    await importFile(jsonFile(candidate));
+
+    expect(container.querySelector('[data-testid="report-selection-grid"]')?.className)
+      .toContain('grid-cols-1');
+    expect(container.querySelector('[data-testid="report-selection-grid"]')?.className)
+      .toContain('lg:grid-cols-2');
+    expect(container.querySelector('[data-testid="report-summary-grid"]')?.className)
+      .toContain('grid-cols-1');
+    expect(container.querySelector('[data-testid="report-metrics-scroller"]')?.className)
+      .toContain('overflow-x-auto');
+  });
+});

--- a/app/src/components/log-viewer/ReportCompareView.tsx
+++ b/app/src/components/log-viewer/ReportCompareView.tsx
@@ -1,0 +1,502 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { loadBenchmarkReports } from '../../lib/benchmark';
+import {
+  MAX_DIAGNOSTIC_REPORT_BYTES,
+  normalizeLocalBenchmarkReport,
+  parseDiagnosticReportJson,
+  type NormalizedBenchmarkReport,
+  type NormalizedDiagnosticReport,
+  type NormalizedEvaluationReport,
+} from '../../lib/diagnosticReports';
+import {
+  compareDiagnosticReports,
+  type ComparisonMetric,
+  type DiagnosticComparison,
+} from '../../lib/diagnosticComparison';
+
+const MAX_SESSION_IMPORTS = 20;
+const MAX_VISIBLE_METRICS = 500;
+const READ_ERROR = 'The selected diagnostic report could not be read.';
+const SESSION_LIMIT_ERROR = `This session can hold up to ${MAX_SESSION_IMPORTS} imported diagnostic reports.`;
+
+interface ReportEntry {
+  id: string;
+  report: NormalizedDiagnosticReport;
+}
+
+function localReportEntries(): ReportEntry[] {
+  return loadBenchmarkReports().flatMap((report, index) => {
+    const result = normalizeLocalBenchmarkReport(report);
+    return result.ok
+      ? [{ id: `local-${index}-${report.createdAt}`, report: result.report }]
+      : [];
+  });
+}
+
+function schemaLabel(report: NormalizedDiagnosticReport): string {
+  if (report.kind === 'benchmark') {
+    return report.schemaVersion === 'legacy' ? 'Legacy' : `v${report.schemaVersion}`;
+  }
+  return `v${report.schemaVersion} · fixtures v${report.fixtureVersion}`;
+}
+
+function reportLabel(report: NormalizedDiagnosticReport): string {
+  const source = report.source === 'local' ? 'Local' : 'Imported';
+  const kind = report.kind === 'benchmark' ? 'benchmark' : 'evaluation';
+  return `${source} ${kind} · ${new Date(report.createdAt).toLocaleString()}`;
+}
+
+function sourceClasses(source: NormalizedDiagnosticReport['source']): string {
+  return source === 'local'
+    ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/35 dark:text-blue-300'
+    : 'bg-violet-100 text-violet-700 dark:bg-violet-900/35 dark:text-violet-300';
+}
+
+function statusClasses(status: DiagnosticComparison['status']): string {
+  if (status === 'compatible') {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/35 dark:text-emerald-300';
+  }
+  if (status === 'warning') {
+    return 'bg-amber-100 text-amber-800 dark:bg-amber-900/35 dark:text-amber-200';
+  }
+  return 'bg-red-100 text-red-700 dark:bg-red-900/35 dark:text-red-300';
+}
+
+function titleCase(value: string): string {
+  return value.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, letter => letter.toUpperCase());
+}
+
+function benchmarkMachine(report: NormalizedBenchmarkReport): string {
+  if (!report.environment) return report.platform;
+  const machine = report.environment.chip
+    ?? report.environment.hardwareModel
+    ?? report.environment.architecture;
+  return `${report.environment.os}${report.environment.osVersion ? ` ${report.environment.osVersion}` : ''} · ${machine}`;
+}
+
+function evaluationMachine(report: NormalizedEvaluationReport): string {
+  return `${report.environment.os} · ${report.environment.machineLabel} · ${report.environment.architecture}`;
+}
+
+function benchmarkModels(report: NormalizedBenchmarkReport): string {
+  if (report.models.length === 0) return 'Unavailable';
+  return report.models
+    .map(model => `${model.label} · ${model.backend} · ${model.accelerator}`)
+    .join('; ');
+}
+
+function evaluationModels(report: NormalizedEvaluationReport): string {
+  const models = Array.from(new Set(report.cases.flatMap(entry =>
+    entry.model
+      ? [`${entry.model.name} · ${entry.model.backend} · ${entry.model.accelerator}`]
+      : [])));
+  return models.length > 0 ? models.join('; ') : 'Fixture-only deterministic run';
+}
+
+function evaluationExecution(report: NormalizedEvaluationReport): string {
+  const signatures = Array.from(new Set(report.cases.map(entry =>
+    `${entry.fixtureOnly ? 'fixture-only' : 'runtime'} · ${entry.delivery.finalOnly ? 'final-only' : 'incremental'} · ${entry.runtime.incrementalCompletion}`)));
+  return signatures.length > 0 ? signatures.join('; ') : 'Unavailable';
+}
+
+function evaluationStages(report: NormalizedEvaluationReport): string {
+  const stageSets = Array.from(new Set(report.cases.map(entry =>
+    entry.transformation.stages.map(stage => stage.name).join(' → '))));
+  return stageSets.filter(Boolean).join('; ') || 'Unavailable';
+}
+
+function formatNumber(value: number, unit: ComparisonMetric['unit']): string {
+  if (unit === 'count') return value.toLocaleString();
+  const maximumFractionDigits = unit === 'ratio' ? 4 : 2;
+  const formatted = value.toLocaleString(undefined, { maximumFractionDigits });
+  if (unit === 'ms') return `${formatted} ms`;
+  if (unit === 'microseconds') return `${formatted} µs`;
+  if (unit === 'mb') return `${formatted} MB`;
+  return formatted;
+}
+
+function formatDelta(value: number, unit: ComparisonMetric['unit']): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${formatNumber(value, unit)}`;
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid min-w-0 grid-cols-[7rem_minmax(0,1fr)] gap-2 border-t border-outline-variant/10 py-1.5 first:border-t-0">
+      <dt className="text-[10px] font-medium uppercase tracking-wide text-on-surface-variant">
+        {label}
+      </dt>
+      <dd className="min-w-0 break-words text-xs text-on-surface">{value}</dd>
+    </div>
+  );
+}
+
+function ReportCard({
+  heading,
+  entry,
+}: {
+  heading: string;
+  entry: ReportEntry | undefined;
+}) {
+  if (!entry) {
+    return (
+      <section className="rounded-xl border border-dashed border-outline-variant/30 bg-surface-container-lowest p-3">
+        <h3 className="text-xs font-semibold text-on-surface">{heading}</h3>
+        <p className="mt-3 text-xs text-on-surface-variant">Choose a report to inspect.</p>
+      </section>
+    );
+  }
+
+  const { report } = entry;
+  const commonRows = [
+    ['Date', new Date(report.createdAt).toLocaleString()],
+    ['Type / schema', `${titleCase(report.kind)} · ${schemaLabel(report)}`],
+  ] as const;
+  const rows = report.kind === 'benchmark'
+    ? [
+      ...commonRows,
+      ['Machine', benchmarkMachine(report)],
+      ['App', `${report.appVersion} · ${report.platform}`],
+      ['Preset', `${titleCase(report.preset)} · ${report.iterations} iterations`],
+      ['Corpus', report.corpus
+        ? `${report.corpus.language} · ${report.corpus.fixtureCount} fixtures · ${report.corpus.referenceWords} reference words`
+        : 'Unavailable in legacy schema'],
+      ['Execution', report.configuration
+        ? report.configuration.executionPath
+        : 'Unavailable in legacy schema'],
+      ['Configuration', report.configuration
+        ? `VAD ${report.configuration.vadThreshold} · ${report.configuration.transcriptTransformProfile} · ${report.configuration.percentileMethod} · model order ${report.configuration.modelRunOrder.join(' → ')} · shared init ${report.configuration.sharedInitOrder.join(' → ')}`
+        : 'Unavailable in legacy schema'],
+      ['Models', benchmarkModels(report)],
+    ]
+    : [
+      ...commonRows,
+      ['Machine', evaluationMachine(report)],
+      ['App', report.environment.appVersion],
+      ['Tier / corpus', `${titleCase(report.tier)} · ${report.summary.total} fixture cases`],
+      ['Execution', evaluationExecution(report)],
+      ['Configuration', `Stages ${evaluationStages(report)}`],
+      ['Models', evaluationModels(report)],
+    ];
+
+  return (
+    <section className="min-w-0 rounded-xl border border-outline-variant/10 bg-surface-container-lowest p-3 shadow-sm">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-xs font-semibold text-on-surface">{heading}</h3>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${sourceClasses(report.source)}`}>
+          {report.source}
+        </span>
+      </div>
+      <dl>
+        {rows.map(([label, value]) => <MetaRow key={label} label={label} value={value} />)}
+      </dl>
+      {report.privacyWarnings.map(warning => (
+        <p
+          key={warning}
+          className="mt-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-2.5 py-2 text-[11px] leading-4 text-amber-800 dark:text-amber-200"
+        >
+          {warning}
+        </p>
+      ))}
+    </section>
+  );
+}
+
+function CompatibilityGate({
+  comparison,
+  candidate,
+}: {
+  comparison: DiagnosticComparison;
+  candidate: NormalizedDiagnosticReport;
+}) {
+  const visibleMetrics = comparison.metrics.slice(0, MAX_VISIBLE_METRICS);
+  return (
+    <section aria-labelledby="report-compatibility-heading" className="rounded-xl border border-outline-variant/10 bg-surface-container-lowest p-3 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 id="report-compatibility-heading" className="text-sm font-semibold text-on-surface">
+            Compatibility gate
+          </h3>
+          <p className="text-[11px] text-on-surface-variant">
+            Compatibility is checked before deltas or recommendations are shown.
+          </p>
+        </div>
+        <span className={`rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide ${statusClasses(comparison.status)}`}>
+          {comparison.status}
+        </span>
+      </div>
+
+      {comparison.issues.length > 0 ? (
+        <ul className="mt-3 space-y-2" aria-label="Compatibility findings">
+          {comparison.issues.map(issue => (
+            <li
+              key={`${issue.code}-${issue.field}`}
+              className={`rounded-lg border px-2.5 py-2 text-xs ${
+                issue.severity === 'blocker'
+                  ? 'border-error/20 bg-error/10 text-error'
+                  : 'border-amber-500/20 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+              }`}
+            >
+              <span className="font-semibold">{titleCase(issue.severity)} · {issue.field}</span>
+              <span className="ml-1">{issue.message}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+          These reports are compatible for like-for-like deltas.
+        </p>
+      )}
+
+      {!comparison.deltasAllowed ? (
+        <p className="mt-3 text-xs font-medium text-error">
+          Deltas and recommendations are unavailable while compatibility blockers remain.
+        </p>
+      ) : (
+        <>
+          <div data-testid="report-metrics-scroller" className="mt-3 overflow-x-auto">
+            <table className="w-full min-w-[42rem] border-separate border-spacing-0 text-left text-xs">
+              <thead>
+                <tr className="text-[10px] uppercase tracking-wide text-on-surface-variant">
+                  <th className="border-b border-outline-variant/20 px-2 py-2 font-medium">Metric</th>
+                  <th className="border-b border-outline-variant/20 px-2 py-2 text-right font-medium">Baseline</th>
+                  <th className="border-b border-outline-variant/20 px-2 py-2 text-right font-medium">Candidate</th>
+                  <th className="border-b border-outline-variant/20 px-2 py-2 text-right font-medium">Absolute Δ</th>
+                  <th className="border-b border-outline-variant/20 px-2 py-2 text-right font-medium">Percentage Δ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleMetrics.map(metric => (
+                  <tr key={metric.key} className="align-top">
+                    <th className="border-b border-outline-variant/10 px-2 py-2 font-medium text-on-surface">
+                      {metric.label}
+                      <span className="block max-w-72 break-all font-mono text-[9px] font-normal text-on-surface-variant">
+                        {metric.scope}
+                      </span>
+                    </th>
+                    <td className="border-b border-outline-variant/10 px-2 py-2 text-right tabular-nums text-on-surface">
+                      {formatNumber(metric.baseline, metric.unit)}
+                    </td>
+                    <td className="border-b border-outline-variant/10 px-2 py-2 text-right tabular-nums text-on-surface">
+                      {formatNumber(metric.candidate, metric.unit)}
+                    </td>
+                    <td className="border-b border-outline-variant/10 px-2 py-2 text-right tabular-nums text-on-surface">
+                      {formatDelta(metric.absoluteDelta, metric.unit)}
+                    </td>
+                    <td className="border-b border-outline-variant/10 px-2 py-2 text-right tabular-nums text-on-surface">
+                      {metric.percentageDelta === null
+                        ? <span className="text-on-surface-variant">Unavailable · zero baseline</span>
+                        : formatDelta(metric.percentageDelta, 'ratio') + '%'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {comparison.metrics.length > MAX_VISIBLE_METRICS && (
+            <p className="mt-2 text-[11px] text-on-surface-variant">
+              Showing the first {MAX_VISIBLE_METRICS.toLocaleString()} of {comparison.metrics.length.toLocaleString()} bounded metrics.
+            </p>
+          )}
+          {comparison.metrics.length === 0 && (
+            <p className="mt-3 text-xs text-on-surface-variant">
+              Compatible reports contain no shared measured metrics. Missing values remain unavailable rather than becoming zero.
+            </p>
+          )}
+        </>
+      )}
+
+      <div className="mt-3 border-t border-outline-variant/10 pt-3">
+        <h4 className="text-xs font-semibold text-on-surface">Recommendation eligibility</h4>
+        <p className="mt-1 text-xs text-on-surface-variant">
+          {comparison.recommendationAllowed
+            ? 'Eligible. Benchmark recommendations may be inspected without compatibility blockers or warnings; evaluation reports remain delta-only.'
+            : 'Not eligible. Murmur will not rank or recommend from this comparison.'}
+        </p>
+        {comparison.recommendationAllowed && candidate.kind === 'benchmark' && (
+          <dl className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            {([
+              ['Fastest', candidate.recommendations.fastest],
+              ['Most accurate', candidate.recommendations.mostAccurate],
+              ['Balanced', candidate.recommendations.balanced],
+            ] as const).map(([label, value]) => (
+              <div key={label} className="rounded-lg bg-surface-container px-2.5 py-2">
+                <dt className="text-[10px] font-medium uppercase tracking-wide text-on-surface-variant">{label}</dt>
+                <dd className="mt-0.5 break-words text-xs font-medium text-on-surface">{value ?? 'Unavailable'}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function ReportCompareView() {
+  const [reports, setReports] = useState<ReportEntry[]>(localReportEntries);
+  const [baselineId, setBaselineId] = useState('');
+  const [candidateId, setCandidateId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const importSequence = useRef(0);
+
+  useEffect(() => {
+    const ids = new Set(reports.map(entry => entry.id));
+    if (!ids.has(baselineId)) setBaselineId(reports[0]?.id ?? '');
+    if (!ids.has(candidateId) || candidateId === baselineId) {
+      setCandidateId(reports.find(entry => entry.id !== baselineId)?.id ?? '');
+    }
+  }, [baselineId, candidateId, reports]);
+
+  const baseline = reports.find(entry => entry.id === baselineId);
+  const candidate = reports.find(entry => entry.id === candidateId);
+  const comparison = useMemo(() => (
+    baseline && candidate && baseline.id !== candidate.id
+      ? compareDiagnosticReports(baseline.report, candidate.report)
+      : null
+  ), [baseline, candidate]);
+
+  const importReport = async (event: ChangeEvent<HTMLInputElement>) => {
+    const input = event.currentTarget;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+
+    setError(null);
+    setNotice(null);
+    if (file.size > MAX_DIAGNOSTIC_REPORT_BYTES) {
+      setError('Diagnostic reports are limited to 8 MiB.');
+      return;
+    }
+    if (reports.filter(entry => entry.report.source === 'imported').length >= MAX_SESSION_IMPORTS) {
+      setError(SESSION_LIMIT_ERROR);
+      return;
+    }
+
+    let contents: string;
+    try {
+      contents = await file.text();
+    } catch {
+      setError(READ_ERROR);
+      return;
+    }
+    const result = parseDiagnosticReportJson(contents, file.size);
+    if (!result.ok) {
+      setError(result.error.message);
+      return;
+    }
+
+    importSequence.current += 1;
+    const next: ReportEntry = {
+      id: `imported-${importSequence.current}`,
+      report: result.report,
+    };
+    setReports(current => [...current, next]);
+    if (!baselineId) setBaselineId(next.id);
+    else setCandidateId(next.id);
+    setNotice(`Imported ${result.report.kind} ${schemaLabel(result.report)} into this session.`);
+  };
+
+  const clearImports = () => {
+    setReports(current => current.filter(entry => entry.report.source === 'local'));
+    setError(null);
+    setNotice('Session imports cleared. Source files and saved Performance Lab history were not changed.');
+  };
+
+  const importedCount = reports.filter(entry => entry.report.source === 'imported').length;
+
+  return (
+    <div className="flex min-h-full flex-col gap-4 p-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">Report comparison</h2>
+          <p className="text-[11px] text-on-surface-variant">
+            Compare local Performance Lab history or explicit JSON imports · imports stay in this Diagnostics session
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <label className="cursor-pointer rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary shadow-sm hover:opacity-90 focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2">
+            Import JSON
+            <input
+              data-testid="diagnostic-report-input"
+              type="file"
+              accept=".json,application/json"
+              className="sr-only"
+              onChange={event => void importReport(event)}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={importedCount === 0}
+            onClick={clearImports}
+            className="rounded-lg border border-outline-variant/20 px-3 py-1.5 text-xs font-medium text-on-surface-variant hover:bg-surface-container focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Clear imports
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-xl border border-error/20 bg-error/10 px-3 py-2 text-xs text-error">
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div aria-live="polite" className="rounded-xl border border-primary/15 bg-primary/10 px-3 py-2 text-xs text-on-surface">
+          {notice}
+        </div>
+      )}
+
+      {reports.length === 0 ? (
+        <div className="flex min-h-48 flex-col items-center justify-center rounded-xl border border-dashed border-outline-variant/30 bg-surface-container-lowest px-6 text-center">
+          <p className="text-sm font-medium text-on-surface">No diagnostic reports available</p>
+          <p className="mt-1 max-w-md text-xs text-on-surface-variant">
+            Import a Murmur benchmark or evaluation JSON report. The file is checked locally and is not added to saved history.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div data-testid="report-selection-grid" className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <label className="text-[10px] font-medium uppercase tracking-wider text-on-surface-variant">
+              Baseline
+              <select
+                aria-label="Baseline report"
+                value={baselineId}
+                onChange={event => setBaselineId(event.target.value)}
+                className="mt-1 block w-full rounded-lg border border-outline-variant/20 bg-surface-container-lowest px-2.5 py-2 text-xs normal-case tracking-normal text-on-surface outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+              >
+                {reports.map(entry => <option key={entry.id} value={entry.id}>{reportLabel(entry.report)}</option>)}
+              </select>
+            </label>
+            <label className="text-[10px] font-medium uppercase tracking-wider text-on-surface-variant">
+              Candidate
+              <select
+                aria-label="Candidate report"
+                value={candidateId}
+                onChange={event => setCandidateId(event.target.value)}
+                className="mt-1 block w-full rounded-lg border border-outline-variant/20 bg-surface-container-lowest px-2.5 py-2 text-xs normal-case tracking-normal text-on-surface outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+              >
+                <option value="">Choose a second report</option>
+                {reports.map(entry => <option key={entry.id} value={entry.id}>{reportLabel(entry.report)}</option>)}
+              </select>
+            </label>
+          </div>
+
+          <div data-testid="report-summary-grid" className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <ReportCard heading="Baseline report" entry={baseline} />
+            <ReportCard heading="Candidate report" entry={candidate} />
+          </div>
+
+          {baseline && candidate && baseline.id === candidate.id && (
+            <div role="status" className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+              Choose two different reports to compare.
+            </div>
+          )}
+          {comparison && candidate && (
+            <CompatibilityGate comparison={comparison} candidate={candidate.report} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/features/diagnostic-report-comparison.md
+++ b/docs/features/diagnostic-report-comparison.md
@@ -24,9 +24,7 @@ picker checks the file size before reading it; the parser rechecks both the
 declared byte count and decoded UTF-8 size before parsing.
 
 Import errors use stable codes and fixed messages. They never include the
-selected path, filename, JSON contents, or a rejected field value. The file
-picker checks the declared size before reading, and the parser checks it again
-against the decoded UTF-8 payload.
+selected path, filename, JSON contents, or a rejected field value.
 
 ## In-memory representation and privacy
 

--- a/docs/features/diagnostic-report-comparison.md
+++ b/docs/features/diagnostic-report-comparison.md
@@ -1,8 +1,8 @@
 # Diagnostic Report Import and Comparison
 
-Issue #353 is delivered in phases. The first phase defines the local parser and
-comparison contract; Diagnostics navigation and presentation follow after the
-Performance/Runs shell from #352 is stable.
+Issue #353 adds an explicit Reports tab to the Diagnostics shell. It uses the
+local parser and comparison contract without changing report generation or the
+Performance/Runs data model.
 
 ## Supported reports
 
@@ -19,17 +19,21 @@ evaluation reports are recognized separately and are never interpreted as one
 another.
 
 Imports are limited to 8 MiB. The parser also caps benchmark models, fixtures
-per model, evaluation cases, stages per case, and string collections. The
-future file picker must check the file size before reading it; the parser
-rechecks both the declared byte count and decoded UTF-8 size before parsing.
+per model, evaluation cases, stages per case, and string collections. The file
+picker checks the file size before reading it; the parser rechecks both the
+declared byte count and decoded UTF-8 size before parsing.
 
 Import errors use stable codes and fixed messages. They never include the
-selected path, filename, JSON contents, or a rejected field value.
+selected path, filename, JSON contents, or a rejected field value. The file
+picker checks the declared size before reading, and the parser checks it again
+against the decoded UTF-8 payload.
 
 ## In-memory representation and privacy
 
-Normalized imports are session-only. The parser has no storage or telemetry
-dependency and never receives a source path. Its normalized output includes the
+Normalized imports are session-only. The Reports tab keeps at most 20 imports
+and never writes them to Performance Lab history. The parser has no storage or
+telemetry dependency and never receives a source path. Its normalized output
+includes the
 metadata and numeric/categorical measurements required for comparison, but
 deliberately drops:
 
@@ -39,9 +43,9 @@ deliberately drops:
 - evaluator bundle IDs, matched profile names, and audio paths.
 
 Evaluation imports always carry a warning that the selected source report may
-contain curated fixture transcripts and stage text. Clearing an import in the
-future UI will discard only in-session state and will not change or delete the
-source file.
+contain curated fixture transcripts and stage text. Clearing imports discards
+only in-session state and does not change source files or saved Performance Lab
+history.
 
 ## Compatibility gate
 
@@ -82,3 +86,17 @@ Percentage delta is unavailable when the baseline is zero. Missing metrics stay
 unavailable rather than becoming zero. Every metric declares its unit and
 whether lower or higher values are preferable; the comparison core does not
 round values or synthesize a cross-report winner.
+
+## Diagnostics presentation
+
+The Reports tab loads the bounded saved Performance Lab history as local report
+options and accepts benchmark or evaluation JSON through an explicit picker.
+Each selected report shows its source, schema, date, machine, app, corpus/tier,
+execution configuration, and model/backend/accelerator identity. Compatibility
+findings are rendered before the delta table and recommendation eligibility.
+
+The metric table shows the baseline, candidate, absolute delta, and percentage
+delta side by side. A measured zero is displayed as zero. A percentage change
+from a zero baseline is labeled unavailable, and metrics absent from either
+report are not fabricated. Rendering is capped to the first 500 comparison
+metrics while preserving the parser's full collection validation.

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -162,6 +162,25 @@ benchmark/evaluation reports are untouched. Loading, never-recorded, cleared,
 filtered-empty, error, stale/partial, unsupported, and unavailable states are
 presented separately.
 
+### Reports Tab
+
+Reports imports local Performance Lab benchmark or `murmur-eval` JSON through
+an explicit file picker and compares two normalized reports. The picker rejects
+files larger than 8 MiB before reading; parser/schema/collection failures use
+fixed content-free messages. Imported paths, filenames, raw JSON, transcript
+fields, and evaluation stage text are neither retained nor logged.
+
+Saved Performance Lab history appears as local choices. Imported reports remain
+in memory for the Diagnostics session only, with at most 20 session imports.
+Clear imports removes only those in-memory choices and does not alter source
+files, local benchmark history, Events, or Performance data.
+
+Compatibility blockers are shown before deltas and recommendation eligibility.
+Blockers suppress metrics entirely; machine and app-version warnings permit
+deltas but disable recommendations. Missing metrics remain unavailable,
+measured zero remains zero, and percentage delta from a zero baseline is
+explicitly unavailable.
+
 ### Event Store (`useEventStore`)
 
 The frontend event buffer is managed by the `useEventStore` hook:


### PR DESCRIPTION
## Summary
- add a session-only Reports tab to the Events / Performance / Runs Diagnostics shell
- import strict, bounded Performance Lab and murmur-eval JSON through the merged #359 parser/comparison core
- show source/schema/context metadata, compatibility blockers and warnings, honest deltas, and gated benchmark recommendations
- keep imported filenames, paths, raw contents, and private fixture/stage text out of state and telemetry; Clear imports leaves source files and saved Performance Lab history unchanged

## Validation
- `cd app && npm test` — 44 files / 326 tests passed
- `cd app && npx tsc --noEmit` — passed
- `cd app && npm run build` — passed
- `cd app/src-tauri && cargo check` — passed
- `cd app/src-tauri && cargo test -q -- --test-threads=1` — 595 library tests plus all enabled integration suites passed
- optimized Tauri app build with the Xcode 26.5 compiler-runtime archive supplied — passed
- macOS app/DMG/updater bundles produced; release updater signing correctly stopped because no private signing key is present in this worktree
- `git diff --check` — passed

## Native evidence boundary
Built and launched the isolated `Local Dictation Dev.app` (`com.localdictation.dev`) while production PID 40360 remained unchanged. The app exposed the expected native main window, but the Accessibility harness stalled when opening Settings and the bounded focus/Return fallback did not yield a verifiable Diagnostics window. Per controller boundary, no further native probing was attempted; the dev app was terminated. Focused component/shell coverage validates import, compare, invalid, oversized, incomplete/failed, clear, accessibility wiring, and compact layout behavior.

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Reports** tab to Diagnostics for comparing imported performance and evaluation reports.
  - View report details, compatibility findings, metric deltas, and eligible recommendations.
  - Import reports securely with size limits, session-only storage, and privacy-protective error messages.
  - Clear imported reports without affecting saved performance history.

- **Documentation**
  - Added guidance covering report comparison, validation, privacy, compatibility, and metric handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->