### PR TITLE
fix(release): accept current codesign Team ID syntax

### DIFF
--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -117,18 +117,29 @@ def _require_helper(helper: dict[str, Any]) -> dict[str, Any]:
     # Apple-anchored Developer ID certificate for this exact Team ID. This rejects
     # bare-cdhash ad-hoc requirements, which carry no identity or anchor.
     dr = str(helper["designated_requirement"])
-    required_clauses = (
-        f'identifier "{HELPER_IDENTIFIER}"',
-        "anchor apple generic",
-        "subject.OU",
+    clause_start = r"(?:^|\band\s+)"
+    clause_end = r"(?=\s*(?:and\b|$))"
+    identifier_clause = re.compile(
+        rf'{clause_start}identifier\s+"{re.escape(HELPER_IDENTIFIER)}"{clause_end}'
     )
-    missing_clauses = [clause for clause in required_clauses if clause not in dr]
+    anchor_clause = re.compile(
+        rf"{clause_start}anchor\s+apple\s+generic{clause_end}"
+    )
     team_clause = re.compile(
-        rf"certificate\s+leaf\[subject\.OU\]\s*=\s*"
+        rf"{clause_start}certificate\s+leaf\[subject\.OU\]\s*=\s*"
         rf"(?:\"{re.escape(team_id)}\"|{re.escape(team_id)})"
-        rf"(?=\s*(?:and\b|or\b|$))"
+        rf"{clause_end}"
     )
-    if missing_clauses or team_clause.search(dr) is None:
+    has_unsafe_alternative = (
+        re.search(r"(?:^|\W)or(?:\W|$)", dr) is not None
+        or re.search(r"(?:^|\W)cdhash(?:\W|$)", dr) is not None
+    )
+    if (
+        has_unsafe_alternative
+        or identifier_clause.search(dr) is None
+        or anchor_clause.search(dr) is None
+        or team_clause.search(dr) is None
+    ):
         raise ArtifactError(
             "helper designated_requirement must pin the fixed identifier, an Apple "
             f"anchor, and subject.OU = {team_id!r}; got {dr!r}"

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -123,7 +123,12 @@ def _require_helper(helper: dict[str, Any]) -> dict[str, Any]:
         "subject.OU",
     )
     missing_clauses = [clause for clause in required_clauses if clause not in dr]
-    if missing_clauses or f'"{team_id}"' not in dr:
+    team_clause = re.compile(
+        rf"certificate\s+leaf\[subject\.OU\]\s*=\s*"
+        rf"(?:\"{re.escape(team_id)}\"|{re.escape(team_id)})"
+        rf"(?=\s*(?:and\b|or\b|$))"
+    )
+    if missing_clauses or team_clause.search(dr) is None:
         raise ArtifactError(
             "helper designated_requirement must pin the fixed identifier, an Apple "
             f"anchor, and subject.OU = {team_id!r}; got {dr!r}"

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -109,6 +109,16 @@ class ReleaseArtifactTests(unittest.TestCase):
         result = validate_release(self.artifacts, SHA, RUN_ID, require_macos_helper=True)
         self.assertEqual(result["platforms"]["macos"]["helper"], self.HELPER)
 
+    def test_helper_unquoted_team_id_requirement_is_valid(self) -> None:
+        dr = (
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345'
+        )
+        helper = {**self.HELPER, "designated_requirement": dr}
+        self._rerecord_macos_with_helper(helper)
+        result = validate_release(self.artifacts, SHA, RUN_ID, require_macos_helper=True)
+        self.assertEqual(result["platforms"]["macos"]["helper"], helper)
+
     def test_require_macos_helper_fails_without_block(self) -> None:
         with self.assertRaisesRegex(ArtifactError, "missing the required local-LLM helper"):
             validate_release(self.artifacts, SHA, RUN_ID, require_macos_helper=True)
@@ -143,6 +153,22 @@ class ReleaseArtifactTests(unittest.TestCase):
         dr = (
             'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
             'and certificate leaf[subject.OU] = "ZZZZZ99999"'
+        )
+        with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+            self._rerecord_macos_with_helper({**self.HELPER, "designated_requirement": dr})
+
+    def test_helper_designated_requirement_team_prefix_rejected(self) -> None:
+        dr = (
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345EXTRA'
+        )
+        with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+            self._rerecord_macos_with_helper({**self.HELPER, "designated_requirement": dr})
+
+    def test_helper_designated_requirement_wrong_operator_rejected(self) -> None:
+        dr = (
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] != ABCDE12345'
         )
         with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
             self._rerecord_macos_with_helper({**self.HELPER, "designated_requirement": dr})

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -173,6 +173,39 @@ class ReleaseArtifactTests(unittest.TestCase):
         with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
             self._rerecord_macos_with_helper({**self.HELPER, "designated_requirement": dr})
 
+    def test_helper_designated_requirement_or_branch_rejected(self) -> None:
+        requirements = (
+            'identifier "com.localdictation.local-llm-sidecar" or anchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345',
+            'identifier "com.localdictation.local-llm-sidecar" and anchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345 or cdhash H"deadbeefcafe"',
+        )
+        for dr in requirements:
+            with self.subTest(dr=dr):
+                with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+                    self._rerecord_macos_with_helper(
+                        {**self.HELPER, "designated_requirement": dr}
+                    )
+
+    def test_helper_designated_requirement_clause_prefix_decoys_rejected(self) -> None:
+        requirements = (
+            'notidentifier "com.localdictation.local-llm-sidecar" '
+            'and anchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345',
+            'identifier "com.localdictation.local-llm-sidecar" '
+            'and xanchor apple generic '
+            'and certificate leaf[subject.OU] = ABCDE12345',
+            'identifier "com.localdictation.local-llm-sidecar" '
+            'and anchor apple generic '
+            'and not certificate leaf[subject.OU] = ABCDE12345',
+        )
+        for dr in requirements:
+            with self.subTest(dr=dr):
+                with self.assertRaisesRegex(ArtifactError, "designated_requirement must pin"):
+                    self._rerecord_macos_with_helper(
+                        {**self.HELPER, "designated_requirement": dr}
+                    )
+
     def test_validate_rejects_helper_block_on_linux(self) -> None:
         # A helper block must never appear on a non-macos platform, even if a
         # provenance file is hand-edited to smuggle one in.


### PR DESCRIPTION
Closes #367

## Summary
- accept both quoted and unquoted canonical `certificate leaf[subject.OU]` equality output from `codesign -d -r-`
- continue requiring the fixed helper identifier, Apple generic anchor, exact Team ID, and correct equality operator
- reject wrong IDs, prefixes, malformed operators, and ad-hoc requirements

## Validation
- `python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py` (38 passed)
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m py_compile scripts/release_artifacts.py tests/test_release_artifacts.py`
- `git diff --check`

## Release evidence
Trusted Release Build 29987417863 signed, notarized, Gatekeeper-validated, and launch-smoked v0.21.0 before failing only on the older quoted-Team-ID parser assumption. No tag or release was created.