### PR TITLE
docs: refresh core documentation to match v0.21.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,40 @@
 # AGENTS.md
 
-Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React), local whisper.cpp transcription with Metal GPU, clipboard-first output. No cloud services.
+Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React). Local transcription on the ANE (Core ML), Metal (whisper.cpp), or CPU (sherpa-onnx); local selected-text rewriting through a signed LLM sidecar. Clipboard-first output. No cloud services.
 
 ## Commands
 
 ```bash
+python3 scripts/build_local_llm_sidecar.py  # Build the macOS local-LLM sidecar FIRST (see note)
 cd app && npm run tauri dev        # Dev with hot reload
 cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
+cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
 ```
 
+> **macOS note:** `tauri.macos.conf.json` declares the `murmur-llm-sidecar` externalBin, so
+> on macOS `tauri dev`/`tauri build` fail on a fresh clone until the sidecar binary exists at
+> `app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. Run
+> `python3 scripts/build_local_llm_sidecar.py` once first (it is a no-op on non-arm64-macOS).
+> The binary is gitignored; release CI builds it before bundling.
+
 ## Docs
+
+Start here for orientation:
+
+- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
+- **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
+- **[docs/reference/](docs/reference/)** — `commands.md` (105 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
 - **[docs/onboarding.md](docs/onboarding.md)** — Setup, permissions, model installation, logs
+- **[docs/features/onboarding-flow.md](docs/features/onboarding-flow.md)** — First-launch setup assistant (permissions wizard + model download)
 - **[docs/features/recording-modes.md](docs/features/recording-modes.md)** — Hold-down and double-tap modes, state machine, rdev threading
 - **[docs/features/transcription.md](docs/features/transcription.md)** — Audio capture, whisper pipeline, status flow
-- **[docs/features/smart-formatting.md](docs/features/smart-formatting.md)** — Deterministic prose grammar, backtracking, bounds, privacy
 - **[docs/features/cli-command-formatting.md](docs/features/cli-command-formatting.md)** — Spoken CLI detection, grammar, lexicon, safety
+- **[docs/features/smart-formatting.md](docs/features/smart-formatting.md)** — Deterministic prose grammar, backtracking, bounds, privacy
 - **[docs/features/text-injection.md](docs/features/text-injection.md)** — Clipboard, auto-paste, osascript
 - **[docs/features/vad.md](docs/features/vad.md)** — VAD speech filtering
 - **[docs/features/overlay.md](docs/features/overlay.md)** — Dynamic Island overlay
@@ -29,6 +44,15 @@ Read these before working on a feature:
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 - **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 - **[docs/features/voice-commands.md](docs/features/voice-commands.md)** — Typed replacements, multiline snippets, safe variables, scopes, and clipboard permission
+- **[docs/features/vocabulary-aliases.md](docs/features/vocabulary-aliases.md)** — Exact spoken variants mapped to canonical written terms
+- **[docs/features/correct-and-teach.md](docs/features/correct-and-teach.md)** — Bounded learned corrections, exact-term teaching, scope and fail-closed rules
+- **[docs/features/personal-knowledge-store.md](docs/features/personal-knowledge-store.md)** — Local SQLite store, migrations, backup/recovery, export/import
+- **[docs/features/performance-lab.md](docs/features/performance-lab.md)** — Benchmarking, WER tiers, recommendation contract
+- **[docs/features/diagnostic-report-comparison.md](docs/features/diagnostic-report-comparison.md)** — Session-only Reports workspace and comparison
+- **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
+- **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion
+- **[docs/features/performance-diagnostics.md](docs/features/performance-diagnostics.md)** — Versioned local run metrics, retention, correlation, scoped resources, and privacy
+- **[docs/decisions/DECISIONS.md](docs/decisions/DECISIONS.md)** — Running log of architectural/scope decisions (newest first)
 
 ## File Map
 
@@ -36,25 +60,56 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 105 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
-| `commands/recording.rs` | `IdleGuard`, transcription pipeline with VAD, 7 recording/status commands |
-| `commands/permissions.rs` | 6 permission and audio device commands |
-| `commands/keyboard.rs` | 4 keyboard listener commands |
-| `commands/logging.rs` | 4 logging commands, delegates to telemetry.rs |
-| `commands/models.rs` | Model download pipeline and existence checks |
+| `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |
+| `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
+| `commands/keyboard.rs` | Dictation + transform listener commands, global disable |
+| `commands/logging.rs` | Log commands, delegates to telemetry.rs |
+| `commands/models.rs` | Model catalog/status queries and the download pipeline |
+| `commands/knowledge.rs` | Personal knowledge store CRUD, resolve, preview, export/import |
+| `commands/correct_and_teach.rs` | Bounded correction proposals + confirm/discard |
+| `commands/benchmark.rs` | Performance Lab run/cancel/save/reveal |
+| `commands/performance.rs` | Local run history, resource window, clear |
+| `commands/transform_diagnostics.rs` | Per-pass attempt records and consented content captures |
 | `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
-| `commands/overlay.rs` | Notch detection, overlay positioning, show/hide commands |
-| `keyboard.rs` | Hold-down and double-tap detectors, shared rdev listener thread |
+| `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window |
+| `commands/native_window.rs` | Shared non-activating window treatment (main-thread dispatched) |
+| `commands/transform_model.rs` | Transform LLM model download/status/remove/reset |
+| `commands/transform_popover.rs` | Transform review window geometry + show/hide/focusable |
+| `keyboard.rs` | Hold-down, double-tap, and transform-hold detectors; shared rdev listener thread |
 | `audio.rs` | cpal capture, mono conversion, 16kHz resampling |
-| `transcriber/` | whisper-rs model loading and inference |
+| `audio_decode.rs` | Imported audio-file decoding |
+| `transcriber/` | `TranscriptionBackend` trait + whisper / parakeet / coreml backends |
+| `model_runtime.rs` | Model catalog + serialized load/warm/readiness/unload lifecycle |
+| `dictation_context.rs` | Immutable per-recording context snapshot |
+| `transcript_transform.rs` | Ordered post-recognition pipeline (cleanup → commands → correction → formatting → IDE → CLI) |
+| `cleanup.rs` / `correction.rs` / `cli_command.rs` | Individual transform stages |
+| `vocab.rs` / `vocabulary_alias.rs` | Code-vocabulary scanning and explicit spoken aliases |
+| `voice_commands.rs` | Typed voice command execution and variable expansion |
+| `correct_and_teach.rs` | Bounded local diff proposals; never writes without confirmation |
+| `knowledge_store/` | SQLite knowledge store: migrations, repository, backup/quarantine |
+| `selection.rs` | AX selection capture for transform (secure-field fail-closed) |
+| `transform_apply.rs` | Approve/undo write-back (only path that writes to the target app) |
+| `transform_flow.rs` | End-to-end transform orchestrator + Tauri commands |
+| `transform_presets.rs` | Built-in spoken transform presets (Shorten/Bullets/…) |
+| `transform_diagnostics.rs` / `transform_trace.rs` | Per-pass records, consented captures, pass-scoped correlation |
+| `llm_sidecar.rs` | Host supervisor for signed local-LLM helper (no in-process llama) |
 | `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
 | `ide_context.rs` | Memory-only bounded IDE symbol and root-relative file index |
-| `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
-| `state.rs` | `DictationState`, `AppState` with mutex-wrapped state |
+| `injector.rs` | Clipboard (arboard) + auto-paste (CGEvent, osascript fallback) |
+| `file_output.rs` | Numbered `.txt` / `.wav` output |
+| `frontmost.rs` | Frontmost-app query + running-application list |
+| `state.rs` | `DictationState`, `TransformStatus`, `AppState`, generation counters |
 | `telemetry.rs` | Structured event system: TauriEmitterLayer, ring buffer, JSONL, privacy stripping |
-| `vad.rs` | Silero VAD speech filtering via whisper-rs |
-| `resource_monitor.rs` | System CPU/memory monitoring via sysinfo |
+| `vad.rs` | Silero VAD speech filtering via whisper-rs (thread-local context cache) |
+| `benchmark.rs` / `evaluation.rs` | Performance Lab scoring and the `murmur-eval` fixture harness |
+| `performance_metrics/` | SQLite run history, stage timings, resource samples, retention |
+| `resource_monitor.rs` | CPU/RSS sampling, 1s heartbeat, idle-timeout enforcement |
+| `alloc.rs` | Custom malloc zone separating Rust heap from whisper.cpp's FFI heap |
+| `platform/` | Platform abstraction seams (macOS / Linux) |
+| `sidecars/local-llm/` | The signed `murmur-llm-sidecar` crate (llama.cpp) |
+| `crates/local-llm-protocol` | Host ↔ sidecar protocol types |
 
 ### Frontend (`app/src/`)
 
@@ -62,6 +117,7 @@ Read these before working on a feature:
 |------|---------|
 | `App.tsx` | Main orchestrator, wires hooks together |
 | `lib/settings.ts` | Settings types, defaults, localStorage persistence |
+| `lib/onboarding.ts` | First-launch setup-assistant completion flag |
 | `lib/events.ts` | Event types, stream/level definitions, color constants |
 | `lib/history.ts` | History entry types and localStorage persistence |
 | `lib/stats.ts` | Usage metrics: words, WPM, recordings, tokens |
@@ -78,33 +134,63 @@ Read these before working on a feature:
 | `lib/hooks/useShowAboutListener.ts` | Listens for show-about tray event |
 | `lib/hooks/useEventStore.ts` | Structured event log buffer with live streaming |
 | `lib/hooks/useResourceMonitor.ts` | CPU/memory polling with rolling buffer |
-| `components/settings/SettingsPanel.tsx` | Settings UI with mode switching |
-| `components/log-viewer/LogViewerApp.tsx` | Structured event viewer with Events + Metrics tabs |
-| `components/OverlayWidget.tsx` | Dynamic Island notch overlay |
+| `lib/hooks/useOverlayGeometry.ts` | Overlay geometry contract from Rust (fetch + `overlay-geometry-changed`) |
+| `lib/hooks/useOverlayExpansion.ts` | Overlay hover-expand lifecycle; single writer to the native resize path |
+| `lib/hooks/useOverlayRuntime.ts` | Overlay cancelled/hotkey-miss flash timers, `app-disabled-changed` mirror |
+| `lib/hooks/useOverlaySettingsMirror.ts` | Overlay's localStorage settings snapshot + quick-control actions |
+| `lib/hooks/useRecordingControls.ts` | Overlay click/double-click disambiguation, locked mode |
+| `lib/hooks/useWaveform.ts` | Overlay audio-level listener + rAF waveform bar animation |
+| `lib/hooks/useTransformFlow.ts` | Main-window transform hold-key driver |
+| `lib/hooks/useTransformReviewDriver.ts` | Review popover state + approve/retry/cancel/undo |
+| `lib/hooks/useEscapeCancel.ts` | Scoped Escape cancellation carrying the exact transform pass ID |
+| `lib/hooks/useSettings.ts` | Settings persistence, backend push, optimistic rollback |
+| `lib/hooks/useFileTranscription.ts` | Imported-file transcription + busy state |
+| `lib/hooks/useKnowledge.ts` | Bounded paged access to the knowledge store |
+| `lib/hooks/useVocabScan.ts` | Live code-vocabulary scan progress, correlated by scan ID |
+| `lib/hooks/usePerformanceDiagnostics.ts` | Run history + resource samples (pure `mergeRuns`/`mergeResourceSamples`) |
+| `lib/hooks/usePerformanceHealth.ts` | Diagnostics store availability summary |
+| `lib/hooks/useOpenSettingsListener.ts` | Opens Settings on the overlay's `open-settings` |
+| `lib/hooks/useOverlaySettingsSync.ts` | Applies overlay-originated `settings-changed` in the main window |
+| `lib/transformSettings.ts` | Transform model + listener command wrappers |
+| `lib/performance.ts` / `lib/performancePresentation.ts` | Run/stage models and presentation |
+| `lib/diagnosticReports.ts` / `lib/diagnosticComparison.ts` | Portable report schema validation and comparison |
+| `lib/benchmark.ts` | Performance Lab request/report types |
+| `lib/transformFlow.ts` | Pure reducer for transform press/release |
+| `lib/transformReview.ts` | Review state/error types + content guards |
+| `components/onboarding/OnboardingFlow.tsx` | First-launch setup assistant (permissions + model wizard) |
+| `components/settings/SettingsPanel.tsx` | Settings UI with mode switching (incl. Transform page) |
+| `components/settings/TransformsManager.tsx` | Saved transform CRUD UI |
+| `components/transform-review/` | Review popover UI (diff, actions, mock driver) |
+| `components/settings/PerformanceLab.tsx` | Benchmark UI, scoring tables, report save/export |
+| `components/settings/KnowledgeManager.tsx` | Knowledge store browse/edit UI |
+| `components/history/CorrectAndTeachDialog.tsx` | Correct-and-Teach review + scope choice |
+| `components/log-viewer/LogViewerApp.tsx` | Log viewer shell: Events, Runs, Transforms, Reports tabs |
+| `components/overlay/deriveVisual.ts` | Pure: overlay top-bar indicator + flash-priority derivation |
+| `components/overlay/OverlayPill.tsx` | Overlay top bar (presentational) |
+| `components/overlay/OverlayDropdown.tsx` | Overlay quick-settings dropdown (presentational) |
+| `components/OverlayWidget.tsx` | Dynamic Island overlay composition shell (~150 lines) |
 
 ## Key Patterns
 
-- **Dual recording modes**: Both hooks always called (Rules of Hooks), gated by `enabled` prop
-- **Clipboard-first**: Text always goes to clipboard; auto-paste is optional
-- **Lazy model loading**: Whisper context created on first transcription
+- **Recording-mode hooks**: all three always called (Rules of Hooks), gated by the `enabled` prop
+- **Clipboard-first**: text always goes to the clipboard; auto-paste is layered on top
+- **Generation counters**: `recording_id` and `transform_pass_id` are monotonic; every async continuation re-checks ownership before mutating shared state
+- **Immutable per-recording context**: model, delivery, profile, and stage config resolve once at recording start; mid-recording changes apply to the next session
+- **Warm-on-record**: `spawn_model_preparation` starts model load when recording starts, so load overlaps with speech
+- **Ordered transcript pipeline**: one entry point, declared stage order and failure policy, per-stage timing
+- **Fail-closed**: unknown model IDs, ambiguous corrections, and unprovable secure-field checks all refuse rather than guess
+- **Rust owns window geometry**: pure `geometry_for()` / `popover_geometry_for()`, fixture-asserted on both sides
+- **Main-thread `NSWindow` mutation**: dispatch via `run_on_main_thread` — macOS 26 hard-traps otherwise (#325)
 - **Mutex poison recovery**: `MutexExt` trait recovers from panics
 - **rdev thread safety**: `set_is_main_thread(false)` before `listen()` — prevents macOS TIS/TSM segfault
+- **No in-process llama**: the app crate must never link `llama-cpp-2` (ggml ABI clash with whisper)
 
 ## MCP Tools
 
 - **Playwright** (`@playwright/mcp`): Browser automation for UI work. When making frontend/UI changes, use `browser_navigate` to `http://localhost:1420` and `browser_take_screenshot` to visually verify your changes. Requires `npm run tauri dev` to be running. Screenshots return inline as images — evaluate them and iterate until the UI looks right.
 
-## Session Modes
-
-Use these modes when the user invokes them by name in a Codex session.
-
-- **Murmur chat mode**: Read `prompts/PROMPT_CHAT.md` and follow it for the conversation. Act as a concise product and engineering advisor. Discuss ideas, tradeoffs, bugs, and feature shape. Do not edit files or write code unless the user explicitly asks.
-- **Murmur feature mode**: Read `prompts/PROMPT.md` and follow it. Load the requested context, check repo health, identify the assigned ticket from the user's prompt, and present a plan before writing code. Do not implement until the user approves the plan. In Codex, **`/feature <issue-number>`** uses `.codex/skills/murmur-feature` for the full pipeline (worktree → plan → implement → review → native smoke → PR → merge when green).
-- **Murmur bug mode**: Read `prompts/PROMPT_BUG.md` and follow it. Keep the work scoped to the selected bug, investigate before editing, and verify with the required checks before wrapping up.
-- **Murmur release mode**: Read `prompts/PROMPT_RELEASE.md` and follow it. Treat release operations as high-risk: inspect state first, explain the intended release action, and only proceed when the user explicitly confirms.
-- **Murmur swarm mode**: Read `prompts/PROMPT_SWARM.md` and follow it. Use only when the user explicitly asks to coordinate multiple issues in parallel.
-
 ## Dependencies
 
-- **Rust**: tauri 2, whisper-rs (Metal), cpal, arboard, hound, rdev (git main branch)
-- **Frontend**: React 18, Tailwind CSS 4, @tauri-apps/api, Vite 6, TypeScript
+- **Rust**: tauri 2, whisper-rs (Metal), FluidAudio (Core ML), sherpa-onnx, cpal, arboard, hound, rusqlite, core-graphics, objc2/objc2-app-kit, rdev (git main branch)
+- **Sidecar**: llama-cpp-2 — in `sidecars/local-llm` only, never in the app crate
+- **Frontend**: React 18, Tailwind CSS 4, @tauri-apps/api, Vite 6, TypeScript, vitest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React), local whisper.cpp transcription with Metal GPU, clipboard-first output. No cloud services.
+Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React). Local transcription on the ANE (Core ML), Metal (whisper.cpp), or CPU (sherpa-onnx); local selected-text rewriting through a signed LLM sidecar. Clipboard-first output. No cloud services.
 
 ## Commands
 
@@ -10,6 +10,7 @@ cd app && npm run tauri dev        # Dev with hot reload
 cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
+cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
 ```
 
 > **macOS note:** `tauri.macos.conf.json` declares the `murmur-llm-sidecar` externalBin, so
@@ -19,6 +20,12 @@ cd app && npx tsc --noEmit         # TypeScript check
 > The binary is gitignored; release CI builds it before bundling.
 
 ## Docs
+
+Start here for orientation:
+
+- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
+- **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
+- **[docs/reference/](docs/reference/)** — `commands.md` (105 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -37,6 +44,11 @@ Read these before working on a feature:
 - **[docs/features/per-app-profiles.md](docs/features/per-app-profiles.md)** — Immutable per-recording context, profile precedence, privacy boundaries
 - **[docs/features/ide-context.md](docs/features/ide-context.md)** — Opt-in local IDE index, @file grammar, path/privacy boundaries
 - **[docs/features/voice-commands.md](docs/features/voice-commands.md)** — Typed replacements, multiline snippets, safe variables, scopes, and clipboard permission
+- **[docs/features/vocabulary-aliases.md](docs/features/vocabulary-aliases.md)** — Exact spoken variants mapped to canonical written terms
+- **[docs/features/correct-and-teach.md](docs/features/correct-and-teach.md)** — Bounded learned corrections, exact-term teaching, scope and fail-closed rules
+- **[docs/features/personal-knowledge-store.md](docs/features/personal-knowledge-store.md)** — Local SQLite store, migrations, backup/recovery, export/import
+- **[docs/features/performance-lab.md](docs/features/performance-lab.md)** — Benchmarking, WER tiers, recommendation contract
+- **[docs/features/diagnostic-report-comparison.md](docs/features/diagnostic-report-comparison.md)** — Session-only Reports workspace and comparison
 - **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
 - **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion
 - **[docs/features/performance-diagnostics.md](docs/features/performance-diagnostics.md)** — Versioned local run metrics, retention, correlation, scoped resources, and privacy
@@ -48,32 +60,56 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 105 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
-| `commands/recording.rs` | `IdleGuard`, transcription pipeline with VAD, 7 recording/status commands |
+| `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |
 | `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
-| `commands/keyboard.rs` | 4 keyboard listener commands |
-| `commands/logging.rs` | 4 logging commands, delegates to telemetry.rs |
-| `commands/models.rs` | Model download pipeline and existence checks |
+| `commands/keyboard.rs` | Dictation + transform listener commands, global disable |
+| `commands/logging.rs` | Log commands, delegates to telemetry.rs |
+| `commands/models.rs` | Model catalog/status queries and the download pipeline |
+| `commands/knowledge.rs` | Personal knowledge store CRUD, resolve, preview, export/import |
+| `commands/correct_and_teach.rs` | Bounded correction proposals + confirm/discard |
+| `commands/benchmark.rs` | Performance Lab run/cancel/save/reveal |
+| `commands/performance.rs` | Local run history, resource window, clear |
+| `commands/transform_diagnostics.rs` | Per-pass attempt records and consented content captures |
 | `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
-| `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window commands |
+| `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window |
+| `commands/native_window.rs` | Shared non-activating window treatment (main-thread dispatched) |
 | `commands/transform_model.rs` | Transform LLM model download/status/remove/reset |
 | `commands/transform_popover.rs` | Transform review window geometry + show/hide/focusable |
 | `keyboard.rs` | Hold-down, double-tap, and transform-hold detectors; shared rdev listener thread |
 | `audio.rs` | cpal capture, mono conversion, 16kHz resampling |
-| `transcriber/` | whisper-rs model loading and inference |
+| `audio_decode.rs` | Imported audio-file decoding |
+| `transcriber/` | `TranscriptionBackend` trait + whisper / parakeet / coreml backends |
+| `model_runtime.rs` | Model catalog + serialized load/warm/readiness/unload lifecycle |
+| `dictation_context.rs` | Immutable per-recording context snapshot |
+| `transcript_transform.rs` | Ordered post-recognition pipeline (cleanup → commands → correction → formatting → IDE → CLI) |
+| `cleanup.rs` / `correction.rs` / `cli_command.rs` | Individual transform stages |
+| `vocab.rs` / `vocabulary_alias.rs` | Code-vocabulary scanning and explicit spoken aliases |
+| `voice_commands.rs` | Typed voice command execution and variable expansion |
+| `correct_and_teach.rs` | Bounded local diff proposals; never writes without confirmation |
+| `knowledge_store/` | SQLite knowledge store: migrations, repository, backup/quarantine |
 | `selection.rs` | AX selection capture for transform (secure-field fail-closed) |
 | `transform_apply.rs` | Approve/undo write-back (only path that writes to the target app) |
 | `transform_flow.rs` | End-to-end transform orchestrator + Tauri commands |
 | `transform_presets.rs` | Built-in spoken transform presets (Shorten/Bullets/…) |
