### PR TITLE
Transform diagnostics: record every attempt and add consented content capture

### DIFF
--- a/app/src-tauri/crates/local-llm-protocol/src/lib.rs
+++ b/app/src-tauri/crates/local-llm-protocol/src/lib.rs
@@ -2,7 +2,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::io::{Read, Write};
 
 pub const PROTOCOL_NAME: &str = "murmur.local_llm";
-pub const PROTOCOL_VERSION: u16 = 1;
+pub const PROTOCOL_VERSION: u16 = 2;
 pub const MODEL_FD: i32 = 3;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_INSTRUCTION_BYTES: usize = 4 * 1024;
@@ -12,6 +12,7 @@ pub const MAX_OUTPUT_TOKENS: u32 = 2_048;
 pub const MAX_CONTEXT_TOKENS: u32 = 8_192;
 pub const DEFAULT_DEADLINE_MS: u64 = 15_000;
 pub const MAX_DEADLINE_MS: u64 = 30_000;
+pub const MAX_DIAGNOSTIC_PHASE_MS: u64 = 10 * 60 * 1_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -109,6 +110,51 @@ pub enum ErrorCode {
     Internal,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticPhase {
+    HelperModelVerification,
+    BackendInitialization,
+    ModelLoad,
+    RequestReceipt,
+    FirstToken,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PhaseState {
+    Started,
+    Completed,
+}
+
+pub fn validate_diagnostic_phase(
+    request_id: Option<&str>,
+    phase: DiagnosticPhase,
+    state: PhaseState,
+    duration_ms: Option<u64>,
+) -> bool {
+    let duration_valid = duration_ms.is_none_or(|value| value <= MAX_DIAGNOSTIC_PHASE_MS);
+    if !duration_valid {
+        return false;
+    }
+    match phase {
+        DiagnosticPhase::HelperModelVerification
+        | DiagnosticPhase::BackendInitialization
+        | DiagnosticPhase::ModelLoad => {
+            request_id.is_none()
+                && matches!(
+                    (state, duration_ms),
+                    (PhaseState::Started, None) | (PhaseState::Completed, Some(_))
+                )
+        }
+        DiagnosticPhase::RequestReceipt | DiagnosticPhase::FirstToken => {
+            request_id.is_some_and(|id| !id.is_empty() && id.len() <= 64)
+                && state == PhaseState::Completed
+                && duration_ms.is_some()
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(
     tag = "type",
@@ -117,6 +163,15 @@ pub enum ErrorCode {
     deny_unknown_fields
 )]
 pub enum HelperMessage {
+    DiagnosticPhase {
+        protocol: String,
+        version: u16,
+        session_nonce: String,
+        request_id: Option<String>,
+        phase: DiagnosticPhase,
+        state: PhaseState,
+        duration_ms: Option<u64>,
+    },
     Ready {
         protocol: String,
         version: u16,
@@ -328,5 +383,39 @@ mod tests {
         assert_eq!(json["sessionNonce"], "nonce");
         assert_eq!(json["requestId"], "request");
         assert!(json.get("session_nonce").is_none());
+    }
+
+    #[test]
+    fn diagnostic_phase_shape_is_strict_and_content_free() {
+        assert!(validate_diagnostic_phase(
+            None,
+            DiagnosticPhase::ModelLoad,
+            PhaseState::Started,
+            None,
+        ));
+        assert!(validate_diagnostic_phase(
+            Some("request"),
+            DiagnosticPhase::FirstToken,
+            PhaseState::Completed,
+            Some(12),
+        ));
+        assert!(!validate_diagnostic_phase(
+            Some("request"),
+            DiagnosticPhase::ModelLoad,
+            PhaseState::Completed,
+            Some(12),
+        ));
+        assert!(!validate_diagnostic_phase(
+            None,
+            DiagnosticPhase::RequestReceipt,
+            PhaseState::Completed,
+            Some(0),
+        ));
+        assert!(!validate_diagnostic_phase(
+            None,
+            DiagnosticPhase::ModelLoad,
+            PhaseState::Completed,
+            Some(MAX_DIAGNOSTIC_PHASE_MS + 1),
+        ));
     }
 }

--- a/app/src-tauri/sidecars/local-llm/src/main.rs
+++ b/app/src-tauri/sidecars/local-llm/src/main.rs
@@ -10,9 +10,9 @@ mod macos_arm64 {
     use llama_cpp_2::sampling::LlamaSampler;
     use llama_cpp_2::{list_llama_ggml_backend_devices, send_logs_to_tracing, LogOptions};
     use murmur_local_llm_protocol::{
-        read_frame, validate_host_message, write_frame, ErrorCode, FinishReason, HelperMessage,
-        HostMessage, ModelIdentity, ProtocolLimits, MAX_CONTEXT_TOKENS, MAX_OUTPUT_BYTES, MODEL_FD,
-        PROTOCOL_NAME, PROTOCOL_VERSION,
+        read_frame, validate_host_message, write_frame, DiagnosticPhase, ErrorCode, FinishReason,
+        HelperMessage, HostMessage, ModelIdentity, PhaseState, ProtocolLimits, MAX_CONTEXT_TOKENS,
+        MAX_OUTPUT_BYTES, MODEL_FD, PROTOCOL_NAME, PROTOCOL_VERSION,
     };
     use sha2::{Digest, Sha256};
     use std::fs::File;
@@ -53,8 +53,62 @@ mod macos_arm64 {
             bail!("host limits do not match helper limits");
         }
 
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::HelperModelVerification,
+            PhaseState::Started,
+            None,
+        )?;
+        let started = Instant::now();
         verify_inherited_model(&expected_model)?;
-        let runtime = Runtime::load()?;
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::HelperModelVerification,
+            PhaseState::Completed,
+            Some(started.elapsed().as_millis() as u64),
+        )?;
+
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::BackendInitialization,
+            PhaseState::Started,
+            None,
+        )?;
+        let started = Instant::now();
+        let (backend, backend_name) = Runtime::init_backend()?;
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::BackendInitialization,
+            PhaseState::Completed,
+            Some(started.elapsed().as_millis() as u64),
+        )?;
+
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::ModelLoad,
+            PhaseState::Started,
+            None,
+        )?;
+        let started = Instant::now();
+        let runtime = Runtime::load_model(backend, backend_name)?;
+        emit_phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            DiagnosticPhase::ModelLoad,
+            PhaseState::Completed,
+            Some(started.elapsed().as_millis() as u64),
+        )?;
         write_frame(
             &mut stdout,
             &HelperMessage::Ready {
@@ -94,26 +148,49 @@ mod macos_arm64 {
                     max_output_tokens,
                     deadline_ms,
                     ..
-                } => match runtime.transform(
-                    &instruction,
-                    &input,
-                    max_output_tokens,
-                    Duration::from_millis(deadline_ms),
-                ) {
-                    Ok((output, finish_reason, output_tokens)) => write_frame(
+                } => {
+                    emit_phase(
                         &mut stdout,
-                        &HelperMessage::Result {
-                            protocol: PROTOCOL_NAME.to_string(),
-                            version: PROTOCOL_VERSION,
-                            session_nonce: session_nonce.clone(),
-                            request_id,
-                            output,
-                            finish_reason,
-                            output_tokens,
+                        &session_nonce,
+                        Some(&request_id),
+                        DiagnosticPhase::RequestReceipt,
+                        PhaseState::Completed,
+                        Some(0),
+                    )?;
+                    match runtime.transform(
+                        &instruction,
+                        &input,
+                        max_output_tokens,
+                        Duration::from_millis(deadline_ms),
+                        |first_token_ms| {
+                            emit_phase(
+                                &mut stdout,
+                                &session_nonce,
+                                Some(&request_id),
+                                DiagnosticPhase::FirstToken,
+                                PhaseState::Completed,
+                                Some(first_token_ms),
+                            )
+                            .map_err(|_| ErrorCode::Internal)
                         },
-                    )?,
-                    Err(code) => write_error(&mut stdout, &session_nonce, Some(request_id), code)?,
-                },
+                    ) {
+                        Ok((output, finish_reason, output_tokens)) => write_frame(
+                            &mut stdout,
+                            &HelperMessage::Result {
+                                protocol: PROTOCOL_NAME.to_string(),
+                                version: PROTOCOL_VERSION,
+                                session_nonce: session_nonce.clone(),
+                                request_id,
+                                output,
+                                finish_reason,
+                                output_tokens,
+                            },
+                        )?,
+                        Err(code) => {
+                            write_error(&mut stdout, &session_nonce, Some(request_id), code)?
+                        }
+                    }
+                }
                 HostMessage::Cancel { request_id, .. } => write_frame(
                     &mut stdout,
                     &HelperMessage::Cancelled {
@@ -170,6 +247,29 @@ mod macos_arm64 {
         Ok(())
     }
 
+    fn emit_phase(
+        stdout: &mut impl std::io::Write,
+        session_nonce: &str,
+        request_id: Option<&str>,
+        phase: DiagnosticPhase,
+        state: PhaseState,
+        duration_ms: Option<u64>,
+    ) -> Result<()> {
+        write_frame(
+            stdout,
+            &HelperMessage::DiagnosticPhase {
+                protocol: PROTOCOL_NAME.to_string(),
+                version: PROTOCOL_VERSION,
+                session_nonce: session_nonce.to_string(),
+                request_id: request_id.map(str::to_string),
+                phase,
+                state,
+                duration_ms,
+            },
+        )?;
+        Ok(())
+    }
+
     fn disable_core_dumps() -> Result<()> {
         let limit = libc::rlimit {
             rlim_cur: 0,
@@ -212,7 +312,7 @@ mod macos_arm64 {
     }
 
     impl Runtime {
-        fn load() -> Result<Self> {
+        fn init_backend() -> Result<(LlamaBackend, String)> {
             let backend = LlamaBackend::init().context("llama backend init")?;
             let devices = list_llama_ggml_backend_devices();
             let metal_device = devices
@@ -230,13 +330,17 @@ mod macos_arm64 {
                         backend.supports_gpu_offload()
                     )
                 })?;
+            Ok((backend, format!("metal:{}", metal_device.name)))
+        }
+
+        fn load_model(backend: LlamaBackend, backend_name: String) -> Result<Self> {
             let params = LlamaModelParams::default().with_n_gpu_layers(1_000);
             let model = LlamaModel::load_from_file(&backend, Path::new("/dev/fd/3"), &params)
                 .context("model load from inherited descriptor")?;
             Ok(Self {
                 _backend: backend,
                 model,
-                backend_name: format!("metal:{}", metal_device.name),
+                backend_name,
             })
         }
 
@@ -246,6 +350,7 @@ mod macos_arm64 {
             input: &str,
             max_output_tokens: u32,
             deadline: Duration,
+            mut on_first_token: impl FnMut(u64) -> Result<(), ErrorCode>,
         ) -> Result<(String, FinishReason, u32), ErrorCode> {
             let prompt = format!(
                 "<|im_start|>system\n{FIXED_SYSTEM_PROMPT}<|im_end|>\n<|im_start|>user\nINSTRUCTION_BEGIN\n{instruction}\nINSTRUCTION_END\nINPUT_BEGIN\n{input}\nINPUT_END<|im_end|>\n<|im_start|>assistant\n"
@@ -294,6 +399,9 @@ mod macos_arm64 {
                 if self.model.is_eog_token(token) {
                     finish_reason = FinishReason::Stop;
                     break;
+                }
+                if generated == 0 {
+                    on_first_token(started.elapsed().as_millis() as u64)?;
                 }
                 let piece = self
                     .model

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod overlay;
 pub mod performance;
 pub mod permissions;
 pub mod recording;
+pub mod transform_diagnostics;
 pub mod transform_model;
 pub mod transform_popover;
 pub mod tray;

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -2177,7 +2177,20 @@ pub async fn start_native_recording(
             app: &app_handle,
             state: &state,
         };
+        let dismissed_transform_pass_id = state.app_state.active_transform_pass_id();
         if crate::transform_flow::dismiss_review_for_recording(&state.app_state, &fx) {
+            if let Some(transform_pass_id) = dismissed_transform_pass_id {
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "supersession",
+                    "completed",
+                    None,
+                    None,
+                );
+                state
+                    .transform_diagnostics
+                    .finish(transform_pass_id, "superseded");
+            }
             tracing::info!(target: "pipeline", "start_native_recording: auto-dismissed transform review");
         }
     }

--- a/app/src-tauri/src/commands/transform_diagnostics.rs
+++ b/app/src-tauri/src/commands/transform_diagnostics.rs
@@ -3,51 +3,89 @@ use crate::transform_diagnostics::{
 };
 use crate::State;
 
+const LOG_VIEWER_LABEL: &str = "log-viewer";
+
+fn require_log_viewer(label: &str) -> Result<(), String> {
+    if label == LOG_VIEWER_LABEL {
+        Ok(())
+    } else {
+        Err("transform diagnostics are only available in the log viewer".to_string())
+    }
+}
+
 #[tauri::command]
 pub fn arm_next_transform_diagnostic_capture(
+    window: tauri::WebviewWindow,
     state: tauri::State<'_, State>,
 ) -> Result<CaptureArmStatusV1, String> {
+    require_log_viewer(window.label())?;
     state.transform_diagnostics.arm_next()
 }
 
 #[tauri::command]
 pub fn get_transform_diagnostic_capture_status(
+    window: tauri::WebviewWindow,
     state: tauri::State<'_, State>,
-) -> CaptureArmStatusV1 {
-    state.transform_diagnostics.arm_status()
+) -> Result<CaptureArmStatusV1, String> {
+    require_log_viewer(window.label())?;
+    Ok(state.transform_diagnostics.arm_status())
 }
 
 #[tauri::command]
 pub fn list_transform_attempts(
+    window: tauri::WebviewWindow,
     limit: Option<usize>,
     state: tauri::State<'_, State>,
-) -> TransformAttemptListV1 {
-    state
+) -> Result<TransformAttemptListV1, String> {
+    require_log_viewer(window.label())?;
+    Ok(state
         .transform_diagnostics
-        .list_attempts(limit.unwrap_or(50))
+        .list_attempts(limit.unwrap_or(50)))
 }
 
 #[tauri::command]
 pub fn list_transform_diagnostic_captures(
+    window: tauri::WebviewWindow,
     state: tauri::State<'_, State>,
 ) -> Result<Vec<DiagnosticCaptureSummaryV1>, String> {
+    require_log_viewer(window.label())?;
     state.transform_diagnostics.list_captures()
 }
 
 #[tauri::command]
 pub fn get_transform_diagnostic_capture(
+    window: tauri::WebviewWindow,
     capture_id: String,
     state: tauri::State<'_, State>,
 ) -> Result<Option<DiagnosticCaptureV1>, String> {
+    require_log_viewer(window.label())?;
     state.transform_diagnostics.get_capture(capture_id.trim())
 }
 
 #[tauri::command]
 pub fn delete_transform_diagnostic_capture(
+    window: tauri::WebviewWindow,
     capture_id: String,
     state: tauri::State<'_, State>,
 ) -> Result<(), String> {
+    require_log_viewer(window.label())?;
     state
         .transform_diagnostics
         .delete_capture(capture_id.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transform_diagnostics_are_strictly_scoped_to_log_viewer() {
+        assert!(require_log_viewer(LOG_VIEWER_LABEL).is_ok());
+        for label in ["main", "transform-review", "overlay", "", "log-viewer-copy"] {
+            assert!(
+                require_log_viewer(label).is_err(),
+                "unexpected diagnostics access for {label:?}"
+            );
+        }
+    }
 }

--- a/app/src-tauri/src/commands/transform_diagnostics.rs
+++ b/app/src-tauri/src/commands/transform_diagnostics.rs
@@ -1,0 +1,53 @@
+use crate::transform_diagnostics::{
+    CaptureArmStatusV1, DiagnosticCaptureSummaryV1, DiagnosticCaptureV1, TransformAttemptListV1,
+};
+use crate::State;
+
+#[tauri::command]
+pub fn arm_next_transform_diagnostic_capture(
+    state: tauri::State<'_, State>,
+) -> Result<CaptureArmStatusV1, String> {
+    state.transform_diagnostics.arm_next()
+}
+
+#[tauri::command]
+pub fn get_transform_diagnostic_capture_status(
+    state: tauri::State<'_, State>,
+) -> CaptureArmStatusV1 {
+    state.transform_diagnostics.arm_status()
+}
+
+#[tauri::command]
+pub fn list_transform_attempts(
+    limit: Option<usize>,
+    state: tauri::State<'_, State>,
+) -> TransformAttemptListV1 {
+    state
+        .transform_diagnostics
+        .list_attempts(limit.unwrap_or(50))
+}
+
+#[tauri::command]
+pub fn list_transform_diagnostic_captures(
+    state: tauri::State<'_, State>,
+) -> Result<Vec<DiagnosticCaptureSummaryV1>, String> {
+    state.transform_diagnostics.list_captures()
+}
+
+#[tauri::command]
+pub fn get_transform_diagnostic_capture(
+    capture_id: String,
+    state: tauri::State<'_, State>,
+) -> Result<Option<DiagnosticCaptureV1>, String> {
+    state.transform_diagnostics.get_capture(capture_id.trim())
+}
+
+#[tauri::command]
+pub fn delete_transform_diagnostic_capture(
+    capture_id: String,
+    state: tauri::State<'_, State>,
+) -> Result<(), String> {
+    state
+        .transform_diagnostics
+        .delete_capture(capture_id.trim())
+}

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -998,6 +998,16 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                                             "superseded",
                                             None,
                                         );
+                                        state.transform_diagnostics.phase(
+                                            previous_pass_id,
+                                            "supersession",
+                                            "completed",
+                                            None,
+                                            None,
+                                        );
+                                        state
+                                            .transform_diagnostics
+                                            .finish(previous_pass_id, "superseded");
                                         app_state.clear_transform_pass(previous_pass_id);
                                     }
                                     crate::transform_apply::clear_session(app_state);
@@ -1017,6 +1027,16 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                                                 "superseded",
                                                 None,
                                             );
+                                            state.transform_diagnostics.phase(
+                                                previous_pass_id,
+                                                "supersession",
+                                                "completed",
+                                                None,
+                                                None,
+                                            );
+                                            state
+                                                .transform_diagnostics
+                                                .finish(previous_pass_id, "superseded");
                                             app_state.clear_transform_pass(previous_pass_id);
                                         }
                                         crate::transform_apply::clear_session(app_state);

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub mod telemetry;
 pub mod transcriber;
 mod transcript_transform;
 mod transform_apply;
+mod transform_diagnostics;
 pub mod transform_flow;
 mod transform_presets;
 mod transform_trace;
@@ -113,6 +114,7 @@ pub(crate) struct State {
     pub(crate) knowledge: knowledge_store::KnowledgeStore,
     pub(crate) correct_and_teach: correct_and_teach::CorrectAndTeachState,
     pub(crate) performance: performance_metrics::PerformanceMetrics,
+    pub(crate) transform_diagnostics: transform_diagnostics::TransformDiagnostics,
     /// Cached notch dimensions (notch_width, menu_bar_height) from setup (main thread).
     pub(crate) notch_info: Mutex<Option<(f64, f64)>>,
     /// The selection-bounds anchor from the most recent `show_transform_popover`
@@ -219,6 +221,7 @@ pub fn run() {
             knowledge: knowledge_store::KnowledgeStore::default(),
             correct_and_teach: correct_and_teach::CorrectAndTeachState::default(),
             performance: performance_metrics::PerformanceMetrics::default(),
+            transform_diagnostics: transform_diagnostics::TransformDiagnostics::default(),
             notch_info: Mutex::new(None),
             transform_popover_anchor: Mutex::new(None),
             transform_main_was_visible: Mutex::new(None),
@@ -293,6 +296,12 @@ pub fn run() {
             commands::performance::get_performance_run,
             commands::performance::get_performance_resource_window,
             commands::performance::clear_performance_diagnostics,
+            commands::transform_diagnostics::arm_next_transform_diagnostic_capture,
+            commands::transform_diagnostics::get_transform_diagnostic_capture_status,
+            commands::transform_diagnostics::list_transform_attempts,
+            commands::transform_diagnostics::list_transform_diagnostic_captures,
+            commands::transform_diagnostics::get_transform_diagnostic_capture,
+            commands::transform_diagnostics::delete_transform_diagnostic_capture,
             commands::models::check_model_exists,
             commands::models::check_specific_model_exists,
             commands::models::get_model_runtime_catalog,
@@ -342,12 +351,24 @@ pub fn run() {
             if let Err(error) = app
                 .state::<State>()
                 .performance
-                .initialize(performance_root, Some(app.handle().clone()))
+                .initialize(performance_root.clone(), Some(app.handle().clone()))
             {
                 tracing::warn!(
                     target: "system",
                     diagnostics_available = false,
                     "performance diagnostics store unavailable: {}",
+                    error
+                );
+            }
+            if let Err(error) = app
+                .state::<State>()
+                .transform_diagnostics
+                .initialize(performance_root.join("transforms"))
+            {
+                tracing::warn!(
+                    target: "system",
+                    diagnostics_available = false,
+                    "transform diagnostics store unavailable: {}",
                     error
                 );
             }

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -106,6 +106,51 @@ pub struct CorrelatedTransformOutcome {
     pub spawn_load_ms: Option<u64>,
     pub generation_ms: Option<u64>,
     pub cache_hit: Option<bool>,
+    pub diagnostics: SidecarDiagnostics,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SidecarDiagnostics {
+    pub host_model_verification_ms: Option<u64>,
+    pub helper_spawn_ms: Option<u64>,
+    pub helper_model_verification_ms: Option<u64>,
+    pub backend_initialization_ms: Option<u64>,
+    pub model_load_ms: Option<u64>,
+    pub ready_handshake_ms: Option<u64>,
+    pub request_receipt_ms: Option<u64>,
+    pub first_token_ms: Option<u64>,
+    pub process_exit_code: Option<i32>,
+    pub process_exit_signal: Option<i32>,
+    pub failure_phase: Option<SidecarDiagnosticPhase>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidecarDiagnosticPhase {
+    HostModelVerification,
+    HelperSpawn,
+    HelperModelVerification,
+    BackendInitialization,
+    ModelLoad,
+    ReadyHandshake,
+    RequestReceipt,
+    FirstToken,
+    Generation,
+}
+
+impl SidecarDiagnosticPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HostModelVerification => "host_model_verification",
+            Self::HelperSpawn => "helper_spawn",
+            Self::HelperModelVerification => "helper_model_verification",
+            Self::BackendInitialization => "backend_initialization",
+            Self::ModelLoad => "model_load",
+            Self::ReadyHandshake => "ready_handshake",
+            Self::RequestReceipt => "request_receipt",
+            Self::FirstToken => "first_token",
+            Self::Generation => "generation",
+        }
+    }
 }
 
 impl CorrelatedTransformOutcome {
@@ -115,6 +160,7 @@ impl CorrelatedTransformOutcome {
             spawn_load_ms: None,
             generation_ms: None,
             cache_hit: None,
+            diagnostics: SidecarDiagnostics::default(),
         }
     }
 }
@@ -300,6 +346,7 @@ fn open_and_verify_model(
     path: &Path,
     expected_size: u64,
     expected_sha: &str,
+    cancel: &CancelToken,
 ) -> Result<std::fs::File, TransformError> {
     use sha2::{Digest, Sha256};
     use std::io::{Read, Seek, SeekFrom};
@@ -309,6 +356,9 @@ fn open_and_verify_model(
     // transient/environmental → ModelUnreadable (fail closed, keep the model).
     // Only a wrong size / hash / non-regular file is a content mismatch →
     // ModelMismatch (the caller removes it so it can be re-downloaded).
+    if cancel.is_cancelled() {
+        return Err(TransformError::Cancelled);
+    }
     let mut file = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW)
@@ -325,6 +375,9 @@ fn open_and_verify_model(
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; 1024 * 1024];
     loop {
+        if cancel.is_cancelled() {
+            return Err(TransformError::Cancelled);
+        }
         let n = file
             .read(&mut buffer)
             .map_err(|_| TransformError::ModelUnreadable)?;
@@ -332,6 +385,9 @@ fn open_and_verify_model(
             break;
         }
         hasher.update(&buffer[..n]);
+    }
+    if cancel.is_cancelled() {
+        return Err(TransformError::Cancelled);
     }
     let actual = format!("{:x}", hasher.finalize());
     if actual != expected_sha {
@@ -348,6 +404,7 @@ fn open_and_verify_model(
     _path: &Path,
     _expected_size: u64,
     _expected_sha: &str,
+    _cancel: &CancelToken,
 ) -> Result<std::fs::File, TransformError> {
     Err(TransformError::Unsupported)
 }
@@ -466,11 +523,6 @@ impl SpawnPlan {
             Self::Production => Duration::from_secs(5 * 60),
             Self::Test(c) => c.idle_after,
         }
-    }
-    fn stderr_inherit(&self) -> bool {
-        // Release suppresses helper stderr (no sensitive crash artifacts);
-        // debug and tests inherit it for diagnosis.
-        cfg!(debug_assertions)
     }
     // Only referenced by the equally-gated env-injection loop; compiled out of
     // release builds so the scenario-env path is not present at all there.
@@ -675,6 +727,26 @@ mod supported {
     }
 
     impl LlmSidecar {
+        fn record_process_exit(
+            proc: &mut std::process::Child,
+            diagnostics: &mut SidecarDiagnostics,
+        ) {
+            // EOF can beat waitpid visibility by a few scheduler ticks. Poll
+            // briefly without ever turning diagnostics into an unbounded wait.
+            for _ in 0..20 {
+                if let Ok(Some(status)) = proc.try_wait() {
+                    diagnostics.process_exit_code = status.code();
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::process::ExitStatusExt;
+                        diagnostics.process_exit_signal = status.signal();
+                    }
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+
         pub fn new() -> Self {
             Self::with_plan(SpawnPlan::Production)
         }
@@ -932,6 +1004,7 @@ mod supported {
             let mut inner = self.lock();
             let cache_hit = inner.child.is_some();
             let load_started = Instant::now();
+            let mut diagnostics = SidecarDiagnostics::default();
 
             if inner.breaker.is_disabled(Instant::now()) {
                 return CorrelatedTransformOutcome {
@@ -939,6 +1012,7 @@ mod supported {
                     spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
                     generation_ms: None,
                     cache_hit: Some(cache_hit),
+                    diagnostics,
                 };
             }
             if let Some(_reason) = self.guard().heavy_runtime_active() {
@@ -947,6 +1021,7 @@ mod supported {
                     spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
                     generation_ms: None,
                     cache_hit: Some(cache_hit),
+                    diagnostics,
                 };
             }
 
@@ -959,6 +1034,7 @@ mod supported {
                         spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
                         generation_ms: None,
                         cache_hit: Some(cache_hit),
+                        diagnostics,
                     };
                 }
             };
@@ -967,7 +1043,7 @@ mod supported {
             // is ever resident (mutual exclusion, ADR "Lifecycle and resources").
             if inner.child.is_none() {
                 self.guard().release_asr();
-                match self.spawn_and_handshake(&model_path) {
+                match self.spawn_and_handshake(&model_path, cancel, &mut diagnostics) {
                     Ok(child) => inner.child = Some(child),
                     Err(TransformError::ModelMismatch) => {
                         // A corrupt / wrong-content model at the ready path. Remove
@@ -980,15 +1056,19 @@ mod supported {
                             spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
                             generation_ms: None,
                             cache_hit: Some(cache_hit),
+                            diagnostics,
                         };
                     }
                     Err(err) => {
-                        inner.breaker.record_failure(Instant::now());
+                        if err != TransformError::Cancelled {
+                            inner.breaker.record_failure(Instant::now());
+                        }
                         return CorrelatedTransformOutcome {
                             result: Err(err),
                             spawn_load_ms: Some(load_started.elapsed().as_millis() as u64),
                             generation_ms: None,
                             cache_hit: Some(cache_hit),
+                            diagnostics,
                         };
                     }
                 }
@@ -997,6 +1077,7 @@ mod supported {
 
             let request_id = unique_id("req");
             let generation_started = Instant::now();
+            diagnostics.failure_phase = Some(SidecarDiagnosticPhase::RequestReceipt);
             let outcome = {
                 let child = inner.child.as_mut().expect("child present");
                 run_request(
@@ -1007,12 +1088,14 @@ mod supported {
                     deadline,
                     &self.plan,
                     cancel,
+                    &mut diagnostics,
                 )
             };
 
             let result = match outcome {
                 RequestOutcome::Ok(out) => {
                     inner.last_activity = Instant::now();
+                    diagnostics.failure_phase = None;
                     Ok(out)
                 }
                 RequestOutcome::HelperError(err) => {
@@ -1066,18 +1149,33 @@ mod supported {
                 spawn_load_ms: Some(spawn_load_ms),
                 generation_ms: Some(generation_started.elapsed().as_millis() as u64),
                 cache_hit: Some(cache_hit),
+                diagnostics,
             }
         }
 
-        fn spawn_and_handshake(&self, model_path: &Path) -> Result<Child, TransformError> {
+        fn spawn_and_handshake(
+            &self,
+            model_path: &Path,
+            cancel: &CancelToken,
+            diagnostics: &mut SidecarDiagnostics,
+        ) -> Result<Child, TransformError> {
             use murmur_local_llm_protocol::MODEL_FD;
             use std::os::unix::io::AsRawFd;
             use std::os::unix::process::CommandExt;
 
             let (size, sha) = self.plan.pins();
-            let model_file = open_and_verify_model(model_path, size, sha)?;
+            diagnostics.failure_phase = Some(SidecarDiagnosticPhase::HostModelVerification);
+            let verify_started = Instant::now();
+            let model_file = open_and_verify_model(model_path, size, sha, cancel)?;
+            diagnostics.host_model_verification_ms =
+                Some(verify_started.elapsed().as_millis() as u64);
+            if cancel.is_cancelled() {
+                return Err(TransformError::Cancelled);
+            }
+            diagnostics.failure_phase = Some(SidecarDiagnosticPhase::HelperSpawn);
             let helper_path = self.plan.helper_path()?;
             let raw_fd = model_file.as_raw_fd();
+            let spawn_started = Instant::now();
 
             // TODO(#312 PR-A3/C2 packaging integration): before spawn, validate
             // `helper_path` with `SecStaticCodeCheckValidity` against the fixed
@@ -1091,11 +1189,10 @@ mod supported {
                 .current_dir("/")
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
-                .stderr(if self.plan.stderr_inherit() {
-                    std::process::Stdio::inherit()
-                } else {
-                    std::process::Stdio::null()
-                });
+                // Never ingest or inherit helper stderr: failure details can
+                // contain runtime paths or device strings. The enum-only phase
+                // protocol is the sole diagnostics channel.
+                .stderr(std::process::Stdio::null());
             command.env_clear();
             // Scenario env is injected only in test-support builds; production
             // spawns with a strictly empty environment.
@@ -1131,6 +1228,9 @@ mod supported {
             }
 
             let mut proc = command.spawn().map_err(|_| TransformError::SpawnFailed)?;
+            diagnostics.helper_spawn_ms = Some(spawn_started.elapsed().as_millis() as u64);
+            diagnostics.failure_phase = Some(SidecarDiagnosticPhase::ReadyHandshake);
+            let handshake_started = Instant::now();
             let pid = proc.id();
             let pid_guard = SpawnPidGuard::new(&self.resident_pid, pid);
             let mut stdin = match proc.stdin.take() {
@@ -1190,13 +1290,93 @@ mod supported {
 
             // Await Ready within the handshake / model-load deadline.
             let deadline_at = Instant::now() + self.plan.handshake_timeout();
+            let expected_phases = [
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::HelperModelVerification,
+                    murmur_local_llm_protocol::PhaseState::Started,
+                ),
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::HelperModelVerification,
+                    murmur_local_llm_protocol::PhaseState::Completed,
+                ),
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::BackendInitialization,
+                    murmur_local_llm_protocol::PhaseState::Started,
+                ),
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::BackendInitialization,
+                    murmur_local_llm_protocol::PhaseState::Completed,
+                ),
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::ModelLoad,
+                    murmur_local_llm_protocol::PhaseState::Started,
+                ),
+                (
+                    murmur_local_llm_protocol::DiagnosticPhase::ModelLoad,
+                    murmur_local_llm_protocol::PhaseState::Completed,
+                ),
+            ];
+            let mut expected_phase_index = 0_usize;
             loop {
+                if cancel.is_cancelled() {
+                    kill_and_reap(&mut proc);
+                    return Err(TransformError::Cancelled);
+                }
                 let now = Instant::now();
                 if now >= deadline_at {
                     kill_and_reap(&mut proc);
-                    return Err(TransformError::HandshakeFailed);
+                    return Err(TransformError::Timeout);
                 }
-                match rx.recv_timeout(deadline_at - now) {
+                let slice = (deadline_at - now).min(Duration::from_millis(25));
+                match rx.recv_timeout(slice) {
+                    Ok(HelperEvent::Frame(HelperMessage::DiagnosticPhase {
+                        request_id,
+                        phase,
+                        state,
+                        duration_ms,
+                        ..
+                    })) => {
+                        use murmur_local_llm_protocol::{DiagnosticPhase, PhaseState};
+                        if !murmur_local_llm_protocol::validate_diagnostic_phase(
+                            request_id.as_deref(),
+                            phase,
+                            state,
+                            duration_ms,
+                        ) || expected_phases.get(expected_phase_index) != Some(&(phase, state))
+                        {
+                            kill_and_reap(&mut proc);
+                            return Err(TransformError::HandshakeFailed);
+                        }
+                        expected_phase_index += 1;
+                        let mapped = match phase {
+                            DiagnosticPhase::HelperModelVerification => {
+                                SidecarDiagnosticPhase::HelperModelVerification
+                            }
+                            DiagnosticPhase::BackendInitialization => {
+                                SidecarDiagnosticPhase::BackendInitialization
+                            }
+                            DiagnosticPhase::ModelLoad => SidecarDiagnosticPhase::ModelLoad,
+                            DiagnosticPhase::RequestReceipt => {
+                                SidecarDiagnosticPhase::RequestReceipt
+                            }
+                            DiagnosticPhase::FirstToken => SidecarDiagnosticPhase::FirstToken,
+                        };
+                        diagnostics.failure_phase = Some(mapped);
+                        if state == PhaseState::Completed {
+                            match phase {
+                                DiagnosticPhase::HelperModelVerification => {
+                                    diagnostics.helper_model_verification_ms = duration_ms
+                                }
+                                DiagnosticPhase::BackendInitialization => {
+                                    diagnostics.backend_initialization_ms = duration_ms
+                                }
+                                DiagnosticPhase::ModelLoad => {
+                                    diagnostics.model_load_ms = duration_ms
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
                     Ok(HelperEvent::Frame(HelperMessage::Ready {
                         protocol,
                         version,
@@ -1209,6 +1389,7 @@ mod supported {
                             || got_nonce != session_nonce
                             || model.sha256 != sha
                             || model.size_bytes != size
+                            || expected_phase_index != expected_phases.len()
                         {
                             kill_and_reap(&mut proc);
                             return Err(TransformError::HandshakeFailed);
@@ -1222,9 +1403,17 @@ mod supported {
                             _model_file: model_file,
                         };
                         pid_guard.keep();
+                        diagnostics.ready_handshake_ms =
+                            Some(handshake_started.elapsed().as_millis() as u64);
+                        diagnostics.failure_phase = None;
                         return Ok(child);
                     }
-                    Ok(_) | Err(RecvTimeoutError::Disconnected) => {
+                    Ok(HelperEvent::Exited) | Err(RecvTimeoutError::Disconnected) => {
+                        Self::record_process_exit(&mut proc, diagnostics);
+                        kill_and_reap(&mut proc);
+                        return Err(TransformError::HandshakeFailed);
+                    }
+                    Ok(_) => {
                         kill_and_reap(&mut proc);
                         return Err(TransformError::HandshakeFailed);
                     }
@@ -1348,7 +1537,13 @@ mod supported {
     /// mismatch is a protocol violation that fails closed.
     fn helper_frame_valid(message: &HelperMessage, nonce: &str) -> bool {
         let (protocol, version, session_nonce) = match message {
-            HelperMessage::Ready {
+            HelperMessage::DiagnosticPhase {
+                protocol,
+                version,
+                session_nonce,
+                ..
+            }
+            | HelperMessage::Ready {
                 protocol,
                 version,
                 session_nonce,
@@ -1390,6 +1585,7 @@ mod supported {
         deadline: Duration,
         plan: &SpawnPlan,
         cancel: &CancelToken,
+        diagnostics: &mut SidecarDiagnostics,
     ) -> RequestOutcome {
         let transform = HostMessage::Transform {
             protocol: PROTOCOL_NAME.to_string(),
@@ -1409,6 +1605,8 @@ mod supported {
         // DeadlineExceeded before we escalate to a cooperative cancel.
         let wait = deadline + plan.request_slack();
         let deadline_at = Instant::now() + wait;
+        let mut receipt_seen = false;
+        let mut first_token_seen = false;
         loop {
             // User cancel (e.g. Esc / short-tap) wins over the deadline wait.
             if cancel.is_cancelled() {
@@ -1437,6 +1635,45 @@ mod supported {
                         return RequestOutcome::Protocol;
                     }
                     match frame {
+                        HelperMessage::DiagnosticPhase {
+                            request_id: got,
+                            phase,
+                            state,
+                            duration_ms,
+                            ..
+                        } => {
+                            use murmur_local_llm_protocol::DiagnosticPhase;
+                            if got.as_deref() != Some(request_id)
+                                || !murmur_local_llm_protocol::validate_diagnostic_phase(
+                                    got.as_deref(),
+                                    phase,
+                                    state,
+                                    duration_ms,
+                                )
+                            {
+                                return RequestOutcome::Protocol;
+                            }
+                            match phase {
+                                DiagnosticPhase::RequestReceipt
+                                    if !receipt_seen && !first_token_seen =>
+                                {
+                                    receipt_seen = true;
+                                    diagnostics.request_receipt_ms = duration_ms;
+                                    diagnostics.failure_phase =
+                                        Some(SidecarDiagnosticPhase::FirstToken);
+                                }
+                                DiagnosticPhase::FirstToken
+                                    if receipt_seen && !first_token_seen =>
+                                {
+                                    first_token_seen = true;
+                                    diagnostics.first_token_ms = duration_ms;
+                                    diagnostics.failure_phase =
+                                        Some(SidecarDiagnosticPhase::Generation);
+                                }
+                                _ => return RequestOutcome::Protocol,
+                            }
+                            continue;
+                        }
                         HelperMessage::Result {
                             request_id: got,
                             output,
@@ -1445,6 +1682,9 @@ mod supported {
                             ..
                         } => {
                             if got != request_id {
+                                return RequestOutcome::Protocol;
+                            }
+                            if !receipt_seen {
                                 return RequestOutcome::Protocol;
                             }
                             if output.len() > MAX_OUTPUT_BYTES
@@ -1485,7 +1725,8 @@ mod supported {
                 }
                 Ok(HelperEvent::ProtocolViolation) => return RequestOutcome::Protocol,
                 Ok(HelperEvent::Exited) | Err(RecvTimeoutError::Disconnected) => {
-                    return RequestOutcome::Crashed
+                    LlmSidecar::record_process_exit(&mut child.proc, diagnostics);
+                    return RequestOutcome::Crashed;
                 }
                 Err(RecvTimeoutError::Timeout) => continue,
             }
@@ -1794,7 +2035,7 @@ mod tests {
 
         let (size, sha) = model_file_digest(&path).unwrap();
         // Exact pins verify and leave the handle rewound to offset 0.
-        let mut handle = open_and_verify_model(&path, size, &sha).unwrap();
+        let mut handle = open_and_verify_model(&path, size, &sha, &CancelToken::new()).unwrap();
         use std::io::Read;
         let mut first = [0_u8; 4];
         handle.read_exact(&mut first).unwrap();
@@ -1803,12 +2044,18 @@ mod tests {
         // Wrong hash and wrong size both fail closed.
         let wrong_sha = "0".repeat(64);
         assert_eq!(
-            open_and_verify_model(&path, size, &wrong_sha).unwrap_err(),
+            open_and_verify_model(&path, size, &wrong_sha, &CancelToken::new()).unwrap_err(),
             TransformError::ModelMismatch
         );
         assert_eq!(
-            open_and_verify_model(&path, size + 1, &sha).unwrap_err(),
+            open_and_verify_model(&path, size + 1, &sha, &CancelToken::new()).unwrap_err(),
             TransformError::ModelMismatch
+        );
+        let cancelled = CancelToken::new();
+        cancelled.cancel();
+        assert_eq!(
+            open_and_verify_model(&path, size, &sha, &cancelled).unwrap_err(),
+            TransformError::Cancelled
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -1330,19 +1330,25 @@ mod supported {
                 let slice = (deadline_at - now).min(Duration::from_millis(25));
                 match rx.recv_timeout(slice) {
                     Ok(HelperEvent::Frame(HelperMessage::DiagnosticPhase {
+                        protocol,
+                        version,
+                        session_nonce: got_nonce,
                         request_id,
                         phase,
                         state,
                         duration_ms,
-                        ..
                     })) => {
                         use murmur_local_llm_protocol::{DiagnosticPhase, PhaseState};
-                        if !murmur_local_llm_protocol::validate_diagnostic_phase(
-                            request_id.as_deref(),
-                            phase,
-                            state,
-                            duration_ms,
-                        ) || expected_phases.get(expected_phase_index) != Some(&(phase, state))
+                        if protocol != PROTOCOL_NAME
+                            || version != PROTOCOL_VERSION
+                            || got_nonce != session_nonce
+                            || !murmur_local_llm_protocol::validate_diagnostic_phase(
+                                request_id.as_deref(),
+                                phase,
+                                state,
+                                duration_ms,
+                            )
+                            || expected_phases.get(expected_phase_index) != Some(&(phase, state))
                         {
                             kill_and_reap(&mut proc);
                             return Err(TransformError::HandshakeFailed);
@@ -1773,9 +1779,36 @@ mod supported {
                     if !helper_frame_valid(&frame, &child.session_nonce) {
                         return kill;
                     }
-                    // A matching Cancelled, or any other well-formed frame,
-                    // proves the helper is responsive: cancellation confirmed.
-                    return keep;
+                    match frame {
+                        // Only an explicit acknowledgement for this exact
+                        // request confirms cooperative cancellation. Receipt /
+                        // first-token frames may already be queued when Cancel
+                        // is sent and must never be mistaken for an ack.
+                        HelperMessage::Cancelled {
+                            request_id: got, ..
+                        } if got == request_id => return keep,
+                        HelperMessage::DiagnosticPhase {
+                            request_id,
+                            phase,
+                            state,
+                            duration_ms,
+                            ..
+                        } => {
+                            if !murmur_local_llm_protocol::validate_diagnostic_phase(
+                                request_id.as_deref(),
+                                phase,
+                                state,
+                                duration_ms,
+                            ) {
+                                return kill;
+                            }
+                            continue;
+                        }
+                        // A stale/mismatched Cancelled or any other valid frame
+                        // is not confirmation. Keep waiting until the grace
+                        // deadline, then kill and reap the helper.
+                        _ => continue,
+                    }
                 }
                 Ok(HelperEvent::Exited)
                 | Ok(HelperEvent::ProtocolViolation)

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -337,6 +337,11 @@ pub struct AppState {
     pub transform_pass_sequence: AtomicU64,
     /// The pass that currently owns the transform lifecycle. Zero means none.
     pub active_transform_pass_id: AtomicU64,
+    /// Highest transform pass explicitly cancelled by the user. Selection
+    /// capture runs asynchronously, so it must be able to distinguish a late
+    /// capture abort from an ordinary capture failure even before the cancel
+    /// path has finished clearing `active_transform_pass_id`.
+    cancelled_transform_pass_id: AtomicU64,
     /// One-based spoken-instruction attempt within the active pass. Retries
     /// keep the pass ID and advance only this counter.
     pub transform_instruction_attempt: AtomicU64,
@@ -464,6 +469,15 @@ impl AppState {
             .is_ok()
     }
 
+    pub fn mark_transform_pass_cancelled(&self, pass_id: u64) {
+        self.cancelled_transform_pass_id
+            .fetch_max(pass_id, Ordering::SeqCst);
+    }
+
+    pub fn is_transform_pass_cancelled(&self, pass_id: u64) -> bool {
+        pass_id != 0 && self.cancelled_transform_pass_id.load(Ordering::SeqCst) >= pass_id
+    }
+
     pub fn current_instruction_attempt(&self) -> u64 {
         self.transform_instruction_attempt
             .load(Ordering::SeqCst)
@@ -558,6 +572,7 @@ impl Default for AppState {
             transform_status: Mutex::new(TransformStatus::default()),
             transform_pass_sequence: AtomicU64::new(0),
             active_transform_pass_id: AtomicU64::new(0),
+            cancelled_transform_pass_id: AtomicU64::new(0),
             transform_instruction_attempt: AtomicU64::new(1),
             transform_session: Mutex::new(None),
             transform_session_generation: AtomicU64::new(0),
@@ -701,6 +716,17 @@ mod tests {
         assert_eq!(state.active_transform_pass_id(), Some(second));
         assert!(state.clear_transform_pass(second));
         assert_eq!(state.active_transform_pass_id(), None);
+    }
+
+    #[test]
+    fn transform_cancel_marker_is_visible_before_active_pass_is_cleared() {
+        let state = AppState::default();
+        state.activate_transform_pass(11);
+        state.mark_transform_pass_cancelled(11);
+
+        assert!(state.is_transform_pass_cancelled(11));
+        assert_eq!(state.active_transform_pass_id(), Some(11));
+        assert!(!state.is_transform_pass_cancelled(12));
     }
 
     #[test]

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -231,6 +231,18 @@ fn is_safe_transform_string(key: &str, value: &str) -> bool {
                 | "review_pending"
                 | "applying"
         ),
+        "phase" => matches!(
+            value,
+            "host_model_verification"
+                | "helper_spawn"
+                | "helper_model_verification"
+                | "backend_initialization"
+                | "model_load"
+                | "ready_handshake"
+                | "request_receipt"
+                | "first_token"
+                | "generation"
+        ),
         "error_code" => matches!(
             value,
             "accessibility_denied"
@@ -244,6 +256,15 @@ fn is_safe_transform_string(key: &str, value: &str) -> bool {
                 | "busy"
                 | "invalid_request"
                 | "crashed"
+                | "model_verification_timeout"
+                | "model_load_timeout"
+                | "handshake_timeout"
+                | "generation_timeout"
+                | "helper_spawn_failed"
+                | "handshake_protocol_failed"
+                | "process_exit"
+                | "model_verification_failed"
+                | "model_load_failed"
                 | "model_unreadable"
                 | "timeout"
                 | "cancelled"

--- a/app/src-tauri/src/transform_diagnostics.rs
+++ b/app/src-tauri/src/transform_diagnostics.rs
@@ -339,6 +339,7 @@ impl TransformDiagnostics {
     pub fn finish(&self, transform_pass_id: u64, outcome: &str) {
         let mut inner = self.inner.lock_or_recover();
         let now = now_ms();
+        let mut recorded_outcome = outcome.to_string();
         if let Some(mut attempt) = inner.active.remove(&transform_pass_id) {
             attempt.finished_at_ms = Some(now);
             attempt.outcome = outcome.to_string();
@@ -355,12 +356,21 @@ impl TransformDiagnostics {
             .rev()
             .find(|attempt| attempt.transform_pass_id == transform_pass_id)
         {
-            attempt.finished_at_ms = Some(now);
-            attempt.outcome = outcome.to_string();
-            let _ = write_attempts(&inner);
+            // Cancellation/supersession can win while an async capture future
+            // is still unwinding. A late `Aborted -> failed` cleanup must not
+            // downgrade the terminal user outcome already persisted.
+            if matches!(attempt.outcome.as_str(), "cancelled" | "superseded")
+                && attempt.outcome != outcome
+            {
+                recorded_outcome = attempt.outcome.clone();
+            } else {
+                attempt.finished_at_ms = Some(now);
+                attempt.outcome = outcome.to_string();
+                let _ = write_attempts(&inner);
+            }
         }
         if let Some(capture) = inner.captures.get_mut(&transform_pass_id) {
-            capture.outcome = outcome.to_string();
+            capture.outcome = recorded_outcome;
             let capture = capture.clone();
             let _ = write_capture(&inner, &capture);
             let _ = prune_captures(&mut inner);
@@ -719,6 +729,32 @@ mod tests {
             .attempts
             .iter()
             .any(|attempt| { attempt.transform_pass_id == 1 && attempt.outcome == "cancelled" }));
+    }
+
+    #[test]
+    fn cancel_during_capture_cannot_be_downgraded_by_late_abort() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = TransformDiagnostics::default();
+        store.initialize(temp.path().join("diagnostics")).unwrap();
+
+        store.arm_next().unwrap();
+        store.begin(88);
+        store.phase(88, "cancellation", "completed", None, None);
+        store.finish(88, "cancelled");
+
+        // Mirrors start_transform_capture returning Aborted after the
+        // cancellation path already terminalized and cleared the pass.
+        store.finish(88, "failed");
+
+        let attempt = store
+            .list_attempts(10)
+            .attempts
+            .into_iter()
+            .find(|attempt| attempt.transform_pass_id == 88)
+            .unwrap();
+        assert_eq!(attempt.outcome, "cancelled");
+        let capture = store.list_captures().unwrap().pop().unwrap();
+        assert_eq!(capture.outcome, "cancelled");
     }
 
     #[cfg(unix)]

--- a/app/src-tauri/src/transform_diagnostics.rs
+++ b/app/src-tauri/src/transform_diagnostics.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use crate::MutexExt;
@@ -18,6 +19,7 @@ const MAX_ATTEMPTS: usize = 200;
 const MAX_CAPTURES: usize = 3;
 const CAPTURE_ARM_MS: i64 = 10 * 60 * 1_000;
 const CAPTURE_RETENTION_MS: i64 = 7 * 24 * 60 * 60 * 1_000;
+static CAPTURE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -569,12 +571,86 @@ fn read_attempts(inner: &Inner) -> Result<Vec<TransformAttemptV1>, String> {
 }
 
 fn write_capture(inner: &Inner, capture: &DiagnosticCaptureV1) -> Result<(), String> {
+    validate_capture_id(&capture.capture_id)?;
+    let root = capture_root(inner)?;
     let path = capture_path(inner, &capture.capture_id)?;
     let payload = serde_json::to_vec(capture)
         .map_err(|_| "diagnostic capture could not be encoded".to_string())?;
-    let mut file = open_private(&path)?;
-    file.write_all(&payload)
-        .map_err(|_| "diagnostic capture could not be written".to_string())
+    let (temp_path, mut file) = create_capture_temp(&root, &capture.capture_id)?;
+    let result = (|| {
+        file.write_all(&payload)
+            .map_err(|_| "diagnostic capture could not be written".to_string())?;
+        file.flush()
+            .map_err(|_| "diagnostic capture could not be written".to_string())?;
+        file.sync_all()
+            .map_err(|_| "diagnostic capture could not be written".to_string())?;
+        drop(file);
+
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err("diagnostic capture target refused".to_string());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Err("diagnostic capture unavailable".to_string()),
+        }
+
+        fs::rename(&temp_path, &path)
+            .map_err(|_| "diagnostic capture could not be written".to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                .map_err(|_| "diagnostic capture permissions unavailable".to_string())?;
+            std::fs::File::open(&root)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|_| "diagnostic capture could not be written".to_string())?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        remove_regular_store_file(&temp_path);
+    }
+    result
+}
+
+fn create_capture_temp(root: &Path, capture_id: &str) -> Result<(PathBuf, std::fs::File), String> {
+    for _ in 0..16 {
+        let sequence = CAPTURE_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let path = root.join(format!(
+            ".capture-{capture_id}-{}-{sequence}.tmp",
+            std::process::id()
+        ));
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        }
+        match options.open(&path) {
+            Ok(file) => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if file
+                        .set_permissions(fs::Permissions::from_mode(0o600))
+                        .is_err()
+                    {
+                        drop(file);
+                        remove_regular_store_file(&path);
+                        return Err("diagnostic capture permissions unavailable".to_string());
+                    }
+                }
+                return Ok((path, file));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return Err("diagnostic capture unavailable".to_string()),
+        }
+    }
+    Err("diagnostic capture unavailable".to_string())
 }
 
 fn validate_capture_id(capture_id: &str) -> Result<(), String> {
@@ -622,16 +698,51 @@ fn read_captures(inner: &Inner) -> Result<Vec<DiagnosticCaptureV1>, String> {
     for entry in
         fs::read_dir(root).map_err(|_| "diagnostic capture store unavailable".to_string())?
     {
-        let entry = entry.map_err(|_| "diagnostic capture store unavailable".to_string())?;
+        let Ok(entry) = entry else {
+            continue;
+        };
         let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+        let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if is_capture_temp_name(file_name) {
+            remove_regular_store_file(&path);
             continue;
         }
-        if let Some(capture) = read_capture_path(&path)? {
-            captures.push(capture);
+        if capture_id_from_file_name(file_name).is_none() {
+            continue;
+        }
+        match read_capture_path(&path) {
+            Ok(Some(capture)) => captures.push(capture),
+            Ok(None) => {}
+            Err(_) => remove_regular_store_file(&path),
         }
     }
     Ok(captures)
+}
+
+fn capture_id_from_file_name(file_name: &str) -> Option<&str> {
+    let capture_id = file_name.strip_suffix(".json")?;
+    validate_capture_id(capture_id).ok()?;
+    Some(capture_id)
+}
+
+fn is_capture_temp_name(file_name: &str) -> bool {
+    file_name
+        .strip_prefix(".capture-")
+        .and_then(|value| value.strip_suffix(".tmp"))
+        .is_some_and(|value| {
+            !value.is_empty()
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || byte == b'-')
+        })
+}
+
+fn remove_regular_store_file(path: &Path) {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.is_file()) {
+        let _ = fs::remove_file(path);
+    }
 }
 
 fn prune_captures(inner: &mut Inner) -> Result<(), String> {
@@ -755,6 +866,103 @@ mod tests {
         assert_eq!(attempt.outcome, "cancelled");
         let capture = store.list_captures().unwrap().pop().unwrap();
         assert_eq!(capture.outcome, "cancelled");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn corrupt_capture_and_stale_temp_do_not_block_initialization_or_retention() {
+        use std::os::unix::fs::{symlink, OpenOptionsExt, PermissionsExt};
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let store = TransformDiagnostics::default();
+        store.initialize(root.clone()).unwrap();
+
+        store.arm_next().unwrap();
+        store.begin(100);
+        store.selection(
+            100,
+            Ok(("accessibility", "1-16", true, true, "success")),
+            Some("current private input"),
+        );
+        store.finish(100, "ready");
+        let current = store.list_captures().unwrap().pop().unwrap();
+
+        let expired = DiagnosticCaptureV1 {
+            schema_version: SCHEMA_VERSION,
+            capture_id: "98-1".to_string(),
+            transform_pass_id: 98,
+            captured_at_ms: now_ms() - CAPTURE_RETENTION_MS - 1,
+            expires_at_ms: now_ms() - 1,
+            outcome: "ready".to_string(),
+            selection: Some("expired private input".to_string()),
+            instruction: Some("expired private instruction".to_string()),
+            output: Some("expired private output".to_string()),
+            phases: Vec::new(),
+        };
+        {
+            let inner = store.inner.lock_or_recover();
+            write_capture(&inner, &expired).unwrap();
+        }
+
+        let capture_root = root.join("transform-captures");
+        let corrupt_path = capture_root.join("99-2.json");
+        let mut corrupt = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&corrupt_path)
+            .unwrap();
+        corrupt.write_all(br#"{"schemaVersion":1"#).unwrap();
+        corrupt.sync_all().unwrap();
+        drop(corrupt);
+
+        let stale_temp_path = capture_root.join(".capture-97-3-123-456.tmp");
+        let mut stale_temp = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&stale_temp_path)
+            .unwrap();
+        stale_temp.write_all(b"stale private content").unwrap();
+        drop(stale_temp);
+
+        let unrelated_path = capture_root.join("notes.json");
+        fs::write(&unrelated_path, b"unrelated").unwrap();
+        let symlink_path = capture_root.join("96-4.json");
+        let symlink_target = temp.path().join("outside-private-data");
+        fs::write(&symlink_target, b"outside").unwrap();
+        symlink(&symlink_target, &symlink_path).unwrap();
+
+        let reloaded = TransformDiagnostics::default();
+        reloaded.initialize(root.clone()).unwrap();
+        let summaries = reloaded.list_captures().unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].capture_id, current.capture_id);
+        let capture = reloaded.get_capture(&current.capture_id).unwrap().unwrap();
+        assert_eq!(capture.selection.as_deref(), Some("current private input"));
+
+        assert!(!corrupt_path.exists());
+        assert!(!stale_temp_path.exists());
+        assert!(!capture_root.join("98-1.json").exists());
+        assert!(unrelated_path.exists());
+        assert!(fs::symlink_metadata(&symlink_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(reloaded.get_capture("96-4").is_err());
+        assert_eq!(
+            fs::metadata(&capture_root).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(capture_root.join(format!("{}.json", current.capture_id)))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
     }
 
     #[cfg(unix)]

--- a/app/src-tauri/src/transform_diagnostics.rs
+++ b/app/src-tauri/src/transform_diagnostics.rs
@@ -1,0 +1,752 @@
+//! Privacy-bounded diagnostics for selected-text transforms.
+//!
+//! `TransformAttemptV1` is always content-free. Exact selection, instruction,
+//! and output text is only written after an explicit one-shot arm, to a
+//! separate local store with restrictive permissions and bounded retention.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::MutexExt;
+
+const SCHEMA_VERSION: u32 = 1;
+const MAX_ATTEMPTS: usize = 200;
+const MAX_CAPTURES: usize = 3;
+const CAPTURE_ARM_MS: i64 = 10 * 60 * 1_000;
+const CAPTURE_RETENTION_MS: i64 = 7 * 24 * 60 * 60 * 1_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformPhaseV1 {
+    pub phase: String,
+    pub outcome: String,
+    pub duration_ms: Option<u64>,
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformAttemptV1 {
+    pub schema_version: u32,
+    pub transform_pass_id: u64,
+    pub started_at_ms: i64,
+    pub finished_at_ms: Option<i64>,
+    pub outcome: String,
+    pub selection_source: Option<String>,
+    pub selection_result: Option<String>,
+    pub selection_size_bucket: Option<String>,
+    pub range_available: Option<bool>,
+    pub bounds_available: Option<bool>,
+    pub instruction_confidence_bucket: Option<String>,
+    pub model_warm_state: Option<String>,
+    pub output_token_count: Option<u32>,
+    pub finish_reason: Option<String>,
+    pub process_exit_code: Option<i32>,
+    pub process_exit_signal: Option<i32>,
+    pub phases: Vec<TransformPhaseV1>,
+}
+
+impl TransformAttemptV1 {
+    fn new(transform_pass_id: u64, now_ms: i64) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            transform_pass_id,
+            started_at_ms: now_ms,
+            finished_at_ms: None,
+            outcome: "inProgress".to_string(),
+            selection_source: None,
+            selection_result: None,
+            selection_size_bucket: None,
+            range_available: None,
+            bounds_available: None,
+            instruction_confidence_bucket: None,
+            model_warm_state: None,
+            output_token_count: None,
+            finish_reason: None,
+            process_exit_code: None,
+            process_exit_signal: None,
+            phases: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformAttemptListV1 {
+    pub schema_version: u32,
+    pub attempts: Vec<TransformAttemptV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureArmStatusV1 {
+    pub armed: bool,
+    pub expires_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticCaptureSummaryV1 {
+    pub capture_id: String,
+    pub transform_pass_id: u64,
+    pub captured_at_ms: i64,
+    pub expires_at_ms: i64,
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticCaptureV1 {
+    pub schema_version: u32,
+    pub capture_id: String,
+    pub transform_pass_id: u64,
+    pub captured_at_ms: i64,
+    pub expires_at_ms: i64,
+    pub outcome: String,
+    pub selection: Option<String>,
+    pub instruction: Option<String>,
+    pub output: Option<String>,
+    pub phases: Vec<TransformPhaseV1>,
+}
+
+impl DiagnosticCaptureV1 {
+    fn summary(&self) -> DiagnosticCaptureSummaryV1 {
+        DiagnosticCaptureSummaryV1 {
+            capture_id: self.capture_id.clone(),
+            transform_pass_id: self.transform_pass_id,
+            captured_at_ms: self.captured_at_ms,
+            expires_at_ms: self.expires_at_ms,
+            outcome: self.outcome.clone(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    root: Option<PathBuf>,
+    attempts: Vec<TransformAttemptV1>,
+    active: HashMap<u64, TransformAttemptV1>,
+    armed_until_ms: Option<i64>,
+    captures: HashMap<u64, DiagnosticCaptureV1>,
+}
+
+#[derive(Default)]
+pub struct TransformDiagnostics {
+    inner: Mutex<Inner>,
+}
+
+impl TransformDiagnostics {
+    pub fn initialize(&self, root: PathBuf) -> Result<(), String> {
+        ensure_private_dir(&root)?;
+        let capture_root = root.join("transform-captures");
+        ensure_private_dir(&capture_root)?;
+        let mut inner = self.inner.lock_or_recover();
+        inner.root = Some(root);
+        inner.attempts = read_attempts(&inner)?;
+        prune_captures(&mut inner)?;
+        Ok(())
+    }
+
+    pub fn begin(&self, transform_pass_id: u64) {
+        if transform_pass_id == 0 {
+            return;
+        }
+        let now = now_ms();
+        let mut inner = self.inner.lock_or_recover();
+        inner.active.insert(
+            transform_pass_id,
+            TransformAttemptV1::new(transform_pass_id, now),
+        );
+        if inner
+            .armed_until_ms
+            .take()
+            .is_some_and(|expiry| expiry >= now)
+        {
+            inner.captures.insert(
+                transform_pass_id,
+                DiagnosticCaptureV1 {
+                    schema_version: SCHEMA_VERSION,
+                    capture_id: format!("{transform_pass_id}-{now}"),
+                    transform_pass_id,
+                    captured_at_ms: now,
+                    expires_at_ms: now + CAPTURE_RETENTION_MS,
+                    outcome: "inProgress".to_string(),
+                    selection: None,
+                    instruction: None,
+                    output: None,
+                    phases: Vec::new(),
+                },
+            );
+        }
+    }
+
+    pub fn phase(
+        &self,
+        transform_pass_id: u64,
+        phase: &str,
+        outcome: &str,
+        duration_ms: Option<u64>,
+        error_code: Option<&str>,
+    ) {
+        let mut inner = self.inner.lock_or_recover();
+        let entry = TransformPhaseV1 {
+            phase: phase.to_string(),
+            outcome: outcome.to_string(),
+            duration_ms,
+            error_code: error_code.map(str::to_string),
+        };
+        let mut persisted_attempt_changed = false;
+        if let Some(attempt) = inner.active.get_mut(&transform_pass_id) {
+            attempt.phases.push(entry.clone());
+        } else if let Some(attempt) = inner
+            .attempts
+            .iter_mut()
+            .rev()
+            .find(|attempt| attempt.transform_pass_id == transform_pass_id)
+        {
+            attempt.phases.push(entry.clone());
+            persisted_attempt_changed = true;
+        }
+        if let Some(capture) = inner.captures.get_mut(&transform_pass_id) {
+            capture.phases.push(entry);
+        }
+        if persisted_attempt_changed {
+            let _ = write_attempts(&inner);
+        }
+        if let Some(capture) = inner.captures.get(&transform_pass_id) {
+            let _ = write_capture(&inner, capture);
+        }
+    }
+
+    pub fn selection(
+        &self,
+        transform_pass_id: u64,
+        result: Result<(&str, &str, bool, bool, &str), &str>,
+        raw: Option<&str>,
+    ) {
+        let mut inner = self.inner.lock_or_recover();
+        if let Some(attempt) = inner.active.get_mut(&transform_pass_id) {
+            match result {
+                Ok((source, bucket, range, bounds, outcome)) => {
+                    attempt.selection_source = Some(source.to_string());
+                    attempt.selection_result = Some(outcome.to_string());
+                    attempt.selection_size_bucket = Some(bucket.to_string());
+                    attempt.range_available = Some(range);
+                    attempt.bounds_available = Some(bounds);
+                }
+                Err(error) => attempt.selection_result = Some(error.to_string()),
+            }
+        }
+        if let (Some(capture), Some(raw)) = (inner.captures.get_mut(&transform_pass_id), raw) {
+            capture.selection = Some(raw.to_string());
+        }
+    }
+
+    pub fn instruction(&self, transform_pass_id: u64, raw: &str) {
+        let mut inner = self.inner.lock_or_recover();
+        let mut persisted_attempt_changed = false;
+        if let Some(attempt) = inner.active.get_mut(&transform_pass_id) {
+            // The current ASR seam does not expose calibrated confidence.
+            attempt.instruction_confidence_bucket = Some("unavailable".to_string());
+        } else if let Some(attempt) = inner
+            .attempts
+            .iter_mut()
+            .rev()
+            .find(|attempt| attempt.transform_pass_id == transform_pass_id)
+        {
+            attempt.instruction_confidence_bucket = Some("unavailable".to_string());
+            persisted_attempt_changed = true;
+        }
+        if let Some(capture) = inner.captures.get_mut(&transform_pass_id) {
+            capture.instruction = Some(raw.to_string());
+        }
+        if persisted_attempt_changed {
+            let _ = write_attempts(&inner);
+        }
+        if let Some(capture) = inner.captures.get(&transform_pass_id) {
+            let _ = write_capture(&inner, capture);
+        }
+    }
+
+    pub fn sidecar_result(
+        &self,
+        transform_pass_id: u64,
+        warm_state: Option<&str>,
+        output_tokens: Option<u32>,
+        finish_reason: Option<&str>,
+        raw_output: Option<&str>,
+    ) {
+        let mut inner = self.inner.lock_or_recover();
+        let mut persisted_attempt_changed = false;
+        if let Some(attempt) = inner.active.get_mut(&transform_pass_id) {
+            attempt.model_warm_state = warm_state.map(str::to_string);
+            attempt.output_token_count = output_tokens;
+            attempt.finish_reason = finish_reason.map(str::to_string);
+        } else if let Some(attempt) = inner
+            .attempts
+            .iter_mut()
+            .rev()
+            .find(|attempt| attempt.transform_pass_id == transform_pass_id)
+        {
+            attempt.model_warm_state = warm_state.map(str::to_string);
+            attempt.output_token_count = output_tokens;
+            attempt.finish_reason = finish_reason.map(str::to_string);
+            persisted_attempt_changed = true;
+        }
+        if let (Some(capture), Some(output)) =
+            (inner.captures.get_mut(&transform_pass_id), raw_output)
+        {
+            capture.output = Some(output.to_string());
+        }
+        if persisted_attempt_changed {
+            let _ = write_attempts(&inner);
+        }
+        if let Some(capture) = inner.captures.get(&transform_pass_id) {
+            let _ = write_capture(&inner, capture);
+        }
+    }
+
+    pub fn process_exit(
+        &self,
+        transform_pass_id: u64,
+        exit_code: Option<i32>,
+        signal: Option<i32>,
+    ) {
+        let mut inner = self.inner.lock_or_recover();
+        let mut persisted_attempt_changed = false;
+        if let Some(attempt) = inner.active.get_mut(&transform_pass_id) {
+            attempt.process_exit_code = exit_code;
+            attempt.process_exit_signal = signal;
+        } else if let Some(attempt) = inner
+            .attempts
+            .iter_mut()
+            .rev()
+            .find(|attempt| attempt.transform_pass_id == transform_pass_id)
+        {
+            attempt.process_exit_code = exit_code;
+            attempt.process_exit_signal = signal;
+            persisted_attempt_changed = true;
+        }
+        if persisted_attempt_changed {
+            let _ = write_attempts(&inner);
+        }
+    }
+
+    pub fn finish(&self, transform_pass_id: u64, outcome: &str) {
+        let mut inner = self.inner.lock_or_recover();
+        let now = now_ms();
+        if let Some(mut attempt) = inner.active.remove(&transform_pass_id) {
+            attempt.finished_at_ms = Some(now);
+            attempt.outcome = outcome.to_string();
+            inner.attempts.push(attempt);
+            inner.attempts.sort_by_key(|attempt| attempt.started_at_ms);
+            if inner.attempts.len() > MAX_ATTEMPTS {
+                let excess = inner.attempts.len() - MAX_ATTEMPTS;
+                inner.attempts.drain(0..excess);
+            }
+            let _ = write_attempts(&inner);
+        } else if let Some(attempt) = inner
+            .attempts
+            .iter_mut()
+            .rev()
+            .find(|attempt| attempt.transform_pass_id == transform_pass_id)
+        {
+            attempt.finished_at_ms = Some(now);
+            attempt.outcome = outcome.to_string();
+            let _ = write_attempts(&inner);
+        }
+        if let Some(capture) = inner.captures.get_mut(&transform_pass_id) {
+            capture.outcome = outcome.to_string();
+            let capture = capture.clone();
+            let _ = write_capture(&inner, &capture);
+            let _ = prune_captures(&mut inner);
+        }
+    }
+
+    pub fn arm_next(&self) -> Result<CaptureArmStatusV1, String> {
+        let mut inner = self.inner.lock_or_recover();
+        if inner.root.is_none() {
+            return Err("diagnostic capture store unavailable".to_string());
+        }
+        let expiry = now_ms() + CAPTURE_ARM_MS;
+        inner.armed_until_ms = Some(expiry);
+        Ok(CaptureArmStatusV1 {
+            armed: true,
+            expires_at_ms: Some(expiry),
+        })
+    }
+
+    pub fn arm_status(&self) -> CaptureArmStatusV1 {
+        let mut inner = self.inner.lock_or_recover();
+        let now = now_ms();
+        if inner.armed_until_ms.is_some_and(|expiry| expiry < now) {
+            inner.armed_until_ms = None;
+        }
+        CaptureArmStatusV1 {
+            armed: inner.armed_until_ms.is_some(),
+            expires_at_ms: inner.armed_until_ms,
+        }
+    }
+
+    pub fn list_attempts(&self, limit: usize) -> TransformAttemptListV1 {
+        let inner = self.inner.lock_or_recover();
+        let attempts = inner
+            .attempts
+            .iter()
+            .rev()
+            .take(limit.min(MAX_ATTEMPTS))
+            .cloned()
+            .collect();
+        TransformAttemptListV1 {
+            schema_version: SCHEMA_VERSION,
+            attempts,
+        }
+    }
+
+    pub fn list_captures(&self) -> Result<Vec<DiagnosticCaptureSummaryV1>, String> {
+        let mut inner = self.inner.lock_or_recover();
+        prune_captures(&mut inner)?;
+        let mut captures = read_captures(&inner)?;
+        captures.sort_by_key(|capture| std::cmp::Reverse(capture.captured_at_ms));
+        Ok(captures
+            .into_iter()
+            .map(|capture| capture.summary())
+            .collect())
+    }
+
+    pub fn get_capture(&self, capture_id: &str) -> Result<Option<DiagnosticCaptureV1>, String> {
+        validate_capture_id(capture_id)?;
+        let mut inner = self.inner.lock_or_recover();
+        prune_captures(&mut inner)?;
+        let path = capture_path(&inner, capture_id)?;
+        read_capture_path(&path)
+    }
+
+    pub fn delete_capture(&self, capture_id: &str) -> Result<(), String> {
+        validate_capture_id(capture_id)?;
+        let mut inner = self.inner.lock_or_recover();
+        inner
+            .captures
+            .retain(|_, capture| capture.capture_id != capture_id);
+        let path = capture_path(&inner, capture_id)?;
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                Err("diagnostic capture target refused".to_string())
+            }
+            Ok(_) => fs::remove_file(path)
+                .map_err(|_| "diagnostic capture could not be deleted".to_string()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(_) => Err("diagnostic capture could not be deleted".to_string()),
+        }
+    }
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn ensure_private_dir(path: &Path) -> Result<(), String> {
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err("diagnostic store target refused".to_string());
+        }
+    } else {
+        fs::create_dir_all(path).map_err(|_| "diagnostic store unavailable".to_string())?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|_| "diagnostic store permissions unavailable".to_string())?;
+    }
+    Ok(())
+}
+
+fn open_private(path: &Path) -> Result<std::fs::File, String> {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err("diagnostic file target refused".to_string());
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .map_err(|_| "diagnostic file unavailable".to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|_| "diagnostic file permissions unavailable".to_string())?;
+    }
+    Ok(file)
+}
+
+fn open_private_read(path: &Path, unavailable: &'static str) -> Result<std::fs::File, String> {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err("diagnostic file target refused".to_string());
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path).map_err(|_| unavailable.to_string())
+}
+
+fn attempts_path(inner: &Inner) -> Result<PathBuf, String> {
+    inner
+        .root
+        .as_ref()
+        .map(|root| root.join("transform-attempts.json"))
+        .ok_or_else(|| "diagnostic store unavailable".to_string())
+}
+
+fn capture_root(inner: &Inner) -> Result<PathBuf, String> {
+    inner
+        .root
+        .as_ref()
+        .map(|root| root.join("transform-captures"))
+        .ok_or_else(|| "diagnostic capture store unavailable".to_string())
+}
+
+fn capture_path(inner: &Inner, capture_id: &str) -> Result<PathBuf, String> {
+    Ok(capture_root(inner)?.join(format!("{capture_id}.json")))
+}
+
+fn write_attempts(inner: &Inner) -> Result<(), String> {
+    let path = attempts_path(inner)?;
+    let payload = serde_json::to_vec(&TransformAttemptListV1 {
+        schema_version: SCHEMA_VERSION,
+        attempts: inner.attempts.clone(),
+    })
+    .map_err(|_| "diagnostic records could not be encoded".to_string())?;
+    let mut file = open_private(&path)?;
+    file.write_all(&payload)
+        .map_err(|_| "diagnostic records could not be written".to_string())
+}
+
+fn read_attempts(inner: &Inner) -> Result<Vec<TransformAttemptV1>, String> {
+    let path = attempts_path(inner)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    if fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err("diagnostic file target refused".to_string());
+    }
+    let mut file = open_private_read(&path, "diagnostic records unavailable")?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| "diagnostic records unavailable".to_string())?;
+    let mut list: TransformAttemptListV1 =
+        serde_json::from_slice(&bytes).map_err(|_| "diagnostic records invalid".to_string())?;
+    if list.schema_version != SCHEMA_VERSION {
+        return Err("diagnostic records version unsupported".to_string());
+    }
+    if list.attempts.len() > MAX_ATTEMPTS {
+        list.attempts.drain(0..list.attempts.len() - MAX_ATTEMPTS);
+    }
+    Ok(list.attempts)
+}
+
+fn write_capture(inner: &Inner, capture: &DiagnosticCaptureV1) -> Result<(), String> {
+    let path = capture_path(inner, &capture.capture_id)?;
+    let payload = serde_json::to_vec(capture)
+        .map_err(|_| "diagnostic capture could not be encoded".to_string())?;
+    let mut file = open_private(&path)?;
+    file.write_all(&payload)
+        .map_err(|_| "diagnostic capture could not be written".to_string())
+}
+
+fn validate_capture_id(capture_id: &str) -> Result<(), String> {
+    if capture_id.is_empty()
+        || capture_id.len() > 64
+        || !capture_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err("invalid diagnostic capture id".to_string());
+    }
+    Ok(())
+}
+
+fn read_capture_path(path: &Path) -> Result<Option<DiagnosticCaptureV1>, String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err("diagnostic capture unavailable".to_string()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("diagnostic capture target refused".to_string());
+    }
+    let mut file = open_private_read(path, "diagnostic capture unavailable")?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| "diagnostic capture unavailable".to_string())?;
+    let capture: DiagnosticCaptureV1 =
+        serde_json::from_slice(&bytes).map_err(|_| "diagnostic capture invalid".to_string())?;
+    if capture.schema_version != SCHEMA_VERSION {
+        return Err("diagnostic capture version unsupported".to_string());
+    }
+    validate_capture_id(&capture.capture_id)?;
+    if path.file_name().and_then(|value| value.to_str())
+        != Some(format!("{}.json", capture.capture_id).as_str())
+    {
+        return Err("diagnostic capture identity mismatch".to_string());
+    }
+    Ok(Some(capture))
+}
+
+fn read_captures(inner: &Inner) -> Result<Vec<DiagnosticCaptureV1>, String> {
+    let root = capture_root(inner)?;
+    let mut captures = Vec::new();
+    for entry in
+        fs::read_dir(root).map_err(|_| "diagnostic capture store unavailable".to_string())?
+    {
+        let entry = entry.map_err(|_| "diagnostic capture store unavailable".to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if let Some(capture) = read_capture_path(&path)? {
+            captures.push(capture);
+        }
+    }
+    Ok(captures)
+}
+
+fn prune_captures(inner: &mut Inner) -> Result<(), String> {
+    let mut captures = read_captures(inner)?;
+    captures.sort_by_key(|capture| std::cmp::Reverse(capture.captured_at_ms));
+    let now = now_ms();
+    for (index, capture) in captures.into_iter().enumerate() {
+        if index >= MAX_CAPTURES || capture.expires_at_ms <= now {
+            inner
+                .captures
+                .retain(|_, active| active.capture_id != capture.capture_id);
+            let path = capture_path(inner, &capture.capture_id)?;
+            if !fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+            {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_is_off_by_default_one_shot_and_reviewable() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = TransformDiagnostics::default();
+        store.initialize(temp.path().join("diagnostics")).unwrap();
+        assert!(!store.arm_status().armed);
+
+        let armed = store.arm_next().unwrap();
+        assert!(armed.armed);
+        store.begin(41);
+        assert!(!store.arm_status().armed);
+        store.selection(
+            41,
+            Ok(("accessibility", "1-16", true, true, "success")),
+            Some("private input"),
+        );
+        store.instruction(41, "make it shorter");
+        store.sidecar_result(
+            41,
+            Some("cold"),
+            Some(4),
+            Some("stop"),
+            Some("private output"),
+        );
+        store.finish(41, "ready");
+
+        store.begin(42);
+        store.finish(42, "failed");
+        let summaries = store.list_captures().unwrap();
+        assert_eq!(summaries.len(), 1);
+        let capture = store
+            .get_capture(&summaries[0].capture_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(capture.selection.as_deref(), Some("private input"));
+        assert_eq!(capture.instruction.as_deref(), Some("make it shorter"));
+        assert_eq!(capture.output.as_deref(), Some("private output"));
+        store.delete_capture(&capture.capture_id).unwrap();
+        store.phase(41, "apply", "completed", Some(1), None);
+        store.finish(41, "applied");
+        assert!(store.list_captures().unwrap().is_empty());
+    }
+
+    #[test]
+    fn arm_expires_and_retention_is_capped_at_three() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = TransformDiagnostics::default();
+        store.initialize(temp.path().join("diagnostics")).unwrap();
+
+        store.inner.lock_or_recover().armed_until_ms = Some(now_ms() - 1);
+        store.begin(1);
+        store.finish(1, "cancelled");
+        assert!(store.list_captures().unwrap().is_empty());
+
+        for pass in 2..=5 {
+            store.arm_next().unwrap();
+            store.begin(pass);
+            store.finish(pass, if pass == 5 { "failed" } else { "ready" });
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        let captures = store.list_captures().unwrap();
+        assert_eq!(captures.len(), MAX_CAPTURES);
+        assert!(captures
+            .iter()
+            .all(|capture| capture.transform_pass_id >= 3));
+
+        let attempts = store.list_attempts(10);
+        assert_eq!(attempts.attempts.len(), 5);
+        assert!(attempts
+            .attempts
+            .iter()
+            .any(|attempt| { attempt.transform_pass_id == 1 && attempt.outcome == "cancelled" }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn store_uses_restrictive_permissions_and_refuses_symlink_capture() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let store = TransformDiagnostics::default();
+        store.initialize(root.clone()).unwrap();
+        store.arm_next().unwrap();
+        store.begin(7);
+        store.finish(7, "failed");
+        let summary = store.list_captures().unwrap().pop().unwrap();
+        let capture_path = root
+            .join("transform-captures")
+            .join(format!("{}.json", summary.capture_id));
+        assert_eq!(
+            fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&capture_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        fs::remove_file(&capture_path).unwrap();
+        symlink(temp.path().join("elsewhere"), &capture_path).unwrap();
+        assert!(store.get_capture(&summary.capture_id).is_err());
+    }
+}

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -311,6 +311,43 @@ pub fn transform_error_code(error: TransformError) -> &'static str {
     }
 }
 
+fn transform_error_code_for_phase(
+    error: TransformError,
+    diagnostics: crate::llm_sidecar::SidecarDiagnostics,
+) -> &'static str {
+    use crate::llm_sidecar::SidecarDiagnosticPhase as Phase;
+    match (error, diagnostics.failure_phase) {
+        (
+            TransformError::Timeout,
+            Some(Phase::HostModelVerification | Phase::HelperModelVerification),
+        ) => "model_verification_timeout",
+        (TransformError::Timeout, Some(Phase::BackendInitialization | Phase::ModelLoad)) => {
+            "model_load_timeout"
+        }
+        (TransformError::Timeout, Some(Phase::ReadyHandshake)) => "handshake_timeout",
+        (
+            TransformError::Timeout,
+            Some(Phase::RequestReceipt | Phase::FirstToken | Phase::Generation),
+        ) => "generation_timeout",
+        (TransformError::SpawnFailed, _) => "helper_spawn_failed",
+        (TransformError::HandshakeFailed, Some(Phase::HelperModelVerification)) => {
+            "model_verification_failed"
+        }
+        (
+            TransformError::HandshakeFailed,
+            Some(Phase::BackendInitialization | Phase::ModelLoad),
+        ) => "model_load_failed",
+        (TransformError::HandshakeFailed | TransformError::Protocol, _) => {
+            "handshake_protocol_failed"
+        }
+        (TransformError::Crashed, _) => "process_exit",
+        (TransformError::ModelMismatch | TransformError::ModelUnreadable, _) => {
+            "model_verification_failed"
+        }
+        _ => transform_error_code(error),
+    }
+}
+
 /// Map an `ApplyError` (write-back) to a stable popover error code. Total by
 /// construction.
 pub fn apply_error_code(error: ApplyError) -> &'static str {
@@ -621,6 +658,7 @@ pub(crate) struct SidecarRunMetrics {
     spawn_load_ms: Option<u64>,
     generation_ms: Option<u64>,
     cache_hit: Option<bool>,
+    diagnostics: crate::llm_sidecar::SidecarDiagnostics,
 }
 
 pub(crate) enum TransformRunReport {
@@ -628,12 +666,14 @@ pub(crate) enum TransformRunReport {
         metrics: SidecarRunMetrics,
         output_bytes: usize,
         output_tokens: u32,
+        finish_reason: &'static str,
         review_ready_ms: u64,
     },
     Failed {
         metrics: Option<SidecarRunMetrics>,
         timed_out: bool,
         stage: PerformanceStageV1,
+        error_code: &'static str,
     },
     Cancelled,
 }
@@ -800,6 +840,7 @@ pub(crate) async fn run_transform(
                 metrics: None,
                 timed_out: false,
                 stage: PerformanceStageV1::InstructionAsr,
+                error_code: "no_instruction",
             };
         }
     };
@@ -829,6 +870,7 @@ pub(crate) async fn run_transform(
                     spawn_load_ms: None,
                     generation_ms: None,
                     cache_hit: None,
+                    diagnostics: crate::llm_sidecar::SidecarDiagnostics::default(),
                 }
             } else {
                 sidecar
@@ -864,6 +906,7 @@ pub(crate) async fn run_transform(
                 metrics: None,
                 timed_out: false,
                 stage: PerformanceStageV1::Generation,
+                error_code: "internal",
             }
         }
         Ok(outcome) => {
@@ -871,6 +914,7 @@ pub(crate) async fn run_transform(
                 spawn_load_ms: outcome.spawn_load_ms,
                 generation_ms: outcome.generation_ms,
                 cache_hit: outcome.cache_hit,
+                diagnostics: outcome.diagnostics,
             };
             match outcome.result {
                 Ok(output) => {
@@ -882,6 +926,10 @@ pub(crate) async fn run_transform(
                     }
                     let output_bytes = output.output.len();
                     let output_tokens = output.output_tokens;
+                    let finish_reason = match output.finish_reason {
+                        murmur_local_llm_protocol::FinishReason::Stop => "stop",
+                        murmur_local_llm_protocol::FinishReason::Length => "length",
+                    };
                     let review_ready_started = std::time::Instant::now();
                     transform_apply::set_proposed_text(app_state, output.output);
                     fx.set_expanded(true);
@@ -899,6 +947,7 @@ pub(crate) async fn run_transform(
                         metrics,
                         output_bytes,
                         output_tokens,
+                        finish_reason,
                         review_ready_ms: review_ready_started.elapsed().as_millis() as u64,
                     }
                 }
@@ -910,7 +959,7 @@ pub(crate) async fn run_transform(
                         TransformStatus::Thinking,
                         TransformStatus::ReviewPending,
                     ) {
-                        let error_code = transform_error_code(error);
+                        let error_code = transform_error_code_for_phase(error, metrics.diagnostics);
                         fx.set_focusable(true);
                         fx.emit_state(ReviewState::Failed, Some(error_code));
                         if transform_pass_id != 0 {
@@ -927,10 +976,12 @@ pub(crate) async fn run_transform(
                     } else {
                         PerformanceStageV1::SidecarSpawnLoad
                     };
+                    let error_code = transform_error_code_for_phase(error, metrics.diagnostics);
                     TransformRunReport::Failed {
                         metrics: Some(metrics),
                         timed_out: error == TransformError::Timeout,
                         stage,
+                        error_code,
                     }
                 }
             }
@@ -944,6 +995,45 @@ fn record_sidecar_metrics(
     metrics: SidecarRunMetrics,
     succeeded: bool,
 ) -> PerformanceStageV1 {
+    let d = metrics.diagnostics;
+    state.transform_diagnostics.process_exit(
+        transform_pass_id,
+        d.process_exit_code,
+        d.process_exit_signal,
+    );
+    for (phase, duration) in [
+        ("host_model_verification", d.host_model_verification_ms),
+        ("helper_spawn", d.helper_spawn_ms),
+        ("helper_model_verification", d.helper_model_verification_ms),
+        ("backend_initialization", d.backend_initialization_ms),
+        ("model_load", d.model_load_ms),
+        ("ready_handshake", d.ready_handshake_ms),
+        ("request_receipt", d.request_receipt_ms),
+        ("first_token", d.first_token_ms),
+    ] {
+        if let Some(duration_ms) = duration {
+            crate::transform_trace::sidecar_phase(
+                transform_pass_id,
+                phase,
+                "completed",
+                duration_ms,
+                None,
+            );
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                phase,
+                "completed",
+                Some(duration_ms),
+                None,
+            );
+        }
+    }
+    if let Some(phase) = d.failure_phase {
+        crate::transform_trace::sidecar_phase(transform_pass_id, phase.as_str(), "failed", 0, None);
+        state
+            .transform_diagnostics
+            .phase(transform_pass_id, phase.as_str(), "failed", None, None);
+    }
     let warm_state = match metrics.cache_hit {
         Some(true) => ModelWarmStateV1::Warm,
         Some(false) => ModelWarmStateV1::ColdLoaded,
@@ -1111,10 +1201,9 @@ impl FlowEffects for TauriFlowEffects<'_> {
             let _ = crate::commands::transform_popover::hide_popover_internal(&app);
             // Linger auto-hide is backend-initiated — reset stale content (item 13).
             emit_transform_hidden(&app);
-            if let (Some(transform_pass_id), Some(state)) = (
-                transform_pass_id,
-                app.try_state::<crate::State>(),
-            ) {
+            if let (Some(transform_pass_id), Some(state)) =
+                (transform_pass_id, app.try_state::<crate::State>())
+            {
                 crate::transform_trace::resolution(
                     transform_pass_id,
                     "applied",
@@ -1326,6 +1415,7 @@ pub(crate) async fn start_transform_capture(
     device_name: Option<String>,
     transform_pass_id: u64,
 ) -> Result<(), String> {
+    state.transform_diagnostics.begin(transform_pass_id);
     // Serialize against dictation start/stop, taking the same locks in the
     // same order (`recording_transition` then `dictation`) as
     // `start_native_recording`, so the two audio paths can't tear each other's
@@ -1365,6 +1455,16 @@ pub(crate) async fn start_transform_capture(
         }
     };
     if let Err(error_code) = claim_result {
+        state.transform_diagnostics.phase(
+            transform_pass_id,
+            "start",
+            "failed",
+            None,
+            Some(error_code),
+        );
+        state
+            .transform_diagnostics
+            .finish(transform_pass_id, "failed");
         crate::transform_trace::resolution(transform_pass_id, "failed", "start", Some(error_code));
         if state.app_state.transform_status() == TransformStatus::Idle {
             state.app_state.clear_transform_pass(transform_pass_id);
@@ -1431,6 +1531,16 @@ pub(crate) async fn start_transform_capture(
             let _ = crate::commands::transform_popover::hide_popover_internal(&app_handle);
             emit_transform_hidden(&app_handle);
             state.app_state.clear_transform_pass(transform_pass_id);
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "instructionCapture",
+                "failed",
+                Some(audio_start_started.elapsed().as_millis() as u64),
+                Some("audio_start_failed"),
+            );
+            state
+                .transform_diagnostics
+                .finish(transform_pass_id, "failed");
             return Err(e);
         }
         crate::transform_trace::audio(transform_pass_id, "armed", "ok", 0, 0);
@@ -1443,6 +1553,55 @@ pub(crate) async fn start_transform_capture(
         None
     };
     let capture_succeeded = capture_result.as_ref().is_some_and(|result| result.is_ok());
+    let capture_duration_ms = capture_started.elapsed().as_millis() as u64;
+    match capture_result.as_ref() {
+        Some(Ok(snapshot)) => {
+            let source = if snapshot.range.is_some() || snapshot.bounds.is_some() {
+                "accessibility"
+            } else {
+                "clipboardFallback"
+            };
+            state.transform_diagnostics.selection(
+                transform_pass_id,
+                Ok((
+                    source,
+                    crate::selection::length_bucket(snapshot.text.len()),
+                    snapshot.range.is_some(),
+                    snapshot.bounds.is_some(),
+                    "success",
+                )),
+                Some(&snapshot.text),
+            );
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "selectionCapture",
+                "completed",
+                Some(capture_duration_ms),
+                None,
+            );
+        }
+        Some(Err(error)) => {
+            state
+                .transform_diagnostics
+                .selection(transform_pass_id, Err(error.as_str()), None);
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "selectionCapture",
+                "failed",
+                Some(capture_duration_ms),
+                Some(error.as_str()),
+            );
+        }
+        None => {
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "selectionCapture",
+                "failed",
+                Some(capture_duration_ms),
+                Some("model_not_downloaded"),
+            );
+        }
+    }
     record_transform_stage(
         &state,
         transform_pass_id,
@@ -1487,6 +1646,9 @@ pub(crate) async fn start_transform_capture(
         if state.app_state.transform_status() == TransformStatus::Idle {
             state.app_state.clear_transform_pass(transform_pass_id);
         }
+        state
+            .transform_diagnostics
+            .finish(transform_pass_id, "failed");
         return Ok(());
     }
     if let Some(guard) = performance_guard.as_mut() {
@@ -1589,6 +1751,17 @@ pub(crate) async fn finish_transform_instruction(
                 },
             ),
         );
+        state.transform_diagnostics.phase(
+            transform_pass_id,
+            "instructionCapture",
+            if samples.is_empty() {
+                "failed"
+            } else {
+                "completed"
+            },
+            Some(audio_duration_ms),
+            samples.is_empty().then_some("audio_empty"),
+        );
 
         if !enter_thinking(&state.app_state, &fx) {
             // Lost the race to a concurrent cancel.
@@ -1625,12 +1798,34 @@ pub(crate) async fn finish_transform_instruction(
     };
 
     let attempt = state.app_state.current_instruction_attempt();
+    let instruction_asr_started = std::time::Instant::now();
     let instruction =
         match transcribe_instruction(&app_handle, &state, &samples, transform_pass_id, attempt)
             .await
         {
-            Ok(raw) => Ok(expand_instruction(&state, &raw)),
-            Err(_) => Err(()),
+            Ok(raw) => {
+                state
+                    .transform_diagnostics
+                    .instruction(transform_pass_id, &raw);
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "instructionAsr",
+                    "completed",
+                    Some(instruction_asr_started.elapsed().as_millis() as u64),
+                    None,
+                );
+                Ok(expand_instruction(&state, &raw))
+            }
+            Err(error) => {
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "instructionAsr",
+                    "failed",
+                    Some(instruction_asr_started.elapsed().as_millis() as u64),
+                    Some(error.as_str()),
+                );
+                Err(())
+            }
         };
     let audio_duration_ms = samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64;
     let input_bytes = original.len();
@@ -1652,8 +1847,14 @@ pub(crate) async fn finish_transform_instruction(
             metrics,
             output_bytes,
             output_tokens,
+            finish_reason,
             review_ready_ms,
         } => {
+            let warm_state = match metrics.cache_hit {
+                Some(true) => "warm",
+                Some(false) => "cold",
+                None => "unknown",
+            };
             record_sidecar_metrics(&state, transform_pass_id, metrics, true);
             record_transform_stage(
                 &state,
@@ -1670,10 +1871,31 @@ pub(crate) async fn finish_transform_instruction(
                     Some((output_bytes, output_tokens)),
                 )),
             );
+            let snapshot = transform_apply::session_snapshot(&state.app_state);
+            state.transform_diagnostics.sidecar_result(
+                transform_pass_id,
+                Some(warm_state),
+                Some(output_tokens),
+                Some(finish_reason),
+                snapshot
+                    .as_ref()
+                    .and_then(|session| session.proposed.as_deref()),
+            );
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "reviewReady",
+                "completed",
+                Some(review_ready_ms),
+                None,
+            );
+            state
+                .transform_diagnostics
+                .finish(transform_pass_id, "ready");
         }
         TransformRunReport::Failed {
             metrics: Some(metrics),
             timed_out,
+            error_code,
             ..
         } => {
             let terminal_stage = record_sidecar_metrics(&state, transform_pass_id, metrics, false);
@@ -1696,10 +1918,22 @@ pub(crate) async fn finish_transform_instruction(
                     None,
                 )),
             );
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                "sidecar",
+                if timed_out { "timedOut" } else { "failed" },
+                None,
+                Some(error_code),
+            );
+            state.transform_diagnostics.finish(
+                transform_pass_id,
+                if timed_out { "timedOut" } else { "failed" },
+            );
         }
         TransformRunReport::Failed {
             metrics: None,
             stage,
+            error_code,
             ..
         } => {
             complete_transform_performance(
@@ -1719,11 +1953,28 @@ pub(crate) async fn finish_transform_instruction(
                     None,
                 )),
             );
+            state.transform_diagnostics.phase(
+                transform_pass_id,
+                if stage == PerformanceStageV1::InstructionAsr {
+                    "instructionAsr"
+                } else {
+                    "sidecar"
+                },
+                "failed",
+                None,
+                Some(error_code),
+            );
+            state
+                .transform_diagnostics
+                .finish(transform_pass_id, "failed");
         }
         TransformRunReport::Cancelled => {
             if let Some(guard) = performance_guard {
                 guard.defer();
             }
+            state
+                .transform_diagnostics
+                .finish(transform_pass_id, "cancelled");
         }
     }
     Ok(())
@@ -1911,6 +2162,16 @@ pub(crate) async fn approve_transform(
                 );
                 crate::transform_trace::effect(transform_pass_id, "apply", via.as_str(), None);
                 crate::transform_trace::resolution(transform_pass_id, "applied", "apply", None);
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "apply",
+                    "completed",
+                    Some(performance_started.elapsed().as_millis() as u64),
+                    None,
+                );
+                state
+                    .transform_diagnostics
+                    .finish(transform_pass_id, "applied");
             }
             Ok(())
         }
@@ -1939,6 +2200,16 @@ pub(crate) async fn approve_transform(
                     "apply",
                     Some(error_code),
                 );
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "apply",
+                    "failed",
+                    Some(performance_started.elapsed().as_millis() as u64),
+                    Some(error_code),
+                );
+                state
+                    .transform_diagnostics
+                    .finish(transform_pass_id, "applyFailed");
             }
             Err(error_code.to_string())
         }
@@ -2034,6 +2305,16 @@ pub(crate) async fn cancel_transform(
             None,
         );
         crate::transform_trace::resolution(transform_pass_id, "cancelled", prev.as_str(), None);
+        state.transform_diagnostics.phase(
+            transform_pass_id,
+            "cancellation",
+            "completed",
+            None,
+            None,
+        );
+        state
+            .transform_diagnostics
+            .finish(transform_pass_id, "cancelled");
         state.app_state.clear_transform_pass(transform_pass_id);
     }
     Ok(())
@@ -2167,6 +2448,16 @@ pub(crate) async fn undo_transform_and_close(
                 );
                 crate::transform_trace::effect(transform_pass_id, "undo", "ok", None);
                 crate::transform_trace::resolution(transform_pass_id, "undone", "undo", None);
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "undo",
+                    "completed",
+                    Some(performance_started.elapsed().as_millis() as u64),
+                    None,
+                );
+                state
+                    .transform_diagnostics
+                    .finish(transform_pass_id, "undone");
                 state.app_state.clear_transform_pass(transform_pass_id);
             }
             Ok(())
@@ -2204,6 +2495,16 @@ pub(crate) async fn undo_transform_and_close(
                     "undo",
                     Some(apply_error_code(error)),
                 );
+                state.transform_diagnostics.phase(
+                    transform_pass_id,
+                    "undo",
+                    "failed",
+                    Some(performance_started.elapsed().as_millis() as u64),
+                    Some(apply_error_code(error)),
+                );
+                state
+                    .transform_diagnostics
+                    .finish(transform_pass_id, "undoFailed");
             }
             Err(apply_error_code(error).to_string())
         }
@@ -2648,6 +2949,42 @@ mod tests {
         );
         assert_eq!(transform_error_code(TransformError::Busy), "busy");
         assert_eq!(transform_error_code(TransformError::Disabled), "disabled");
+    }
+
+    #[test]
+    fn sidecar_failures_are_precise_for_the_observed_phase() {
+        use crate::llm_sidecar::{SidecarDiagnosticPhase as Phase, SidecarDiagnostics};
+
+        let diagnostics = |phase| SidecarDiagnostics {
+            failure_phase: Some(phase),
+            ..SidecarDiagnostics::default()
+        };
+        assert_eq!(
+            transform_error_code_for_phase(
+                TransformError::Timeout,
+                diagnostics(Phase::HelperModelVerification),
+            ),
+            "model_verification_timeout"
+        );
+        assert_eq!(
+            transform_error_code_for_phase(TransformError::Timeout, diagnostics(Phase::ModelLoad),),
+            "model_load_timeout"
+        );
+        assert_eq!(
+            transform_error_code_for_phase(TransformError::Timeout, diagnostics(Phase::Generation),),
+            "generation_timeout"
+        );
+        assert_eq!(
+            transform_error_code_for_phase(
+                TransformError::HandshakeFailed,
+                diagnostics(Phase::ReadyHandshake),
+            ),
+            "handshake_protocol_failed"
+        );
+        assert_eq!(
+            transform_error_code_for_phase(TransformError::Crashed, diagnostics(Phase::FirstToken),),
+            "process_exit"
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -224,6 +224,10 @@ fn complete_transform_performance(
     );
 }
 
+fn capture_abort_was_cancelled(app_state: &AppState, transform_pass_id: u64) -> bool {
+    app_state.is_transform_pass_cancelled(transform_pass_id)
+}
+
 fn append_transform_follow_up(
     state: &crate::State,
     transform_pass_id: u64,
@@ -1621,15 +1625,23 @@ pub(crate) async fn start_transform_capture(
     .await;
 
     if outcome != StartOutcome::Listening {
-        complete_transform_performance(
-            &state,
-            transform_pass_id,
-            RunOutcomeV1::Failed {
-                stage: PerformanceStageV1::SelectedTextCapture,
-                error_code: StableRunErrorV1::TransformStageFailed,
-            },
-            None,
-        );
+        // cancel_transform marks cancellation before tearing down the pass,
+        // while a slow AX capture may still be unwinding. Use that monotonic
+        // marker instead of inferring from Idle/active state: this command can
+        // resume during the window after cancel forced Idle but before it
+        // clears the active pass.
+        let cancellation_won = capture_abort_was_cancelled(&state.app_state, transform_pass_id);
+        if !cancellation_won {
+            complete_transform_performance(
+                &state,
+                transform_pass_id,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::SelectedTextCapture,
+                    error_code: StableRunErrorV1::TransformStageFailed,
+                },
+                None,
+            );
+        }
         // Capture aborted (secure field, capture error, model-not-ready
         // failed popover, or a cancel racing the capture) — the pre-armed mic
         // must not stay live.
@@ -1643,12 +1655,14 @@ pub(crate) async fn start_transform_capture(
                 samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64,
             );
         }
-        if state.app_state.transform_status() == TransformStatus::Idle {
+        if !cancellation_won && state.app_state.transform_status() == TransformStatus::Idle {
             state.app_state.clear_transform_pass(transform_pass_id);
         }
-        state
-            .transform_diagnostics
-            .finish(transform_pass_id, "failed");
+        if !cancellation_won {
+            state
+                .transform_diagnostics
+                .finish(transform_pass_id, "failed");
+        }
         return Ok(());
     }
     if let Some(guard) = performance_guard.as_mut() {
@@ -2232,6 +2246,15 @@ pub(crate) async fn cancel_transform(
         return Ok(());
     }
     let transform_pass_id = active_pass_id.unwrap_or(0);
+    if transform_pass_id != 0 {
+        // Publish the terminal winner before any awaitable/main-thread
+        // teardown. A concurrent selection capture can return immediately
+        // after status becomes Idle and must not persist a failed outcome for
+        // a pass the user already cancelled.
+        state
+            .app_state
+            .mark_transform_pass_cancelled(transform_pass_id);
+    }
     let prev = state.app_state.transform_status();
     let _performance_guard = (transform_pass_id != 0).then(|| {
         state.performance.guard(
@@ -3350,6 +3373,21 @@ mod tests {
         assert!(transform_apply::session_snapshot(&app_state).is_none());
         assert!(!fx.popover_shown());
         assert!(fx.emitted_states().is_empty());
+    }
+
+    #[test]
+    fn capture_abort_does_not_terminalize_during_cancel_before_pass_clear() {
+        let app_state = AppState::default();
+        app_state.activate_transform_pass(41);
+        app_state.set_transform_status(TransformStatus::Capturing);
+
+        // Mirrors cancel_transform's ordering: publish cancellation first,
+        // then force Idle, with the active pass still present until teardown.
+        app_state.mark_transform_pass_cancelled(41);
+        app_state.set_transform_status(TransformStatus::Idle);
+
+        assert_eq!(app_state.active_transform_pass_id(), Some(41));
+        assert!(capture_abort_was_cancelled(&app_state, 41));
     }
 
     // ---- Spec-by-test divergence points (finding 8) ------------------------

--- a/app/src-tauri/src/transform_trace.rs
+++ b/app/src-tauri/src/transform_trace.rs
@@ -180,6 +180,20 @@ pub fn effect(
     }
 }
 
+pub fn sidecar_phase(
+    transform_pass_id: u64,
+    phase: &'static str,
+    outcome: &'static str,
+    duration_ms: u64,
+    error_code: Option<&'static str>,
+) {
+    if let Some(error_code) = error_code {
+        tracing::info!(target: "transform", transform_pass_id, phase, outcome, duration_ms, error_code, "transform_sidecar_phase");
+    } else {
+        tracing::info!(target: "transform", transform_pass_id, phase, outcome, duration_ms, "transform_sidecar_phase");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -297,6 +297,29 @@ async fn wrong_handshake_nonce_fails_closed() {
 }
 
 #[tokio::test]
+async fn startup_diagnostic_frames_require_exact_nonce_and_version() {
+    for scenario in [
+        "wrong_nonce_on_startup_phase",
+        "wrong_version_on_startup_phase",
+    ] {
+        let fixture = fixture_model();
+        let sidecar = sidecar(scenario, &fixture);
+        let err = run_transform(&sidecar, Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err,
+            TransformError::HandshakeFailed,
+            "startup diagnostic envelope was accepted for {scenario}"
+        );
+        assert!(
+            !sidecar.has_live_child(),
+            "invalid startup diagnostic left helper alive for {scenario}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn one_transform_in_flight_rejects_the_second() {
     let fixture = fixture_model();
     // A deliberate delay so the two requests overlap.
@@ -379,6 +402,72 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
     // hang again — reusability of the supervisor after cancel is covered by
     // the happy-path round-trip and dropping_the_transform_future tests.
     assert!(sidecar.has_live_child());
+}
+
+#[tokio::test]
+async fn cancellation_diagnostic_without_matching_ack_kills_and_reaps() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("slow_diagnostic_no_cancel_ack", &fixture);
+    let request_sidecar = Arc::clone(&sidecar);
+    let handle =
+        tokio::spawn(async move { run_transform(&request_sidecar, Duration::from_secs(30)).await });
+
+    for _ in 0..200 {
+        if sidecar.is_transform_busy() && sidecar.has_live_child() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        sidecar.is_transform_busy() && sidecar.has_live_child(),
+        "transform/helper never became ready for cancellation"
+    );
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    sidecar.cancel_inflight_request();
+
+    let err = handle.await.unwrap().unwrap_err();
+    assert_eq!(err, TransformError::Cancelled);
+    assert!(!sidecar.is_transform_busy());
+    assert!(
+        !sidecar.has_live_child(),
+        "a diagnostic frame was incorrectly accepted as cancel confirmation"
+    );
+}
+
+#[tokio::test]
+async fn diagnostics_before_cancel_ack_do_not_leak_into_immediate_reuse() {
+    let fixture = fixture_model();
+    let sidecar = sidecar("diagnostic_before_cancel_ack_then_happy", &fixture);
+    let request_sidecar = Arc::clone(&sidecar);
+    let handle =
+        tokio::spawn(async move { run_transform(&request_sidecar, Duration::from_secs(30)).await });
+
+    for _ in 0..200 {
+        if sidecar.is_transform_busy() && sidecar.has_live_child() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        sidecar.is_transform_busy() && sidecar.has_live_child(),
+        "transform/helper never became ready for cancellation"
+    );
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    sidecar.cancel_inflight_request();
+
+    let err = handle.await.unwrap().unwrap_err();
+    assert_eq!(err, TransformError::Cancelled);
+    assert!(!sidecar.is_transform_busy());
+    assert!(
+        sidecar.has_live_child(),
+        "matching cancellation acknowledgement should preserve the helper"
+    );
+
+    let output = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(output.output, "mock-output");
+    assert!(!sidecar.is_transform_busy());
 }
 
 #[tokio::test]

--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the local-LLM sidecar supervisor (#312).
 //!
-//! These drive the real supervisor against the protocol-v1 mock helper
+//! These drive the real supervisor against the versioned mock helper
 //! (`target/<profile>/examples/mock_llm_helper`). No real GGUF model or
 //! llama.cpp is involved: the "model" is a small temp file whose pins the test
 //! derives.
@@ -84,7 +84,9 @@ async fn run_transform(
 async fn successful_transform_round_trip() {
     let fixture = fixture_model();
     let sidecar = sidecar("happy", &fixture);
-    let out = run_transform(&sidecar, Duration::from_secs(5)).await.unwrap();
+    let out = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap();
     assert_eq!(out.output, "mock-output");
     assert_eq!(out.output_tokens, 3);
     // The helper is healthy and kept resident for reuse.
@@ -108,6 +110,15 @@ async fn correlated_transform_reports_cold_then_warm_phase_timings() {
     assert_eq!(cold.cache_hit, Some(false));
     assert!(cold.spawn_load_ms.is_some());
     assert!(cold.generation_ms.is_some());
+    assert!(cold.diagnostics.host_model_verification_ms.is_some());
+    assert!(cold.diagnostics.helper_spawn_ms.is_some());
+    assert_eq!(cold.diagnostics.helper_model_verification_ms, Some(1));
+    assert_eq!(cold.diagnostics.backend_initialization_ms, Some(1));
+    assert_eq!(cold.diagnostics.model_load_ms, Some(1));
+    assert!(cold.diagnostics.ready_handshake_ms.is_some());
+    assert_eq!(cold.diagnostics.request_receipt_ms, Some(0));
+    assert_eq!(cold.diagnostics.first_token_ms, Some(1));
+    assert!(cold.diagnostics.failure_phase.is_none());
     assert!(sidecar.resident_pid().is_some());
 
     let warm = sidecar
@@ -123,6 +134,39 @@ async fn correlated_transform_reports_cold_then_warm_phase_timings() {
     assert_eq!(warm.cache_hit, Some(true));
     assert!(warm.spawn_load_ms.is_some());
     assert!(warm.generation_ms.is_some());
+}
+
+#[tokio::test]
+async fn every_helper_startup_phase_failure_is_identified() {
+    use ui_lib::llm_sidecar::SidecarDiagnosticPhase;
+
+    for (scenario, expected_phase) in [
+        (
+            "fail_helpermodelverification",
+            SidecarDiagnosticPhase::HelperModelVerification,
+        ),
+        (
+            "fail_backendinitialization",
+            SidecarDiagnosticPhase::BackendInitialization,
+        ),
+        ("fail_modelload", SidecarDiagnosticPhase::ModelLoad),
+    ] {
+        let fixture = fixture_model();
+        let sidecar = sidecar(scenario, &fixture);
+        let outcome = sidecar
+            .transform_for_pass(
+                91,
+                "Rewrite this politely.",
+                "gimme the report",
+                Duration::from_secs(5),
+                CancelToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.result.unwrap_err(), TransformError::HandshakeFailed);
+        assert_eq!(outcome.diagnostics.failure_phase, Some(expected_phase));
+        assert_eq!(outcome.diagnostics.process_exit_code, Some(70));
+        assert!(!sidecar.has_live_child());
+    }
 }
 
 #[tokio::test]
@@ -173,6 +217,29 @@ async fn crash_reports_crashed_and_trips_circuit_breaker() {
         .await
         .unwrap_err();
     assert_eq!(err, TransformError::Crashed);
+}
+
+#[tokio::test]
+async fn process_exit_is_reported_with_generation_phase_and_status() {
+    use ui_lib::llm_sidecar::SidecarDiagnosticPhase;
+
+    let fixture = fixture_model();
+    let sidecar = sidecar("crash_on_transform", &fixture);
+    let outcome = sidecar
+        .transform_for_pass(
+            92,
+            "Rewrite this politely.",
+            "gimme the report",
+            Duration::from_secs(5),
+            CancelToken::new(),
+        )
+        .await;
+    assert_eq!(outcome.result.unwrap_err(), TransformError::Crashed);
+    assert_eq!(
+        outcome.diagnostics.failure_phase,
+        Some(SidecarDiagnosticPhase::FirstToken)
+    );
+    assert_eq!(outcome.diagnostics.process_exit_code, Some(101));
 }
 
 #[tokio::test]
@@ -315,6 +382,62 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
 }
 
 #[tokio::test]
+async fn cooperative_cancel_during_ready_handshake_reaps_and_allows_next_request() {
+    let fixture = fixture_model();
+    let sidecar = Arc::new(LlmSidecar::for_test(config_with(
+        "happy",
+        &fixture,
+        vec![("MOCK_READY_DELAY_MS".to_string(), "600".to_string())],
+    )));
+
+    let first_sidecar = Arc::clone(&sidecar);
+    let first = tokio::spawn(async move {
+        first_sidecar
+            .transform(
+                "Rewrite this politely.",
+                "gimme the report",
+                Duration::from_secs(5),
+                CancelToken::new(),
+            )
+            .await
+    });
+
+    let mut spawned = false;
+    for _ in 0..100 {
+        if sidecar.resident_pid().is_some() {
+            spawned = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(spawned, "helper never reached the Ready handshake");
+
+    let cancel_started = std::time::Instant::now();
+    sidecar.cancel_inflight_request();
+    let err = tokio::time::timeout(Duration::from_secs(1), first)
+        .await
+        .expect("handshake cancellation did not settle promptly")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err, TransformError::Cancelled);
+    assert!(
+        cancel_started.elapsed() < Duration::from_secs(1),
+        "busy did not clear promptly after handshake cancel: {:?}",
+        cancel_started.elapsed()
+    );
+    assert!(!sidecar.is_transform_busy());
+    assert!(
+        !sidecar.has_live_child(),
+        "partially started helper was not reaped"
+    );
+
+    let output = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(output.output, "mock-output");
+}
+
+#[tokio::test]
 async fn dropping_the_transform_future_clears_busy_and_does_not_wedge() {
     let fixture = fixture_model();
     // Happy path with a delayed Result so the request is still in flight when
@@ -329,7 +452,10 @@ async fn dropping_the_transform_future_clears_busy_and_does_not_wedge() {
         // Drop the transform future well before the delayed Result arrives.
         let fut = run_transform(&sidecar, Duration::from_secs(5));
         let dropped = tokio::time::timeout(Duration::from_millis(50), fut).await;
-        assert!(dropped.is_err(), "future should be cancelled by the timeout");
+        assert!(
+            dropped.is_err(),
+            "future should be cancelled by the timeout"
+        );
     }
 
     // The blocking task keeps running and must clear `busy` when it finishes.
@@ -344,7 +470,9 @@ async fn dropping_the_transform_future_clears_busy_and_does_not_wedge() {
     assert!(cleared, "busy flag wedged after the future was dropped");
 
     // And the supervisor is not bricked: a fresh transform proceeds.
-    let out = run_transform(&sidecar, Duration::from_secs(5)).await.unwrap();
+    let out = run_transform(&sidecar, Duration::from_secs(5))
+        .await
+        .unwrap();
     assert_eq!(out.output, "mock-output");
 }
 

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -14,6 +14,12 @@
 //! - `slow_honor_cancel`   — alias of `slow_ack_cancel` (cancel-honoring slow path
 //!                           for host-side cooperative-cancel tests)
 //! - `slow_ignore_cancel`  — never Result; ignore Cancel (forces a kill)
+//! - `slow_diagnostic_no_cancel_ack` — emit a diagnostic after Cancel, but no
+//!                           matching Cancelled acknowledgement
+//! - `diagnostic_before_cancel_ack_then_happy` — first request emits a
+//!                           diagnostic then Cancelled; later requests succeed
+//! - `wrong_nonce_on_startup_phase` — a startup completion has a bad nonce
+//! - `wrong_version_on_startup_phase` — a later startup completion has a bad version
 //!
 //! The real supervisor spawns with `env_clear`, so these vars only exist for the
 //! mock via the supervisor's test-only constructor.
@@ -35,11 +41,34 @@ fn phase(
     state: PhaseState,
     duration_ms: Option<u64>,
 ) {
+    phase_with_envelope(
+        stdout,
+        PROTOCOL_NAME,
+        PROTOCOL_VERSION,
+        nonce,
+        request_id,
+        diagnostic,
+        state,
+        duration_ms,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn phase_with_envelope(
+    stdout: &mut impl Write,
+    protocol: &str,
+    version: u16,
+    nonce: &str,
+    request_id: Option<&str>,
+    diagnostic: DiagnosticPhase,
+    state: PhaseState,
+    duration_ms: Option<u64>,
+) {
     let _ = write_frame(
         stdout,
         &HelperMessage::DiagnosticPhase {
-            protocol: PROTOCOL_NAME.to_string(),
-            version: PROTOCOL_VERSION,
+            protocol: protocol.to_string(),
+            version,
             session_nonce: nonce.to_string(),
             request_id: request_id.map(str::to_string),
             phase: diagnostic,
@@ -98,8 +127,10 @@ fn main() {
         DiagnosticPhase::BackendInitialization,
         DiagnosticPhase::ModelLoad,
     ] {
-        phase(
+        phase_with_envelope(
             &mut stdout,
+            PROTOCOL_NAME,
+            PROTOCOL_VERSION,
             &session_nonce,
             None,
             diagnostic,
@@ -109,9 +140,25 @@ fn main() {
         if scenario == format!("fail_{diagnostic:?}").to_ascii_lowercase() {
             std::process::exit(70);
         }
-        phase(
+        let completed_nonce = if scenario == "wrong_nonce_on_startup_phase"
+            && diagnostic == DiagnosticPhase::BackendInitialization
+        {
+            "WRONG-NONCE"
+        } else {
+            &session_nonce
+        };
+        let completed_version = if scenario == "wrong_version_on_startup_phase"
+            && diagnostic == DiagnosticPhase::ModelLoad
+        {
+            PROTOCOL_VERSION + 1
+        } else {
+            PROTOCOL_VERSION
+        };
+        phase_with_envelope(
             &mut stdout,
-            &session_nonce,
+            PROTOCOL_NAME,
+            completed_version,
+            completed_nonce,
             None,
             diagnostic,
             PhaseState::Completed,
@@ -163,9 +210,12 @@ fn main() {
         }
     });
 
+    let mut transform_count = 0_u32;
+    let mut active_request_id: Option<String> = None;
     while let Ok(Some(message)) = rx.recv() {
         match message {
             HostMessage::Transform { request_id, .. } => {
+                transform_count += 1;
                 phase(
                     &mut stdout,
                     &session_nonce,
@@ -190,8 +240,14 @@ fn main() {
                         let _ = stdout.write_all(b"xx");
                         let _ = stdout.flush();
                     }
-                    "slow_ack_cancel" | "slow_honor_cancel" | "slow_ignore_cancel" => {
+                    "slow_ack_cancel"
+                    | "slow_honor_cancel"
+                    | "slow_ignore_cancel"
+                    | "slow_diagnostic_no_cancel_ack" => {
                         // Never send a Result; wait for the Cancel below.
+                    }
+                    "diagnostic_before_cancel_ack_then_happy" if transform_count == 1 => {
+                        active_request_id = Some(request_id);
                     }
                     "error_deadline_on_transform" => {
                         // A self-reported DeadlineExceeded: a designed outcome the
@@ -255,6 +311,34 @@ fn main() {
                         request_id,
                     };
                     let _ = write_frame(&mut stdout, &cancelled);
+                } else if scenario == "slow_diagnostic_no_cancel_ack" {
+                    phase(
+                        &mut stdout,
+                        &session_nonce,
+                        Some(&request_id),
+                        DiagnosticPhase::FirstToken,
+                        PhaseState::Completed,
+                        Some(1),
+                    );
+                } else if scenario == "diagnostic_before_cancel_ack_then_happy"
+                    && active_request_id.as_deref() == Some(request_id.as_str())
+                {
+                    phase(
+                        &mut stdout,
+                        &session_nonce,
+                        Some(&request_id),
+                        DiagnosticPhase::FirstToken,
+                        PhaseState::Completed,
+                        Some(1),
+                    );
+                    let cancelled = HelperMessage::Cancelled {
+                        protocol: PROTOCOL_NAME.to_string(),
+                        version: PROTOCOL_VERSION,
+                        session_nonce: session_nonce.clone(),
+                        request_id,
+                    };
+                    let _ = write_frame(&mut stdout, &cancelled);
+                    active_request_id = None;
                 }
                 // slow_ignore_cancel: intentionally drop it.
             }

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -23,9 +23,31 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use murmur_local_llm_protocol::{
-    read_frame, write_frame, ErrorCode, FinishReason, HelperMessage, HostMessage, ModelIdentity,
-    MODEL_FD, PROTOCOL_NAME, PROTOCOL_VERSION,
+    read_frame, write_frame, DiagnosticPhase, ErrorCode, FinishReason, HelperMessage, HostMessage,
+    ModelIdentity, PhaseState, MODEL_FD, PROTOCOL_NAME, PROTOCOL_VERSION,
 };
+
+fn phase(
+    stdout: &mut impl Write,
+    nonce: &str,
+    request_id: Option<&str>,
+    diagnostic: DiagnosticPhase,
+    state: PhaseState,
+    duration_ms: Option<u64>,
+) {
+    let _ = write_frame(
+        stdout,
+        &HelperMessage::DiagnosticPhase {
+            protocol: PROTOCOL_NAME.to_string(),
+            version: PROTOCOL_VERSION,
+            session_nonce: nonce.to_string(),
+            request_id: request_id.map(str::to_string),
+            phase: diagnostic,
+            state,
+            duration_ms,
+        },
+    );
+}
 
 fn scenario() -> String {
     std::env::var("MOCK_SCENARIO").unwrap_or_else(|_| "happy".to_string())
@@ -71,6 +93,36 @@ fn main() {
     } else {
         session_nonce.clone()
     };
+    for diagnostic in [
+        DiagnosticPhase::HelperModelVerification,
+        DiagnosticPhase::BackendInitialization,
+        DiagnosticPhase::ModelLoad,
+    ] {
+        phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            diagnostic,
+            PhaseState::Started,
+            None,
+        );
+        if scenario == format!("fail_{diagnostic:?}").to_ascii_lowercase() {
+            std::process::exit(70);
+        }
+        phase(
+            &mut stdout,
+            &session_nonce,
+            None,
+            diagnostic,
+            PhaseState::Completed,
+            Some(1),
+        );
+    }
+    if let Ok(ms) = std::env::var("MOCK_READY_DELAY_MS") {
+        if let Ok(ms) = ms.parse::<u64>() {
+            std::thread::sleep(Duration::from_millis(ms));
+        }
+    }
     let ready = HelperMessage::Ready {
         protocol: PROTOCOL_NAME.to_string(),
         version: PROTOCOL_VERSION,
@@ -114,6 +166,14 @@ fn main() {
     while let Ok(Some(message)) = rx.recv() {
         match message {
             HostMessage::Transform { request_id, .. } => {
+                phase(
+                    &mut stdout,
+                    &session_nonce,
+                    Some(&request_id),
+                    DiagnosticPhase::RequestReceipt,
+                    PhaseState::Completed,
+                    Some(0),
+                );
                 match scenario.as_str() {
                     "crash_on_transform" => std::process::exit(101),
                     "malformed_on_transform" => {
@@ -165,6 +225,14 @@ fn main() {
                                 std::thread::sleep(Duration::from_millis(ms));
                             }
                         }
+                        phase(
+                            &mut stdout,
+                            &session_nonce,
+                            Some(&request_id),
+                            DiagnosticPhase::FirstToken,
+                            PhaseState::Completed,
+                            Some(1),
+                        );
                         let result = HelperMessage::Result {
                             protocol: PROTOCOL_NAME.to_string(),
                             version: PROTOCOL_VERSION,

--- a/app/src/components/log-viewer/LogViewerApp.test.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.test.tsx
@@ -35,6 +35,15 @@ vi.mock('../../lib/hooks/usePerformanceHealth', () => ({
   }),
 }));
 
+vi.mock('../../lib/transformDiagnostics', () => ({
+  listTransformAttempts: vi.fn(async () => []),
+  listTransformCaptures: vi.fn(async () => []),
+  getCaptureArmStatus: vi.fn(async () => ({ armed: false, expiresAtMs: null })),
+  armNextTransformCapture: vi.fn(),
+  getTransformCapture: vi.fn(),
+  deleteTransformCapture: vi.fn(),
+}));
+
 import { LogViewerApp } from './LogViewerApp';
 
 describe('LogViewerApp shared diagnostics shell', () => {
@@ -53,9 +62,15 @@ describe('LogViewerApp shared diagnostics shell', () => {
     container.remove();
   });
 
-  it('keeps Events, Performance, and Runs and adds an accessible Reports panel', async () => {
+  it('keeps the diagnostics views and adds accessible Transforms and Reports panels', async () => {
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
-    expect(tabs.map(tab => tab.textContent)).toEqual(['Events', 'Performance', 'Runs', 'Reports']);
+    expect(tabs.map(tab => tab.textContent)).toEqual([
+      'Events',
+      'Performance',
+      'Runs',
+      'Transforms',
+      'Reports',
+    ]);
     expect(container.textContent).not.toContain('Metrics');
 
     await act(async () => (tabs[1] as HTMLButtonElement).click());
@@ -67,8 +82,13 @@ describe('LogViewerApp shared diagnostics shell', () => {
     expect(tabs[2].getAttribute('aria-selected')).toBe('true');
 
     await act(async () => (tabs[3] as HTMLButtonElement).click());
-    expect(container.querySelector('#diagnostics-panel-reports')).not.toBeNull();
+    expect(container.querySelector('#diagnostics-panel-transforms')).not.toBeNull();
     expect(tabs[3].getAttribute('aria-selected')).toBe('true');
+    expect(container.textContent).toContain('Transform diagnostics');
+
+    await act(async () => (tabs[4] as HTMLButtonElement).click());
+    expect(container.querySelector('#diagnostics-panel-reports')).not.toBeNull();
+    expect(tabs[4].getAttribute('aria-selected')).toBe('true');
     expect(container.textContent).toContain('Report comparison');
   });
 });

--- a/app/src/components/log-viewer/LogViewerApp.tsx
+++ b/app/src/components/log-viewer/LogViewerApp.tsx
@@ -8,6 +8,7 @@ import { EventRow } from './EventRow';
 import { PerformanceView } from './PerformanceView';
 import { RunsView } from './RunsView';
 import { ReportCompareView } from './ReportCompareView';
+import { TransformDiagnosticsView } from './TransformDiagnosticsView';
 import { LEVELS, STREAMS, type StreamName, type LevelName } from '../../lib/events';
 import {
   CORRELATION_FIELD_LABELS,
@@ -17,8 +18,8 @@ import {
   type CorrelationFilter,
 } from '../../lib/eventFilters';
 
-type Tab = 'events' | 'performance' | 'runs' | 'reports';
-const TABS: Tab[] = ['events', 'performance', 'runs', 'reports'];
+type Tab = 'events' | 'performance' | 'runs' | 'transforms' | 'reports';
+const TABS: Tab[] = ['events', 'performance', 'runs', 'transforms', 'reports'];
 
 export function LogViewerApp() {
   const { events, clear } = useEventStore();
@@ -233,6 +234,16 @@ export function LogViewerApp() {
             onClear={performance.clear}
             onShowEvents={showCorrelatedEvents}
           />
+        </div>
+      )}
+      {tab === 'transforms' && (
+        <div
+          role="tabpanel"
+          id="diagnostics-panel-transforms"
+          aria-labelledby="diagnostics-tab-transforms"
+          className="flex-1 overflow-y-auto"
+        >
+          <TransformDiagnosticsView />
         </div>
       )}
       <div

--- a/app/src/components/log-viewer/TransformDiagnosticsView.tsx
+++ b/app/src/components/log-viewer/TransformDiagnosticsView.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  armNextTransformCapture,
+  deleteTransformCapture,
+  getCaptureArmStatus,
+  getTransformCapture,
+  listTransformAttempts,
+  listTransformCaptures,
+  type CaptureArmStatusV1,
+  type DiagnosticCaptureSummaryV1,
+  type DiagnosticCaptureV1,
+  type TransformAttemptV1,
+} from '../../lib/transformDiagnostics';
+
+function displayTime(value: number): string {
+  return new Date(value).toLocaleString();
+}
+
+function textPanel(label: string, value: string | null) {
+  return (
+    <section>
+      <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-on-surface-variant">{label}</h4>
+      <pre className="max-h-44 overflow-auto whitespace-pre-wrap rounded-lg bg-surface-container p-3 text-xs text-on-surface">
+        {value ?? 'Not captured for this attempt'}
+      </pre>
+    </section>
+  );
+}
+
+export function TransformDiagnosticsView() {
+  const [attempts, setAttempts] = useState<TransformAttemptV1[]>([]);
+  const [captures, setCaptures] = useState<DiagnosticCaptureSummaryV1[]>([]);
+  const [arm, setArm] = useState<CaptureArmStatusV1>({ armed: false, expiresAtMs: null });
+  const [selected, setSelected] = useState<DiagnosticCaptureV1 | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextAttempts, nextCaptures, status] = await Promise.all([
+        listTransformAttempts(),
+        listTransformCaptures(),
+        getCaptureArmStatus(),
+      ]);
+      setAttempts(nextAttempts);
+      setCaptures(nextCaptures);
+      setArm(status);
+    } catch {
+      setError('Transform diagnostics could not be refreshed.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const armCapture = async () => {
+    const confirmed = window.confirm(
+      'Capture the next transform with exact text?\n\n'
+      + 'The selected text, recognized instruction, generated output, and phase trace will be stored only on this Mac. '
+      + 'The arm expires in 10 minutes, applies to one attempt, keeps at most 3 captures for 7 days, and never enters ordinary logs or copied diagnostics.',
+    );
+    if (!confirmed) return;
+    try {
+      setArm(await armNextTransformCapture());
+      setError(null);
+    } catch {
+      setError('The one-shot diagnostic capture could not be armed.');
+    }
+  };
+
+  const reviewCapture = async (captureId: string) => {
+    try {
+      setSelected(await getTransformCapture(captureId));
+      setError(null);
+    } catch {
+      setError('The local diagnostic capture could not be opened.');
+    }
+  };
+
+  const deleteCapture = async (capture: DiagnosticCaptureSummaryV1) => {
+    if (!window.confirm('Delete this local content capture now? This cannot be undone.')) return;
+    try {
+      await deleteTransformCapture(capture.captureId);
+      if (selected?.captureId === capture.captureId) setSelected(null);
+      await refresh();
+    } catch {
+      setError('The local diagnostic capture could not be deleted.');
+    }
+  };
+
+  if (selected) {
+    return (
+      <div className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <button type="button" onClick={() => setSelected(null)} className="text-xs font-medium text-primary hover:underline">
+              ← Back to transform diagnostics
+            </button>
+            <h2 className="mt-2 text-sm font-semibold text-on-surface">Local content capture · pass {selected.transformPassId}</h2>
+            <p className="text-[11px] text-error">Private content — review here only. This view has no export action.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void deleteCapture(selected)}
+            className="rounded-lg border border-error/20 px-3 py-1.5 text-xs font-medium text-error hover:bg-error/10"
+          >
+            Delete capture
+          </button>
+        </div>
+        {textPanel('Selected text', selected.selection)}
+        {textPanel('Recognized instruction', selected.instruction)}
+        {textPanel('Generated output', selected.output)}
+        <section>
+          <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-on-surface-variant">Phase trace</h4>
+          <div className="overflow-hidden rounded-lg border border-outline-variant/15">
+            {selected.phases.map((phase, index) => (
+              <div key={`${phase.phase}-${index}`} className="grid grid-cols-[1fr_auto_auto] gap-3 border-t border-outline-variant/10 px-3 py-2 text-xs first:border-t-0">
+                <span>{phase.phase}</span>
+                <span>{phase.outcome}</span>
+                <span className="font-mono text-on-surface-variant">
+                  {phase.durationMs === null ? '—' : `${phase.durationMs} ms`}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">Transform diagnostics</h2>
+          <p className="text-[11px] text-on-surface-variant">
+            Every attempt is recorded without text. Exact content capture is explicit, one-shot, local, and expiring.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {arm.armed && (
+            <span className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-medium text-amber-800 dark:bg-amber-900/35 dark:text-amber-200">
+              Next transform armed{arm.expiresAtMs ? ` until ${new Date(arm.expiresAtMs).toLocaleTimeString()}` : ''}
+            </span>
+          )}
+          <button type="button" onClick={() => void refresh()} className="rounded-lg border border-outline-variant/15 px-3 py-1.5 text-xs">
+            Refresh
+          </button>
+          <button type="button" disabled={arm.armed} onClick={() => void armCapture()} className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50">
+            Capture next transform
+          </button>
+        </div>
+      </div>
+
+      {error && <div role="alert" className="rounded-lg border border-error/20 bg-error/10 px-3 py-2 text-xs text-error">{error}</div>}
+
+      <section>
+        <h3 className="mb-2 text-xs font-semibold text-on-surface">Consented local captures</h3>
+        {captures.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-outline-variant/25 p-4 text-xs text-on-surface-variant">
+            No exact-content captures stored.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-outline-variant/15">
+            {captures.map(capture => (
+              <div key={capture.captureId} className="flex items-center justify-between gap-3 border-t border-outline-variant/10 px-3 py-2 first:border-t-0">
+                <div className="text-xs">
+                  <span className="font-semibold">Pass {capture.transformPassId}</span>
+                  <span className="ml-2 text-on-surface-variant">{capture.outcome} · {displayTime(capture.capturedAtMs)}</span>
+                </div>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => void reviewCapture(capture.captureId)} className="text-xs font-medium text-primary hover:underline">Review</button>
+                  <button type="button" onClick={() => void deleteCapture(capture)} className="text-xs font-medium text-error hover:underline">Delete</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h3 className="mb-2 text-xs font-semibold text-on-surface">Content-free attempts</h3>
+        {loading && attempts.length === 0 ? (
+          <div className="h-24 animate-pulse rounded-xl bg-surface-container" />
+        ) : attempts.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-outline-variant/25 p-4 text-xs text-on-surface-variant">
+            No transform attempts recorded yet.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-outline-variant/15">
+            <table className="w-full min-w-[760px] text-left text-xs">
+              <thead className="bg-surface-container-low text-[10px] uppercase tracking-wider text-on-surface-variant">
+                <tr><th className="px-3 py-2">Pass</th><th className="px-3 py-2">Outcome</th><th className="px-3 py-2">Selection</th><th className="px-3 py-2">Model</th><th className="px-3 py-2">Phases</th></tr>
+              </thead>
+              <tbody>
+                {attempts.map(attempt => (
+                  <tr key={`${attempt.transformPassId}-${attempt.startedAtMs}`} className="border-t border-outline-variant/10 align-top">
+                    <td className="px-3 py-2"><span className="font-semibold">{attempt.transformPassId}</span><span className="block text-[10px] text-on-surface-variant">{displayTime(attempt.startedAtMs)}</span></td>
+                    <td className="px-3 py-2">{attempt.outcome}</td>
+                    <td className="px-3 py-2">{attempt.selectionResult ?? '—'} · {attempt.selectionSource ?? '—'} · {attempt.selectionSizeBucket ?? '—'}</td>
+                    <td className="px-3 py-2">{attempt.modelWarmState ?? '—'} · {attempt.outputTokenCount ?? '—'} tokens</td>
+                    <td className="px-3 py-2 font-mono text-[10px] text-on-surface-variant">{attempt.phases.map(phase => `${phase.phase}:${phase.outcome}`).join(' → ') || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/src/lib/transformDiagnostics.test.ts
+++ b/app/src/lib/transformDiagnostics.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { isDiagnosticCaptureV1, isTransformAttemptV1 } from './transformDiagnostics';
+
+const phase = {
+  phase: 'modelLoad',
+  outcome: 'completed',
+  durationMs: 42,
+  errorCode: null,
+};
+
+describe('transform diagnostics validators', () => {
+  it('accepts a content-free attempt record', () => {
+    expect(isTransformAttemptV1({
+      schemaVersion: 1,
+      transformPassId: 9,
+      startedAtMs: 100,
+      finishedAtMs: 200,
+      outcome: 'ready',
+      selectionSource: 'accessibility',
+      selectionResult: 'success',
+      selectionSizeBucket: '17-64',
+      rangeAvailable: true,
+      boundsAvailable: true,
+      instructionConfidenceBucket: 'unavailable',
+      modelWarmState: 'cold',
+      outputTokenCount: 12,
+      finishReason: 'stop',
+      processExitCode: null,
+      processExitSignal: null,
+      phases: [phase],
+    })).toBe(true);
+  });
+
+  it('rejects malformed attempts and accepts explicit local capture content', () => {
+    expect(isTransformAttemptV1({ schemaVersion: 1, transformPassId: '9' })).toBe(false);
+    expect(isDiagnosticCaptureV1({
+      schemaVersion: 1,
+      captureId: '9-100',
+      transformPassId: 9,
+      capturedAtMs: 100,
+      expiresAtMs: 200,
+      outcome: 'ready',
+      selection: 'private selected text',
+      instruction: 'private instruction',
+      output: 'private output',
+      phases: [phase],
+    })).toBe(true);
+  });
+});

--- a/app/src/lib/transformDiagnostics.ts
+++ b/app/src/lib/transformDiagnostics.ts
@@ -1,0 +1,170 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface TransformPhaseV1 {
+  phase: string;
+  outcome: string;
+  durationMs: number | null;
+  errorCode: string | null;
+}
+
+export interface TransformAttemptV1 {
+  schemaVersion: 1;
+  transformPassId: number;
+  startedAtMs: number;
+  finishedAtMs: number | null;
+  outcome: string;
+  selectionSource: string | null;
+  selectionResult: string | null;
+  selectionSizeBucket: string | null;
+  rangeAvailable: boolean | null;
+  boundsAvailable: boolean | null;
+  instructionConfidenceBucket: string | null;
+  modelWarmState: string | null;
+  outputTokenCount: number | null;
+  finishReason: string | null;
+  processExitCode: number | null;
+  processExitSignal: number | null;
+  phases: TransformPhaseV1[];
+}
+
+export interface TransformAttemptListV1 {
+  schemaVersion: 1;
+  attempts: TransformAttemptV1[];
+}
+
+export interface CaptureArmStatusV1 {
+  armed: boolean;
+  expiresAtMs: number | null;
+}
+
+export interface DiagnosticCaptureSummaryV1 {
+  captureId: string;
+  transformPassId: number;
+  capturedAtMs: number;
+  expiresAtMs: number;
+  outcome: string;
+}
+
+export interface DiagnosticCaptureV1 extends DiagnosticCaptureSummaryV1 {
+  schemaVersion: 1;
+  selection: string | null;
+  instruction: string | null;
+  output: string | null;
+  phases: TransformPhaseV1[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNullable<T>(value: unknown, check: (candidate: unknown) => candidate is T): value is T | null {
+  return value === null || check(value);
+}
+
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+
+export function isTransformPhaseV1(value: unknown): value is TransformPhaseV1 {
+  return isRecord(value)
+    && isString(value.phase)
+    && isString(value.outcome)
+    && isNullable(value.durationMs, isNumber)
+    && isNullable(value.errorCode, isString);
+}
+
+export function isTransformAttemptV1(value: unknown): value is TransformAttemptV1 {
+  return isRecord(value)
+    && value.schemaVersion === 1
+    && isNumber(value.transformPassId)
+    && isNumber(value.startedAtMs)
+    && isNullable(value.finishedAtMs, isNumber)
+    && isString(value.outcome)
+    && isNullable(value.selectionSource, isString)
+    && isNullable(value.selectionResult, isString)
+    && isNullable(value.selectionSizeBucket, isString)
+    && isNullable(value.rangeAvailable, isBoolean)
+    && isNullable(value.boundsAvailable, isBoolean)
+    && isNullable(value.instructionConfidenceBucket, isString)
+    && isNullable(value.modelWarmState, isString)
+    && isNullable(value.outputTokenCount, isNumber)
+    && isNullable(value.finishReason, isString)
+    && isNullable(value.processExitCode, isNumber)
+    && isNullable(value.processExitSignal, isNumber)
+    && Array.isArray(value.phases)
+    && value.phases.every(isTransformPhaseV1);
+}
+
+export function isDiagnosticCaptureV1(value: unknown): value is DiagnosticCaptureV1 {
+  return isRecord(value)
+    && value.schemaVersion === 1
+    && isString(value.captureId)
+    && isNumber(value.transformPassId)
+    && isNumber(value.capturedAtMs)
+    && isNumber(value.expiresAtMs)
+    && isString(value.outcome)
+    && isNullable(value.selection, isString)
+    && isNullable(value.instruction, isString)
+    && isNullable(value.output, isString)
+    && Array.isArray(value.phases)
+    && value.phases.every(isTransformPhaseV1);
+}
+
+export async function listTransformAttempts(): Promise<TransformAttemptV1[]> {
+  const value: unknown = await invoke('list_transform_attempts', { limit: 100 });
+  if (!isRecord(value)
+    || value.schemaVersion !== 1
+    || !Array.isArray(value.attempts)
+    || !value.attempts.every(isTransformAttemptV1)) {
+    throw new Error('Transform attempt diagnostics returned an unsupported format.');
+  }
+  return value.attempts;
+}
+
+export async function getCaptureArmStatus(): Promise<CaptureArmStatusV1> {
+  const value: unknown = await invoke('get_transform_diagnostic_capture_status');
+  if (!isRecord(value)
+    || typeof value.armed !== 'boolean'
+    || !isNullable(value.expiresAtMs, isNumber)) {
+    throw new Error('Diagnostic capture status returned an unsupported format.');
+  }
+  return { armed: value.armed, expiresAtMs: value.expiresAtMs };
+}
+
+export async function armNextTransformCapture(): Promise<CaptureArmStatusV1> {
+  const value: unknown = await invoke('arm_next_transform_diagnostic_capture');
+  if (!isRecord(value)
+    || value.armed !== true
+    || !isNullable(value.expiresAtMs, isNumber)) {
+    throw new Error('Diagnostic capture could not be armed.');
+  }
+  return { armed: true, expiresAtMs: value.expiresAtMs };
+}
+
+export async function listTransformCaptures(): Promise<DiagnosticCaptureSummaryV1[]> {
+  const value: unknown = await invoke('list_transform_diagnostic_captures');
+  if (!Array.isArray(value) || !value.every(candidate =>
+    isRecord(candidate)
+      && isString(candidate.captureId)
+      && isNumber(candidate.transformPassId)
+      && isNumber(candidate.capturedAtMs)
+      && isNumber(candidate.expiresAtMs)
+      && isString(candidate.outcome))) {
+    throw new Error('Diagnostic capture list returned an unsupported format.');
+  }
+  return value as DiagnosticCaptureSummaryV1[];
+}
+
+export async function getTransformCapture(captureId: string): Promise<DiagnosticCaptureV1 | null> {
+  const value: unknown = await invoke('get_transform_diagnostic_capture', { captureId });
+  if (value === null) return null;
+  if (!isDiagnosticCaptureV1(value)) {
+    throw new Error('Diagnostic capture returned an unsupported format.');
+  }
+  return value;
+}
+
+export async function deleteTransformCapture(captureId: string): Promise<void> {
+  await invoke('delete_transform_diagnostic_capture', { captureId });
+}

--- a/app/src/lib/transformReview.ts
+++ b/app/src/lib/transformReview.ts
@@ -21,6 +21,15 @@ export type ReviewErrorCode =
   | 'timeout'
   | 'output_invalid'
   | 'crashed'
+  | 'model_verification_timeout'
+  | 'model_load_timeout'
+  | 'handshake_timeout'
+  | 'generation_timeout'
+  | 'helper_spawn_failed'
+  | 'handshake_protocol_failed'
+  | 'process_exit'
+  | 'model_verification_failed'
+  | 'model_load_failed'
   | 'disabled'
   | 'busy'
   | 'no_instruction'
@@ -40,6 +49,10 @@ const REVIEW_STATES: readonly ReviewState[] = [
 
 const REVIEW_ERROR_CODES: readonly ReviewErrorCode[] = [
   'model_not_downloaded', 'model_unreadable', 'timeout', 'output_invalid', 'crashed',
+  'model_verification_timeout', 'model_load_timeout', 'handshake_timeout',
+  'generation_timeout', 'helper_spawn_failed', 'handshake_protocol_failed',
+  'process_exit', 'model_verification_failed',
+  'model_load_failed',
   'disabled', 'busy', 'no_instruction', 'no_selection', 'too_large', 'ax_unavailable',
   'accessibility_denied', 'target_gone', 'selection_changed',
   'clipboard_unavailable', 'paste_failed', 'not_applied',
@@ -60,6 +73,15 @@ export const REVIEW_ERROR_COPY: Record<ReviewErrorCode, string> = {
   timeout: 'Timed out',
   output_invalid: 'Model gave no usable output',
   crashed: 'Sidecar crashed — original text untouched',
+  model_verification_timeout: 'Model verification timed out',
+  model_load_timeout: 'Local model loading timed out',
+  handshake_timeout: 'Local helper did not become ready in time',
+  generation_timeout: 'Generation timed out',
+  helper_spawn_failed: 'Local helper could not start',
+  handshake_protocol_failed: 'Local helper identity or protocol check failed',
+  process_exit: 'Local helper exited — original text untouched',
+  model_verification_failed: 'Local model verification failed',
+  model_load_failed: 'Local model or Metal backend failed to load',
   disabled: 'Transform temporarily disabled — try again shortly',
   busy: 'Busy — try again in a moment',
   no_instruction: "Didn't catch an instruction — hold the key and speak",

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -162,6 +162,22 @@ benchmark/evaluation reports are untouched. Loading, never-recorded, cleared,
 filtered-empty, error, stale/partial, unsupported, and unavailable states are
 presented separately.
 
+### Transforms Tab
+
+Transforms lists the newest content-free `TransformAttemptV1` records. Each
+attempt carries the same `transform_pass_id` used by Events and
+`PerformanceRunV1`, plus ordered selection, instruction, sidecar, review,
+apply/undo, cancellation, and process-lifecycle phase evidence. The companion
+performance run remains schema V1 and supplies the correlated resource peaks.
+
+**Capture next transform** is an explicit one-shot privacy boundary. After a
+warning and confirmation, an in-memory arm lasts for one attempt or ten minutes.
+Exact selection, recognized instruction, and output are stored locally with
+restrictive permissions, capped at three captures and seven days. Opening a
+capture is the only command that returns its text to the Diagnostics webview.
+The tab offers Review and Delete, but no copy/export integration. Ordinary
+Events, Performance records, reports, and log export stay content-free.
+
 ### Reports Tab
 
 Reports imports local Performance Lab benchmark or `murmur-eval` JSON through
@@ -205,6 +221,12 @@ The frontend event buffer is managed by the `useEventStore` hook:
 | `get_performance_run` | Returns one typed run by opaque `run_id` |
 | `get_performance_resource_window` | Returns the bounded typed resource window |
 | `clear_performance_diagnostics` | Clears only local Performance runs and samples |
+| `list_transform_attempts` | Lists bounded, content-free transform attempts |
+| `arm_next_transform_diagnostic_capture` | Arms one local exact-content capture for up to 10 minutes |
+| `get_transform_diagnostic_capture_status` | Reads the in-memory one-shot arm state |
+| `list_transform_diagnostic_captures` | Lists content-free capture summaries |
+| `get_transform_diagnostic_capture` | Returns one exact local capture for explicit review |
+| `delete_transform_diagnostic_capture` | Deletes one exact local capture |
 
 ## Log Files
 

--- a/docs/features/selected-text-transform.md
+++ b/docs/features/selected-text-transform.md
@@ -98,6 +98,16 @@ follow-up duration/outcome records. Sidecar CPU/RSS samples use the helper's
 resident PID and are summarized only for the transform run's wall-clock
 interval. No second transform tracing path is introduced.
 
+`TransformAttemptV1` is a backward-compatible companion record rather than a
+change to `PerformanceRunV1`. It records every claimed or refused pass,
+including cancellation and supersession, with ordered, enum-only phase
+outcomes. The signed helper protocol reports helper model verification,
+backend/Metal initialization, model load, request receipt, and first-token
+timings. The host adds its own verification, spawn, ready-handshake,
+generation, review, apply, undo, process-exit, and failure-phase evidence.
+Startup failures therefore remain distinguishable instead of collapsing into
+“sidecar crashed.”
+
 Transform diagnostics are content-free. They may contain IDs, enum values,
 numeric AX outcomes, booleans, sample/token counts, timings, apply/capture
 routes, and length buckets. They never contain selected text, instruction or
@@ -105,6 +115,16 @@ preset text, proposals, clipboard contents, paths, bundle IDs, device names, or
 model-setting values. The structured-event layer independently removes any
 string whose key or value is outside the transform stream's explicit stable
 vocabulary.
+
+Diagnostics → **Transforms** also offers **Capture next transform** for cases
+where the user explicitly needs to inspect exact content. The warning must be
+confirmed; the arm lives only in memory, applies to one pass, and expires after
+10 minutes. A captured selection, recognized instruction, output, and phase
+trace stay on this Mac in a `0700` directory with `0600` files. Symlink targets
+are refused, at most three captures are retained, and each expires after seven
+days. Captures can only be reviewed or deleted in the app. They are never added
+to Events, copied diagnostics, Performance records, or reports, and the UI has
+no raw-content export action.
 
 ## Sidecar removal / lifecycle
 


### PR DESCRIPTION
## Summary
- record bounded, content-free diagnostics for every selected-text transform attempt
- add protocol/helper timing phases and process termination details
- add an explicit one-shot, local, expiring exact-content capture with review/delete-only UI
- add a Transforms diagnostics tab and document the privacy and retention model
- make model verification and helper Ready startup cancellable, including partial-child cleanup and immediate reuse

## Validation
- Rust serial suite: 599 passed, 5 ignored
- local LLM sidecar integration: 18 passed
- frontend: 45 files, 328 tests passed
- TypeScript: npx tsc --noEmit
- release helper and signed Tauri app build
- native macOS smoke: cold transform success, warm transform success, exact capture review/delete, 0700/0600 permissions, no selected content in ordinary logs or content-free attempts, capture deletion verified
- deterministic delayed-Ready integration test verifies cancellation under one second, child reaping, busy-state clear, and immediate second-request success

Fixes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Transforms** tab to the diagnostics viewer with phase-by-phase transform attempts and timing details.
  * Added an optional, confirmation-based **Capture next transform** feature for reviewing exact local transform content, with review, deletion, expiration, and retention controls.
  * Added clearer error reporting for model, handshake, generation, timeout, and process failures.
* **Bug Fixes**
  * Improved cancellation during startup and handshakes so interrupted transforms settle promptly and allow subsequent requests.
* **Documentation**
  * Documented transform diagnostics, capture privacy boundaries, retention, and available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->