### PR TITLE
fix(release): exclude developer binaries from app bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
         run: >-
           cd app/src-tauri &&
-          cargo run --bin murmur-eval -- deterministic
+          cargo run --example murmur-eval -- deterministic
           --output target/murmur-eval/ci-report.json
 
   linux:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Production app bundles now contain only the Murmur executable and signed local-LLM sidecar. The mock sidecar and local evaluation CLI remain available as Cargo examples for development and CI, and release finalization fails closed on any unexpected executable (#324).
+
 ## [0.21.0] - 2026-07-23
 
 ### Added

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -65,11 +65,12 @@ sha2 = "0.10"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 
 # Test-support helper: a protocol-v1 mock of the local-LLM sidecar, driven by
-# scenario env vars. Built as a normal bin so integration tests can locate it
-# via CARGO_BIN_EXE_mock_llm_helper. Not an externalBin, so it is never bundled.
-[[bin]]
+# scenario env vars. It is an example target so `cargo test` builds it for the
+# integration suite without exposing it to Tauri's automatic `--bins` bundle.
+[[example]]
 name = "mock_llm_helper"
 path = "tests/support/mock_llm_helper.rs"
+test = false
 
 [dev-dependencies]
 tempfile = "3"

--- a/app/src-tauri/examples/murmur-eval.rs
+++ b/app/src-tauri/examples/murmur-eval.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use ui_lib::evaluation::{self, EvaluationTier, RunOptions};
 
 fn usage() -> &'static str {
-    "Usage: murmur-eval <deterministic|hardware> [--fixtures DIR] [--output FILE] [--workspace-root DIR] [--machine-label LABEL]"
+    "Usage: cargo run --example murmur-eval -- <deterministic|hardware> [--fixtures DIR] [--output FILE] [--workspace-root DIR] [--machine-label LABEL]"
 }
 
 fn main() {

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -1,8 +1,9 @@
 //! Integration tests for the local-LLM sidecar supervisor (#312).
 //!
 //! These drive the real supervisor against the protocol-v1 mock helper
-//! (`CARGO_BIN_EXE_mock_llm_helper`). No real GGUF model or llama.cpp is
-//! involved: the "model" is a small temp file whose pins the test derives.
+//! (`target/<profile>/examples/mock_llm_helper`). No real GGUF model or
+//! llama.cpp is involved: the "model" is a small temp file whose pins the test
+//! derives.
 
 #![cfg(all(target_os = "macos", target_arch = "aarch64"))]
 
@@ -15,7 +16,12 @@ use ui_lib::llm_sidecar::{
 };
 
 fn helper_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_mock_llm_helper"))
+    std::env::current_exe()
+        .expect("integration test executable path")
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("Cargo target profile directory")
+        .join("examples/mock_llm_helper")
 }
 
 /// A small fixture "model" file plus its exact pins.

--- a/app/src-tauri/tests/transform_flow_integration.rs
+++ b/app/src-tauri/tests/transform_flow_integration.rs
@@ -17,7 +17,12 @@ use ui_lib::llm_sidecar::{model_file_digest, LlmSidecar, TestSpawnConfig};
 use ui_lib::transform_flow::run_happy_path_for_test;
 
 fn helper_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_mock_llm_helper"))