+| `transform_diagnostics.rs` / `transform_trace.rs` | Per-pass records, consented captures, pass-scoped correlation |
 | `llm_sidecar.rs` | Host supervisor for signed local-LLM helper (no in-process llama) |
 | `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
 | `ide_context.rs` | Memory-only bounded IDE symbol and root-relative file index |
-| `injector.rs` | Clipboard (arboard) + auto-paste (osascript) |
-| `state.rs` | `DictationState`, `AppState` with mutex-wrapped state |
+| `injector.rs` | Clipboard (arboard) + auto-paste (CGEvent, osascript fallback) |
+| `file_output.rs` | Numbered `.txt` / `.wav` output |
+| `frontmost.rs` | Frontmost-app query + running-application list |
+| `state.rs` | `DictationState`, `TransformStatus`, `AppState`, generation counters |
 | `telemetry.rs` | Structured event system: TauriEmitterLayer, ring buffer, JSONL, privacy stripping |
-| `vad.rs` | Silero VAD speech filtering via whisper-rs |
-| `resource_monitor.rs` | System CPU/memory monitoring via sysinfo |
+| `vad.rs` | Silero VAD speech filtering via whisper-rs (thread-local context cache) |
+| `benchmark.rs` / `evaluation.rs` | Performance Lab scoring and the `murmur-eval` fixture harness |
+| `performance_metrics/` | SQLite run history, stage timings, resource samples, retention |
+| `resource_monitor.rs` | CPU/RSS sampling, 1s heartbeat, idle-timeout enforcement |
+| `alloc.rs` | Custom malloc zone separating Rust heap from whisper.cpp's FFI heap |
+| `platform/` | Platform abstraction seams (macOS / Linux) |
+| `sidecars/local-llm/` | The signed `murmur-llm-sidecar` crate (llama.cpp) |
+| `crates/local-llm-protocol` | Host ↔ sidecar protocol types |
 
 ### Frontend (`app/src/`)
 
@@ -106,14 +142,29 @@ Read these before working on a feature:
 | `lib/hooks/useWaveform.ts` | Overlay audio-level listener + rAF waveform bar animation |
 | `lib/hooks/useTransformFlow.ts` | Main-window transform hold-key driver |
 | `lib/hooks/useTransformReviewDriver.ts` | Review popover state + approve/retry/cancel/undo |
+| `lib/hooks/useEscapeCancel.ts` | Scoped Escape cancellation carrying the exact transform pass ID |
+| `lib/hooks/useSettings.ts` | Settings persistence, backend push, optimistic rollback |
+| `lib/hooks/useFileTranscription.ts` | Imported-file transcription + busy state |
+| `lib/hooks/useKnowledge.ts` | Bounded paged access to the knowledge store |
+| `lib/hooks/useVocabScan.ts` | Live code-vocabulary scan progress, correlated by scan ID |
+| `lib/hooks/usePerformanceDiagnostics.ts` | Run history + resource samples (pure `mergeRuns`/`mergeResourceSamples`) |
+| `lib/hooks/usePerformanceHealth.ts` | Diagnostics store availability summary |
+| `lib/hooks/useOpenSettingsListener.ts` | Opens Settings on the overlay's `open-settings` |
+| `lib/hooks/useOverlaySettingsSync.ts` | Applies overlay-originated `settings-changed` in the main window |
 | `lib/transformSettings.ts` | Transform model + listener command wrappers |
+| `lib/performance.ts` / `lib/performancePresentation.ts` | Run/stage models and presentation |
+| `lib/diagnosticReports.ts` / `lib/diagnosticComparison.ts` | Portable report schema validation and comparison |
+| `lib/benchmark.ts` | Performance Lab request/report types |
 | `lib/transformFlow.ts` | Pure reducer for transform press/release |
 | `lib/transformReview.ts` | Review state/error types + content guards |
 | `components/onboarding/OnboardingFlow.tsx` | First-launch setup assistant (permissions + model wizard) |
 | `components/settings/SettingsPanel.tsx` | Settings UI with mode switching (incl. Transform page) |
 | `components/settings/TransformsManager.tsx` | Saved transform CRUD UI |
 | `components/transform-review/` | Review popover UI (diff, actions, mock driver) |
-| `components/log-viewer/LogViewerApp.tsx` | Structured event viewer with Events + Metrics tabs |
+| `components/settings/PerformanceLab.tsx` | Benchmark UI, scoring tables, report save/export |
+| `components/settings/KnowledgeManager.tsx` | Knowledge store browse/edit UI |
+| `components/history/CorrectAndTeachDialog.tsx` | Correct-and-Teach review + scope choice |
+| `components/log-viewer/LogViewerApp.tsx` | Log viewer shell: Events, Runs, Transforms, Reports tabs |
 | `components/overlay/deriveVisual.ts` | Pure: overlay top-bar indicator + flash-priority derivation |
 | `components/overlay/OverlayPill.tsx` | Overlay top bar (presentational) |
 | `components/overlay/OverlayDropdown.tsx` | Overlay quick-settings dropdown (presentational) |
@@ -121,11 +172,18 @@ Read these before working on a feature:
 
 ## Key Patterns
 
-- **Dual recording modes**: Both hooks always called (Rules of Hooks), gated by `enabled` prop
-- **Clipboard-first**: Text always goes to clipboard; auto-paste is optional
-- **Lazy model loading**: Whisper context created on first transcription
+- **Recording-mode hooks**: all three always called (Rules of Hooks), gated by the `enabled` prop
+- **Clipboard-first**: text always goes to the clipboard; auto-paste is layered on top
+- **Generation counters**: `recording_id` and `transform_pass_id` are monotonic; every async continuation re-checks ownership before mutating shared state
+- **Immutable per-recording context**: model, delivery, profile, and stage config resolve once at recording start; mid-recording changes apply to the next session
+- **Warm-on-record**: `spawn_model_preparation` starts model load when recording starts, so load overlaps with speech
+- **Ordered transcript pipeline**: one entry point, declared stage order and failure policy, per-stage timing
+- **Fail-closed**: unknown model IDs, ambiguous corrections, and unprovable secure-field checks all refuse rather than guess
+- **Rust owns window geometry**: pure `geometry_for()` / `popover_geometry_for()`, fixture-asserted on both sides
+- **Main-thread `NSWindow` mutation**: dispatch via `run_on_main_thread` — macOS 26 hard-traps otherwise (#325)
 - **Mutex poison recovery**: `MutexExt` trait recovers from panics
 - **rdev thread safety**: `set_is_main_thread(false)` before `listen()` — prevents macOS TIS/TSM segfault
+- **No in-process llama**: the app crate must never link `llama-cpp-2` (ggml ABI clash with whisper)
 
 ## MCP Tools
 
@@ -133,5 +191,6 @@ Read these before working on a feature:
 
 ## Dependencies
 
-- **Rust**: tauri 2, whisper-rs (Metal), cpal, arboard, hound, rdev (git main branch)
-- **Frontend**: React 18, Tailwind CSS 4, @tauri-apps/api, Vite 6, TypeScript
+- **Rust**: tauri 2, whisper-rs (Metal), FluidAudio (Core ML), sherpa-onnx, cpal, arboard, hound, rusqlite, core-graphics, objc2/objc2-app-kit, rdev (git main branch)
+- **Sidecar**: llama-cpp-2 — in `sidecars/local-llm` only, never in the app crate
+- **Frontend**: React 18, Tailwind CSS 4, @tauri-apps/api, Vite 6, TypeScript, vitest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture><source media="(prefers-color-scheme: dark)" srcset="docs/banner-dark.svg"><img src="docs/banner.svg" alt="murmur — Local voice-to-text for macOS" width="100%"></picture>
 
-# Local Dictation
+# Murmur
 
 Privacy-first voice-to-text for macOS. Hold a key, speak, release — your words land in any app. No cloud, no subscriptions, no data leaves your machine.
 
@@ -8,25 +8,26 @@ Built with [Tauri 2](https://tauri.app/) (Rust + React), with local transcriptio
 
 ## Features
 
-- **100% local** — all transcription runs on-device. Audio and benchmark results never leave the machine
-- **Apple Neural Engine default on Apple silicon** — multilingual Parakeet v3 through Core ML for very low-latency transcription; Intel Macs use the CPU fallback
-- **Multiple local engines** — compare Core ML/ANE, whisper.cpp/Metal, and sherpa-onnx/CPU configurations
-- **Performance Lab** — benchmark installed models on identical speech, including median/p95 latency, real-time speed, memory, and word error rate
-- **Two recording modes** — Hold Down (hold to record, release to stop) or Double-Tap (tap twice to start, tap once to stop)
-- **Clipboard-first output** — text always copied to clipboard. Optional auto-paste into your focused app
-- **Floating overlay** — always-on-top widget with animated waveform, click to toggle recording
-- **In-app model downloader** — first-launch onboarding downloads your chosen model with progress bar
-- **Transcription history** — timestamped entries with copy-to-clipboard
-- **Stats tracking** — total words, average WPM, total recordings, approximate tokens
-- **System tray** — color-coded status icon (idle / recording / processing)
-- **Log viewer** — last 200 lines with color-coded levels, per-transcription timing
+- **100% local** — transcription, text rewriting, and benchmarking all run on-device. Nothing leaves the machine
+- **Apple Neural Engine by default** — multilingual Parakeet v3 through Core ML for very low-latency transcription; other engines a click away
+- **Three recording modes** — Hold Down, Double-Tap, or Both (hold and double-tap on the same key)
+- **Clipboard-first output** — text always copied to the clipboard. Optional auto-paste into your focused app, plus optional transcript/audio file output
+- **Selected-text Transform** — select text anywhere, hold a second key, say "make this shorter", and review a local LLM's proposal before it replaces anything. Never auto-applies
+- **Text that comes out right** — deterministic local cleanup, smart formatting, spoken CLI command grammar, custom vocabulary with sounds-like correction, and typed voice commands with snippets and variables
+- **Learns your terms** — correct a transcription once and teach Murmur the exact replacement, scoped globally, per app, or per project
+- **Per-app profiles** — writing style and delivery behavior per application, resolved once per recording
+- **Floating overlay** — notch-anchored widget with a live waveform and hover quick-settings; never steals focus
+- **Performance Lab** — benchmark installed models on identical speech: latency, realtime factor, memory, and three tiers of word error rate
+- **Diagnostics** — structured event log, bounded local run history, and CPU/memory timelines, all content-free
 - **MIT licensed** — use it, fork it, build on it
 
 ## Installation
 
 1. Download the latest `.dmg` from the [Releases](https://github.com/georgenijo/murmur-app/releases) page
-2. Open the DMG and drag **Local Dictation** to your Applications folder
-3. Launch the app — if no model is found, the onboarding screen will guide you through downloading one
+2. Open the DMG and drag **Murmur** to your Applications folder
+3. Launch the app — the setup assistant walks you through microphone and Accessibility permissions and downloads a model
+
+Requires macOS 14+ on Apple Silicon.
 
 ### Permissions
 
@@ -35,7 +36,7 @@ Grant these in **System Settings > Privacy & Security** when prompted:
 | Permission | Required for |
 |------------|-------------|
 | Microphone | Recording your voice |
-| Accessibility | Keyboard detection + auto-paste |
+| Accessibility | Keyboard detection, auto-paste, and reading/replacing the selection for Transform |
 
 ## Models
 
@@ -43,8 +44,8 @@ Choose a model based on your speed/accuracy tradeoff. Models download automatica
 
 | Model | Engine | Accelerator | Size | Notes |
 |-------|--------|-------------|------|-------|
-| Parakeet v3 | Core ML | Apple Neural Engine | ~470 MB | Apple silicon default, multilingual, lowest latency |
-| Parakeet v2 | sherpa-onnx | CPU | ~1.2 GB | English fallback, including Intel macOS |
+| Parakeet v3 | Core ML | Apple Neural Engine | ~470 MB | Default, multilingual, lowest latency |
+| Parakeet v2 | sherpa-onnx | CPU | ~1.2 GB | English CPU fallback; also the non-Apple-Silicon path |
 | Whisper Tiny | whisper.cpp | Metal GPU | ~75 MB | English |
 | Whisper Base | whisper.cpp | Metal GPU | ~150 MB | English |
 | Whisper Small | whisper.cpp | Metal GPU | ~500 MB | English |
@@ -63,7 +64,15 @@ Configure in the Settings panel:
 
 **Double-Tap** — quickly double-tap a modifier key to start recording. Single tap to stop. The detector rejects held keys, modifier+letter combos, slow taps, and triple-tap spam.
 
+**Both** — both gestures on the same key, disambiguated by a 200ms hold-promotion window.
+
 Transcribed text is always copied to your clipboard. Enable **Auto-Paste** in Settings to have it pasted automatically into your focused app.
+
+## Selected-text Transform
+
+Select text in any app, hold the transform key (Right Option by default, off until you enable it), and speak an instruction — "make this shorter", "fix grammar", or the name of a preset or saved transform.
+
+A local LLM proposes a rewrite in a small popover with a word diff. Nothing is written until you approve, and Undo restores the original. The model is a pinned Qwen2.5-1.5B-Instruct that runs in a separate signed helper process with no network access. Password fields fail closed.
 
 ## Tech Stack
 
@@ -73,40 +82,51 @@ Transcribed text is always copied to your clipboard. Enable **Auto-Paste** in Se
 | Backend | Rust |
 | Frontend | React 18, TypeScript, Tailwind CSS 4 |
 | Transcription | FluidAudio/Core ML, whisper-rs/Metal, sherpa-onnx/CPU |
+| Local rewriting | llama.cpp in a signed sidecar process |
 | Audio capture | cpal |
 | Keyboard listener | rdev |
 | Clipboard | arboard |
-| Auto-paste | osascript |
+| Auto-paste | CGEvent (osascript fallback) |
+| Local storage | SQLite (rusqlite) |
 | Build tool | Vite 6 |
 
 ## Building from Source
 
 ```bash
 git clone https://github.com/georgenijo/murmur-app.git
-cd murmur-app/app
+cd murmur-app
+
+python3 scripts/build_local_llm_sidecar.py   # required first on macOS
+
+cd app
 npm install
 npm run tauri dev        # Dev with hot reload
 npm run tauri build      # Production .app and .dmg
 ```
 
-Requires macOS 12+, [Node.js](https://nodejs.org/) 18+, and [Rust](https://rustup.rs/) (latest stable).
+Requires macOS 14+ on Apple Silicon, [Node.js](https://nodejs.org/) 18+, [Rust](https://rustup.rs/) (latest stable), and Python 3.
+
+The sidecar step is not optional: the macOS Tauri config declares the sidecar as an `externalBin`, so builds — and even `cargo check` — fail until that binary exists. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ### Running Tests
 
 ```bash
 cd app/src-tauri && cargo test -- --test-threads=1   # Rust unit tests
+cd app && npm test                                    # frontend unit tests
 cd app && npx tsc --noEmit                            # TypeScript type check
 ```
 
 ## Architecture
 
 ```
-Hotkey (rdev) → Audio Capture (cpal) → Local Transcription Engine → Clipboard (arboard) → Auto-Paste (osascript)
-       ↕                    ↕                        ↕                                    ↕
-   Frontend (React) ←——— Tauri IPC ———→ Rust Backend ———→ System Tray + Overlay
+Hotkey (rdev) → Audio Capture (cpal) → Transcription Engine → Transcript Pipeline → Clipboard (arboard) → Auto-Paste (CGEvent)
+       ↕                  ↕                     ↕                      ↕                                        ↕
+   Frontend (React) ←——— Tauri IPC ———→ Rust Backend ———→ Tray + Overlay + Transform Popover ———→ LLM Sidecar (separate process)
 ```
 
-The backend uses a `TranscriptionBackend` trait — a clean interface that makes it easy to add new transcription engines in the future.
+Transcription engines sit behind one `TranscriptionBackend` trait and one model catalog. Post-recognition text passes through a single ordered pipeline (cleanup → voice commands → correction → formatting → IDE context → CLI). The local rewriting LLM runs out of process, because llama.cpp's ggml ABI clashes with whisper's.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full picture and [docs/FEATURES.md](docs/FEATURES.md) for the feature map.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,9 +2,12 @@
 
 ## Overview
 
-Murmur is a privacy-first, local-only voice dictation app for macOS. You speak, it transcribes -- no cloud, no API keys, no internet. All inference runs on-device using Apple Silicon's GPU (Whisper).
+Murmur is a privacy-first, local-only voice dictation app for macOS. You speak, it transcribes — no cloud, no API keys, no internet. All inference runs on-device: transcription on the Apple Neural Engine (Core ML), the GPU (Metal/whisper.cpp), or CPU (sherpa-onnx), and selected-text rewriting through a signed local-LLM helper process.
 
-Built with **Tauri 2** (Rust backend + React frontend). ~25MB installed, no Python, no sidecar.
+Built with **Tauri 2** (Rust backend + React frontend). Two shipped inference stacks:
+
+- **In-process transcription** — Core ML / whisper.cpp / sherpa-onnx behind one `TranscriptionBackend` trait.
+- **Out-of-process rewriting** — a separate signed `murmur-llm-sidecar` executable runs llama.cpp. The app crate must **never** link `llama-cpp-2` directly: its ggml ABI clashes with whisper's.
 
 ---
 
@@ -12,477 +15,308 @@ Built with **Tauri 2** (Rust backend + React frontend). ~25MB installed, no Pyth
 
 | Layer | Technology | Notes |
 |-------|-----------|-------|
-| Desktop framework | Tauri 2 | Rust backend, React frontend, smaller than Electron |
+| Desktop framework | Tauri 2 | Rust backend, React frontend |
 | UI | React 18 + TypeScript + Tailwind CSS 4 | Vite 6 build |
 | Audio capture | cpal | Native multi-channel input, mono mix, 16kHz resample |
-| VAD | Silero v5.1.2 via whisper-rs | Filters silence before transcription; prevents Whisper hallucination loops |
-| Transcription | whisper-rs -> whisper.cpp | Metal GPU-accelerated on Apple Silicon |
-| Text injection | arboard + osascript | Clipboard-first; osascript for auto-paste |
-| Keyboard listening | rdev (git main branch) | Global key events; single background thread |
+| VAD | Silero v5.1.2 via whisper-rs | Filters silence before transcription; thread-local cached context |
+| Transcription | FluidAudio (Core ML/ANE), whisper-rs → whisper.cpp (Metal), sherpa-onnx (CPU) | Selected per model from one catalog |
+| Local rewriting | `murmur-llm-sidecar` (llama.cpp, Qwen2.5-1.5B-Instruct Q4_K_M) | Separate signed process, model passed as read-only fd |
+| Text injection | arboard + CGEvent (osascript fallback) | Clipboard-first |
+| Selection capture | Accessibility (AX) APIs + sentinel-guarded clipboard fallback | Secure fields fail closed |
+| Keyboard listening | rdev (git main branch) | Global key events; one background thread, three detectors |
+| Local storage | rusqlite (SQLite) | Personal knowledge store + performance diagnostics |
 | Telemetry | tracing + tracing-subscriber | Structured events: ring buffer, JSONL file, real-time frontend emission |
-| System info | sysinfo | CPU and memory monitoring for resource panel |
-| Release | GitHub Actions + Apple notarization | Signed DMG, platform-safe updater channels |
+| System info | sysinfo + custom malloc zone | CPU, RSS, and separated Rust/FFI heap accounting |
+| Release | GitHub Actions + Apple notarization | Signed DMG, hardened runtime, sidecar entitlements |
 
 ---
 
 ## Data Flow
 
-```
+### Dictation
+
+```text
 Hotkey event (rdev listener thread)
     |
 Frontend hook (useHoldDownToggle / useDoubleTapToggle / useCombinedToggle)
     |
-invoke('start_native_recording') --> cpal captures audio
+invoke('start_native_recording')
+    |-- cpal capture begins
+    |-- immutable DictationContextSnapshot resolved (global settings + per-app profile)
+    +-- spawn_model_preparation() warms the model *concurrently with speech*
     |
 invoke('stop_native_recording') --> audio thread joins, samples resampled to 16kHz mono
     |
-Silero VAD filters silence (configurable sensitivity 0-100)
+Silero VAD trims silence (NoSpeech short-circuits the whole pipeline)
     |
-TranscriptionBackend::transcribe() --> whisper.cpp (Metal GPU)
+ModelRuntimeManager::with_ready_backend() --> transcribe()
     |
-injector::inject_text() --> arboard writes to clipboard
+transform_transcript() -- ordered, backend-neutral text pipeline (see below)
     |
-[optional] osascript simulates Cmd+V --> text appears in focused app
+injector::inject_text() --> arboard clipboard write
     |
-'transcription-complete' event --> all windows: history + stats update
+[optional] CGEvent Cmd+V (osascript fallback) --> text appears in focused app
+    |
+[optional] file_output --> numbered .txt / .wav
+    |
+'transcription-complete' event + PerformanceRunV1 persisted
 ```
+
+The **transcript transform pipeline** (`transcript_transform.rs`) runs stages in exactly this order, each with a declared failure policy and per-stage timing/outcome telemetry:
+
+1. `cleanup` — filler removal, capitalization
+2. `voice_commands` — typed replacements/snippets from the knowledge store
+3. `smart_correction` — vocabulary matcher (exact tier + optional fuzzy tier)
+4. `smart_formatting` — deterministic prose grammar, lists, same-utterance backtracking (live only)
+5. `ide_context` — project symbol correction and `@file` canonicalization (live only, opt-in)
+6. `cli_command` — spoken CLI command formatting
+
+### Selected-text transform
+
+```text
+Transform hold key down (rdev, assigns a monotonic transform_pass_id)
+    |
+Mic arms immediately (before capture — Chromium capture can take >1s)
+    |
+selection.rs freezes an AX selection snapshot
+    |-- secure/password field --> fail closed, no popover content
+    +-- no AX selection --> AX retry ladder, then sentinel-guarded synthetic Cmd+C
+    |
+Popover shows 'listening' (non-focusable, never steals focus)
+    |
+Key release --> instruction ASR (cleanup-only transcript path)
+    |
+expand_instruction(): built-in preset > saved transform > raw text
+    |
+llm_sidecar: spawn + handshake (if cold) --> generate --> 'thinking' to 'ready'
+    |
+User reviews a word diff. Approve --> transform_apply (AX set-value, or paste
+fallback with full-pasteboard save/restore). Undo restores the frozen original.
+```
+
+Dictation and transform are mutually exclusive in both directions (status guards, sidecar busy guard, helper shutdown before recording).
 
 ---
 
-## Three-Window Architecture
+## Four-Window Architecture
 
-Murmur runs three distinct webview windows, each with separate Tauri capabilities following the principle of least privilege:
+Each window is a separate webview with its own Tauri capability set, following least privilege.
 
-| Window | Label | Entry Point | Purpose |
-|--------|-------|-------------|---------|
-| Main | `main` | `index.html` | Settings, recording controls, transcription history, stats, resource monitor, permissions, model download, about/update modals |
-| Overlay | `overlay` | `overlay.html` | Dynamic Island-style notch widget with waveform visualization. Always-on-top, transparent, not focusable |
-| Log Viewer | `log-viewer` | `log-viewer.html` | Structured event browser with Events tab (stream/level filtering) and Metrics tab (transcription timing charts) |
+| Window | Label | Entry Point | Size | Purpose |
+|--------|-------|-------------|------|---------|
+| Main | `main` | `index.html` | 720×560 | Settings, recording controls, history, stats, onboarding, modals |
+| Overlay | `overlay` | `overlay.html` | 260×100 | Dynamic Island notch widget. Always-on-top, transparent, non-activating |
+| Log Viewer | `log-viewer` | `log-viewer.html` | 800×600 | Events, Performance/Runs, Transform diagnostics, Reports |
+| Transform Review | `transform-review` | popover entry | 320×76 (compact) | Transform proposal review. Non-focusable until `ready`/`failed` |
 