+    std::env::current_exe()
+        .expect("integration test executable path")
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("Cargo target profile directory")
+        .join("examples/mock_llm_helper")
 }
 
 struct Fixture {

--- a/docs/features/evaluation-harness.md
+++ b/docs/features/evaluation-harness.md
@@ -13,7 +13,7 @@ It does not read Murmur history, app settings, the microphone, the system clipbo
 Run the deterministic suite from `app/src-tauri`:
 
 ```bash
-cargo run --bin murmur-eval -- deterministic \
+cargo run --example murmur-eval -- deterministic \
   --output target/murmur-eval/deterministic-report.json
 ```
 
@@ -22,7 +22,7 @@ This is the CI tier. It uses fixture-provided raw ASR, a fixed clock, a fake cli
 The hardware tier is explicit and opt-in:
 
 ```bash
-cargo run --bin murmur-eval -- hardware \
+cargo run --example murmur-eval -- hardware \
   --machine-label local-mac \
   --output target/murmur-eval/hardware-report.json
 ```

--- a/scripts/finalize_macos_bundle.py
+++ b/scripts/finalize_macos_bundle.py
@@ -113,6 +113,20 @@ def signature_details(path: Path) -> str:
     return result.stdout + result.stderr
 
 
+def require_exact_macos_executables(
+    app: Path, main_binary: Path, helper: Path
+) -> None:
+    """Fail closed unless the app ships exactly its two production executables."""
+    executable_dir = app / "Contents" / "MacOS"
+    expected = {main_binary.name, helper.name}
+    actual = {path.name for path in executable_dir.iterdir()}
+    if actual != expected:
+        raise SystemExit(
+            "app bundle executables differ: "
+            f"expected={sorted(expected)!r} actual={sorted(actual)!r}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--app", type=Path, required=True)
@@ -132,6 +146,7 @@ def main() -> int:
     main_binary = app / "Contents" / "MacOS" / str(main_name)
     if not main_binary.is_file() or main_binary == helper:
         raise SystemExit("app bundle has an invalid main executable")
+    require_exact_macos_executables(app, main_binary, helper)
 
     sign_nested_code(app, args.identity, exclude={helper, main_binary})
     sign(helper, args.identity, args.helper_entitlements, HELPER_IDENTIFIER)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import tempfile
 import unittest
 
+from scripts.finalize_macos_bundle import require_exact_macos_executables
 from scripts.release_artifacts import (
     ArtifactError,
     create_provenance,
@@ -215,6 +216,38 @@ class ReleaseArtifactTests(unittest.TestCase):
         (linux / "provenance.json").write_text(json.dumps(payload))
         with self.assertRaisesRegex(ArtifactError, "must not carry a helper block"):
             validate_release(self.artifacts, SHA, RUN_ID)
+
+    def test_macos_bundle_requires_exact_production_executables(self) -> None:
+        app = self.root / "Murmur.app"
+        executable_dir = app / "Contents" / "MacOS"
+        executable_dir.mkdir(parents=True)
+        main = executable_dir / "ui"
+        helper = executable_dir / "murmur-llm-sidecar"
+        main.write_bytes(b"main")
+        helper.write_bytes(b"helper")
+
+        require_exact_macos_executables(app, main, helper)
+
+        for unexpected in ("mock_llm_helper", "murmur-eval"):
+            with self.subTest(unexpected=unexpected):
+                extra = executable_dir / unexpected
+                extra.write_bytes(b"developer tool")
+                with self.assertRaisesRegex(
+                    SystemExit, "app bundle executables differ"
+                ):
+                    require_exact_macos_executables(app, main, helper)
+                extra.unlink()
+
+    def test_macos_bundle_rejects_missing_production_executable(self) -> None:
+        app = self.root / "Murmur.app"
+        executable_dir = app / "Contents" / "MacOS"
+        executable_dir.mkdir(parents=True)
+        main = executable_dir / "ui"
+        helper = executable_dir / "murmur-llm-sidecar"
+        main.write_bytes(b"main")
+
+        with self.assertRaisesRegex(SystemExit, "app bundle executables differ"):
+            require_exact_macos_executables(app, main, helper)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #324.

## Summary
- model the mock sidecar and `murmur-eval` as Cargo examples so Tauri sees only the production `ui` binary
- preserve the mock-sidecar integration suite by resolving Cargo-built example paths at runtime
- fail release finalization unless `Contents/MacOS` contains exactly `ui` and `murmur-llm-sidecar`
- update evaluation CLI invocations and add packaging regression tests

## Validation
- `cargo check`
- `cargo test -- --test-threads=1` (595 library tests + integration suites; expected opt-in tests ignored)
- `npx tsc --noEmit`
- `npm test` (326 tests)
- workflow/artifact policy suite (42 tests)
- local unsigned Tauri production bundle built successfully with exactly `ui` and `murmur-llm-sidecar`
- ad-hoc finalizer and strict deep code-sign verification passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS production app bundles now contain only the expected application and signed local-LLM helper executables.
  * Release finalization now stops if unexpected or missing executables are detected.
  * Updated evaluation commands and help text to use the correct Cargo example format.

* **Documentation**
  * Updated evaluation harness instructions to reflect the revised commands.

* **Tests**
  * Improved integration coverage for bundled helper executable discovery and bundle validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->