-All three windows intercept close requests and hide instead of being destroyed, preserving state. The overlay reads settings from localStorage directly (no shared React context across windows).
+Main and log-viewer hide on close instead of being destroyed. The overlay and transform popover both use the shared non-activating window treatment in `commands/native_window.rs`, and **all** of their raw `NSWindow` mutation is dispatched to the main thread via `run_on_main_thread` — macOS 26 hard-traps on off-main `NSWindow` mutation (#325).
+
+Rust is the sole author of every overlay and popover pixel: `geometry_for()` and `popover_geometry_for()` are pure functions asserted by checked-in fixtures on both sides (cargo test + vitest). The frontend never hardcodes dimensions.
 
 ---
 
 ## Rust Backend (`app/src-tauri/src/`)
 
-### `lib.rs` -- App Wiring
+### Module map
 
-- Declares all modules, registers 30 Tauri commands via `invoke_handler!`
-- Defines `State` (top-level Tauri state): holds `AppState` + cached notch dimensions
-- Defines `MutexExt` trait with `lock_or_recover()`: recovers poisoned mutexes after panics instead of propagating the panic -- keeps the app alive if any thread panics while holding a lock
-- Hides window on close (keeps app alive in tray), suppresses default "Reopen" behavior -- dock icon click only shows the main window when no windows are visible (prevents overlay clicks from unhiding the main window)
-- Caches notch info on the main thread during setup (NSScreen APIs are main-thread-only)
-- Registers 5 Tauri plugins: opener, autostart (LaunchAgent), updater, notification, process
+| Module | Purpose |
+|--------|---------|
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 105 registered commands, setup, tray, run loop |
+| `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
+| `audio.rs` | cpal capture, mono mix, 16kHz resample, `audio-level` emission |
+| `audio_decode.rs` | Decoding imported audio files for `transcribe_file` |
+| `benchmark.rs` | Performance Lab: fixture corpus, scoring (raw/normalized/delivered WER), reports |
+| `cleanup.rs` | Filler removal and capitalization |
+| `cli_command.rs` | Spoken CLI command grammar and lexicon |
+| `correct_and_teach.rs` | Bounded local diff proposals from a user's edit; never writes without confirmation |
+| `correction.rs` | Smart Correction matcher (exact + fuzzy tiers) |
+| `dictation_context.rs` | Immutable per-recording context snapshot resolution |
+| `evaluation.rs` | Versioned fixture evaluation harness (`murmur-eval`) |
+| `file_output.rs` | Numbered `.txt` / `.wav` output |
+| `frontmost.rs` | Native frontmost-app query + running-application list |
+| `ide_context.rs` | Memory-only bounded IDE symbol / root-relative file index |
+| `injector.rs` | Clipboard write, CGEvent paste (osascript fallback), focused-field AX role checks |
+| `keyboard.rs` | Hold-down, double-tap, and transform-hold detectors on one shared rdev thread |
+| `knowledge_store/` | SQLite personal knowledge store: migrations, repository, backup/recovery |
+| `llm_sidecar.rs` | Host supervisor for the signed local-LLM helper: spawn, handshake, RSS ceilings, idle unload, circuit breaker |
+| `model_runtime.rs` | Model catalog + lifecycle manager (load/warm/readiness/unload, generation-ordered status events) |
+| `performance_metrics/` | SQLite run history, stage timings, resource samples, retention |
+| `platform/` | Platform abstraction seams (macOS / Linux) |
+| `resource_monitor.rs` | CPU/RSS sampling, 1s heartbeat, idle-timeout enforcement |
+| `selection.rs` | AX selection capture with secure-field fail-closed and clipboard fallback |
+| `smart_formatting.rs` | Deterministic prose formatting and same-utterance backtracking |
+| `state.rs` | `DictationStatus`, `TransformStatus`, `DictationState`, `AppState` |
+| `telemetry.rs` | Structured event system: `TauriEmitterLayer`, ring buffer, JSONL, privacy stripping |
+| `transcriber/` | `TranscriptionBackend` trait + whisper / parakeet / coreml implementations |
+| `transcript_transform.rs` | The ordered post-recognition pipeline and its stage contracts |
+| `transform_apply.rs` | Approve/undo write-back — the only path that writes into the target app |
+| `transform_diagnostics.rs` | Per-attempt transform records and consented content captures |
+| `transform_flow.rs` | End-to-end transform orchestrator and its Tauri commands |
+| `transform_presets.rs` | Built-in spoken presets (Shorten, Bullets, Professional, Fix grammar, Casual) |
+| `transform_trace.rs` | Pass-scoped correlation tracing |
+| `vad.rs` | Silero VAD filtering, thread-local context cache |
+| `vocab.rs`, `vocabulary_alias.rs` | Code-vocabulary scanning and explicit spoken aliases |
+| `voice_commands.rs` | Typed voice command execution and variable expansion |
 
-### `state.rs` -- Shared State
+Commands live under `commands/` (`recording`, `permissions`, `keyboard`, `logging`, `models`, `knowledge`, `correct_and_teach`, `benchmark`, `performance`, `transform_model`, `transform_popover`, `transform_diagnostics`, `overlay`, `native_window`, `tray`).
+
+### `state.rs` — Shared State
 
 ```rust
 enum DictationStatus { Idle, Recording, Processing }
-
-struct DictationState {
-    status: DictationStatus,
-    model_name: String,        // e.g. "base.en"
-    language: String,
-    auto_paste: bool,
-    auto_paste_delay_ms: u64,  // 10-500, default 50
-    vad_sensitivity: u32,      // 0-100, default 50
-}
+enum TransformStatus { /* Idle, Capturing, Listening, Thinking, ReviewPending, ... */ }
 
 struct AppState {
     dictation: Mutex<DictationState>,
-    backend: Mutex<Box<dyn TranscriptionBackend>>,
+    recording_transition: tokio::sync::Mutex<()>,   // serializes start/stop/cancel/transform
+    model_runtime: ModelRuntimeManager,
+    recording_id: AtomicU64,                        // generation counter; supersedes stale work
+    cancelled_id: AtomicU64,
+    settings_revision: AtomicU64,
+    correction_matcher: Mutex<...>,                 // immutable, swapped by generation
+    ide_context: Mutex<IdeContextStore>,
+    transform_status: Mutex<TransformStatus>,
+    transform_pass_sequence: AtomicU64,             // monotonic per physical key hold
+    transform_session: Mutex<Option<TransformSession>>,
+    transform_apply_epoch: AtomicU64,               // guards clipboard restore races
+    // ...
 }
 ```
 
-`DictationState::default()` uses `"base.en"` only as the pre-configuration fallback. The frontend's new-install default and first-launch recommendation are `"parakeet-tdt-0.6b-v3-coreml"`; the first `configure_dictation` call selects FluidAudio. Existing persisted Whisper and sherpa selections remain valid.
+Two patterns do most of the concurrency work:
 
-### `audio.rs` -- Audio Capture
+- **Generation counters.** `recording_id` and `transform_pass_id` are monotonic. Every async continuation re-checks whether it still owns the current generation before mutating shared state, so a delayed handler can never cancel or overwrite the pass that replaced it.
+- **Immutable snapshots.** A recording resolves its full context (model, language, delivery, profile overrides, vocabulary, transform stage config) once at start. Settings or focus changes mid-recording apply to the *next* session, never the running one.
 
-- cpal opens the input device and builds a stream; multi-channel interleaved samples are averaged to mono
-- RMS computed per chunk -> `audio-level` events emitted at ~60fps (throttled via `AtomicU64` to 16ms minimum gap) -> waveform animation in UI
-- Each recording gets a fresh `Arc<Mutex<Vec<f32>>>` buffer -- prevents stale data from previous recordings
-- Stop command sent via channel; thread joins before samples are consumed
-- Linear interpolation resamples captured audio to 16kHz (what Whisper expects)
-- Recording state stored in a global `OnceLock<Mutex<RecordingState>>` with command sender, thread handle, shared buffer, sample rate, start timestamp, and device name
-- Initialization handshake: `start_recording` waits up to 5 seconds for the audio thread to signal ready
-- Device name redacted in release build logs
+### Model runtime (`model_runtime.rs`)
 
-### `keyboard.rs` -- Keyboard Detection
+One catalog is the single source of truth for all seven shipped models:
 
-All keyboard detection runs through a **single persistent rdev background thread** shared by two detectors.
+| Model | Backend | Accelerator | Size |
+|-------|---------|-------------|------|
+| `parakeet-tdt-0.6b-v3-coreml` | FluidAudio / Core ML | Apple Neural Engine | ~470 MB |
+| `parakeet-tdt-0.6b-v2-fp16` | sherpa-onnx | CPU | ~1.2 GB |
+| `tiny.en` | whisper.cpp | Metal GPU | ~75 MB |
+| `base.en` | whisper.cpp | Metal GPU | ~150 MB |
+| `small.en` | whisper.cpp | Metal GPU | ~500 MB |
+| `medium.en` | whisper.cpp | Metal GPU | ~1.5 GB |
+| `large-v3-turbo` | whisper.cpp | Metal GPU | ~3 GB |
 
-#### Hold-Down Detector
+Each entry declares its backend, accelerator, capabilities (multilingual, translation, timestamps, confidence, punctuation control), install kind, platform requirement, `warm_on_startup`, and `retry_unfiltered_on_empty`. Unknown model identifiers **fail closed** — Murmur never silently falls back to a different model.
 
-Simple 2-state machine:
-```text
-Idle --> [key press] --> Held (emit 'hold-down-start')
-Held --> [key release] --> Idle (emit 'hold-down-stop')
-```
-Rejects combos (e.g. Shift+A while Shift is the trigger key cancels hold and emits Stop).
+The manager serializes load/warm/readiness/unload, emits generation-ordered `model-runtime-status-changed` events, and reports a `LoadReport` (`lock_wait_ms`, `load_ms`, `cache_hit`) that feeds the performance record. Idle release is user-configurable (`idleTimeoutMinutes`).
 
-In hold-down-only mode, there is no minimum hold duration: a key press immediately emits `hold-down-start` and a key release immediately emits `hold-down-stop`. The 0.3-second minimum recording threshold in `stop_native_recording` handles discarding phantom triggers.
+**Warm-on-record:** `start_native_recording` kicks off `spawn_model_preparation()` immediately after audio capture starts, so model load overlaps with the user still speaking. By the time the key is released the model is usually resident. (The transform sidecar does **not** do this yet — see issue #340.)
 
-#### Double-Tap Detector
-
-4-state machine:
-```text
-Idle --> [press] --> WaitingFirstUp
-     --> [release <200ms] --> WaitingSecondDown
-     --> [press, gap <400ms] --> WaitingSecondUp
-     --> [release <200ms] --> FIRE --> Idle
-```
-Rejects: taps held >200ms, modifier+letter combos, gaps >400ms, triple-tap spam.
-When `recording=true`, a single tap fires immediately (to stop, not start).
-
-#### Both Mode (Hold-Down + Double-Tap simultaneously)
-
-The interesting one. The problem: a key press could be the start of a double-tap *or* a hold. You can't know which until time passes.
-
-Solution: **deferred hold promotion via a background timer thread + atomic invalidation counter.**
-
-1. On key press, a timer thread is spawned for 200ms
-2. If the key is released before 200ms -- it was a tap. Timer fires but is invalidated by `HOLD_PRESS_COUNTER` (atomically incremented on release)
-3. If the key is still held after 200ms -- timer fires, sets `HOLD_PROMOTED` to true, and emits `hold-down-start`. Now we're in hold mode
-4. The hold-down detector is suppressed when the double-tap detector is in its second phase (WaitingSecondDown or WaitingSecondUp), preventing false hold events during double-tap sequences
-5. On key release: if promoted, emits `hold-down-stop`. If not promoted but double-tap fired, emits `double-tap-toggle`. Otherwise (short single tap with no double-tap), nothing is emitted -- no recording was ever started
-
-#### Processing State Management
-
-When entering the transcription pipeline, `set_processing(true)` is called:
-- Both-mode callback ignores all key events
-- Pending hold-promotion timers are invalidated via `HOLD_PRESS_COUNTER`
-- Both detectors are reset
-- On exit from processing, cooldowns are applied to prevent accidental re-triggers
-
-#### macOS Thread Safety -- The rdev Segfault Fix
-
-rdev's keyboard translation uses macOS **TIS/TSM** (Text Input Sources) APIs to map raw key codes to characters. These APIs **must run on the main thread**. rdev listens on a background thread. Without intervention, this silently segfaults.
-
-Fix -- one line, called before `rdev::listen()`:
-```rust
-rdev::set_is_main_thread(false);
-```
-This tells rdev it is *not* on the main thread, which causes it to wrap TIS/TSM calls in `dispatch_sync(dispatch_get_main_queue(), ...)` -- marshaling only those calls to main, while the listener loop stays on the background thread.
-
-A heartbeat monitor thread logs trace-level messages every 60 seconds while the listener is active.
-
-### `vad.rs` -- Voice Activity Detection
-
-- Uses **Silero VAD v5.1.2** via whisper-rs `WhisperVadContext`
-- Filters out silence before transcription to prevent Whisper hallucination loops on quiet recordings
-- VAD threshold computed from user-configurable sensitivity: `threshold = 1.0 - (vad_sensitivity / 100.0)` (0-100 scale, default 50)
-- Configured: 1 thread, GPU disabled
-- Returns speech segments as centisecond timestamps, converted to sample indices
-- Three outcomes: `NoSpeech` (skip transcription entirely), `Speech` (trimmed samples), `Error` (fallback to unfiltered audio)
-- `filter_speech` is `!Send` (WhisperVadContext constraint), must run via `spawn_blocking`
-- VAD context is created and destroyed per transcription (not cached like WhisperState)
-
-### `transcriber/` -- Inference Backend
-
-The backend implements a shared trait (kept for future extensibility):
+### `transcriber/` — Inference Backends
 
 ```rust
 trait TranscriptionBackend: Send + Sync {
     fn name(&self) -> &str;
     fn load_model(&mut self, model_name: &str) -> Result<(), String>;
-    fn transcribe(&mut self, samples: &[f32], language: &str) -> Result<String, String>;
+    fn is_model_loaded(&self, model_name: &str) -> bool;
+    fn transcribe(&mut self, samples: &[f32], language: &str,
+                  initial_prompt: Option<&str>, smart_punctuation: bool) -> Result<String, String>;
+    fn token_count(&self, text: &str) -> Option<usize>;
     fn model_exists(&self) -> bool;
-    fn models_dir(&self) -> PathBuf;
+    fn models_dir(&self) -> Result<PathBuf, String>;
     fn reset(&mut self);
 }
 ```
 
-When the model changes, `reset()` is called to force a reload on the next transcription.
+- **Whisper** — `WhisperContext` and `WhisperState` are both cached; GPU/Metal buffers are allocated once and reused across transcriptions. Greedy sampling, blank suppression, timestamp-based continuation for long audio.
+- **Core ML (FluidAudio)** — Parakeet v3 on the ANE. Decoder state is reset between one-shot dictations. An empty result after VAD trimming retries once with the original unfiltered audio.
+- **Parakeet CPU (sherpa-onnx)** — English fallback, also the non-macOS path.
 
-**Whisper (`whisper.rs`)**
-- Wraps whisper.cpp via `whisper-rs` with the Metal GPU backend enabled by default
-- Single `.bin` file per model (GGML format), sourced from Hugging Face
-- **WhisperState caching (v0.7.8)**: The `WhisperBackend` struct holds `context: Option<WhisperContext>`, `state: Option<WhisperState>`, and `loaded_model_name: Option<String>`. On first `load_model()`, a `WhisperContext` is created from the model file and `ctx.create_state()` allocates GPU/Metal buffers exactly once. The `WhisperState` is stored and reused across all subsequent transcriptions (`state.full(params, samples)`). Only a model name change triggers `reset()` and reallocation. Previously, `create_state()` was called per-transcription, causing expensive alloc/free cycles
-- Uses greedy sampling (best_of=1), single segment mode, timestamps/progress/special tokens suppressed, blank suppression enabled
-- Scans 6 standard paths to find existing model files
-- Suppresses whisper.cpp's verbose stdout via log trampoline (`install_logging_hooks()` called once via `std::sync::Once`)
+All backends take one final-after-stop pass. The Whisper-only incremental/preview worker was removed in #279; delivery happens exactly once.
 
-**Available Models (5 total)**
+### `llm_sidecar.rs` — Local LLM Supervisor
 
-| Model | Backend | Size |
-|-------|---------|------|
-| `tiny.en` | Whisper (Metal GPU) | ~75 MB |
-| `base.en` | Whisper (Metal GPU) | ~150 MB |
-| `small.en` | Whisper (Metal GPU) | ~500 MB |
-| `medium.en` | Whisper (Metal GPU) | ~1.5 GB |
-| `large-v3-turbo` | Whisper (Metal GPU) | ~3 GB |
+The helper is a separate signed executable (`murmur-llm-sidecar`), packaged as a Tauri `externalBin`, running with hardened runtime and App Sandbox.
 
-The initial model downloader screen shows a curated subset of 2 models: `large-v3-turbo` and `base.en`. Default selection: `large-v3-turbo`.
+- **Model pin:** Qwen2.5-1.5B-Instruct Q4_K_M, ~1.1 GB, exact byte size **and** SHA-256 verified at download and again before every spawn.
+- **Spawn hardening:** empty environment, fixed cwd, no path arguments, no network. The model is handed over as an inherited read-only file descriptor (fd 3), so the helper never resolves a path itself.
+- **Handshake:** nonce + protocol + model-id verification within a deadline; a mismatch is a hard failure, not a downgrade.
+- **Resource ceilings:** RSS warn at 2 GB, kill at 3 GB. Idle unload after inactivity. A circuit breaker (3 faults in a 10-minute window) disables the runtime until `reset_transform_runtime`.
+- **Maintenance:** a 30-second tokio interval task runs `maintenance_tick()` for idle unload and RSS enforcement; `RunEvent::Exit` shuts the helper down so it never outlives the app.
 
-### `injector.rs` -- Text Injection
+### `keyboard.rs` — Keyboard Detection
 
-1. **Clipboard** (always): `arboard` writes text to the system clipboard. Empty/whitespace-only text is silently skipped.
-2. **Auto-paste** (optional): waits a configurable delay (10-500ms, default 50ms), then:
-   ```bash
-   osascript -e 'tell application "System Events" to keystroke "v" using command down'
-   ```
-   The delay allows the target window to regain focus.
-   Retries once on failure with 100ms backoff. 2-second timeout on the entire operation.
-   On failure, emits `auto-paste-failed` with a hint message ("press Cmd+V to paste manually").
-   Requires Accessibility permission -- if not granted, text stays in clipboard with a warning log.
-   Previous approaches (`engio`, rdev simulate) broke on Sonoma/Sequoia. osascript is the reliable path.
+One persistent rdev background thread feeds three detectors: hold-down, double-tap, and transform-hold.
 
-### `commands/recording.rs` -- Transcription Pipeline & RAII Guard
+- **Hold-down** — 2 states; press emits `hold-down-start`, release emits `hold-down-stop`. Combos (trigger+letter) cancel.
+- **Double-tap** — 4 states; each tap under 200ms, gap under 400ms. Rejects holds, combos, slow taps, triple-tap spam. Emits `hotkey-tap-rejected` when an idle first tap expires (opt-in overlay feedback).
+- **Both** — deferred hold promotion: a 200ms timer thread with an atomic invalidation counter decides tap-vs-hold. Releasing before 200ms invalidates the timer; still held at 200ms promotes to a hold.
+- **Transform hold** — an independent key (`alt_r` / `ctrl_l` / `shift_r`, rejects the dictation key). Each physical hold gets a monotonic `transform_pass_id` assigned *in the rdev callback*, which is then carried explicitly through every event, command, and worker — correlation never relies on an ambient tracing span.
 
-**`IdleGuard`** -- RAII guard wrapping the transcription pipeline:
-- On drop (if not disarmed), resets status to `Idle` and clears the "processing" keyboard flag
-- Guarantees the UI never gets stuck in "Processing" on any error path
-- Both the outer command and inner pipeline have their own guards with a disarm handoff pattern
+**macOS thread safety.** rdev's key translation uses TIS/TSM APIs that must run on the main thread. `rdev::set_is_main_thread(false)` is called before `listen()`, which makes rdev marshal only those calls to main via `dispatch_sync` while the listener loop stays on its background thread. Without it, the app silently segfaults.
 
-**`run_transcription_pipeline()`**:
-1. Read state -- model name, language, auto-paste settings, paste delay, VAD sensitivity in a single lock acquisition
-2. Pre-VAD diagnostics -- compute RMS and peak amplitude of raw audio, log device name
-3. VAD phase -- if VAD model exists, run Silero VAD on a blocking thread. Three outcomes: NoSpeech (skip), Speech (trimmed), Error (fallback). If VAD model missing, spawn background download for next time
-4. Transcription phase -- lock backend mutex, call `load_model()` (lazy), then `transcribe()`
-5. Text injection -- dispatched to main thread via `run_on_main_thread()` (osascript requires main thread). Clipboard write + optional paste with 2-second timeout
-6. Structured logging -- emits `vad_ms`, `inference_ms`, `paste_ms`, `total_ms`, `audio_secs`, `word_count`, `char_count`, `model`, `backend` as tracing fields
+Global modifier hotkeys recover when macOS disables the underlying event tap, and the hot path performs no main-thread key-name translation and ignores mouse movement.
 
-**`cancel_native_recording`**: Transitions Recording -> Idle without transcription. Used by "both" mode to discard speculative recordings from short taps.
+### `injector.rs` — Text Injection
 
-**Minimum recording threshold**: Recordings shorter than 0.3 seconds (4,800 samples at 16kHz) are silently discarded as phantom triggers.
+1. **Clipboard** (always): `arboard`. Empty/whitespace-only text is skipped.
+2. **Auto-paste** (optional): waits the configured delay, then posts a native `CGEvent` Cmd+V key-down/key-up pair to `CGEventTapLocation::HID`. If the native path fails, it falls back to `osascript`. Retries once on failure; the whole operation is timeout-bounded. On failure, `auto-paste-failed` is emitted and the text stays on the clipboard.
 
-### `commands/overlay.rs` -- Notch Overlay
+Focused-field role checks use native AX with a per-element messaging timeout and an osascript fallback, so a hung app can't stall the pipeline.
 
-- `detect_notch_info()`: reads `NSScreen.mainScreen().safeAreaInsets()` via `objc2`; uses `auxiliaryTopLeftArea` + `auxiliaryTopRightArea` to compute notch width. Main-thread only. Returns `None` when no notch is present; fallback dimensions come from `geometry_for()`.
-- `raise_window_above_menubar()`: sets NSWindow level to **25** (NSMainMenuWindowLevel = 24). Calls private API `_setPreventsActivation(true)` to prevent focus-stealing on click; guarded with `respondsToSelector()` for forward compatibility.
-- `register_screen_change_observer()`: subscribes to `NSApplicationDidChangeScreenParametersNotification` -- repositions overlay automatically when displays are plugged/unplugged or lid opens. Emits `overlay-geometry-changed` (the recomputed `OverlayGeometry`) to frontend. Observer intentionally leaked (app lifetime).
-- Every overlay dimension comes from one source, `geometry_for(notch)` in `commands/overlay.rs`, which returns an `OverlayGeometry`; the frontend only reads it (`get_overlay_geometry`, `overlay-geometry-changed`) and never hardcodes pixels. See [docs/features/overlay.md](features/overlay.md) for the full geometry contract and the hover-expand lifecycle. Mouse events are explicitly re-enabled (`setIgnoreCursorEvents(false)`) because `focusable:false` disables them on macOS.
-
-### `commands/tray.rs` -- Tray Icon
-
-- Static 66x66 RGBA icon (3x resolution for 22pt Retina menu bar) showing 5 vertical capsule bars in an equalizer style, rendered as white with anti-aliased edges
-- `update_tray_icon` is a registered no-op command -- the tray icon is always static white. Command kept to avoid breaking the registered handler
-- Tray menu: "Show Murmur" (shows and focuses main window) and "Quit Murmur" (exits app). Left-click on tray icon also shows the main window
-
-### `commands/models.rs` -- Model Downloads
-
-- `check_model_exists`: checks whether a model exists for the configured backend
-- `check_specific_model_exists`: verifies a named model exists on disk. Includes path traversal protection (rejects `..`, `/`, `\` in model names)
-- `download_model`: streaming download with progress events. Whisper models download as single `.bin` files from Hugging Face
-- **VAD model co-download**: when downloading any transcription model, the Silero VAD model (`ggml-silero-v5.1.2.bin`, ~1.8MB) is automatically co-downloaded if not already present. VAD download failure is non-fatal
-- **Lazy VAD download**: `ensure_vad_model` is a fallback for users who upgrade from a pre-VAD version. If the VAD model is missing at transcription time, a silent background download is kicked off for next time (no UI side effects)
-- All downloads use a temp-file-then-rename pattern for atomicity. Partial downloads never appear as valid models
-
-### `telemetry.rs` -- Structured Event System
-
-Replaces the former `logging.rs`. All application logging goes through `tracing` with two output layers:
+### `telemetry.rs` — Structured Events
 
 ```text
 tracing event
     |
-    +--> Pretty-printed text file (app.log / app.dev.log) via tracing_appender
+    +--> Pretty text file (app.log / app.dev.log)
     |
     +--> TauriEmitterLayer
              |
-             +--> In-memory ring buffer (500 events, FIFO eviction)
-             |
-             +--> JSONL file (events.jsonl / events.dev.jsonl)
-             |
-             +--> 'app-event' emission to all frontend windows
+             +--> Ring buffer (500 events, FIFO)
+             +--> JSONL file (events.jsonl / events.dev.jsonl, rotated at 5 MB)
+             +--> 'app-event' emitted to all windows
 ```
 
-**TauriEmitterLayer**: A custom `tracing_subscriber::Layer` that intercepts all tracing events and:
-1. Collects fields via `JsonVisitor` into serde_json values
-2. Builds an `AppEvent` struct (timestamp, stream/target, level, summary/message, data/fields)
-3. Pushes to ring buffer (capped at 500, evicts oldest)
-4. Writes as JSONL line to persistent file
-5. Emits `app-event` to all Tauri windows
+Five streams (tracing targets): `pipeline`, `audio`, `keyboard`, `transform`, `system`.
 
-**Tracing targets (streams)**: `pipeline`, `audio`, `system`, `keyboard`.
+**Privacy stripping.** In release builds, all string fields on `pipeline` events are removed from the data object; only numerics survive. `transform` events are stricter still and stripped in *all* builds: every string key **and** value must appear in an explicit stable vocabulary of enum values, stage names, error codes, and bucket labels. Anything else is dropped at the layer, independent of the call site — so a careless log statement cannot leak selected text, instructions, proposals, paths, or bundle IDs.
 
-**Privacy stripping**: In release builds, all string fields from `pipeline` target events are stripped from the data object. Only numeric fields survive. The summary (message) is not stripped.
+### Local storage
 
-**JSONL rotation**: File is rotated (renamed to `.jsonl.1`) when it exceeds 5MB.
+Two SQLite databases, both local-only:
 
-**Buffer seeding**: On startup, the ring buffer is pre-populated with up to 500 events from the existing JSONL file.
+| Store | File | Retention |
+|-------|------|-----------|
+| Personal knowledge | `knowledge/knowledge.sqlite3` | User-managed; versioned migrations, backups, quarantine on corruption |
+| Performance diagnostics | `diagnostics/performance.sqlite3` | 200 completed runs, 600 resource samples, 8 follow-ups per run |
 
-**Log files**: Separate filenames for dev (`app.dev.log`, `events.dev.jsonl`) vs release builds.
-
-**Frontend logging**: The `log_frontend` command routes frontend log messages through the Rust tracing system at INFO/WARN/ERROR levels with `source="frontend"`.
-
-### `resource_monitor.rs` -- System Resource Monitoring
-
-- Reports CPU usage percentage and used memory (MB) via `sysinfo` crate
-- Uses a persistent `System` instance stored in a `static Mutex<Option<System>>`, initialized on first call
-- First call returns ~0% CPU (baseline measurement behavior of sysinfo)
-- Polled every 1 second by the frontend when the resource panel is expanded
+Transform diagnostic captures (explicitly consented, content-bearing) live under `diagnostics/transforms/transform-captures/` in a `0700` directory with `0600` files: max 3 retained, 7-day expiry, symlink targets refused, no export path.
 
 ---
 
 ## Frontend (`app/src/`)
 
-### `App.tsx` -- Main Orchestrator
+`App.tsx` is a thin orchestrator that wires hooks together. All recording-mode hooks are always called (Rules of Hooks) and gated by an `enabled` prop:
 
-Wires all hooks together. Key state:
-- `modelReady` -- null (checking) | false (needs download) | true (ready)
-- `initialized` -- backend init complete
-- `accessibilityGranted` -- macOS Accessibility permission
-- `status` -- `'idle' | 'recording' | 'processing'`
-
-**Dual-mode hook pattern** -- all three hooks always called (Rules of Hooks); gated by `enabled`:
 ```tsx
 useHoldDownToggle({ enabled: settings.recordingMode === 'hold_down', ... });
 useDoubleTapToggle({ enabled: settings.recordingMode === 'double_tap', ... });
 useCombinedToggle({ enabled: settings.recordingMode === 'both', ... });
 ```
 
-### Key Hooks
+See [reference/hooks.md](reference/hooks.md) for the full hook inventory.
 
-| Hook | Responsibility |
-|------|---------------|
-| `useRecordingState` | Recording/transcription state machine, event listeners, audio level tracking, locked mode, stats integration |
-| `useHoldDownToggle` | Hold-down mode (rdev press/release events), error recovery + auto-restart |
-| `useDoubleTapToggle` | Double-tap mode (rdev events), syncs `recording` state to backend |
-| `useCombinedToggle` | Both modes; `holdActiveRef` prevents double-tap firing on hold release. Calls `cancel_native_recording` for speculative recording discard |
-| `useSettings` | localStorage persistence, OS autostart sync, backend configuration pushes |
-| `useAutoUpdater` | OTA updates, min-version enforcement, semver comparison, forced updates, macOS notifications |
-| `useInitialization` | One-time init sequence (initDictation + configure) on mount |
-| `useHistoryManagement` | Transcription history array with localStorage persistence (max 50 entries) |
-| `useEventStore` | Structured event log buffer: backend hydration, live `app-event` streaming, batched rendering via rAF, filter/clear |
-| `useResourceMonitor` | CPU/memory polling every 1 second, rolling 60-reading buffer |
-| `useShowAboutListener` | Listens for `show-about` tray event, manages about modal state |
+Two rules keep the multi-window state coherent:
 
-**`transcription-complete` as single source of truth** -- history entries are added *only* via the Rust event, never in `handleStop()`. Prevents duplicates when the overlay initiates recording independently.
-
-**Ref-based state in callbacks** -- `statusRef` stays in sync with `status` state so hotkey callbacks always read current status without stale closure captures. Callbacks stored in refs prevent listener setup from re-running on identity changes.
-
-### `lib/settings.ts` -- Settings & Model Configuration
-
-```typescript
-interface Settings {
-    model: ModelOption;         // default: 'base.en'
-    doubleTapKey: DoubleTapKey; // default: 'shift_l'
-    language: string;           // default: 'en'
-    autoPaste: boolean;         // default: false
-    autoPasteDelayMs: number;   // default: 50 (range: 10-500)
-    recordingMode: RecordingMode; // default: 'hold_down'
-    microphone: string;         // default: 'system_default'
-    launchAtLogin: boolean;     // default: false
-    vadSensitivity: number;     // default: 50 (range: 0-100)
-}
-```
-
-Settings persisted to localStorage under key `"dictation-settings"`. Migration handles legacy `hotkey` recording mode -> `hold_down`.
-
-### `lib/stats.ts` -- Usage Metrics
-
-Persisted to localStorage:
-- `totalWords`, `totalRecordings`, `totalDurationSeconds`
-- `wpmSamples: number[]` -- rolling 100-sample history (outlier-resistant)
-- Approx tokens = `totalWords * 1.3`
-
-### `lib/events.ts` -- Event System Types
-
-```typescript
-interface AppEvent {
-    timestamp: string;
-    stream: StreamName;   // 'pipeline' | 'audio' | 'keyboard' | 'system'
-    level: LevelName;     // 'trace' | 'debug' | 'info' | 'warn' | 'error'
-    summary: string;
-    data: Record<string, unknown>;
-}
-```
-
-Color constants map each stream and level to Tailwind classes (bg, text, dot) for the log viewer UI.
-
-### `OverlayWidget.tsx` -- Notch Widget
-
-Rendered in the overlay window, always-on-top, transparent, no decorations. `OverlayWidget.tsx` itself is a thin composition shell (~150 lines) that wires together the geometry contract, the expansion controller, and four extracted hooks, then renders two presentational components. See [docs/features/overlay.md](features/overlay.md) for the full architecture; summary:
-
-- **Three visual states**: Idle (small mic icon, dimmed), Recording (expanded, red pulsing dot + animated waveform), Processing (expanded, spinning circle + dimmed waveform) -- derived by the pure `deriveVisual()` (`components/overlay/deriveVisual.ts`)
-- **7-bar waveform** (`lib/hooks/useWaveform.ts`), driven by `requestAnimationFrame` + direct DOM refs -- bypasses React reconciliation for 60fps. Center bars are taller (envelope shaping), random jitter for organic feel
-- Spring-like expand/collapse transition (`cubic-bezier(0.34, 1.56, 0.64, 1)`, width 400ms / height 360ms -- see `lib/overlayMotion.ts`), owned end to end by `lib/hooks/useOverlayExpansion.ts`
-- Single click: stop recording (250ms debounce). Double-click: toggle locked mode (keeps recording across single clicks) -- `lib/hooks/useRecordingControls.ts`
-- Reads settings via the validated `loadSettings()` API (localStorage; no Tauri IPC needed) -- `lib/hooks/useOverlaySettingsMirror.ts`
-
-### Log Viewer (`components/log-viewer/`)
-
-**Events tab**:
-- Stream filter chips -- toggle which event streams to show (default active: `pipeline`, `audio`, `system`)
-- Level filter -- toggle info/warn/error visibility
-- Event list with auto-scroll (disengages on manual scroll up, re-engages within 40px of bottom)
-- Expandable rows: timestamp, colored stream chip, level label, summary text. Click to reveal JSON data
-- Copy All and Clear buttons
-
-**Metrics tab**:
-- Extracts transcription timing from pipeline events where `summary === 'transcription complete'`
-- Last 20 transcriptions displayed
-- Four toggleable series: Total, Inference, VAD, Paste
-- Stat cards with latest value, average, trend indicator (up/down/flat, 10% threshold)
-- Two SVG line charts: Total + Inference (upper, 150px), VAD + Paste (lower, 120px)
-- Auto-scaled Y-axis with round tick marks
-
-### Resource Monitor
-
-- Collapsible panel in the main window; collapse state persisted to localStorage
-- Header always shows current CPU% and memory MB
-- Expanded view: SVG polyline chart with CPU and memory lines, grid at 25/50/75%, legend
-- Only polls when expanded (performance optimization)
-- Rolling window of 60 readings (1 minute of data)
+- **`transcription-complete` is the single source of truth** for history and stats. Entries are added only from the Rust event, never in `handleStop()` — otherwise an overlay-initiated recording double-counts.
+- **The overlay reads settings from localStorage directly** (`useOverlaySettingsMirror`), not through React context or IPC. There is no shared context across windows.
 
 ---
 
-## Tauri Commands (30)
+## Tauri Commands
 
-| Module | Command | Description |
-|--------|---------|-------------|
-| recording | `init_dictation` | Returns initialized/idle response (no-op marker) |
-| recording | `process_audio` | Accepts base64-encoded WAV, runs full pipeline |
-| recording | `get_status` | Returns status, model name, language |
-| recording | `configure_dictation` | Updates model, language, autoPaste, autoPasteDelayMs, vadSensitivity |
-| recording | `start_native_recording` | Begins cpal audio capture; Idle -> Recording |
-| recording | `stop_native_recording` | Stops capture, runs VAD + transcription + injection pipeline |
-| recording | `cancel_native_recording` | Discards recording without transcribing (speculative hold-down) |
-| permissions | `open_system_preferences` | Opens macOS System Settings to Microphone pane |
-| permissions | `check_accessibility_permission` | Returns boolean for Accessibility status |
-| permissions | `request_accessibility_permission` | Triggers Accessibility prompt + opens Settings |
-| permissions | `request_microphone_permission` | Opens Microphone privacy pane |
-| permissions | `list_audio_devices` | Returns Vec of input device names |
-| keyboard | `start_keyboard_listener` | Starts rdev listener with hotkey and mode |
-| keyboard | `stop_keyboard_listener` | Stops processing keyboard events (thread stays alive) |
-| keyboard | `update_keyboard_key` | Changes hotkey at runtime; emits stop if held |
-| keyboard | `set_keyboard_recording` | Syncs recording state to double-tap detector |
-| logging | `get_log_contents` | Returns last N lines of pretty-printed log file |
-| logging | `clear_logs` | Deletes all log files + clears event ring buffer |
-| logging | `log_frontend` | Routes frontend message through Rust tracing |
-| logging | `open_log_viewer` | Shows and focuses the log-viewer window |
-| models | `check_model_exists` | Checks if any model exists (either backend) |
-| models | `check_specific_model_exists` | Checks named model on disk (path traversal protected) |
-| models | `download_model` | Streaming download + VAD co-download |
-| tray | `update_tray_icon` | No-op (static white icon). Kept for API compat |
-| overlay | `show_overlay` | Positions and shows the overlay window |
-| overlay | `hide_overlay` | Hides the overlay window |
-| overlay | `get_overlay_geometry` | Returns the current `OverlayGeometry` contract (never null) |
-| overlay | `set_overlay_expanded` | Resizes between the collapsed and expanded frames; returns the applied frame as a resize ack |
-| overlay | `show_main_window` | Shows and focuses the main window (used by the overlay's gear button) |
-| telemetry | `get_event_history` | Returns ring buffer (up to 500 events) |
-| telemetry | `clear_event_history` | Clears the event ring buffer |
-| resource_monitor | `get_resource_usage` | Returns CPU% and memory MB |
+105 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
 
----
+## Events
 
-## Events (Rust -> Frontend)
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| `audio-level` | f32 (RMS 0.0-1.0) | Real-time audio level during recording, ~60fps |
-| `recording-status-changed` | String | Status transitions: `"idle"`, `"recording"`, `"processing"` |
-| `transcription-complete` | `{text, duration}` | Broadcast to all windows after non-empty transcription |
-| `auto-paste-failed` | String (hint) | Paste failed; text is in clipboard |
-| `download-progress` | `{received, total}` | Streaming download progress (bytes) |
-| `double-tap-toggle` | `()` | Double-tap detected |
-| `hold-down-start` | `()` | Hold key pressed (or promoted in both mode) |
-| `hold-down-stop` | `()` | Hold key released |
-| `keyboard-listener-error` | String | rdev thread error; frontend retries after 2s |
-| `overlay-geometry-changed` | `OverlayGeometry` (never null) | Display config changed; carries the recomputed geometry contract |
-| `overlay-visible-changed` | Boolean | Overlay shown/hidden (no production emitter today — see events.md) |
-| `app-event` | `AppEvent` | Every tracing event, powers log viewer |
-| `show-about` | `()` | Tray menu "About" click |
+See [reference/events.md](reference/events.md) for every Rust → frontend event, its payload, and its listeners.
 
 ---
 
@@ -490,61 +324,60 @@ Rendered in the overlay window, always-on-top, transparent, no decorations. `Ove
 
 | Permission | Required For |
 |-----------|-------------|
-| Microphone | Audio capture (always required) |
-| Accessibility | Global hotkeys (rdev), auto-paste (osascript) |
+| Microphone | Audio capture — dictation and transform instructions |
+| Accessibility | Global hotkeys (rdev), auto-paste, AX selection capture, AX write-back |
 
-Accessibility is checked via `AXIsProcessTrusted()` FFI. If not granted, a system prompt is triggered via `AXIsProcessTrustedWithOptions()` with `kAXTrustedCheckOptionPrompt`.
+Accessibility is checked via `AXIsProcessTrusted()`; the prompt is triggered with `AXIsProcessTrustedWithOptions()`. Microphone access can be requested in-app via `AVCaptureDevice.requestAccess`. Both have reset paths for stale TCC entries.
 
 ---
 
-## Data Directory
+## Data Directories
 
-All models, logs, and event data are stored under:
+Murmur uses two roots — a legacy one from before the rename, and the Tauri app-data root:
+
 ```text
 ~/Library/Application Support/local-dictation/
+├── models/                    # whisper .bin files, Silero VAD, sherpa-onnx bundle
+│   └── transform-llm/<sha256>/qwen2.5-1.5b-instruct-q4_k_m.gguf
+└── logs/                      # app.log, events.jsonl (+ .dev variants)
+
+~/Library/Application Support/com.localdictation/        (com.localdictation.dev in dev)
+├── knowledge/                 # knowledge.sqlite3, backups/, quarantine/
+└── diagnostics/               # performance.sqlite3, transforms/
 ```
 
-This is a legacy name from before the app was renamed to Murmur. Contents:
-- `models/` -- Whisper GGML `.bin` files, Silero VAD model
-- `logs/` -- `app.log` / `app.dev.log` (pretty-printed), `events.jsonl` / `events.dev.jsonl` (structured)
+Core ML models are managed by FluidAudio under `~/Library/Application Support/FluidAudio/Models/`.
 
 ---
 
 ## Build & Release
 
-### Dev Configuration
+### Dev
 
 ```bash
-cd app && npm run tauri dev        # Dev with hot reload
-cd app && npm run tauri build      # Production .app and .dmg
-cd app/src-tauri && cargo test -- --test-threads=1  # Rust tests (single-threaded)
-cd app && npx tsc --noEmit         # TypeScript check
+python3 scripts/build_local_llm_sidecar.py   # once, before anything else on macOS
+cd app && npm install
+cd app && npm run tauri dev                  # hot reload
+cd app && npm run tauri build                # .app and .dmg
+cd app/src-tauri && cargo test -- --test-threads=1
+cd app && npx tsc --noEmit && npm test
 ```
 
-`tauri.dev.conf.json` overrides only two fields from production config: `identifier` -> `"com.localdictation.dev"` and `productName` -> `"Local Dictation Dev"`. This ensures the dev build installs as a separate app.
+`tauri.macos.conf.json` declares the `murmur-llm-sidecar` externalBin, so on macOS both `tauri dev` and `cargo check`/`cargo test` fail on a fresh clone until that binary exists. The build script produces a real helper on arm64 macOS and is a no-op elsewhere. See [DEVELOPMENT.md](DEVELOPMENT.md).
 
-### Release Pipeline
+`tauri.dev.conf.json` overrides only `identifier` → `com.localdictation.dev` and `productName` → `Local Dictation Dev`, so dev installs alongside the release build.
 
-1. Push the `chore: bump version ...` commit to trusted `main`.
-2. `Release Build` runs frontend verification, macOS signing/notarization, and
-   Linux CUDA packaging concurrently, including package launch smoke tests.
-3. The successful build stores macOS and Linux artifacts plus SHA-256
-   provenance under names keyed by the exact commit SHA.
-4. The completed-build event verifies the trusted push, version-bump message,
-   matching versions, exact run ID, source SHA, and immutable artifacts.
-5. Promotion creates `vX.Y.Z` at that commit, verifies the remote `.sig` files,
-   generates `latest-v2.json` and the legacy-safe `latest.json`, then publishes.
+### Release pipeline
 
-Manual build dispatches are rehearsal-only, and the tag trigger remains a
-recovery path protected by the same validation chain.
+1. Push a `chore: bump version ...` commit to trusted `main`.
+2. `Release Build` runs frontend verification, macOS signing/notarization (including the sidecar's split entitlements), and Linux packaging concurrently, with launch smoke tests.
+3. Artifacts plus SHA-256 provenance are stored under names keyed by the exact commit SHA.
+4. The completed-build event verifies the trusted push, version-bump message, matching versions, exact run ID, source SHA, and immutable artifacts.
+5. Promotion creates `vX.Y.Z`, verifies remote `.sig` files, generates `latest-v2.json` plus the legacy-safe `latest.json`, then publishes.
 
-Tag workflows never build or save Cargo/CUDA caches. See
-[`docs/release.md`](release.md) for trust boundaries, rehearsals, cache policy,
-and the supported cold fallback.
+Release finalization **fails closed** on any unexpected executable in the bundle: only the Murmur binary and the signed sidecar may ship (#324). Manual dispatches are rehearsal-only. See [release.md](release.md).
 
-**Auto-updater**: New builds check the dual-platform `latest-v2.json`; legacy `latest.json` routes old Macs through the signed, macOS 13-compatible v0.14.1 bridge before they receive the macOS 14 build. Updates are signed (ed25519). Min-version enforcement removes "Skip"/"Later" for required updates.
-
-### Release Profile
+### Release profile
 
 ```toml
 [profile.release]
@@ -552,23 +385,26 @@ panic = "abort"
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = false # retain Tauri's updater bundle-type marker
+strip = false   # retain Tauri's updater bundle-type marker
 ```
 
 ---
 
 ## Thread Model
 
-The app uses at least 4 persistent background threads plus short-lived workers:
-
-| Thread | Lifetime | Purpose |
+| Thread / task | Lifetime | Purpose |
 |--------|----------|---------|
-| rdev keyboard listener | App lifetime (spawned once) | Global key event loop |
-| Keyboard heartbeat | App lifetime | Trace-level heartbeat every 60s |
-| Audio capture | Per-recording session | cpal stream + mono mix |
-| Hold-promotion timer | Per key press (both mode) | 200ms sleep, atomic check |
+| rdev keyboard listener | App lifetime | Global key event loop for all three detectors |
+| Keyboard heartbeat | App lifetime | Trace-level liveness check every 60s |
+| Resource heartbeat (tokio) | App lifetime | 1s CPU/RSS sample → diagnostics; idle-timeout enforcement |
+| Sidecar maintenance (tokio) | App lifetime | 30s tick: RSS ceiling + idle unload |
+| `murmur-llm-sidecar` process | On demand | Out-of-process llama.cpp; killed on idle, fault, or app exit |
+| Sidecar reader thread | Per spawn | Reads the helper's protocol stream |
+| Audio capture | Per recording | cpal stream + mono mix |
+| Hold-promotion timer | Per key press (both mode) | 200ms sleep, atomic validity check |
+| Model preparation | Per recording start / model change | Warms the backend concurrently with speech |
 
-Plus Tokio async tasks for VAD (`spawn_blocking`), downloads, and text injection dispatch.
+Plus tokio `spawn_blocking` for VAD (its context is `!Send`), downloads, and injection dispatch.
 
 ---
 
@@ -576,19 +412,22 @@ Plus Tokio async tasks for VAD (`spawn_blocking`), downloads, and text injection
 
 | Decision | Rationale |
 |----------|-----------|
-| Pure Rust backend | No Python subprocess; faster startup, smaller bundle, no dependency hell |
-| Pluggable `TranscriptionBackend` trait | Clean abstraction for future backends; same pipeline code |
-| Lazy model loading + WhisperState caching | Fast app startup; GPU buffers allocated once, reused across transcriptions |
-| VAD pre-filtering | Prevents Whisper hallucination loops on silence; skips unnecessary inference |
-| Clipboard-first injection | Reliable across all apps; auto-paste layered on top |
-| osascript for auto-paste | `engio` and rdev simulate broke on Sonoma/Sequoia |
-| Single rdev thread, two detectors | Avoids multiple listeners; both detectors share one event stream |
-| `set_is_main_thread(false)` | Prevents TIS/TSM segfault on background rdev thread |
-| `MutexExt::lock_or_recover()` | Survives panics; no stuck UI state |
-| `IdleGuard` RAII | Guarantees status reset on any error path in the transcription pipeline |
-| Atomic timer invalidation (Both mode) | Stale hold-timers can't fire after key is released and re-pressed |
-| `_setPreventsActivation` + `respondsToSelector` | Overlay never steals focus; forward-compatible with future macOS |
-| tracing-based telemetry | Unified observability: every backend event captured, persisted, and streamed to frontend |
-| Privacy stripping in release builds | Pipeline string fields stripped from structured events; only numerics survive |
-| Three-window least-privilege | Overlay gets minimal permissions; log viewer gets event-only access; main window gets full permissions |
-| VAD co-download | Silero model bundled with transcription model downloads; lazy fallback for pre-VAD upgrades |
+| Out-of-process LLM sidecar | llama.cpp's ggml ABI clashes with whisper's; isolation also gives per-process RSS ceilings, a kill switch, and a smaller signed attack surface |
+| Model handed to the helper as fd 3 | The helper takes no paths and needs no filesystem reach; pinning is enforced host-side by size + SHA-256 |
+| One model catalog, fail-closed | Unknown identifiers error instead of silently substituting a model with different accuracy/latency |
+| Warm-on-record | Model load overlaps with speech instead of being charged to the user after key release |
+| Generation counters everywhere | A delayed continuation can observe that it lost ownership rather than corrupting the pass that replaced it |
+| Immutable per-recording context | Settings or focus changes mid-utterance can't reinterpret a recording already in flight |
+| Review-first transform | The LLM never writes into another app without explicit approval; Undo restores the frozen original |
+| Secure-field fail-closed | An *errored* AX secure-field check is treated as "possibly a password field" — no read, no clipboard fallback |
+| Transform telemetry allow-list | String keys and values must be in a stable vocabulary; leakage is prevented at the layer, not at the call site |
+| Ordered transcript pipeline | One entry point, declared stage order and failure policy, per-stage timing — instead of ad-hoc string munging per backend |
+| Rust owns all window geometry | Pure `geometry_for()` / `popover_geometry_for()` with fixtures on both sides; no drifting CSS pixel constants |
+| Main-thread `NSWindow` mutation | macOS 26 hard-traps on off-main mutation (#325) |
+| CGEvent paste with osascript fallback | Native path avoids process spawn; osascript remains the compatibility net |
+| Custom malloc zone | Separates Rust heap from whisper.cpp's FFI heap; `GlobalAlloc` wrappers drift when FFI frees Rust allocations |
+| `set_is_main_thread(false)` | Prevents the rdev TIS/TSM segfault on the background listener thread |
+| `MutexExt::lock_or_recover()` | Survives a panic while a lock is held; no stuck UI state |
+| `IdleGuard` RAII | Guarantees status reset on every error path in the pipeline |
+| Clipboard-first delivery | Reliable across all apps; auto-paste is layered on top and never the only path |
+| Per-window least privilege | Overlay and transform popover get minimal capabilities; only the main window gets the full set |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,102 +2,183 @@
 
 ## Prerequisites
 
-- macOS 14+ on Apple Silicon
+- macOS 14+ on Apple Silicon (Core ML/ANE and the local-LLM sidecar are Apple Silicon only)
 - Node.js 18+
 - Rust (install via rustup)
+- Python 3 (for the sidecar and packaging scripts)
 
 ## Setup
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/georgenijo/murmur-app.git
-   cd murmur-app
-   ```
+```bash
+git clone https://github.com/georgenijo/murmur-app.git
+cd murmur-app
 
-2. Install Node dependencies:
-   ```bash
-   cd app
-   npm install
-   ```
+# 1. Build the local-LLM sidecar FIRST (macOS only — no-op elsewhere)
+python3 scripts/build_local_llm_sidecar.py
 
-3. Download a Whisper model (if not already present):
-   ```bash
-   mkdir -p ~/Library/Application\ Support/local-dictation/models
-   # Download from https://huggingface.co/ggerganov/whisper.cpp
-   # Place ggml-base.en.bin (or other model) in the models folder
-   ```
+# 2. Install Node dependencies
+cd app && npm install
 
-4. Run in development mode:
-   ```bash
-   cd app
-   npm run tauri dev
-   ```
+# 3. Run
+npm run tauri dev
+```
+
+> **Step 1 is not optional on macOS.** `tauri.macos.conf.json` declares the
+> `murmur-llm-sidecar` externalBin, so `tauri dev`, `tauri build`, **and even
+> `cargo check` / `cargo test`** fail on a fresh clone until the binary exists at
+> `app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. The binary is
+> gitignored; release CI builds it before bundling. If you only need the Rust
+> crate to compile, a stub file at that path is enough.
+
+A transcription model is downloaded through the app's first-launch setup
+assistant — you do not need to place model files by hand. The pinned transform
+LLM is a separate, optional download from **Settings → Transform**.
+
+## Commands
+
+```bash
+# Dev
+cd app && npm run tauri dev        # full app, hot reload
+cd app && npm run dev              # frontend only (no Rust backend)
+cd app && npm run tauri build      # production .app and .dmg
+
+# Tests
+cd app/src-tauri && cargo test -- --test-threads=1   # Rust (timing-sensitive; keep single-threaded)
+cd app && npm test                                   # frontend vitest
+cd app && npx tsc --noEmit                           # TypeScript
+```
+
+CI runs `cargo check`, `cargo test`, `npx tsc --noEmit`, **and** `npm test` on
+every push to main and on PRs. A tsc-only check is not sufficient verification —
+several regressions have shipped past it.
+
+Model-backed integration tests are opt-in so CI never downloads hundreds of
+megabytes:
+
+```bash
+cd app/src-tauri && cargo test --test transcription_integration -- --test-threads=1
+cd app/src-tauri && MURMUR_COREML_TEST_WAV=/path/to/16khz-mono.wav \
+    cargo test --test coreml_transcription_integration -- --ignored
+```
 
 ## macOS Permissions
 
-Grant these permissions to your terminal app (e.g., Ghostty, iTerm, Terminal):
+Murmur needs **Microphone** and **Accessibility**. Which process needs them
+depends on how you are running it:
 
-1. **System Settings → Privacy & Security → Microphone** - Add your terminal
-2. **System Settings → Privacy & Security → Accessibility** - Add your terminal
-
-After granting permissions, restart the dev server.
+- **`npm run tauri dev`** — grant them to your *terminal app* (Ghostty, iTerm,
+  Terminal). Dev builds are re-signed on every rebuild, so granting the dev
+  binary itself is futile. Restart the dev server after granting.
+- **A built `.app`** — grant them to the app itself.
 
 ## Project Structure
 
-```
+```text
 murmur-app/
-├── app/                    # Tauri desktop app
-│   ├── src/                # React frontend
-│   │   ├── components/     # UI components
-│   │   ├── lib/           # Utilities
-│   │   └── App.tsx        # Main component
-│   └── src-tauri/         # Rust backend
-│       ├── src/
-│       │   ├── lib.rs     # Tauri commands
-│       │   ├── audio.rs   # Audio capture
-│       │   ├── transcriber.rs
-│       │   ├── injector.rs
-│       │   └── state.rs
-│       └── Cargo.toml
-└── docs/                   # Documentation
+├── app/
+│   ├── src/                     # React frontend
+│   │   ├── components/          # UI (settings, overlay, log-viewer, transform-review, …)
+│   │   └── lib/                 # hooks, settings, pure logic
+│   └── src-tauri/
+│       ├── src/                 # Rust backend (see docs/ARCHITECTURE.md for the module map)
+│       ├── sidecars/local-llm/  # the signed murmur-llm-sidecar crate
+│       ├── crates/              # local-llm-protocol
+│       ├── binaries/            # built sidecar (gitignored)
+│       └── tests/               # integration tests
+├── bench/                       # benchmark audio fixtures
+├── docs/                        # architecture, features, references, decisions
+├── prompts/                     # agent prompt files (work / chat / release / bug / swarm)
+├── scripts/                     # sidecar build, notarization, release artifacts
+├── tests/                       # release-artifact and workflow-policy tests (Python)
+└── tools/murmur-diag/           # local MCP log-diagnostics tool
 ```
 
 ## Building for Production
 
 ```bash
-cd app
-npm run tauri build
+cd app && npm run tauri build
 ```
 
 Output:
-- `app/src-tauri/target/release/bundle/macos/Local Dictation.app`
-- `app/src-tauri/target/release/bundle/dmg/Local Dictation_x.x.x_aarch64.dmg`
+- `app/src-tauri/target/release/bundle/macos/Murmur.app`
+- `app/src-tauri/target/release/bundle/dmg/Murmur_x.x.x_aarch64.dmg`
 
-## Viewing Logs
+The `build` shell function installs the result into `/Applications` and resets
+the stale Accessibility grant for you (see below).
 
-During development, check the terminal running `npm run tauri dev` for Rust println! output.
+## Logs
+
+Both build flavors write to `~/Library/Application Support/local-dictation/logs/`:
+
+| File | Build |
+|------|-------|
+| `app.log` / `events.jsonl` | release |
+| `app.dev.log` / `events.dev.jsonl` | dev |
+
+Structured JSONL rotates at 5 MB. In-app: **Settings → General → View Logs**, or
+the Log Viewer window. See [features/log-viewer.md](features/log-viewer.md) and
+[`tools/murmur-diag/README.md`](../tools/murmur-diag/README.md).
 
 ## Common Issues
 
-### Permission Popup Every Rebuild
-Dev builds have different signatures each time. Grant Accessibility permission to your terminal app instead of the dev build.
+### Sidecar binary not found
 
-### Accessibility Silently Broken After Local Production Build
-When you build and copy a new `.app` to `/Applications`, macOS carries over the old accessibility permission but it's stale — the new binary has a different code signature so the permission doesn't actually apply. Microphone carries over fine, but anything keyboard-related (double-tap, auto-paste) silently fails.
+```
+failed to bundle project: `murmur-llm-sidecar-aarch64-apple-darwin` not found
+```
 
-Use the `build` shell function which handles this automatically, or reset manually:
+Run `python3 scripts/build_local_llm_sidecar.py`. This also breaks plain
+`cargo check`/`cargo test`, because Tauri's build script validates externalBin
+entries.
+
+### Permission prompt on every rebuild
+
+Dev builds get a different signature each time. Grant Accessibility to your
+terminal app instead of the dev binary.
+
+### Accessibility silently broken after a local production build
+
+When you copy a freshly built `.app` over the old one, macOS keeps the old
+Accessibility entry — but it is stale, because the new binary has a different
+signature. Microphone carries over fine; anything keyboard-related (double-tap,
+auto-paste, transform hold key) silently fails.
+
 ```bash
 tccutil reset Accessibility com.localdictation
 ```
 
-### "No input device available"
-Grant Microphone permission to your terminal app, then restart the dev server.
+The `build` shell function does this automatically. **Note:** the
+Accessibility-denied banner cannot be reproduced under `tauri dev` — you need a
+built `.app` to exercise that path.
 
-### Model Not Found
-Ensure a Whisper model exists in one of these locations (checked in order):
-- `WHISPER_MODEL_DIR` environment variable (recommended)
-- `~/Library/Application Support/local-dictation/models/`
-- `~/Library/Application Support/pywhispercpp/models/`
-- `~/.cache/whisper.cpp/`
-- `~/.cache/whisper/`
-- `~/.whisper/models/`
+### "No input device available"
+
+Grant Microphone to your terminal app, then restart the dev server.
+
+### Transform crashes / popover misbehaves only in a real build
+
+The transform popover's `NSWindow` treatment is raw AppKit and must run on the
+main thread. `?mock=1` and `tauri dev` do not exercise that path — press the real
+transform hold key on a built `.app` to smoke-test it (this is what reproduced
+[#325](https://github.com/georgenijo/murmur-app/issues/325) immediately).
+
+### Model not found
+
+Use the in-app setup assistant. If you are placing files manually, Whisper
+`.bin` models are searched in this order:
+
+1. `$WHISPER_MODEL_DIR`
+2. `~/Library/Application Support/local-dictation/models/`
+3. `~/Library/Application Support/pywhispercpp/models/`
+4. `~/.cache/whisper.cpp/`
+5. `~/.cache/whisper/`
+6. `~/.whisper/models/`
+
+Core ML models are managed by FluidAudio under
+`~/Library/Application Support/FluidAudio/Models/`.
+
+## Release
+
+Releases are tag-based off a trusted `main` version-bump commit, with signed and
+notarized artifacts promoted only when the commit SHA, run ID, and artifact
+hashes all match. See [release.md](release.md).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,200 +1,185 @@
-## Murmur v0.8.0 — Feature Map
+# Murmur — Feature Map
 
-### Core: Voice-to-Text
-- Record voice, transcribe locally, output text to clipboard
-- Whisper transcription backend (Metal GPU via whisper-rs)
-- 5 models: tiny.en (~75 MB), base.en (~150 MB), small.en (~500 MB), medium.en (~1.5 GB), large-v3-turbo (~3 GB)
-- Default model: base.en
-- Greedy inference, single-segment, blank suppression
-- Lazy model loading: model context created on first transcription, cached across subsequent runs
-- WhisperState caching: GPU/Metal buffers allocated once and reused (v0.7.8 optimization)
-- Zero cloud dependencies — fully offline
+Current as of **v0.21.2**. This is the breadth-first inventory of what ships; each area links to its detailed feature doc. For system structure see [ARCHITECTURE.md](ARCHITECTURE.md).
 
-### Voice Activity Detection (VAD)
-- Silero VAD v5.1.2 pre-filters silence before transcription
-- Prevents Whisper hallucination loops on silent/noisy audio
-- Configurable sensitivity: 0-100 scale (default 50), exposed as slider in settings
-- Higher sensitivity keeps more audio; lower trims silence more aggressively
-- VAD model (~1.8 MB) co-downloaded automatically alongside any transcription model
-- Fallback: if VAD model is missing at transcription time, a background download is started for next time
-- If VAD detects no speech, transcription is skipped entirely (empty string returned)
+---
 
-### Recording Activation (3 modes)
-- **Hold Down** — hold a modifier key to record; release to stop and transcribe
-- **Double-Tap** — tap a modifier key twice (within 400ms, each hold under 200ms) to start; single tap to stop
-- **Both** — hold-down and double-tap run simultaneously on the same key. Uses 200ms deferred hold promotion: short taps feed double-tap detection; only presses held beyond 200ms start a recording
-- Trigger key choices: Left Shift, Left Option/Alt, Right Control
-- Recordings shorter than 0.3 seconds are silently discarded as phantom triggers
-- Both detectors reject modifier+letter combos to avoid triggering during normal typing
+## 1. Core dictation
 
-### Text Output
-- Clipboard copy always (via arboard)
-- Optional auto-paste via osascript Cmd+V simulation
-- Configurable paste delay: 10-500ms (default 50ms), slider in settings (only shown when auto-paste enabled)
-- Auto-paste retries once on failure with 100ms backoff
-- On paste failure: "auto-paste-failed" event with hint to paste manually (auto-clears after 5 seconds)
-- Auto-paste requires accessibility permission
-- Empty/whitespace-only text is silently skipped
+**[docs/features/transcription.md](features/transcription.md)**
 
-### UI — Main Window
-- 720x560 default size, 520x400 minimum, centered on launch
-- Dark/light theme follows macOS system appearance (Tailwind dark: variants)
-- Header with "Murmur" title, status indicator, settings gear button; acts as Tauri drag region
-- Status indicator: Initializing (gray), Ready (green), Recording Xs (red, pulsing mic), Processing (amber, spinner)
-- Start/Stop recording buttons (disabled while not initialized or processing)
-- Transcription history: reverse-chronological, click to copy, timestamped, duration displayed
-- History capped at 50 entries, clear with confirmation dialog
-- Stats bar: Total Words, Avg WPM, Recordings, Approx Tokens
-- Error display banner; auto-paste failure hint with 5-second auto-dismiss
-- Permissions banner: microphone + accessibility status with grant buttons, auto-rechecks on window focus, dismissable
-- Close-to-hide: close request hides the window instead of destroying it
+- Hold a key, speak, release — text lands on the clipboard and (optionally) pastes into the focused app.
+- Fully offline. No cloud calls, no API keys, no telemetry leaving the machine.
+- Seven models across three local engines, all from one catalog (see [Models](#3-models-and-runtime)).
+- One final-after-stop transcription path for every backend. Delivery happens exactly once.
+- Recordings under 0.3s are discarded as phantom triggers.
+- Imported-file transcription (`transcribe_file`) runs the same pipeline with live-only stages skipped.
 
-### Settings Panel (side drawer, 280px)
-- Slides in/out from the right with width transition
-- Organized into collapsible sections with animated expand/collapse
+### Voice activity detection — [features/vad.md](features/vad.md)
 
-#### Section: Transcription
-- Model selector dropdown with all Whisper models
-- Each option shows label and file size
-- Inline model download: warning when model not downloaded, progress bar, retry on error
-- Microphone selector: lists all audio input devices via system query, "System Default" option, warning if saved device not found
+- Silero VAD v5.1.2 trims silence before inference, preventing whisper hallucination loops.
+- Sensitivity 0–100 (default 50) → threshold `1.0 - sensitivity/100`.
+- No speech detected → transcription is skipped entirely.
+- Context is cached per blocking worker rather than rebuilt per utterance.
 
-#### Section: Recording
-- VAD Sensitivity slider: 0-100%, step 5, draft value while dragging
-- Recording Trigger mode: three toggle buttons (Hold Down, Double-Tap, Both)
-- Accessibility permission warning with grant link when not granted
-- Trigger Key selector: label changes per mode (Hold Key / Double-Tap Key / Trigger Key), contextual help text
+### Recording modes — [features/recording-modes.md](features/recording-modes.md)
 
-#### Section: Output
-- Auto-Paste toggle with accessibility status indicator
-- Paste Delay slider: 10-500ms, step 10ms (only visible when auto-paste enabled)
-- Launch at Login toggle, syncs with macOS login item state on mount
+| Mode | Behavior |
+|------|----------|
+| Hold Down | Hold the trigger key to record; release to stop and transcribe |
+| Double-Tap | Two taps (each <200ms, gap <400ms) start; single tap stops |
+| Both | Both at once, via 200ms deferred hold promotion |
 
-#### Section: About (collapsed by default)
-- Model info display: name, backend, size
-- Reset Stats button with two-click confirmation (auto-resets after 3 seconds)
-- View Logs button (opens log viewer window)
-- Check for Updates button with status text
-- Version display
+- Trigger keys: Left Shift, Left Option, Right Control.
+- Modifier+letter combos are rejected so normal typing never triggers recording.
+- Optional amber overlay flash when a double-tap's second-tap window expires (`hotkeyMissFeedback`, off by default).
+- Global disable from the tray ("Disable Murmur") or the overlay's power button.
 
-### Model Downloader (first-launch onboarding)
-- Full-screen view shown when no model is installed
-- 2 curated model cards: large-v3-turbo, base.en
-- Each card shows label, size, description
-- Default selection: large-v3-turbo
-- Download button with progress bar (percentage + byte counter)
-- Error display with retry
-- Selection disabled during download
+---
 
-### System Tray
-- Static white waveform icon: 66x66 RGBA (3x for 22pt Retina menu bar), 5 vertical capsule bars
-- Menu: "Show Murmur" and "Quit Murmur" only
-- Left-click on tray icon shows and focuses the main window
-- Hide-on-close (doesn't quit)
+## 2. Text delivery
 
-### Overlay Widget (Dynamic Island / notch overlay)
-- Separate always-on-top window (260x100), transparent, borderless, not focusable, visible on all workspaces
-- Positioned over the MacBook notch area, window level above menu bar (NSMainMenuWindowLevel + 1)
-- Notch-aware sizing: detects notch dimensions via NSScreen APIs (safe area insets, auxiliary areas)
-- Fallback dimensions: 200px wide, 37px tall when no notch detected
-- Three visual states: idle (dimmed mic icon), recording (red dot + waveform), processing (spinner + dimmed waveform)
-- 7-bar animated waveform driven by real-time audio levels via requestAnimationFrame with direct DOM manipulation
-- Center bars taller (envelope shaping), random jitter for organic feel
-- Single click (250ms debounced): stops recording if active, exits locked mode
-- Double-click: toggles locked mode; starts/stops recording
-- Locked mode persists recording across single clicks until explicitly unlocked
-- Screen change observer: re-detects notch on monitor plug/unplug or lid open/close
-- Uses `_setPreventsActivation:` private API (guarded by respondsToSelector:) to prevent overlay clicks from activating the app
-- Entire overlay is a Tauri drag region
+**[docs/features/text-injection.md](features/text-injection.md)**
 
-### Log Viewer Window
-- Separate window (800x600, min 600x400), titled "Murmur -- Log Viewer"
-- Close-to-hide behavior (not destroyed)
-- Two tabs: Events and Metrics
+- **Clipboard-first, always.** Auto-paste is layered on top and never the only path.
+- Native `CGEvent` Cmd+V with an `osascript` fallback; configurable 10–500ms delay; one retry; timeout-bounded.
+- Auto-paste failure emits a hint — the text is already on the clipboard.
+- **File output** — numbered `.txt` transcripts and/or 16kHz mono `.wav` audio to a chosen folder (default `Documents/Murmur`). While file output is on, auto-paste is suppressed without overwriting the user's stored preference.
 
-#### Events Tab
-- Stream filter chips: toggle pipeline, audio, keyboard, system streams (colored)
-- Level filter: toggle info, warn, error levels
-- Scrollable event list with monospace font and auto-scroll (disengages on scroll up, re-engages near bottom)
-- Each row: timestamp, stream chip, level label, summary text
-- Expandable rows with JSON data detail view
-- Copy All button (filtered events as text lines)
-- Clear button (clears frontend buffer and backend ring buffer)
+---
 
-#### Metrics Tab
-- Extracts timing from pipeline events where summary is "transcription complete"
-- Last 20 transcriptions displayed
-- Toggleable series legend: Total, Inference, VAD, Paste
-- Stat cards per visible series: latest value, average, trend indicator (up/down/flat, 10% threshold)
-- Two SVG line charts: upper (Total + Inference, 150px), lower (VAD + Paste, 120px)
-- Auto-scaled Y-axis with round tick marks, X-axis by transcription index
-- Polylines with dots at each data point
+## 3. Models and runtime
 
-### Structured Event System
-- All logging via tracing crate with two layers: pretty-printed log file + structured JSONL + Tauri event emission
-- TauriEmitterLayer intercepts all tracing events, converts to AppEvent structs
-- In-memory ring buffer: 500 events max, FIFO eviction, seeded from existing JSONL on startup
-- JSONL persistence: events.jsonl (release) / events.dev.jsonl (dev), rotated at 5 MB
-- Real-time streaming: every tracing event broadcast to all frontend windows via app-event
-- Four streams: pipeline, audio, keyboard, system
-- Five levels: trace, debug, info, warn, error
-- Privacy stripping: in release builds, all string fields stripped from pipeline stream events in data object
-- Frontend logging: log_frontend command routes frontend messages through Rust tracing
+**[docs/features/models.md](features/models.md)**
 
-### Auto-Updater
-- Background update check on launch and every 24 hours
-- Endpoint: GitHub releases latest-v2.json (current dual-platform channel)
-- Forced updates: if current version is below remote min_version, update is required (no skip/dismiss)
-- Skip version: user can skip a specific version (persisted to localStorage)
-- Dismiss: user can dismiss without skipping
-- Download progress with percentage
-- Auto-relaunch after successful download and install
-- Native macOS notification when update available (background check)
-- Update modal phases: available (with markdown release notes), downloading (progress), ready (installing), error (retry)
+| Model | Engine | Accelerator | Size |
+|-------|--------|-------------|------|
+| Parakeet v3 | FluidAudio / Core ML | Apple Neural Engine | ~470 MB |
+| Parakeet v2 | sherpa-onnx | CPU | ~1.2 GB |
+| Whisper Tiny / Base / Small / Medium (`.en`) | whisper.cpp | Metal GPU | 75 MB – 1.5 GB |
+| Whisper Large v3 Turbo | whisper.cpp | Metal GPU | ~3 GB |
 
-### About Modal
-- App name "Murmur", version, description, copyright
-- Microphone icon, close button, backdrop click to close
+- One catalog declares backend, accelerator, capabilities, install kind, and platform requirement per model. Unknown identifiers fail closed — no silent cross-model fallback.
+- Serialized load / warm / readiness / unload lifecycle with generation-ordered status events.
+- **Warm-on-record**: the model begins loading the moment recording starts, overlapping load with speech.
+- Configurable idle release (5 min / 15 min / never).
+- Streaming downloads with progress, atomic temp-then-rename publication, resumable Core ML extraction, and automatic Silero VAD co-download.
 
-### Resource Monitor (dev builds only)
-- Collapsible CPU% + Memory MB panel
-- Dual-line SVG chart: CPU (stone) and Memory (amber), 60-point rolling history
-- Grid lines at 25%, 50%, 75%
-- Polls every 1 second only when expanded (performance optimization)
-- Collapse state persisted to localStorage
+---
 
-### Permissions
-- Microphone: required for recording
-- Accessibility: required for keyboard listener (all modes) and auto-paste
-- In-app status checks with grant buttons that open System Settings
-- Automatic re-check on window focus
-- Dismissable banner (session-scoped)
+## 4. Text intelligence
 
-### Three-Window Architecture
-- Main window (720x560): full app UI, settings, recording controls, history
-- Overlay window (260x100): notch-anchored Dynamic Island
-- Log viewer window (800x600): structured event browser and metrics
-- Each window has separate Tauri capabilities following least privilege
-- Overlay reads settings from localStorage directly (no shared React context across windows)
-- Close-to-hide for main and log-viewer windows
+All stages are deterministic and local. They run in one ordered pipeline: **cleanup → voice commands → smart correction → smart formatting → IDE context → CLI formatting**.
 
-### Platform and Distribution
-- macOS only (12+), Apple Silicon optimized
-- Metal GPU acceleration for Whisper backend
-- Developer ID signed + notarized
-- DMG installer via GitHub Actions (tag-triggered)
-- Release optimized with opt-level "s", LTO, codegen-units 1, and panic abort; stripping is disabled so Tauri can patch the updater bundle-type marker
-- Dev build has separate bundle identifier (com.localdictation.dev) and name (Local Dictation Dev)
+### Cleanup
+Filler removal ("um", "uh") and sentence capitalization, each independently toggleable.
 
-### CI/CD
-- TypeScript type checking on push/PR
-- Omen code quality analysis on PRs
-- Claude Code automated PR review
-- Claude Code issue/PR comment bot (@claude)
-- Rust tests: single-threaded (cargo test -- --test-threads=1)
-- Frontend tests: vitest with jsdom
+### Smart formatting — [features/smart-formatting.md](features/smart-formatting.md)
+Turns clear spoken enumerations into lists; applies explicitly cued email/URL/symbol/quote/paragraph grammar; handles bounded same-utterance restatements ("no wait, make that…"). Bypassed in CLI/code/verbatim contexts and for imported files.
 
-### Dependencies
-- **Rust**: Tauri 2, whisper-rs (Metal), cpal, arboard, rdev (git main), reqwest (rustls-tls), sysinfo, tracing/tracing-subscriber/tracing-appender, objc2/objc2-app-kit (macOS)
-- **Frontend**: React 18, Tailwind CSS 4, Vite 6, TypeScript ~5.6, react-markdown, rehype-sanitize, @tauri-apps/api and plugins (autostart, updater, notification, process, opener)
-- **5 Tauri plugins**: opener, autostart (LaunchAgent), updater, notification, process
+### CLI command formatting — [features/cli-command-formatting.md](features/cli-command-formatting.md)
+Deterministic formatting for spoken npm/npx, Git, Cargo, Docker, kubectl and similar commands — versions, flags, paths, operators, quotes, canonical aliases. Detection is prefix/trigger/profile bounded; project `package.json` names extend the local lexicon; ordinary prose is untouched.
+
+### Vocabulary and correction
+- **Code-vocabulary scan** — breadth-first walk of a chosen project folder (caps: 1000 files / 32 MB / 512 KB per file), extracting identifiers with live progress, a searchable view-all pop-out, and a cap warning. Top 96 terms feed Whisper's token-bound prompt; top 500 feed Smart Correction.
+- **Smart Correction** — post-model correction applied to *every* backend's output. Tier 1 exact map, Tier 2 phonetic "sounds-like" restricted to structured identifiers (camelCase / snake_case / digit) so ordinary English isn't rewritten.
+- **Explicit spoken aliases** — [features/vocabulary-aliases.md](features/vocabulary-aliases.md). Map exact recognized variants ("Tori", "Tory") to a canonical written term ("Tauri"). Ambiguity, cycles, and command conflicts are rejected atomically.
+
+### Voice Commands 2.0 — [features/voice-commands.md](features/voice-commands.md)
+Typed, persistent local commands: text replacements and multiline snippets, deterministic `{{date}}` / `{{time}}` variables, explicitly permitted `{{clipboard}}` insertion, global and per-app scopes, conflict validation, and a no-paste preview/test UI.
+
+### Correct and Teach — [features/correct-and-teach.md](features/correct-and-teach.md)
+Edit the newest history entry and Murmur proposes **one bounded replacement** to learn, scoped global / app / project. Uses uniquely provable case-insensitive context alignment, so casing differences can't widen a one-word fix into a sentence rule; ambiguous alignments fail closed. **Teach specific term** lets you select one exact heard term inside a longer sentence when automatic extraction is too broad. Nothing persists without explicit confirmation.
+
+### Personal knowledge store — [features/personal-knowledge-store.md](features/personal-knowledge-store.md)
+Versioned local SQLite store for replacement rules, vocabulary terms, snippets, and saved transforms. Bounded search, scoped inspection, create/edit/enable/disable/delete, atomic export/import, visible recovery state, confirmed delete-all, deterministic migration with backup recovery and quarantine.
+
+### Per-app dictation context — [features/per-app-profiles.md](features/per-app-profiles.md)
+Per-bundle-ID profiles override auto-paste, cleanup, smart formatting, and CLI formatting, and select an explicit **Writing Style** (Inherit / Conversational / Polished prose / Code-technical / Verbatim / Notes). Resolved once into an immutable recording-start snapshot; app type is never inferred and app content is never captured. A bounded memory-only running-app picker with manual bundle-ID fallback fills the profile list.
+
+### IDE context — [features/ide-context.md](features/ide-context.md)
+Opt-in, per-profile, memory-only index of user-selected local roots. Corrects unique project symbols and canonicalizes explicitly triggered `@file` mentions to root-relative text. Never reads screen, selection, or clipboard. Ambiguous or stale references stay unchanged. Index contents are never persisted — only the chosen root strings are.
+
+---
+
+## 5. Selected-text transform
+
+**[docs/features/selected-text-transform.md](features/selected-text-transform.md)** · ADR: [signed local-LLM sidecar](decisions/2026-07-20-signed-local-llm-sidecar.md)
+
+Hold a dedicated key with text selected in any app, speak an instruction, review a local LLM's proposal, approve or undo.
+
+- **Independent hotkey** (`alt_r` / `ctrl_l` / `shift_r`), rejects the dictation key. Off by default.
+- **Signed local sidecar** running Qwen2.5-1.5B-Instruct Q4_K_M — size + SHA-256 pinned, spawned with empty env and the model as a read-only fd, no network, hardened runtime + App Sandbox.
+- **Review-first**: a word diff in a non-focusable popover. Approve writes via AX set-value or a clipboard-restoring paste fallback; Undo restores the frozen original. It never auto-applies.
+- **Presets and saved transforms**: Shorten, Bullets, Professional, Fix grammar, Casual, plus user-defined transforms. Presets shadow saved transforms with the same normalized name.
+- **Selection capture** works in AX-native apps directly, and in Chromium/Electron webviews via an AX retry ladder then a sentinel-guarded synthetic Cmd+C that snapshots and restores the entire pasteboard.
+- **Fail-closed**: positively detected secure fields, denied Accessibility, and *errored* secure-field checks all refuse — the clipboard fallback never runs where a password field can't be ruled out.
+- **Escape cancels** during capture, listening, and thinking, carrying the exact pass ID so a delayed handler can't cancel the next pass.
+- Mutually exclusive with dictation in both directions; a refused keypress flashes an amber busy indicator instead of failing silently.
+
+---
+
+## 6. Interface
+
+### Main window
+Status indicator, recording controls, transcription history (50 entries, click to copy, Correct-and-Teach entry point), usage stats (words, WPM, recordings, approximate tokens), permissions banner, update and about modals. Hides on close.
+
+### Overlay — [features/overlay.md](features/overlay.md)
+Notch-anchored Dynamic Island. Idle sits flush with the notch showing a small mic tab; recording expands with a red dot and a 7-bar waveform driven by real audio levels at 60fps via direct DOM writes; processing shows a spinner. Hover for 150ms opens a compact quick-settings card (intent-gated, so a graze doesn't pop it). Single click stops; double-click toggles locked mode. Non-activating — clicks never steal focus. Geometry comes entirely from Rust and re-derives on display changes.
+
+### Settings — [reference/settings.md](reference/settings.md)
+Seven task-oriented pages: **Recording**, **Transcription**, **Transform**, **Text & Vocabulary**, **Delivery**, **Performance**, **General**. Knowledge management lives under Text & Vocabulary.
+
+### Onboarding — [features/onboarding-flow.md](features/onboarding-flow.md)
+First-launch wizard: Welcome → Microphone → Accessibility → Model download → Done. The mic step fires the native macOS prompt in-app; both permission steps poll live so a grant made in System Settings flips the step on return; denied/stale-TCC states get inline reset-and-retry. Already-downloaded models are detected and badged. Existing installs with permissions and a model are grandfathered. Re-runnable from Settings → General.
+
+### System tray
+Static white waveform icon. Menu: Show Murmur, Disable Murmur (check item), Quit. Left-click shows the main window.
+
+---
+
+## 7. Diagnostics and evaluation
+
+### Log viewer — [features/log-viewer.md](features/log-viewer.md)
+Separate window with Events, Performance/Runs, Transforms, and Reports tabs. Stream chips (`pipeline`, `audio`, `keyboard`, `transform`, `system`) and level filters, expandable JSON rows, auto-scroll that disengages on manual scroll, copy-all and clear.
+
+### Performance diagnostics — [features/performance-diagnostics.md](features/performance-diagnostics.md)
+Bounded local run history (200 runs, 600 resource samples) in SQLite: per-stage timings, CPU/memory timelines, transform-stage correlation, warm-vs-cold state, and RSS deltas. Incomplete runs claiming success are rejected. No dictated text is ever recorded.
+
+### Report comparison — [features/diagnostic-report-comparison.md](features/diagnostic-report-comparison.md)
+Portable reports import into a session-only Reports workspace for schema-validated side-by-side comparison. Imported data is never silently adopted into local run history; invalid or oversized reports fail closed.
+
+### Performance Lab — [features/performance-lab.md](features/performance-lab.md)
+Benchmark installed models against bundled fixtures on your own machine. Three accuracy tiers per model/fixture — raw decoder WER, normalized WER (formatting differences don't count as errors), and delivered WER after the production transform pipeline. Stress fixtures (jargon, numbers, disfluent, 64s extra-long, fast speech) de-saturate ranking. Shared Metal/ANE init is measured separately rather than charged to the first model loaded. Fastest ranks by strict minimum duration-weighted realtime factor; Balanced uses normalized WER within two accuracy points, a 10% speed band, then lower memory. Reports export as self-identifying JSON with optional auto-save.
+
+### Evaluation harness — [features/evaluation-harness.md](features/evaluation-harness.md)
+Strict versioned fixtures, a deterministic no-hardware CI tier, an opt-in installed-model/audio tier, and machine-readable recognition/transformation/delivery reports via `murmur-eval`.
+
+### Transform diagnostics
+Every transform-key hold is recorded as a content-free `TransformAttemptV1` with ordered enum-only phase outcomes — including refused, cancelled, and superseded passes. **Capture next transform** is an explicit, confirmed, in-memory arm that stores one pass's real content locally (`0700`/`0600`, max 3, 7-day expiry, no export) for cases where exact content must be inspected.
+
+---
+
+## 8. Platform, privacy, distribution
+
+- macOS 14+ on Apple Silicon (Core ML/ANE); Whisper and CPU Parakeet also build for Linux.
+- Developer ID signed and notarized; hardened runtime; sidecar ships with split entitlements; release finalization fails closed on any unexpected bundle executable.
+- **Auto-updater** — [features/auto-updater.md](features/auto-updater.md). Background check on launch and every 24h against `latest-v2.json`, ed25519-signed, min-version enforcement (no skip/dismiss when required), skip/dismiss otherwise, progress and auto-relaunch.
+- **Privacy boundaries**: release `pipeline` events drop all strings; `transform` events are restricted to an explicit stable vocabulary in *all* builds; knowledge content and selected paths are excluded from logs; instructions never enter history or stats; audio and transcripts are written to disk only when the user turns file output on.
+- All local data is inspectable and deletable from within the app.
+
+---
+
+## 9. Development surface
+
+| Area | Location |
+|------|----------|
+| Rust backend | `app/src-tauri/src/` — 105 Tauri commands |
+| Frontend | `app/src/` — React 18 + TypeScript + Tailwind 4 |
+| LLM sidecar | `app/src-tauri/sidecars/local-llm/`, protocol in `crates/local-llm-protocol` |
+| Diagnostics MCP tool | `tools/murmur-diag/` |
+| Benchmark fixtures | `bench/` |
+| Release/packaging scripts | `scripts/` |
+| Workflow/artifact policy tests | `tests/` |
+
+Tests: Rust unit and integration (`cargo test -- --test-threads=1`), frontend vitest (`npm test`), TypeScript (`npx tsc --noEmit`). CI runs all of these plus Omen code-quality analysis and automated PR review.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -4,14 +4,23 @@
 
 - [Node.js](https://nodejs.org/) 18+
 - [Rust](https://rustup.rs/) (latest stable)
+- Python 3 (sidecar and packaging scripts)
 - macOS 14 or newer on Apple Silicon
 - A transcription model (the app downloads one on first launch)
 
 ## Setup
 
 ```bash
+# Build the local-LLM sidecar FIRST — on macOS, tauri dev/build and even
+# cargo check/test fail on a fresh clone until this binary exists.
+python3 scripts/build_local_llm_sidecar.py
+
 cd app && npm install
 ```
+
+The sidecar lands at
+`app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. It is
+gitignored and rebuilt by release CI. The script is a no-op on non-arm64-macOS.
 
 ## Development
 
@@ -69,7 +78,7 @@ The app requires a ggml `.bin` model file. Download one:
 | `base.en` | ~150 MB | Fast | Good |
 | `small.en` | ~500 MB | Medium | Better |
 | `medium.en` | ~1.5 GB | Slow | Great |
-| `large-v3-turbo` | ~1.6 GB | Fast | Best (recommended) |
+| `large-v3-turbo` | ~3 GB | Fast | Best of the Whisper set, multilingual |
 
 Download from: `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{model}.bin`
 
@@ -91,8 +100,11 @@ The app searches these locations in order:
 
 | Permission | Required For | How to Grant |
 |------------|-------------|--------------|
-| **Microphone** | Audio capture (always required) | Prompted on first use |
-| **Accessibility** | Double-tap recording mode + auto-paste | System Settings > Privacy & Security > Accessibility |
+| **Microphone** | Audio capture — dictation and transform instructions | Prompted in-app by the setup assistant |
+| **Accessibility** | All hotkeys (rdev), auto-paste, and transform selection capture / write-back | System Settings > Privacy & Security > Accessibility |
+
+Under `npm run tauri dev`, grant both to your *terminal app* — dev builds are
+re-signed on each rebuild, so a grant to the dev binary never sticks.
 
 ## Logs
 
@@ -103,6 +115,20 @@ Release and dev builds write to the same local directory:
 [`features/log-viewer.md`](features/log-viewer.md) for the event architecture and
 [`tools/murmur-diag/README.md`](../tools/murmur-diag/README.md) for local MCP
 diagnostics.
+
+## Transform model
+
+The selected-text transform uses a separate, optional local LLM: Qwen2.5-1.5B-Instruct Q4_K_M (~1.1 GB), downloaded from **Settings → Transform**. It is pinned by exact size and SHA-256, verified again before every spawn, and stored at:
+
+```text
+~/Library/Application Support/local-dictation/models/transform-llm/<sha256>/qwen2.5-1.5b-instruct-q4_k_m.gguf
+```
+
+Remove it from the same page. The helper process is shut down first so the file is not open. If repeated faults trip the circuit breaker, **Reset runtime** re-enables it.
+
+## Diagnostics data
+
+Local run history and CPU/memory samples live in `diagnostics/performance.sqlite3` under the Tauri app-data directory (`~/Library/Application Support/com.localdictation/`, or `com.localdictation.dev` in dev builds). They are content-free and bounded (200 runs, 600 samples), and are cleared from the Log Viewer. Explicitly consented transform content captures live beside them under `diagnostics/transforms/` with restrictive permissions, a 3-capture cap, and a 7-day expiry.
 
 ## Personal knowledge data
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,125 +1,204 @@
 # Tauri Commands Reference
 
-This document lists the registered Tauri commands exposed from the Rust backend to the frontend via `invoke()`. Commands are grouped by their source module under `app/src-tauri/src/`.
+The 105 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
-For event-based communication (Rust to frontend), see [events.md](events.md). For frontend hooks that call these commands, see [hooks.md](hooks.md).
+Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
+
+For Rust → frontend events see [events.md](events.md). For the hooks that call these commands see [hooks.md](hooks.md).
 
 ---
 
-## Recording (`commands/recording.rs`)
+## Recording and dictation (`commands/recording.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `init_dictation` | _(none)_ | `Result<JSON, String>` | Returns a static `{"type":"initialized","state":"idle"}` response. No-op initialization marker. |
-| `process_audio` | `audio_data: String` | `Result<JSON, String>` | Accepts base64-encoded WAV audio, decodes it, runs the full VAD + transcription + text injection pipeline, and returns `{"type":"transcription","text":"..."}`. |
-| `get_status` | _(none)_ | `Result<JSON, String>` | Returns current dictation status, model name, and language as `{"type":"status","state":"...","model":"...","language":"..."}`. |
-| `configure_dictation` | `options: JSON` | `Result<JSON, String>` | Updates dictation settings. Accepts optional fields: `model` (string), `language` (string), `autoPaste` (bool), `autoPasteDelayMs` (u64, clamped 10-500), `vadSensitivity` (u64, clamped 0-100). Resets the transcription backend if model changes. |
-| `start_native_recording` | `device_name: Option<String>` | `Result<JSON, String>` | Begins native audio capture via cpal with an optional device name. Transitions status from Idle to Recording. Returns early if already recording or processing. |
-| `stop_native_recording` | _(none)_ | `Result<JSON, String>` | Stops audio capture, runs the full pipeline (VAD, transcription, text injection), and returns the transcription result. Recordings shorter than 0.3s are silently discarded. |
-| `cancel_native_recording` | _(none)_ | `Result<(), String>` | Cancels an in-progress recording without transcribing. Audio is discarded. Used by "both" mode for speculative recordings from short taps. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `init_dictation` | — | `Result<JSON, String>` | Static `{"type":"initialized","state":"idle"}` marker. |
+| `get_status` | — | `Result<JSON, String>` | Current status, model name, and language. |
+| `configure_dictation` | `options: JSON` | `Result<JSON, String>` | Pushes settings into `DictationState`: model, language, auto-paste and delay (clamped 10–500), VAD sensitivity (0–100), punctuation, file output, vocabulary entries, voice commands, app profiles, cleanup/formatting/correction toggles, code-vocab folder, idle timeout. A model change reselects the runtime backend, deferring across an active recording generation. Rejects conflicting vocabulary/command configurations without mutating prior state. |
+| `start_native_recording` | `device_name: Option<String>` | `Result<JSON, String>` | Starts cpal capture, resolves the immutable per-recording context, and warms the model concurrently. Idle → Recording. |
+| `stop_native_recording` | — | `Result<JSON, String>` | Stops capture and runs VAD → inference → transcript transform → delivery. Recordings under 0.3s are discarded. |
+| `cancel_native_recording` | — | `Result<(), String>` | Discards an in-progress recording without transcribing (used for speculative Both-mode holds). |
+| `process_audio` | `audio_data: String` | `Result<JSON, String>` | Runs the full pipeline over base64-encoded 16kHz mono WAV. |
+| `transcribe_file` | `file_path: String` | `Result<JSON, String>` | Decodes and transcribes an audio file through the same pipeline with live-only stages skipped. Emits `file-transcription-status-changed`. |
+| `transform_status` | — | `TransformStatus` | Current selected-text transform state (used to arbitrate against dictation). |
+| `count_vocab_tokens` | `text: String` | `Result<Option<usize>, String>` | Token count for the loaded model's tokenizer; `None` if no model is loaded. Drives the Whisper prompt budget UI. |
+| `preview_vocabulary_aliases` | `entries`, `voice_commands`, `text`, `cli_formatting` | `Result<String, String>` | Runs alias + command resolution over sample text in memory. No persistence, no delivery. |
+| `scan_code_vocab` | `folder: String`, `scan_id: String` | `Result<VocabScanSummary, String>` | Breadth-first identifier scan of a project folder with throttled progress events. Returns ranked terms, counts, cap state, and whether the result was adopted. |
+| `cancel_code_vocab_scan` | `scan_id: String` | `bool` | Cancels only the matching scan. |
+| `get_ide_context_status` | `bundle_id: String` | `IdeContextStatus` | Index state for one profile. |
+| `refresh_ide_context` | `bundle_id: String` | `Result<IdeContextStatus, String>` | Rebuilds the memory-only index from that profile's opted-in roots. |
+| `clear_ide_context` | `bundle_id: String` | `Result<IdeContextStatus, String>` | Drops the in-memory index for that profile. |
 
 ## Permissions (`commands/permissions.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `open_system_preferences` | _(none)_ | `Result<(), String>` | Opens macOS System Settings to the Microphone privacy pane. |
-| `check_accessibility_permission` | _(none)_ | `bool` | Returns `true` if macOS Accessibility permission is granted (via `AXIsProcessTrusted()`). |
-| `request_accessibility_permission` | _(none)_ | `Result<(), String>` | Triggers the macOS Accessibility permission prompt and opens System Settings to the Accessibility pane. |
-| `request_microphone_permission` | _(none)_ | `Result<(), String>` | Opens macOS System Settings to the Microphone privacy pane. |
-| `list_audio_devices` | _(none)_ | `Result<Vec<String>, String>` | Returns a list of available audio input device names via cpal. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `check_accessibility_permission` | — | `bool` | `AXIsProcessTrusted()`. |
+| `request_accessibility_permission` | — | `Result<(), String>` | Triggers the system prompt and opens the Accessibility pane. |
+| `reset_accessibility_permission` | — | `Result<(), String>` | Clears a stale TCC entry so the grant can be re-made. |
+| `check_microphone_permission` | — | `bool` | Whether microphone access is granted. |
+| `check_microphone_permission_status` | — | `String` | Fine-grained state (granted / denied / undetermined / restricted) for the onboarding step. |
+| `request_microphone_access` | — | `Result<(), String>` | Fires the native in-app prompt via `AVCaptureDevice.requestAccess`. |
+| `request_microphone_permission` | — | `Result<(), String>` | Opens the Microphone privacy pane. |
+| `reset_microphone_permission` | — | `Result<(), String>` | Clears a stale microphone TCC entry. |
+| `open_system_preferences` | — | `Result<(), String>` | Opens System Settings to the Microphone pane. |
+| `list_audio_devices` | — | `Result<Vec<String>, String>` | Input device names via cpal. |
 
 ## Keyboard (`commands/keyboard.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `start_keyboard_listener` | `hotkey: String`, `mode: String` | `Result<(), String>` | Starts the global rdev keyboard listener with the specified hotkey and mode (`"double_tap"`, `"hold_down"`, or `"both"`). Validates mode and requires Accessibility permission. |
-| `stop_keyboard_listener` | _(none)_ | `()` | Stops processing keyboard events. The rdev listener thread remains alive but idle. |
-| `update_keyboard_key` | `hotkey: String` | `()` | Changes the target hotkey at runtime without restarting the listener. If the key is changed while held down, emits `hold-down-stop` to prevent stuck recording state. |
-| `set_keyboard_recording` | `recording: bool` | `()` | Synchronizes the keyboard module's internal recording state flag. Used by the frontend to keep the double-tap detector's state machine in sync. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `start_keyboard_listener` | `hotkey: String`, `mode: String` | `Result<(), String>` | Starts the rdev listener in `hold_down`, `double_tap`, or `both`. Validates mode; requires Accessibility. |
+| `stop_keyboard_listener` | — | `()` | Stops processing key events; the thread stays alive. |
+| `update_keyboard_key` | `hotkey: String` | `()` | Changes the trigger key at runtime. Emits `hold-down-stop` if the old key was held, so no recording is stranded. |
+| `set_keyboard_recording` | `recording: bool` | `()` | Syncs recording state into the double-tap detector. |
+| `set_app_disabled` | `disabled: bool` | `Result<(), String>` | Global disable/enable. Mirrors state to the tray check item and emits `app-disabled-changed`. |
+| `get_app_disabled` | — | `bool` | Current global-disable state. |
+| `start_transform_listener` | `hotkey: String` | `Result<(), String>` | Arms the independent transform hold key. Rejects the active dictation key. |
+| `stop_transform_listener` | — | `()` | Disarms the transform key. |
+| `set_transform_key` | `hotkey: String` | `Result<(), String>` | Changes the transform key at runtime. |
 
-## Logging (`commands/logging.rs`)
+## Selected-text transform (`transform_flow.rs`, `transform_apply.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `get_log_contents` | `lines: usize` | `String` | Returns the last N lines from the pretty-printed log file (`app.log` or `app.dev.log`). |
-| `clear_logs` | _(none)_ | `Result<(), String>` | Removes all log files (including rotated variants, JSONL event files, frontend logs) and clears the in-memory event ring buffer. |
-| `log_frontend` | `level: String`, `message: String` | `()` | Routes a frontend log message through the Rust tracing system. Accepts levels: `"INFO"`, `"WARN"`, `"ERROR"`. Messages appear in the structured event stream with `source="frontend"`. |
-| `open_log_viewer` | _(none)_ | `Result<(), String>` | Shows and focuses the `log-viewer` window. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `start_transform_capture` | `device_name: Option<String>`, `transform_pass_id: u64` | `Result<(), String>` | Begins a pass: arms the mic, freezes the AX selection snapshot, shows the popover in `listening`. Refuses (with a stable error code) when dictation, a benchmark, a file transcription, or another transform owns the pipeline. |
+| `finish_transform_instruction` | `transform_pass_id: u64` | `Result<(), String>` | Stops the instruction mic, transcribes it (cleanup-only), expands preset/saved-transform names, and runs the sidecar. `listening` → `thinking` → `ready`/`failed`. |
+| `retry_transform_instruction` | `device_name: Option<String>` | `Result<(), String>` | Re-arms listening for a new instruction against the **same** frozen selection, keeping the pass ID and advancing the attempt counter. |
+| `approve_transform` | — | `Result<(), String>` | Applies the proposal through `transform_apply` (AX set-value, else paste fallback with clipboard restore) and schedules the linger-hide. |
+| `cancel_transform` | `transform_pass_id: Option<u64>` | `Result<(), String>` | Scoped cancellation. A no-op if that pass no longer owns the flow, so a delayed Escape cannot cancel the next pass. Idempotent. |
+| `undo_transform_and_close` | — | `Result<(), String>` | Restores the frozen original and closes the popover. On failure the Applied session is kept and `applied` is re-emitted with an error code so Undo stays available. |
+| `apply_transform_result` | — | `Result<String, String>` | Lower-level write-back entry point. |
+| `undo_transform` | — | `Result<(), String>` | Lower-level undo entry point. |
 
-## Personal Knowledge (`commands/knowledge.rs`)
+## Transform review popover (`commands/transform_popover.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `get_knowledge_store_status` | _(none)_ | `KnowledgeStoreStatus` | Returns ready/recovered/reinitialized/unavailable state, schema version, record count, store revision, and privacy-safe recovery information. |
-| `retry_knowledge_store` | _(none)_ | `KnowledgeStoreStatus` | Re-runs local initialization after an unavailable state. |
-| `list_knowledge` | `request: KnowledgeListRequest` | `Result<KnowledgeListResponse, String>` | Bounded search/filter page, including an optional Voice Command filter; defaults to 50 and caps at 100 records. |
-| `get_knowledge` | `id: String` | `Result<KnowledgeEntry, String>` | Returns one local record by stable ID. |
-| `upsert_knowledge` | `draft: KnowledgeDraft` | `Result<KnowledgeEntry, String>` | Creates a manual record or edits one using its expected revision. Typed Voice Commands also validate payload/type, scope, built-ins, duplicate phrases, variables, clipboard permission, and vocabulary conflicts. |
-| `set_knowledge_enabled` | `id`, `enabled`, `expected_revision` | `Result<KnowledgeEntry, String>` | Enables/disables one record with optimistic concurrency. |
-| `delete_knowledge` | `id`, `expected_revision` | `Result<u64, String>` | Deletes one record and returns the new store revision. |
-| `resolve_knowledge` | `request: KnowledgeResolveRequest` | `Result<Option<KnowledgeEntry>, String>` | Deterministically resolves an exact trigger across applicable scopes, using the same scope/provenance precedence that separately feeds the immutable Smart Correction matcher after knowledge mutations. |
-| `preview_voice_command` | `request: VoiceCommandPreviewRequest` | `Result<VoiceCommandPreviewResponse, String>` | Runs the real local matcher and variable expansion without clipboard output or paste. Clipboard input requires both saved command permission and an explicit preview request. |
-| `export_knowledge_to_file` | `path: String` | `Result<u64, String>` | Atomically exports the local store to versioned JSON selected by the user. |
-| `inspect_knowledge_import` | `path: String` | `Result<KnowledgeImportSummary, String>` | Validates an import and reports new, duplicate, and conflicting records without writing. |
-| `import_knowledge_from_file` | `path: String` | `Result<KnowledgeImportResult, String>` | Atomically imports validated new records without overwriting local records. |
-| `delete_all_knowledge` | `expected_revision: u64` | `Result<u64, String>` | Deletes all records and in-store recovery artifacts after a revision-checked UI confirmation. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_transform_popover_geometry` | `anchor: Option<Rect>` | `TransformPopoverGeometry` | `{compact, expanded}` boxes resolved against the selection anchor and the active screen — 8px below, flipped above when it would clip, clamped horizontally, or centered at 38% screen height with no anchor. Pure `popover_geometry_for()`, asserted by a shared fixture. |
+| `show_transform_popover` | `anchor: Option<Rect>` | `Result<(), String>` | Sizes/positions to the compact box, applies the non-activating window treatment, shows it, and caches the anchor. |
+| `hide_transform_popover` | — | `Result<(), String>` | Hides the popover. |
+| `set_transform_popover_expanded` | `expanded: bool` | `Result<PopoverBox, String>` | Resizes between compact (listening/thinking) and expanded (ready/failed) against the cached anchor; returns the applied box as an acknowledgment. |
+| `set_transform_popover_focusable` | `focusable: bool` | `Result<(), String>` | `false` during listening/thinking so focus is never stolen; `true` at ready/failed so Enter/Esc/Cmd+R reach the webview. |
+| `get_transform_review_content` | — | `TransformReviewContent` | `{instruction, original, proposed}`. Fetched on each state change rather than broadcast, so sensitive text never rides an event payload. |
 
-## Correct and Teach (`commands/correct_and_teach.rs`)
+## Transform model (`commands/transform_model.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `propose_learned_correction` | `request: CorrectionProposalRequest` | `CorrectionProposalOutcome` | Computes one bounded local diff and stores only an ephemeral reviewed proposal. It never writes knowledge. |
-| `propose_specific_learned_correction` | `request: SpecificCorrectionProposalRequest` | `CorrectionProposalOutcome` | Validates one user-selected bounded whole-term replacement, counts and previews exact matches locally, and stores only an ephemeral reviewed proposal. It never writes knowledge. |
-| `confirm_learned_correction` | `proposal_id`, `scope` | `Result<KnowledgeEntry, String>` | Persists the exact reviewed replacement with `learned_correction` provenance and refreshes the next matcher generation. |
-| `discard_learned_correction_proposal` | `proposal_id` | `()` | Discards the matching ephemeral proposal without persistence. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `transform_model_status` | — | `TransformModelStatus` | Install state, size, and platform support for the pinned local LLM. |
+| `download_transform_model` | — | `Result<(), String>` | Streams the pinned GGUF to a `.partial`, hashes while streaming, fsyncs, then atomically publishes under its SHA-256 directory. Exact size and hash are enforced. |
+| `remove_transform_model` | — | `Result<(), String>` | Shuts the helper down first, then deletes the hash directory and any partial. |
+| `reset_transform_runtime` | — | `()` | Clears the circuit breaker after repeated helper faults. |
+
+## Transform diagnostics (`commands/transform_diagnostics.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `list_transform_attempts` | `limit: Option<usize>` | `Result<TransformAttemptListV1, String>` | Bounded, content-free per-pass records including refused, cancelled, and superseded passes. |
+| `arm_next_transform_diagnostic_capture` | — | `Result<CaptureArmStatusV1, String>` | Arms one consented content capture. In-memory only, single pass, 10-minute expiry. |
+| `get_transform_diagnostic_capture_status` | — | `Result<CaptureArmStatusV1, String>` | Whether an arm is live and when it expires. |
+| `list_transform_diagnostic_captures` | — | `Result<Vec<DiagnosticCaptureSummaryV1>, String>` | Stored captures (max 3, 7-day expiry). |
+| `get_transform_diagnostic_capture` | `capture_id: String` | `Result<Option<DiagnosticCaptureV1>, String>` | Full capture for in-app review. There is no export path. |
+| `delete_transform_diagnostic_capture` | `capture_id: String` | `Result<(), String>` | Deletes one capture. |
 
 ## Models (`commands/models.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `check_model_exists` | _(none)_ | `bool` | Returns `true` if any transcription model exists. Used to determine whether the model download screen should be shown on first launch. |
-| `check_specific_model_exists` | `model_name: String` | `bool` | Returns `true` if the specified model file or directory exists on disk. Includes path traversal protection (rejects `..`, `/`, `\` in model names). |
-| `download_model` | `model_name: String` | `Result<(), String>` | Downloads a transcription model with streaming progress events. Allowed models: `large-v3-turbo`, `small.en`, `base.en`, `tiny.en`, `medium.en`. Also co-downloads the Silero VAD model if missing. Whisper models are downloaded as single `.bin` files from Hugging Face. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `check_model_exists` | — | `bool` | Whether any transcription model is installed (drives first-launch routing). |
+| `check_specific_model_exists` | `model_name: String` | `bool` | Whether a named model is on disk. Path-traversal protected. |
+| `get_model_runtime_catalog` | — | `Vec<ModelRuntimeSnapshot>` | Every catalog entry with backend, accelerator, capabilities, platform support, install state, and lifecycle state. |
+| `get_model_runtime_status` | `model_name: String` | `Result<ModelRuntimeSnapshot, String>` | Snapshot for one model. Unknown identifiers error. |
+| `download_model` | `model_name: String` | `Result<(), String>` | Streaming download with `download-progress` events, atomic publication, and Silero VAD co-download. Core ML installs show an indeterminate Installing state during extraction/compilation. |
 
-## Tray (`commands/tray.rs`)
+## Personal knowledge (`commands/knowledge.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `update_tray_icon` | `_icon_state: String` | `Result<(), String>` | No-op. The tray icon is always a static white waveform. Command is retained for API compatibility. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_knowledge_store_status` | — | `KnowledgeStoreStatus` | Ready / recovered / reinitialized / unavailable, schema version, record count, store revision, privacy-safe recovery info. |
+| `retry_knowledge_store` | — | `KnowledgeStoreStatus` | Re-runs local initialization after an unavailable state. |
+| `list_knowledge` | `request: KnowledgeListRequest` | `Result<KnowledgeListResponse, String>` | Bounded search/filter page (default 50, cap 100), with an optional Voice Command filter. |
+| `get_knowledge` | `id: String` | `Result<KnowledgeEntry, String>` | One record by stable ID. |
+| `upsert_knowledge` | `draft: KnowledgeDraft` | `Result<KnowledgeEntry, String>` | Creates or edits with an expected revision. Voice Commands additionally validate payload/type, scope, built-ins, duplicate phrases, variables, clipboard permission, and vocabulary conflicts. |
+| `set_knowledge_enabled` | `id`, `enabled`, `expected_revision` | `Result<KnowledgeEntry, String>` | Enable/disable with optimistic concurrency. |
+| `delete_knowledge` | `id`, `expected_revision` | `Result<u64, String>` | Deletes one record, returns the new store revision. |
+| `resolve_knowledge` | `request: KnowledgeResolveRequest` | `Result<Option<KnowledgeEntry>, String>` | Deterministic exact-trigger resolution using the same scope/provenance precedence that feeds the Smart Correction matcher. |
+| `preview_voice_command` | `request: VoiceCommandPreviewRequest` | `Result<VoiceCommandPreviewResponse, String>` | Runs the real matcher and variable expansion with no clipboard output and no paste. Clipboard input requires both saved permission and an explicit preview request. |
+| `export_knowledge_to_file` | `path: String` | `Result<u64, String>` | Atomic export to versioned JSON. |
+| `inspect_knowledge_import` | `path: String` | `Result<KnowledgeImportSummary, String>` | Validates an import and reports new / duplicate / conflicting records without writing. |
+| `import_knowledge_from_file` | `path: String` | `Result<KnowledgeImportResult, String>` | Atomically imports validated new records; never overwrites local records. |
+| `delete_all_knowledge` | `expected_revision: u64` | `Result<u64, String>` | Deletes all records and in-store recovery artifacts after typed confirmation. |
+
+## Correct and Teach (`commands/correct_and_teach.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `propose_learned_correction` | `request: CorrectionProposalRequest` | `CorrectionProposalOutcome` | Computes one bounded local diff and stores an ephemeral proposal. Never writes knowledge. Ambiguous alignments fail closed. |
+| `propose_specific_learned_correction` | `request: SpecificCorrectionProposalRequest` | `CorrectionProposalOutcome` | Validates one user-selected whole-term replacement, counts and previews exact matches locally, stores an ephemeral proposal. |
+| `confirm_learned_correction` | `proposal_id: u64`, `scope: KnowledgeScope` | `Result<KnowledgeEntry, String>` | Persists the reviewed replacement with `learned_correction` provenance and refreshes the next matcher generation. |
+| `discard_learned_correction_proposal` | `proposal_id: u64` | `()` | Discards the proposal without persistence. |
+
+## Performance Lab (`commands/benchmark.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_benchmark_models` | — | `Vec<BenchmarkModel>` | Installed models eligible for benchmarking. |
+| `get_benchmark_activity` | — | `BenchmarkActivity` | Whether a run is active, for busy-state isolation against dictation and transform. |
+| `run_benchmark` | `request: BenchmarkRequest` | `Result<BenchmarkReport, String>` | Runs the selected models over the fixture corpus, emitting `benchmark-progress`. Reports raw, normalized, and delivered WER plus latency, realtime factor, and memory, with privacy-safe environment/corpus/execution metadata. |
+| `cancel_benchmark` | — | `bool` | Cancels the active run. |
+| `save_benchmark_report` | `report_json`, `output_dir`, `file_name` | `Result<String, String>` | Writes a report as `benchmark-<version>-<machine>-<createdAt>.json`. |
+| `open_benchmark_output_folder` | `output_dir: String` | `Result<(), String>` | Reveals the report folder in Finder. |
+
+## Performance diagnostics (`commands/performance.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `list_performance_runs` | `limit: Option<u32>` | `Result<PerformanceRunListV1, String>` | Completed runs, newest first (cap 200). |
+| `get_performance_run` | `run_id: String` | `Result<Option<PerformanceRunV1>, String>` | One run with stage timings, warm state, RSS deltas, and transform follow-ups. |
+| `get_performance_resource_window` | — | `Result<Vec<ResourceSampleV1>, String>` | The rolling CPU/memory sample window (cap 600). |
+| `clear_performance_diagnostics` | — | `Result<(), String>` | Deletes local run history and samples; emits `performance-diagnostics-cleared`. |
+
+## Logging (`commands/logging.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_log_contents` | `lines: usize` | `String` | Last N lines of the pretty log file. |
+| `clear_logs` | — | `Result<(), String>` | Removes log files (including rotated and JSONL variants) and clears the ring buffer. |
+| `log_frontend` | `level`, `message`, `transform_pass_id: Option<u64>` | `()` | Routes a frontend message through Rust tracing with `source="frontend"`, optionally correlated to a transform pass. |
+| `open_log_viewer` | — | `Result<(), String>` | Shows and focuses the log-viewer window. |
 
 ## Overlay (`commands/overlay.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `show_overlay` | _(none)_ | `Result<(), String>` | Positions and shows the always-on-top overlay window at the macOS notch area. Re-enables mouse events (disabled by `focusable:false`). Emits `overlay-visible-changed(true)`. |
-| `hide_overlay` | _(none)_ | `Result<(), String>` | Hides the overlay window. Gracefully handles missing window. Emits `overlay-visible-changed(false)`. |
-| `get_overlay_geometry` | _(none)_ | `OverlayGeometry` | Returns the current overlay geometry contract (window/pill/dropdown dimensions), derived from the cached notch via `geometry_for()`. Never null — a synthetic fallback notch is substituted when none is detected. |
-| `set_overlay_expanded` | `expanded: bool` | `Result<AppliedSurface, String>` | Resizes the overlay window between the collapsed and expanded frames (top-anchored), returning the applied frame `{windowW, windowH}` as a resize acknowledgment. The frontend's expansion controller awaits this before revealing the dropdown, so CSS never animates into a window that has not yet grown. |
-| `show_main_window` | _(none)_ | `Result<(), String>` | Shows and focuses the main app window. Used by the overlay's gear button instead of frontend window APIs, avoiding broad window permissions in the overlay webview. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_overlay_geometry` | — | `OverlayGeometry` | The geometry contract (window/pill/dropdown boxes) derived from the cached notch by `geometry_for()`. Never null — a synthetic fallback notch substitutes when none is detected. |
+| `show_overlay` | — | `Result<(), String>` | Positions and shows the overlay; re-enables mouse events (disabled by `focusable:false`). |
+| `hide_overlay` | — | `Result<(), String>` | Hides the overlay. |
+| `set_overlay_expanded` | `expanded: bool` | `Result<AppliedSurface, String>` | Resizes between collapsed and expanded frames (top-anchored) and returns the applied frame, so CSS never animates into a window that hasn't grown yet. |
+| `show_main_window` | — | `Result<(), String>` | Shows and focuses the main window — used by the overlay's gear button instead of granting the overlay broad window permissions. |
 
-## Transform Review Popover (`commands/transform_popover.rs`)
+## Frontmost apps (`frontmost.rs`)
 
-Issue #312 PR-C1: UI scaffolding for the animated review popover, driven by a
-mock in the frontend until PR-C2 wires the real sidecar/transform backend.
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `list_running_applications` | — | `Vec<RunningApplication>` | Bounded memory-only list of running apps (bundle ID + name) for the per-app profile picker. Empty on non-macOS. |
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `get_transform_popover_geometry` | `anchor: Option<Rect>` | `TransformPopoverGeometry` | Returns `{compact, expanded}` boxes resolved against `anchor` (selection bounds) and the active screen's visible frame — anchored 8px below, flipped above when the bottom would clip, clamped horizontally, or centered at 38% screen height with no anchor. Pure `popover_geometry_for()` asserted by a checked-in fixture (cargo test + vitest, mirroring the overlay geometry contract). |
-| `show_transform_popover` | `anchor: Option<Rect>` | `Result<(), String>` | Resizes/positions the popover window to the `compact` box (the popover always opens into `listening`), applies the non-activating window treatment (shared with the overlay via `commands/native_window.rs`), and shows it. Caches `anchor` in `State` for `set_transform_popover_expanded`. |
-| `hide_transform_popover` | _(none)_ | `Result<(), String>` | Hides the popover window. |
-| `set_transform_popover_expanded` | `expanded: bool` | `Result<PopoverBox, String>` | Resizes/repositions the popover to the `expanded` (ready/failed) or `compact` (listening/thinking) box, against the anchor cached by the last `show_transform_popover` call, and returns the applied box as an acknowledgment. Not part of the PR-C1 issue's literal command list — added so Rust stays the sole author of every popover pixel across state transitions, mirroring `set_overlay_expanded`'s `AppliedSurface` return so the caller can gate CSS on the resolved frame. |
-| `set_transform_popover_focusable` | `focusable: bool` | `Result<(), String>` | Toggles whether the popover can take key focus. `false` during listening/thinking (never steal focus from the source app); `true` at ready/failed so Enter/Esc/Cmd+R reach the webview. |
-| `get_transform_review_content` | _(none)_ | `TransformReviewContent` | Returns `{instruction, original, proposed}`. Stubbed to empty strings for PR-C1 — PR-C2 wires this to the real transform pipeline. Fetched by the popover window on every `transform-state-changed` event rather than broadcast in the event payload, since this text may be sensitive. |
+## Tray (`commands/tray.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `update_tray_icon` | `_icon_state: String` | `Result<(), String>` | No-op; the tray icon is always the static white waveform. Retained for API compatibility. |
 
 ## Telemetry (`telemetry.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `get_event_history` | _(none)_ | `Vec<AppEvent>` | Returns all entries from the in-memory structured event ring buffer (up to 500 events). Each event has `timestamp`, `stream`, `level`, `summary`, and `data` fields. |
-| `clear_event_history` | _(none)_ | `()` | Clears the in-memory event ring buffer. Does not delete the JSONL file on disk. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_event_history` | — | `Vec<AppEvent>` | The in-memory ring buffer (up to 500 events). |
+| `clear_event_history` | — | `()` | Clears the ring buffer. Does not delete the JSONL file. |
 
-## Resource Monitor (`resource_monitor.rs`)
+## Resource monitor (`resource_monitor.rs`)
 
-| Command | Parameters | Return Type | Description |
-|---------|-----------|-------------|-------------|
-| `get_resource_usage` | _(none)_ | `ResourceUsage` | Returns current system CPU percentage and used memory in MB as `{cpu_percent: f32, memory_mb: u64}`. Uses a persistent `sysinfo::System` instance for accurate delta-based CPU measurement. First call returns approximately 0% CPU. |
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_resource_usage` | — | `ResourceSampleV1` | Current CPU percentage, process RSS, and separated Rust-heap / FFI-heap figures (the custom malloc zone keeps whisper.cpp's allocations out of the Rust total). |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,84 +1,108 @@
 # Tauri Events Reference
 
-This document lists all events emitted from the Rust backend to the frontend via Tauri's event system. The frontend subscribes to these events using `listen()` from `@tauri-apps/api/event`.
+Every event emitted from the Rust backend to the frontend via Tauri's event system, plus the two window-to-window events the frontend emits itself. The frontend subscribes with `listen()` from `@tauri-apps/api/event`.
 
-For commands invoked from the frontend to the backend, see [commands.md](commands.md). For hooks that consume these events, see [hooks.md](hooks.md).
-
----
-
-## Recording and Transcription Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `audio-level` | `f32` (RMS value, 0.0-1.0) | `audio.rs` | Continuously during recording, throttled to ~60fps (16ms minimum gap between emissions). | Overlay window (waveform visualization), main window (`useRecordingState` stores in `audioLevel` state). |
-| `recording-status-changed` | `string` (`"idle"`, `"recording"`, `"processing"`) | `commands/recording.rs` | At every dictation state transition: start recording, stop recording, begin processing, finish processing. | Main window (`useRecordingState` syncs status), overlay window (drives visual state). |
-| `transcription-complete` | `{text: string, duration: number}` | `commands/recording.rs` | After successful transcription produces non-empty text. Broadcast to all windows. Duration is in whole seconds (integer division). | Main window (`useRecordingState` updates history, stats, and transcription display). |
-| `auto-paste-failed` | `string` (hint message, e.g., "Text is in your clipboard -- press Cmd+V to paste manually.") | `commands/recording.rs` (via `injector.rs`) | When auto-paste fails or times out (2-second timeout). Text is already in the clipboard. | Main window (`useRecordingState` shows error for 5 seconds then auto-clears). |
-
-## Model Download Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `download-progress` | `{received: number, total: number}` (byte counts) | `commands/models.rs` | Periodically during model and VAD model streaming downloads. `total` may be 0 if the server does not provide `Content-Length`. | Main window (SettingsPanel download progress bar, ModelDownloader progress bar). |
-
-## Keyboard Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `double-tap-toggle` | `()` (empty) | `keyboard.rs` | When the double-tap detector recognizes a valid double-tap sequence on the trigger key. In "both" mode, emitted on key release when the hold was not promoted but the double-tap sequence completed. | Main window (`useDoubleTapToggle` calls `onToggle`, `useCombinedToggle` calls `onToggle`). |
-| `hold-down-start` | `()` (empty) | `keyboard.rs` | When the hold-down detector recognizes a key press. In hold-down-only mode, emitted immediately on key press. In "both" mode, emitted after the 200ms promotion timer confirms the key is still held. | Main window (`useHoldDownToggle` calls `onStart`, `useCombinedToggle` calls `onStart`). |
-| `hold-down-stop` | `()` (empty) | `keyboard.rs` | When the hold-down key is released (after a valid hold). Also emitted by `update_keyboard_key` if the hotkey is changed while the key is held down, to prevent stuck recording state. | Main window (`useHoldDownToggle` calls `onStop`, `useCombinedToggle` calls `onStop`). |
-| `hotkey-tap-rejected` | `{ reason: "second_tap_expired", mode: "double_tap" \| "both" }` | `keyboard.rs` | When an idle first tap is not followed by a second tap within 400ms. Emitted at timer expiry; never emitted for holds, combos, processing skips, or valid double-taps. | Overlay window (shows the amber timing-miss flash only when `hotkeyMissFeedback` is enabled). |
-| `keyboard-listener-error` | `string` (error message) | `keyboard.rs` | When the rdev listener thread encounters an error. | Main window (all three keyboard hooks listen; on error, they wait 2 seconds then attempt to restart the listener). |
-
-**Note on `hold-down-cancel`:** The frontend `useCombinedToggle.ts` registers a listener for the event name `hold-down-cancel`, but this event is never emitted from any Rust code. In "both" mode, short taps that are not promoted to holds simply emit nothing -- the recording was never started. The frontend listener is dead code.
-
-## Overlay Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `overlay-geometry-changed` | `OverlayGeometry` (never null) | `commands/overlay.rs` | When display configuration changes (monitor plug/unplug, lid open/close). Triggered by an NSNotificationCenter observer watching `NSApplicationDidChangeScreenParametersNotification`; carries the recomputed geometry contract (a synthetic fallback notch substitutes when none is detected, so the payload is never null). | Overlay window: `useOverlayGeometry` updates the geometry it renders from; the expansion controller (`useOverlayExpansion`) treats this as an authoritative reset — it cancels timers, forces `collapsed`, and issues one corrective collapse resize. |
-| `overlay-visible-changed` | `boolean` | `commands/overlay.rs` | After `show_overlay` (`true`) / `hide_overlay` (`false`). **Not currently invoked in production** — the overlay is shown once at setup (`overlay_win.show()` in `lib.rs`) and stays visible for the app's lifetime, so this event has no live emitter today. | Overlay window: gates the expansion controller's cursor poller so it performs no IPC while hidden. Defaults to visible on mount, so first-hover works even though nothing emits this yet. |
-
-## Transform Review Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `transform-state-changed` | `{state: "listening" \| "thinking" \| "ready" \| "failed" \| "applied", errorCode?: "model_not_downloaded" \| "timeout" \| "output_invalid" \| "crashed"}` | Not yet emitted — contract locked in PR-C1 (`lib/transformReview.ts`), real emitter arrives with PR-C2's transform pipeline. | Every review-state-machine transition. Deliberately carries no instruction/original/proposed text (fetched separately via `get_transform_review_content`) so potentially sensitive text is never broadcast as an event payload. | Transform review popover window (`useTransformReviewDriver` sets state/errorCode and re-fetches content). |
-
-## Structured Logging Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `app-event` | `AppEvent {timestamp: string, stream: StreamName, level: LevelName, summary: string, data: Record<string, unknown>}` | `telemetry.rs` (TauriEmitterLayer) | For every `tracing` event in the entire Rust backend. Every log statement becomes a structured event. | Log viewer window (`useEventStore` appends to buffer). Release `pipeline` strings are stripped; `transform` strings are always restricted by key and value to explicit stable enum/bucket vocabularies. |
-
-## Tray Menu Events
-
-| Event | Payload | Source | When It Fires | Listeners |
-|-------|---------|--------|---------------|-----------|
-| `show-about` | `()` (empty) | `lib.rs` (tray menu setup) | When the user selects the "About" item from the tray menu (if present). | Main window (`useShowAboutListener` sets `showAbout` state to `true`, opening the AboutModal). |
+For commands see [commands.md](commands.md). For the hooks that consume these events see [hooks.md](hooks.md).
 
 ---
 
-## Event Payload Types
+## Recording and transcription
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `audio-level` | `f32` (RMS 0.0–1.0) | `audio.rs` | Continuously during capture, throttled to ~60fps (16ms minimum gap). | Overlay (`useWaveform`), main window (`useRecordingState`). |
+| `recording-status-changed` | `string` — `"idle"` \| `"recording"` \| `"processing"` | `commands/recording.rs` | Every dictation state transition. Suppressed when the recording has been superseded by a newer generation. | Main window (`useRecordingState`), overlay (visual state). |
+| `transcription-complete` | `{recordingId, text, duration, teachingContext}` | `commands/recording.rs` | After a non-empty transcription is delivered. Broadcast to all windows. `teachingContext` seeds Correct and Teach. | Main window (`useRecordingState` → history, stats, display). |
+| `recording-cancelled` | `{recordingId}` | `commands/recording.rs` | A recording was discarded without transcription (speculative Both-mode hold, explicit cancel). | Main window, overlay (clears in-flight UI). |
+| `auto-paste-failed` | `string` (hint) | `commands/recording.rs` via `injector.rs` | Auto-paste failed or timed out. The text is already on the clipboard. | Main window (`useRecordingState`, shown for 5s). |
+| `file-output-failed` | `string` (hint) | `commands/recording.rs` | Saving the transcript/audio file failed; clipboard delivery still happened. | Main window. |
+| `file-transcription-status-changed` | `boolean` | `commands/recording.rs` | `true` when an imported-file transcription starts, `false` when it finishes or aborts. Gates dictation and transform. | Main window (`useFileTranscription`). |
+
+## Models
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `download-progress` | `{received, total}` (bytes) | `commands/models.rs` | Periodically during transcription-model and VAD downloads. `total` may be 0 when the server omits `Content-Length`. | Settings download UI, `ModelDownloader`, onboarding. |
+| `model-runtime-status-changed` | `ModelRuntimeSnapshot` | `model_runtime.rs` | On every lifecycle transition (selecting, loading, warming, ready, unloading, failed). Generation-ordered, so a stale load can't overwrite a newer status. | Settings, onboarding, Performance Lab. |
+| `transform-model-download-progress` | `{received, total, phase}` — `phase` is `"downloading"` \| `"installed"` | `commands/transform_model.rs` | While streaming the pinned local-LLM GGUF, and once on successful publication. | Settings → Transform. |
+
+## Keyboard
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `hold-down-start` | `()` | `keyboard.rs` | Hold key pressed (immediately in hold-down mode; after the 200ms promotion timer in Both mode). | `useHoldDownToggle`, `useCombinedToggle`. |
+| `hold-down-stop` | `()` | `keyboard.rs` | Hold key released after a valid hold. Also emitted by `update_keyboard_key` when the key changes mid-hold, so no recording is stranded. | `useHoldDownToggle`, `useCombinedToggle`. |
+| `double-tap-toggle` | `()` | `keyboard.rs` | A valid double-tap sequence completes. In Both mode, emitted on release when the hold was never promoted. | `useDoubleTapToggle`, `useCombinedToggle`. |
+| `hotkey-tap-rejected` | `{reason: "second_tap_expired", mode: "double_tap" \| "both"}` | `keyboard.rs` | An idle first tap is not followed by a second within 400ms. Never for holds, combos, processing skips, or valid double-taps. | Overlay — amber timing-miss flash, only when `hotkeyMissFeedback` is on. |
+| `keyboard-listener-error` | `string` | `keyboard.rs` | The rdev listener thread errors. | All three recording hooks; they wait 2s and restart the listener. |
+| `app-disabled-changed` | `boolean` | `commands/keyboard.rs` | Global disable toggled from the tray or the overlay's power button. | Main window, overlay (`useOverlayRuntime`). |
+
+**Dead listener:** `useCombinedToggle` registers `hold-down-cancel`, which nothing emits. In Both mode an unpromoted tap emits nothing at all, because no recording was ever started.
+
+## Selected-text transform
+
+All transform events carry a `transformPassId` where a pass exists, so a delayed handler can prove whether it still owns the flow. None of them carry instruction, selection, or proposal text.
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `transform-key-pressed` | `{transformPassId}` | `keyboard.rs` | The transform hold key goes down. The pass ID is assigned here, in the rdev callback. | Main window (`useTransformFlow`). |
+| `transform-key-released` | `{transformPassId}` | `keyboard.rs`, `commands/keyboard.rs` | The transform key is released, or the listener is torn down while it is held. | Main window (`useTransformFlow`). |
+| `transform-state-changed` | `{state, transformPassId, errorCode?}` — `state` is `listening` \| `thinking` \| `ready` \| `failed` \| `applied`; `errorCode` is a stable enum (`model_not_downloaded`, `timeout`, `output_invalid`, `crashed`, `target_gone`, `selection_changed`, `paste_failed`, …) | `transform_flow.rs` | Every review-state transition. Deliberately carries no text — the popover fetches content separately via `get_transform_review_content`. | Transform popover (`useTransformReviewDriver`). |
+| `transform-review-hidden` | `()` | `transform_flow.rs` | The popover has been hidden (cancel, linger expiry, teardown). | Popover, main window. |
+| `transform-busy` | `()` | `transform_flow.rs` | A transform keypress was refused because dictation, a benchmark, a file transcription, or another transform owns the pipeline. | Overlay — amber busy flash, so the press is never silently ignored. |
+| `transform-secure-field` | `()` | `transform_flow.rs` | Capture refused because the focused element is (or cannot be proven not to be) a secure field. No content is shown. | Overlay flash only. |
+| `transform-apply-failed` | `string` (stable error code) | `transform_apply.rs` | Apply or undo write-back failed. | Popover — surfaces the failure inline while keeping Undo available. |
+| `escape-cancel` | `{transformPassId}` | `keyboard.rs` | Escape pressed during Capturing / Listening / Thinking, or the brief ReviewPending window before the popover is focusable. Snapshots the pass ID at press time. | Main window (`useEscapeCancel`) → scoped `cancel_transform`. |
+
+## Overlay
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `overlay-geometry-changed` | `OverlayGeometry` (never null) | `commands/overlay.rs` | Display configuration changes (monitor plug/unplug, lid open/close), via an `NSApplicationDidChangeScreenParametersNotification` observer. Carries the recomputed contract. | Overlay: `useOverlayGeometry` re-renders from it; `useOverlayExpansion` treats it as an authoritative reset — cancels timers, forces collapsed, issues one corrective resize. |
+| `overlay-visible-changed` | `boolean` | `commands/overlay.rs` | After `show_overlay` / `hide_overlay`. **No live emitter in production** — the overlay is shown once at setup and stays visible, so nothing calls these today. | Overlay: gates the expansion controller's cursor poller. Defaults to visible on mount so first hover works regardless. |
+
+## Diagnostics and benchmarking
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `performance-run-completed` | `PerformanceRunV1` | `performance_metrics/mod.rs` | A dictation, file, or transform run finishes and is persisted. | Log viewer (`usePerformanceDiagnostics`). |
+| `performance-resource-sample` | `ResourceSampleV1` | `performance_metrics/mod.rs` | Once per second from the resource heartbeat: host CPU, main-process CPU/RSS/Rust-heap/FFI-heap, and sidecar process figures. | Log viewer charts. |
+| `performance-diagnostics-cleared` | `()` | `performance_metrics/mod.rs` | Local run history and samples were deleted. | Log viewer (resets views). |
+| `benchmark-progress` | `BenchmarkProgress {completed, …}` | `benchmark.rs` | During a Performance Lab run, per completed model/fixture unit. | Performance Lab. |
+| `vocab-scan-progress` | `VocabScanProgress {scanId, files, skipped, terms, …}` | `commands/recording.rs` | Throttled during a code-vocabulary folder walk, plus once at completion. Correlated by `scanId` so a superseded scan can't overwrite a newer one. | Settings (`useVocabScan`, `VocabScanStrip`). |
+
+## Structured logging
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `app-event` | `AppEvent` | `telemetry.rs` (`TauriEmitterLayer`) | For **every** `tracing` event in the Rust backend. | Log viewer (`useEventStore`). Release `pipeline` strings are stripped; `transform` strings are restricted by key **and** value to an explicit stable vocabulary in all builds. |
+
+## Frontend-emitted (window to window)
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `settings-changed` | `()` | `useSettings`, `useOverlaySettingsMirror` | A window mutates persisted settings, so the other windows re-read localStorage. | Main window, overlay. |
+| `open-settings` | `()` | `useOverlaySettingsMirror` | The overlay's quick-settings card asks the main window to open Settings. | Main window (`useOpenSettingsListener`). |
+
+**Dead listener:** `useShowAboutListener` listens for `show-about`, but the tray menu no longer has an About item (it is Show Murmur / Disable Murmur / Quit), so nothing emits it.
+
+---
+
+## Event payload types
 
 ### AppEvent
 
 ```typescript
 interface AppEvent {
-  timestamp: string;        // ISO timestamp
-  stream: StreamName;       // "pipeline" | "audio" | "keyboard" | "transform" | "system"
-  level: LevelName;         // "trace" | "debug" | "info" | "warn" | "error"
-  summary: string;          // The tracing message
-  data: Record<string, unknown>;  // Structured fields from the tracing event
+  timestamp: string;              // ISO timestamp
+  stream: StreamName;             // tracing target
+  level: LevelName;
+  summary: string;                // the tracing message
+  data: Record<string, unknown>;  // structured fields, after privacy stripping
 }
-```
 
-### Stream and Level Types
-
-```typescript
 type StreamName = 'pipeline' | 'audio' | 'keyboard' | 'transform' | 'system';
-type LevelName = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+type LevelName  = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 ```
 
-Streams correspond to Rust tracing targets. Levels correspond to standard tracing severity levels. Color mappings for both streams and levels are defined in `app/src/lib/events.ts`.
+Streams correspond to Rust tracing targets; levels to standard tracing severities. Color mappings for both live in `app/src/lib/events.ts`.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,348 +1,121 @@
 # React Hooks Reference
 
-This document lists all 11 custom React hooks in Murmur. Each hook is located under `app/src/lib/hooks/` and is consumed by `App.tsx` or by window-specific entry points (overlay, log viewer).
+The 28 custom React hooks under `app/src/lib/hooks/`, grouped by the window that uses them. Hooks are where nearly all frontend behavior lives — `App.tsx` and `OverlayWidget.tsx` are thin composition shells.
 
-For the Tauri commands these hooks invoke, see [commands.md](commands.md). For the events they listen to, see [events.md](events.md). For settings managed by `useSettings`, see [settings.md](settings.md).
-
----
-
-## useAutoUpdater
-
-**File:** `app/src/lib/hooks/useAutoUpdater.ts`
-
-**Parameters:** None.
-
-**Returns:** `UseAutoUpdaterReturn`
-
-```typescript
-interface UseAutoUpdaterReturn {
-  updateStatus: UpdateStatus;
-  checkForUpdate: () => Promise<void>;
-  startDownload: () => Promise<void>;
-  skipVersion: () => void;
-  dismissUpdate: () => void;
-}
-```
-
-**Responsibilities:**
-- Checks for updates on launch and every 24 hours (`CHECK_INTERVAL_MS`). Supports forced updates when the current version is below a remote `min_version` field.
-- Manages the full update lifecycle: check, download with progress, install, and relaunch via `@tauri-apps/plugin-updater` and `@tauri-apps/plugin-process`.
-- Sends a macOS notification when an update is discovered during a background check.
-
-**Key interactions:**
-- Fetches `min_version` from the current GitHub releases `latest-v2.json` channel via HTTP.
-- Stores skipped version in localStorage under `skipped-update-version`.
-- Stores last check timestamp in localStorage under `updater-last-check`.
+For the commands these hooks call see [commands.md](commands.md). For the events they subscribe to see [events.md](events.md). For settings managed by `useSettings` see [settings.md](settings.md).
 
 ---
 
-## useCombinedToggle
+## Recording and dictation (main window)
 
-**File:** `app/src/lib/hooks/useCombinedToggle.ts`
+### `useRecordingState`
+The dictation state machine. Owns `status` (`idle` / `recording` / `processing`), audio level, locked mode, and the error/hint banners. Subscribes to `recording-status-changed`, `transcription-complete`, `recording-cancelled`, `audio-level`, `auto-paste-failed`, and `file-output-failed`; invokes `start_native_recording` / `stop_native_recording` / `cancel_native_recording`.
 
-**Parameters:**
+**`transcription-complete` is the single source of truth** for history and stats — entries are never added in `handleStop()`, because the overlay can start a recording independently and that would double-count.
 
-```typescript
-interface UseCombinedToggleProps {
-  enabled: boolean;
-  initialized: boolean;
-  accessibilityGranted: boolean | null;
-  triggerKey: string;
-  status: DictationStatus;
-  onStart: () => void;
-  onStop: () => void;
-  onToggle: () => void;
-}
-```
+`statusRef` mirrors `status` so hotkey callbacks always read current state instead of a stale closure capture; callbacks themselves are stored in refs so listener setup doesn't re-run on identity changes.
 
-**Returns:** `void`
+### `useHoldDownToggle`
+Hold-down mode. Listens for `hold-down-start` / `hold-down-stop`, plus `keyboard-listener-error` for error recovery and auto-restart after 2s. Gated by `enabled`.
 
-**Responsibilities:**
-- Combines hold-down and double-tap keyboard detection on a single trigger key. Active when `recordingMode` is `'both'`.
-- Tracks whether a hold-down press is currently active via `holdActiveRef` to prevent the eager hold-start from corrupting the double-tap state machine.
-- Syncs recording state to the backend double-tap detector via `set_keyboard_recording`, but skips syncing while a hold press is active.
+### `useDoubleTapToggle`
+Double-tap mode. Listens for `double-tap-toggle` and syncs `recording` back into the detector via `set_keyboard_recording`. Gated by `enabled`.
 
-**Key interactions:**
-- Listens to events: `hold-down-start`, `hold-down-stop`, `double-tap-toggle`, `keyboard-listener-error`, `hold-down-cancel` (dead code -- this event is never emitted from Rust).
-- Invokes commands: `start_keyboard_listener` (mode `"both"`), `stop_keyboard_listener`, `set_keyboard_recording`, `cancel_native_recording` (in the dead `hold-down-cancel` handler).
+### `useCombinedToggle`
+Both modes at once. `holdActiveRef` prevents the double-tap path from firing on hold release; calls `cancel_native_recording` to discard speculative recordings from short taps. Gated by `enabled`.
+
+All three are always called (Rules of Hooks) and switched by the `enabled` prop rather than conditional invocation.
+
+### `useFileTranscription`
+Imported-file transcription: file selection, `transcribe_file`, and the `file-transcription-status-changed` busy state. Adds the result to history through the same `addEntry` path as live dictation.
+
+### `useHistoryManagement`
+Transcription history with localStorage persistence (`dictation-history`, max 50 entries), clear-with-confirmation, and the Correct-and-Teach entry point on the newest entry.
 
 ---
 
-## useDoubleTapToggle
+## Configuration and lifecycle (main window)
 
-**File:** `app/src/lib/hooks/useDoubleTapToggle.ts`
+### `useSettings`
+Loads and persists `Settings` to localStorage, pushes the backend-relevant subset to `configure_dictation`, and reconciles `launchAtLogin` with the actual OS autostart state on mount. Updates are optimistic with rollback: if `configure_dictation` fails, the affected fields revert, and a versioned configure ref prevents a stale rollback from clobbering newer settings. Emits `settings-changed` so the overlay re-reads.
 
-**Parameters:**
+### `useInitialization`
+One-time init sequence on mount: `init_dictation`, then `configure_dictation` with the loaded settings.
 
-```typescript
-interface UseDoubleTapToggleProps {
-  enabled: boolean;
-  initialized: boolean;
-  accessibilityGranted: boolean | null;
-  doubleTapKey: string;
-  status: DictationStatus;
-  onToggle: () => void;
-}
-```
+### `useAutoUpdater`
+OTA updates: background check on launch and every 24h, semver comparison, min-version enforcement (forced updates drop Skip/Later), skip/dismiss persistence, download progress, install, and auto-relaunch. Fires a native macOS notification when a background check finds an update.
 
-**Returns:** `void`
+Returns `{updateStatus, checkForUpdate, startDownload, skipVersion, dismissUpdate}`. Reads `min_version` from the `latest-v2.json` channel; persists `skipped-update-version` and `updater-last-check` to localStorage.
 
-**Responsibilities:**
-- Manages the double-tap keyboard listener for standalone double-tap mode. Active when `recordingMode` is `'double_tap'`.
-- Keeps the backend double-tap detector in sync with the current recording status via `set_keyboard_recording`.
-- On `keyboard-listener-error`, waits 2 seconds then attempts to restart the listener.
+### `useOpenSettingsListener`
+Listens for `open-settings` from the overlay's gear button and opens the Settings panel — showing the main window isn't enough, since panel visibility is local React state.
 
-**Key interactions:**
-- Listens to events: `double-tap-toggle`, `keyboard-listener-error`.
-- Invokes commands: `start_keyboard_listener` (mode `"double_tap"`), `stop_keyboard_listener`, `set_keyboard_recording`.
+### `useOverlaySettingsSync`
+The other direction: listens for `settings-changed` emitted by the overlay's quick controls and applies the persisted settings to main-window state and the backend.
+
+### `useShowAboutListener`
+Listens for `show-about`. **Currently inert** — the tray menu no longer has an About item, so nothing emits this event.
 
 ---
 
-## useHoldDownToggle
+## Selected-text transform
 
-**File:** `app/src/lib/hooks/useHoldDownToggle.ts`
+### `useTransformFlow` (main window)
+Drives the transform hold key. Listens for `transform-key-pressed` / `transform-key-released` and calls `start_transform_capture` / `finish_transform_instruction`, carrying the `transformPassId` from the event rather than re-deriving it. Pure press/release reduction lives in `lib/transformFlow.ts`.
 
-**Parameters:**
+### `useEscapeCancel` (main window)
+Listens for `escape-cancel` and issues a **scoped** `cancel_transform` with the pass ID snapshotted at key-press time, so a delayed Escape cannot cancel the pass that replaced it. Ready/failed reviews keep their own popover-local Escape handling.
 
-```typescript
-interface UseHoldDownToggleProps {
-  enabled: boolean;
-  initialized: boolean;
-  accessibilityGranted: boolean | null;
-  holdDownKey: string;
-  onStart: () => void;
-  onStop: () => void;
-}
-```
+### `useTransformReviewDriver` (popover window)
+The review popover's state machine. Subscribes to `transform-state-changed`, re-fetching `get_transform_review_content` on each transition (content is never carried in the event payload), and exposes approve / retry / cancel / undo. Also handles `transform-apply-failed` and `transform-review-hidden`.
 
-**Returns:** `void`
-
-**Responsibilities:**
-- Manages the hold-down keyboard listener for standalone hold-down mode. Active when `recordingMode` is `'hold_down'`.
-- Calls `onStart` on key press and `onStop` on key release. Does not handle `hold-down-cancel`.
-- On `keyboard-listener-error`, waits 2 seconds then attempts to restart the listener.
-
-**Key interactions:**
-- Listens to events: `hold-down-start`, `hold-down-stop`, `keyboard-listener-error`.
-- Invokes commands: `start_keyboard_listener` (mode `"hold_down"`), `stop_keyboard_listener`.
+### `useTransformReviewMockDriver` (dev only)
+Demo driver reachable via `?mock=1` (or `?mock=<state>`) on the popover URL, so the whole review UI can be exercised without a backend. Gated on `import.meta.env.DEV` by its caller; never in a production code path.
 
 ---
 
-## useHistoryManagement
+## Overlay window
 
-**File:** `app/src/lib/hooks/useHistoryManagement.ts`
+### `useOverlayGeometry`
+Owns geometry sourced from Rust — the single source of truth. Fetches `get_overlay_geometry` with a retry/backoff schedule (a single failed fetch used to leave the transparent overlay blank until the next display change) and re-reads on `overlay-geometry-changed`.
 
-**Parameters:** None.
+### `useOverlayExpansion`
+The hover-expand lifecycle, owned end to end: 150ms dwell intent gate, cursor polling, and the **only** writer to the native resize path (`set_overlay_expanded`). Awaits the applied frame before revealing the dropdown, so CSS never animates into a window that hasn't grown yet. Treats `overlay-geometry-changed` as an authoritative reset — cancels timers, forces collapsed, issues one corrective resize.
 
-**Returns:**
+### `useOverlayRuntime`
+Overlay runtime flashes and mirrors: cancelled and hotkey-miss timers, the `transform-busy` and `transform-secure-field` flashes, and the `app-disabled-changed` state mirror.
 
-```typescript
-{
-  historyEntries: HistoryEntry[];
-  addEntry: (text: string, duration: number) => void;
-  clearHistory: () => void;
-}
-```
+### `useOverlaySettingsMirror`
+The overlay's snapshot of persisted settings (read straight from localStorage — there is no shared React context across windows) plus the quick-control actions: auto-paste toggle, global disable, and `open-settings`.
 
-**Responsibilities:**
-- Manages the transcription history array with a maximum of 50 entries (oldest trimmed).
-- Persists history to localStorage under the key `dictation-history`.
-- Provides `addEntry` (used by `useRecordingState` via the `transcription-complete` event) and `clearHistory` callbacks.
+### `useRecordingControls`
+Click disambiguation on the island: single click (250ms debounce) stops recording or exits locked mode; double-click toggles locked mode.
 
-**Key interactions:**
-- Pure frontend state management. No Tauri commands or events. Delegates to `lib/history.ts` for persistence.
+### `useWaveform`
+Owns the `audio-level` listener and the rAF bar-height animation. Writes bar heights through direct DOM refs, bypassing React reconciliation to hold 60fps. Center bars are taller (envelope shaping) with jitter for organic movement.
 
 ---
 
-## useInitialization
+## Diagnostics (log viewer)
 
-**File:** `app/src/lib/hooks/useInitialization.ts`
+### `useEventStore`
+The structured event buffer: hydrates from `get_event_history`, streams live `app-event`s, batches rendering via rAF, and provides stream/level filtering and clear.
 
-**Parameters:** `settings: Settings`
+### `usePerformanceDiagnostics`
+Run history and resource samples. Hydrates from `list_performance_runs` / `get_performance_resource_window`, then merges live `performance-run-completed` and `performance-resource-sample` events (the exported `mergeRuns` / `mergeResourceSamples` are pure and unit-tested), and resets on `performance-diagnostics-cleared`. Gated by an `enabled` flag so a hidden tab does no work.
 
-**Returns:**
+### `usePerformanceHealth`
+Summary health of the diagnostics store (availability, counts) with an explicit `refresh`.
 
-```typescript
-{
-  initialized: boolean;
-  error: string;
-}
-```
-
-**Responsibilities:**
-- Runs the one-time initialization sequence on mount: `initDictation()` then `configure()` with the current model, language, and autoPaste settings.
-- Sets `initialized` to `true` on success, which gates the recording controls and keyboard listeners.
-- Uses a cancellation flag to prevent stale state updates after unmount.
-
-**Key interactions:**
-- Invokes commands: `init_dictation`, `configure_dictation`.
-- Note: Does not pass `autoPasteDelayMs` or `vadSensitivity` during initial configure. Those values are sent to the backend when `useSettings.updateSettings` is called.
+### `useResourceMonitor`
+CPU/memory polling with a rolling 60-reading buffer. Only polls while the panel is expanded.
 
 ---
 
-## useRecordingState
+## Settings surfaces
 
-**File:** `app/src/lib/hooks/useRecordingState.ts`
+### `useKnowledge`
+Bounded, paged access to the personal knowledge store (`list_knowledge`) with search/filter, driven by a request object and an `active` gate so closed panels don't query.
 
-**Parameters:**
-
-```typescript
-interface UseRecordingStateProps {
-  addEntry: (text: string, duration: number) => void;
-  microphone: string;
-}
-```
-
-**Returns:**
-
-```typescript
-{
-  status: DictationStatus;
-  transcription: string;
-  recordingDuration: number;
-  error: string;
-  setError: (error: string) => void;
-  handleStart: () => Promise<void>;
-  handleStop: () => Promise<void>;
-  toggleRecording: () => Promise<void>;
-  audioLevel: number;
-  lockedMode: boolean;
-  toggleLockedMode: () => Promise<void>;
-  statsVersion: number;
-}
-```
-
-**Responsibilities:**
-- Core recording state machine (`idle` -> `recording` -> `processing` -> `idle`) with guard refs to prevent concurrent start/stop calls.
-- Handles history and stats updates exclusively through the `transcription-complete` event listener to avoid race-condition duplicates.
-- Manages locked mode (overlay-initiated persistent recording), audio level tracking, recording duration timer (1-second ticks), and auto-paste error display (5-second auto-clear).
-
-**Key interactions:**
-- Listens to events: `recording-status-changed` (syncs status from overlay), `transcription-complete` (single source of truth for history/stats), `auto-paste-failed` (error display), `audio-level` (waveform data).
-- Invokes commands: `start_native_recording`, `stop_native_recording`.
-
----
-
-## useResourceMonitor
-
-**File:** `app/src/lib/hooks/useResourceMonitor.ts`
-
-**Parameters:** `enabled: boolean`
-
-**Returns:** `ResourceReading[]`
-
-```typescript
-interface ResourceReading {
-  cpu_percent: number;
-  memory_mb: number;
-}
-```
-
-**Responsibilities:**
-- Polls `get_resource_usage` every 1 second when enabled. Stops polling when disabled.
-- Maintains a rolling window of up to 60 readings (1 minute of data).
-- Clears stale readings when re-enabled so the chart starts fresh.
-
-**Key interactions:**
-- Invokes command: `get_resource_usage`.
-- No events listened.
-
----
-
-## useSettings
-
-**File:** `app/src/lib/hooks/useSettings.ts`
-
-**Parameters:** None.
-
-**Returns:**
-
-```typescript
-{
-  settings: Settings;
-  updateSettings: (updates: Partial<Settings>) => void;
-}
-```
-
-**Responsibilities:**
-- Wraps settings load/save with React state. Loads from localStorage on initialization, applies migrations.
-- Pushes relevant setting changes to the Rust backend via `configure_dictation` (model, language, autoPaste, autoPasteDelayMs, vadSensitivity). Uses versioned configure calls to prevent stale rollbacks.
-- Synchronizes `launchAtLogin` with the OS autostart state on mount (detects if user removed login item from System Settings). Serializes autostart enable/disable calls via a promise chain.
-
-**Key interactions:**
-- Invokes commands: `configure_dictation` (via `lib/dictation.ts`).
-- Uses `@tauri-apps/plugin-autostart` for `enable()`, `disable()`, `isEnabled()`.
-- See [settings.md](settings.md) for the full settings schema.
-
----
-
-## useShowAboutListener
-
-**File:** `app/src/lib/hooks/useShowAboutListener.ts`
-
-**Parameters:** None.
-
-**Returns:**
-
-```typescript
-{
-  showAbout: boolean;
-  setShowAbout: (value: boolean) => void;
-}
-```
-
-**Responsibilities:**
-- Listens for the `show-about` Tauri event (emitted from the tray menu) and sets `showAbout` to `true`.
-- Consumed in `App.tsx` to control the AboutModal visibility.
-
-**Key interactions:**
-- Listens to event: `show-about`.
-- No commands invoked.
-
----
-
-## useEventStore
-
-**File:** `app/src/lib/hooks/useEventStore.ts`
-
-**Parameters:** None.
-
-**Returns:**
-
-```typescript
-{
-  events: AppEvent[];
-  getByStream: (stream: StreamName) => AppEvent[];
-  getByLevel: (level: LevelName) => AppEvent[];
-  clear: () => void;
-}
-```
-
-**Responsibilities:**
-- Manages an in-memory buffer of up to 500 `AppEvent` objects. Hydrates from the backend on mount via `get_event_history`.
-- Streams new events in real-time via the `app-event` Tauri event. Coalesces rapid event bursts into a single React state update using `requestAnimationFrame`.
-- Provides filter methods (`getByStream`, `getByLevel`) that read directly from the mutable ref buffer (always up-to-date but not reactive on their own).
-
-**Key interactions:**
-- Listens to event: `app-event`.
-- Invokes commands: `get_event_history` (on mount), `clear_event_history` (on clear).
-
----
-
-## Hook Activation in App.tsx
-
-All hooks are always called (Rules of Hooks), but their behavior is gated by props:
-
-| Hook | Active When |
-|------|-------------|
-| `useHoldDownToggle` | `recordingMode === 'hold_down'` |
-| `useDoubleTapToggle` | `recordingMode === 'double_tap'` |
-| `useCombinedToggle` | `recordingMode === 'both'` |
-| `useAutoUpdater` | Always |
-| `useInitialization` | Always (runs once on mount) |
-| `useRecordingState` | Always |
-| `useHistoryManagement` | Always |
-| `useSettings` | Always |
-| `useShowAboutListener` | Always |
-| `useResourceMonitor` | When the resource monitor panel is expanded |
-| `useEventStore` | Used in the log-viewer window |
+### `useVocabScan`
+Live code-vocabulary scan: starts `scan_code_vocab`, streams `vocab-scan-progress` correlated by `scanId`, and reports non-adoption when a newer scan or a settings change supersedes the walk.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -10,14 +10,15 @@ For the hook that manages settings, see [hooks.md](hooks.md). For the backend co
 
 All settings are stored in `localStorage` under the key `dictation-settings` as a single JSON object.
 
-The native Settings window has six pages in this order:
+The native Settings window has seven pages in this order (`SETTINGS_CATEGORIES` in `SettingsPanel.tsx`):
 
 1. **Recording** — microphone, voice detection, recording trigger, and shortcut feedback
 2. **Transcription** — one model selector, language, model lifecycle/download state, and idle release
-3. **Text & Vocabulary** — punctuation, cleanup, names and terms, developer terms, corrections, structured writing, spoken commands, and personal knowledge
-4. **Delivery** — clipboard-first behavior, auto-paste, file output, and app overrides
-5. **Performance** — the directional local Performance Lab
-6. **General** — launch at login, setup, logs, statistics, updates, and version
+3. **Transform** — enable + hold-key picker, local-LLM model status/download/remove/reset, and saved transforms
+4. **Text & Vocabulary** — punctuation, cleanup, names and terms, developer terms, corrections, structured writing, spoken commands, and personal knowledge
+5. **Delivery** — clipboard-first behavior, auto-paste, file output, and app overrides
+6. **Performance** — the directional local Performance Lab
+7. **General** — launch at login, setup, logs, statistics, updates, and version
 
 Changing pages only changes presentation. It does not rename, discard, or
 reinterpret persisted fields. A round-trip compatibility test serializes and
@@ -26,20 +27,58 @@ IDE roots.
 
 **Source file:** `app/src/lib/settings.ts`
 
-**TypeScript interface:**
+**TypeScript interface** (full current shape — see `settings.ts` for the per-field comments):
 
 ```typescript
 interface Settings {
+  // Transcription
   model: ModelOption;
-  doubleTapKey: DoubleTapKey;
   language: string;
-  autoPaste: boolean;
-  autoPasteDelayMs: number;
+  vadSensitivity: number;
+  idleTimeoutMinutes: number;
+
+  // Recording
   recordingMode: RecordingMode;
+  doubleTapKey: DoubleTapKey;
   hotkeyMissFeedback: boolean;
   microphone: string;
+  disabled: boolean;
+
+  // Transform (selected-text rewrite)
+  transformHoldKey: TransformKey | null;   // null = disabled (default)
+
+  // Delivery
+  autoPaste: boolean;
+  autoPasteDelayMs: number;
+  saveTranscript: boolean;
+  saveAudio: boolean;
+  outputDir: string;
+
+  // Text intelligence
+  smartPunctuation: boolean;
+  cleanupEnabled: boolean;
+  cleanupRemoveFiller: boolean;
+  cleanupCapitalize: boolean;
+  smartFormattingEnabled: boolean;
+  correctionEnabled: boolean;
+  correctionFuzzy: boolean;
+  voiceCommandsEnabled: boolean;
+  voiceCommands: VoiceCommand[];           // legacy pairs, migration-only
+  vocabularyEntries: VocabularyEntry[];
+  customVocabulary: string;                // @deprecated derived mirror
+  codeVocabEnabled: boolean;
+  codeVocabFolder: string;
+  codeVocabLastScan: VocabScanSummary | null;
+
+  // Per-app
+  appProfiles: AppProfile[];
+
+  // Performance Lab
+  benchmarkOutputDir: string;
+  benchmarkAutoSave: boolean;
+
+  // System
   launchAtLogin: boolean;
-  vadSensitivity: number;
 }
 ```
 
@@ -82,6 +121,14 @@ model-selection side effects.
 | `doubleTapKey` | `DoubleTapKey` | `'shift_l'` | `'shift_l'` (Shift), `'alt_l'` (Option), `'ctrl_r'` (Control) | The modifier key used for recording triggers. Used by all three recording modes as the trigger key. Label in the settings UI changes based on `recordingMode`. |
 | `hotkeyMissFeedback` | `boolean` | `false` | `true` / `false` | In Double-Tap or Both mode, briefly flashes the overlay amber when the 400ms second-tap window expires. It does not fire for holds, modifier shortcuts, processing skips, or successful gestures. Frontend/overlay only. |
 | `vadSensitivity` | `number` | `50` | 0-100, step 5 in UI | Voice Activity Detection sensitivity. Higher values keep more audio; lower values trim silence more aggressively. The backend converts this to a threshold: `1.0 - (sensitivity / 100.0)`. Clamped to 0-100 by the backend. |
+| `disabled` | `boolean` | `false` | `true` / `false` | Global disable. Mirrors the tray "Disable Murmur" check item and the overlay's power button; the hover quick-settings card stays reachable while disabled so the overlay can turn Murmur back on. |
+| `idleTimeoutMinutes` | `number` | `5` | `5`, `15`, `0` (Never) | How long an idle loaded model stays resident before the runtime releases it. `0` keeps it loaded indefinitely. |
+
+### Transform Settings
+
+| Setting | Type | Default | Valid Options/Range | Description |
+|---------|------|---------|-------------------|-------------|
+| `transformHoldKey` | `TransformKey \| null` | `null` | `'alt_r'` (Right Option), `'ctrl_l'` (Left Control), `'shift_r'` (Right Shift), or `null` to disable | The independent hold key for selected-text transform. Deliberately a distinct id set from `doubleTapKey` so the two shortcuts coexist; the picker rejects the active dictation key. Anything unrecognized — including an absent field on pre-feature settings — coerces back to `null` rather than silently arming a shortcut.<br><br>The transform **model**, saved transforms, and presets are not localStorage settings: the model install lives on disk under the app models directory, and saved transforms are knowledge-store records. See [Selected-text Transform](../features/selected-text-transform.md). |
 
 ### Recording Mode Details
 
@@ -161,8 +208,10 @@ New text replacements and snippets are Rust-owned knowledge records rather than 
 2. If found, parses as JSON and merges with `DEFAULT_SETTINGS` (stored values override defaults). Legacy comma/newline-separated `customVocabulary` values migrate to enabled global `vocabularyEntries` with no aliases.
 3. Applies migration: if `recordingMode` is missing or invalid (including the legacy `'hotkey'` value), resets to `'hold_down'`.
 4. Strips the legacy `hotkey` field if present.
-5. Validates `model` against the current allow-list. Any invalid or removed model (e.g. `moonshine-tiny`, `moonshine-base`) is reset to `'base.en'`.
-6. If not found or on parse error, returns `DEFAULT_SETTINGS`.
+5. Validates `model` against the platform allow-list. Any invalid or removed model (e.g. `moonshine-tiny`, `moonshine-base`) resets to the platform default — Core ML Parakeet v3 on Apple Silicon macOS, CPU Parakeet elsewhere. `language` is validated against `LANGUAGE_OPTIONS` the same way.
+6. Coerces `transformHoldKey` to `null` unless it matches `TRANSFORM_KEY_OPTIONS`, and sanitizes every structured field — `appProfiles`, `voiceCommands`, `vocabularyEntries`, `codeVocabLastScan` — dropping malformed entries and clamping list lengths so a tampered blob can't reach the Rust side or render bad numbers.
+7. Removes fields from deleted features (`hotkey`, `liveTranscriptPreview`).
+8. If not found or on parse error, returns `DEFAULT_SETTINGS`.
 
 ### Backend Synchronization
 


### PR DESCRIPTION
The top-level docs had drifted badly behind the code. ARCHITECTURE.md predated the LLM sidecar, model runtime, knowledge store, and transform window; FEATURES.md was still labelled v0.8.0; commands.md documented 30 of 105 commands and described Transform as an unimplemented stub; events.md was missing ~12 events; hooks.md covered 11 of 28 hooks.

Rewritten:
- docs/ARCHITECTURE.md — both inference stacks, four windows, full module map, dictation + transform flows, ordered transcript pipeline, sidecar hardening, both data roots, thread model, design decisions
- docs/FEATURES.md — current feature map across nine areas
- docs/reference/commands.md — all 105 commands, verified against invoke_handler! in both directions
- docs/reference/hooks.md — all 28 hooks, grouped by window
- docs/reference/events.md — every event with payloads read from emit sites; dead listeners flagged
- docs/DEVELOPMENT.md — sidecar build step first, real-world gotchas

Patched: README.md, docs/onboarding.md, docs/reference/settings.md (interface block was missing ~25 fields; seven Settings pages, not six), CLAUDE.md file map and key patterns. AGENTS.md was a stale fork of CLAUDE.md and is now identical below the header.

Corrections: 105 commands (not 106 — the generate_handler! line was miscounted), and Settings has seven pages since Transform shipped.

No code changes. All internal doc links verified to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed Murmur installation and onboarding guidance for macOS 14+ on Apple Silicon.
  * Added setup instructions for the local rewriting helper, permissions, models, troubleshooting, testing, and diagnostics.
  * Expanded feature documentation for selected-text Transform, smart formatting, vocabulary tools, personal knowledge, and recording modes.
  * Updated architecture and privacy guidance, including secure-field handling and offline rewriting.
  * Reorganized command, event, hook, and settings references, including the new Transform settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->