### PR TITLE
feat: show release notes after updates

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - wontfix
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,12 +451,19 @@ jobs:
             exit 1
           fi
           BRIDGE_SIG=$(curl --fail --silent --show-error --location "$BRIDGE_SIG_URL")
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "ERROR: $TAG has no generated release notes"
+            exit 1
+          fi
           python3 scripts/release_artifacts.py manifests \
             --validated validated-release.json \
             --tag "$TAG" \
             --repository "$GITHUB_REPOSITORY" \
             --bridge-url "$BRIDGE_URL" \
             --bridge-signature "$BRIDGE_SIG" \
+            --release-notes release-notes.md \
             --output-dir manifests
 
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- After an automatic update relaunches, Murmur now shows a one-time What's New summary with the release's features and fixes. Generated GitHub release notes are embedded directly in the updater manifest so the same sanitized Markdown is available before and after installation (#379).
 - **Local Appearance Theme Engine** adds System, Light, and Dark modes; accessible custom accent, background, foreground, and contrast controls; synchronized main/log-viewer semantic tokens and native title bars; flash-free cached first paint; exact Sonic reset; and bounded atomic JSON import/export that never touches the clipboard. Overlay and transform-review transparency and always-dark glass remain unchanged (#377).
 
 ### Fixed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,8 @@ import { useEscapeCancel } from './lib/hooks/useEscapeCancel';
 import { useSilenceAutoStop } from './lib/hooks/useSilenceAutoStop';
 import { useAutoUpdater } from './lib/hooks/useAutoUpdater';
 import { UpdateModal } from './components/UpdateModal';
-import type { UpdateStatus } from './lib/updater';
+import { WhatsNewModal } from './components/WhatsNewModal';
+import type { CompletedUpdate, UpdateStatus } from './lib/updater';
 import { StatsBar } from './components/StatsBar';
 const ResourceMonitor = lazy(() => import('./components/ResourceMonitor').then(m => ({ default: m.ResourceMonitor })));
 const UsageDashboard = lazy(() => import('./components/UsageDashboard').then(m => ({ default: m.UsageDashboard })));
@@ -169,7 +170,7 @@ function App() {
   const { showAbout, setShowAbout } = useShowAboutListener();
   const updater = useAutoUpdater();
 
-  // DEV ONLY: cycle through mock update modal states for visual testing
+  // DEV ONLY: cycle through updater and post-update modal states for visual testing
   const devUpdateIndex = useRef(-1);
   const devMockStates: UpdateStatus[] = import.meta.env.DEV ? [
     { phase: 'available', version: '0.7.0', notes: '## What\'s New\n- OTA auto-updater\n- Bug fixes\n- Performance improvements', isForced: false },
@@ -178,11 +179,21 @@ function App() {
     { phase: 'error', message: 'Network request failed: could not resolve host', isForced: false },
   ] : [];
   const [devUpdateStatus, setDevUpdateStatus] = useState<UpdateStatus | null>(null);
+  const [devCompletedUpdate, setDevCompletedUpdate] = useState<CompletedUpdate | null>(null);
 
   const checkForUpdate = useCallback(async () => {
     if (import.meta.env.DEV) {
-      devUpdateIndex.current = (devUpdateIndex.current + 1) % devMockStates.length;
-      setDevUpdateStatus(devMockStates[devUpdateIndex.current]);
+      devUpdateIndex.current = (devUpdateIndex.current + 1) % (devMockStates.length + 1);
+      if (devUpdateIndex.current === 0) {
+        setDevUpdateStatus(null);
+        setDevCompletedUpdate({
+          version: '0.22.0',
+          notes: '## New Features\n\n- Faster local transcription\n- Selected-text transforms\n\n## Bug Fixes\n\n- More reliable microphone startup\n- Smoother overlay behavior',
+        });
+      } else {
+        setDevCompletedUpdate(null);
+        setDevUpdateStatus(devMockStates[devUpdateIndex.current - 1]);
+      }
       return;
     }
     return updater.checkForUpdate();
@@ -198,6 +209,14 @@ function App() {
     updater.skipVersion();
   }, [devUpdateStatus, updater.skipVersion]);
   const startDownload = updater.startDownload;
+  const completedUpdate = devCompletedUpdate ?? updater.completedUpdate;
+  const dismissCompletedUpdate = useCallback(() => {
+    if (devCompletedUpdate) {
+      setDevCompletedUpdate(null);
+      return;
+    }
+    updater.dismissCompletedUpdate();
+  }, [devCompletedUpdate, updater.dismissCompletedUpdate]);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [mainTab, setMainTab] = useState<'record' | 'file'>('record');
@@ -462,11 +481,17 @@ function App() {
         isOpen={showAbout}
         onClose={() => setShowAbout(false)}
       />
-      <UpdateModal
-        status={updateStatus}
-        onDownload={startDownload}
-        onSkip={skipVersion}
-        onDismiss={dismissUpdate}
+      {!completedUpdate && (
+        <UpdateModal
+          status={updateStatus}
+          onDownload={startDownload}
+          onSkip={skipVersion}
+          onDismiss={dismissUpdate}
+        />
+      )}
+      <WhatsNewModal
+        update={completedUpdate}
+        onDismiss={dismissCompletedUpdate}
       />
     </div>
   );

--- a/app/src/components/WhatsNewModal.test.tsx
+++ b/app/src/components/WhatsNewModal.test.tsx
@@ -1,0 +1,71 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { WhatsNewModal } from './WhatsNewModal';
+
+describe('WhatsNewModal', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onDismiss: Mock<() => void>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onDismiss = vi.fn();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('renders sanitized release notes for the installed version and focuses the action', async () => {
+    await act(async () => {
+      root.render(
+        <WhatsNewModal
+          update={{
+            version: '0.22.0',
+            notes: '## New Features\n\n- Faster transcription\n\n<script>bad()</script>',
+          }}
+          onDismiss={onDismiss}
+        />,
+      );
+      vi.advanceTimersByTime(60);
+    });
+
+    const dialog = container.querySelector('[role="dialog"]') as HTMLDivElement;
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.textContent).toContain("What's new in Murmur 0.22.0");
+    expect(dialog.textContent).toContain('Faster transcription');
+    expect(dialog.querySelector('script')).toBeNull();
+    expect(document.activeElement?.textContent).toContain('Start using Murmur');
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    expect(document.activeElement?.textContent).toContain('Start using Murmur');
+  });
+
+  it('dismisses from the primary action and Escape', async () => {
+    await act(async () => {
+      root.render(
+        <WhatsNewModal
+          update={{ version: '0.22.0', notes: 'Bug fixes.' }}
+          onDismiss={onDismiss}
+        />,
+      );
+    });
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => button.click());
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/components/WhatsNewModal.test.tsx
+++ b/app/src/components/WhatsNewModal.test.tsx
@@ -68,4 +68,36 @@ describe('WhatsNewModal', () => {
     });
     expect(onDismiss).toHaveBeenCalledTimes(2);
   });
+
+  it('cycles focus through release-note links and lets keyboard users activate them', async () => {
+    await act(async () => {
+      root.render(
+        <WhatsNewModal
+          update={{
+            version: '0.22.0',
+            notes: '[Read the full release notes](https://example.com/release)',
+          }}
+          onDismiss={onDismiss}
+        />,
+      );
+      vi.advanceTimersByTime(60);
+    });
+
+    const link = container.querySelector('a') as HTMLAnchorElement;
+    const onLinkClick = vi.fn((event: MouseEvent) => event.preventDefault());
+    link.addEventListener('click', onLinkClick);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(link);
+
+    await act(async () => link.click());
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+    expect(document.activeElement?.textContent).toContain('Start using Murmur');
+  });
 });

--- a/app/src/components/WhatsNewModal.tsx
+++ b/app/src/components/WhatsNewModal.tsx
@@ -9,6 +9,7 @@ interface WhatsNewModalProps {
 }
 
 export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
   const doneRef = useRef<HTMLButtonElement>(null);
   const onDismissRef = useRef(onDismiss);
   onDismissRef.current = onDismiss;
@@ -23,10 +24,19 @@ export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
         event.preventDefault();
         onDismissRef.current();
       } else if (event.key === 'Tab') {
-        // This dialog has one action; keep keyboard focus from escaping into
-        // the obscured app behind it.
+        const focusable = Array.from(
+          dialogRef.current?.querySelectorAll<HTMLElement>(
+            'a[href], button:not(:disabled), [tabindex]:not([tabindex="-1"])',
+          ) ?? [],
+        );
+        if (focusable.length === 0) return;
+
         event.preventDefault();
-        doneRef.current?.focus();
+        const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+        const nextIndex = event.shiftKey
+          ? (currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1)
+          : (currentIndex === focusable.length - 1 ? 0 : currentIndex + 1);
+        focusable[nextIndex]?.focus();
       }
     };
     document.addEventListener('keydown', onKeyDown);
@@ -49,6 +59,7 @@ export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
       }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="whats-new-title"

--- a/app/src/components/WhatsNewModal.tsx
+++ b/app/src/components/WhatsNewModal.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef } from 'react';
+import Markdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+import type { CompletedUpdate } from '../lib/updater';
+
+interface WhatsNewModalProps {
+  update: CompletedUpdate | null;
+  onDismiss: () => void;
+}
+
+export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
+  const doneRef = useRef<HTMLButtonElement>(null);
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  useEffect(() => {
+    if (!update) return;
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onDismissRef.current();
+      } else if (event.key === 'Tab') {
+        // This dialog has one action; keep keyboard focus from escaping into
+        // the obscured app behind it.
+        event.preventDefault();
+        doneRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const focusTimer = setTimeout(() => doneRef.current?.focus(), 60);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      clearTimeout(focusTimer);
+      previouslyFocused?.focus();
+    };
+  }, [update]);
+
+  if (!update) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-5 backdrop-blur-[2px]"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onDismiss();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whats-new-title"
+        aria-describedby="whats-new-description"
+        className="flex max-h-[82vh] w-full max-w-[520px] flex-col overflow-hidden rounded-3xl border border-outline-variant/25 bg-surface-container-lowest shadow-2xl"
+      >
+        <div className="relative overflow-hidden border-b border-outline-variant/20 px-6 pb-5 pt-6">
+          <div className="absolute -right-12 -top-16 h-44 w-44 rounded-full bg-primary/10 blur-3xl" />
+          <div className="relative">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-on-primary shadow-sm">
+                <svg
+                  className="h-6 w-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.8}
+                    d="M12 3l1.4 4.1L17.5 8.5l-4.1 1.4L12 14l-1.4-4.1-4.1-1.4 4.1-1.4L12 3zm6 10 .9 2.6 2.6.9-2.6.9L18 20l-.9-2.6-2.6-.9 2.6-.9L18 13z"
+                  />
+                </svg>
+              </div>
+              <span className="rounded-full border border-success/25 bg-success/10 px-2.5 py-1 text-[11px] font-semibold text-success">
+                Updated successfully
+              </span>
+            </div>
+
+            <h2 id="whats-new-title" className="text-2xl font-semibold tracking-tight text-on-surface">
+              What&apos;s new in Murmur {update.version}
+            </h2>
+            <p id="whats-new-description" className="mt-1.5 text-sm text-on-surface-variant">
+              Here&apos;s what changed since your last version.
+            </p>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {update.notes.trim() ? (
+            <div className="text-sm leading-6 text-on-surface-variant [&_a]:font-medium [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 [&_code]:rounded [&_code]:bg-surface-container-high [&_code]:px-1 [&_h1]:mb-2 [&_h1]:mt-5 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-on-surface [&_h1:first-child]:mt-0 [&_h2]:mb-2 [&_h2]:mt-5 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-on-surface [&_h2:first-child]:mt-0 [&_h3]:mb-1.5 [&_h3]:mt-4 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-on-surface [&_li]:my-1 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_strong]:font-semibold [&_strong]:text-on-surface [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5">
+              <Markdown rehypePlugins={[rehypeSanitize]}>{update.notes}</Markdown>
+            </div>
+          ) : (
+            <p className="rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+              Murmur is up to date with the latest features and fixes.
+            </p>
+          )}
+        </div>
+
+        <div className="border-t border-outline-variant/20 bg-surface-container-low/45 px-6 py-4">
+          <button
+            ref={doneRef}
+            type="button"
+            onClick={onDismiss}
+            className="w-full rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-on-primary shadow-sm transition-colors hover:bg-primary-dim focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            Start using Murmur
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/semanticTokenDebt.test.ts
+++ b/app/src/components/semanticTokenDebt.test.ts
@@ -21,6 +21,7 @@ const scrimAllowlist = new Set([
   "components/AboutModal.tsx",
   "components/CommandPalette.tsx",
   "components/UpdateModal.tsx",
+  "components/WhatsNewModal.tsx",
   "components/history/CorrectAndTeachDialog.tsx",
   "components/settings/KnowledgeEditorModal.tsx",
   "components/settings/KnowledgeManager.tsx",

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -10,10 +10,14 @@ import {
 import { flog } from '../log';
 import {
   type UpdateStatus,
+  type CompletedUpdate,
   isBelowMinVersion,
   getSkippedVersion,
   setSkippedVersion,
   clearSkippedVersion,
+  setPendingUpdate,
+  clearPendingUpdate,
+  getPendingUpdateForVersion,
   isDueForCheck,
   setLastCheckTimestamp,
   fetchMinVersion,
@@ -22,17 +26,46 @@ import {
 
 export interface UseAutoUpdaterReturn {
   updateStatus: UpdateStatus;
+  completedUpdate: CompletedUpdate | null;
   checkForUpdate: () => Promise<void>;
   startDownload: () => Promise<void>;
   skipVersion: () => void;
   dismissUpdate: () => void;
+  dismissCompletedUpdate: () => void;
 }
 
 export function useAutoUpdater(): UseAutoUpdaterReturn {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ phase: 'idle' });
+  const [completedUpdate, setCompletedUpdate] = useState<CompletedUpdate | null>(null);
   const updateRef = useRef<Update | null>(null);
   const isCheckingRef = useRef(false);
   const isForcedRef = useRef(false);
+
+  // The updater process replaces the app before relaunching, so the release
+  // payload is recovered from localStorage and shown only after the installed
+  // version confirms that the update actually completed.
+  useEffect(() => {
+    let cancelled = false;
+    getVersion()
+      .then((currentVersion) => {
+        if (cancelled) return;
+        const completed = getPendingUpdateForVersion(currentVersion);
+        if (completed) {
+          flog.info('updater', 'showing post-update release notes', {
+            version: completed.version,
+          });
+          setCompletedUpdate(completed);
+        }
+      })
+      .catch((err) => {
+        flog.warn('updater', 'could not resolve installed version for release notes', {
+          error: String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const performCheck = useCallback(async (opts: { isBackground: boolean }) => {
     if (isCheckingRef.current) return;
@@ -147,6 +180,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
 
     setUpdateStatus({ phase: 'downloading', version, progress: 0 });
     flog.info('updater', 'starting download', { version });
+    setPendingUpdate({ version, notes: update.body ?? '' });
 
     try {
       let totalContentLength = 0;
@@ -197,5 +231,18 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
     setUpdateStatus({ phase: 'idle' });
   }, []);
 
-  return { updateStatus, checkForUpdate, startDownload, skipVersion, dismissUpdate };
+  const dismissCompletedUpdate = useCallback(() => {
+    clearPendingUpdate();
+    setCompletedUpdate(null);
+  }, []);
+
+  return {
+    updateStatus,
+    completedUpdate,
+    checkForUpdate,
+    startDownload,
+    skipVersion,
+    dismissUpdate,
+    dismissCompletedUpdate,
+  };
 }

--- a/app/src/lib/updater.test.ts
+++ b/app/src/lib/updater.test.ts
@@ -9,6 +9,9 @@ import {
   getLastCheckTimestamp,
   setLastCheckTimestamp,
   isDueForCheck,
+  setPendingUpdate,
+  clearPendingUpdate,
+  getPendingUpdateForVersion,
   CHECK_INTERVAL_MS,
 } from './updater';
 
@@ -123,5 +126,60 @@ describe('check interval', () => {
   it('isDueForCheck returns true when timestamp is old enough', () => {
     setLastCheckTimestamp(Date.now() - CHECK_INTERVAL_MS - 1);
     expect(isDueForCheck()).toBe(true);
+  });
+});
+
+describe('post-update release notes', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns the saved notes for the exact installed version', () => {
+    setPendingUpdate({
+      version: '0.22.0',
+      notes: '## New Features\n\n- Added a post-update summary.',
+    });
+
+    expect(getPendingUpdateForVersion('0.22.0')).toEqual({
+      version: '0.22.0',
+      notes: '## New Features\n\n- Added a post-update summary.',
+    });
+  });
+
+  it('accepts an equivalent v-prefixed installed version', () => {
+    setPendingUpdate({ version: 'v0.22.0', notes: 'Bug fixes.' });
+
+    expect(getPendingUpdateForVersion('0.22.0')?.version).toBe('v0.22.0');
+  });
+
+  it('removes stale notes when the installed version does not match', () => {
+    setPendingUpdate({ version: '0.22.0', notes: 'Old notes.' });
+
+    expect(getPendingUpdateForVersion('0.23.0')).toBeNull();
+    expect(getPendingUpdateForVersion('0.22.0')).toBeNull();
+  });
+
+  it('does not confuse prerelease and final builds with the same core semver', () => {
+    setPendingUpdate({ version: '0.22.0-beta.1', notes: 'Preview notes.' });
+
+    expect(getPendingUpdateForVersion('0.22.0')).toBeNull();
+  });
+
+  it('rejects invalid versions even when both strings match', () => {
+    setPendingUpdate({ version: 'not-a-version', notes: 'Invalid notes.' });
+
+    expect(getPendingUpdateForVersion('not-a-version')).toBeNull();
+  });
+
+  it('fails closed and removes malformed storage', () => {
+    localStorage.setItem('pending-update-release-notes', '{broken');
+
+    expect(getPendingUpdateForVersion('0.22.0')).toBeNull();
+    expect(localStorage.getItem('pending-update-release-notes')).toBeNull();
+  });
+
+  it('can be dismissed permanently', () => {
+    setPendingUpdate({ version: '0.22.0', notes: 'Notes.' });
+    clearPendingUpdate();
+
+    expect(getPendingUpdateForVersion('0.22.0')).toBeNull();
   });
 });

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -1,5 +1,7 @@
 const SKIPPED_VERSION_KEY = 'skipped-update-version';
 const LAST_CHECK_KEY = 'updater-last-check';
+const PENDING_UPDATE_KEY = 'pending-update-release-notes';
+const MAX_RELEASE_NOTES_LENGTH = 50_000;
 export const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const LATEST_JSON_URL =
@@ -82,6 +84,72 @@ export function setLastCheckTimestamp(ts: number): void {
 
 export function isDueForCheck(): boolean {
   return Date.now() - getLastCheckTimestamp() >= CHECK_INTERVAL_MS;
+}
+
+// --- Post-update release notes ---
+
+export interface CompletedUpdate {
+  version: string;
+  notes: string;
+}
+
+/**
+ * Save the release payload before Tauri replaces and relaunches the app.
+ * localStorage survives the install, while in-memory updater state does not.
+ */
+export function setPendingUpdate(update: CompletedUpdate): void {
+  try {
+    localStorage.setItem(PENDING_UPDATE_KEY, JSON.stringify({
+      version: update.version,
+      notes: update.notes.slice(0, MAX_RELEASE_NOTES_LENGTH),
+    }));
+  } catch { /* ignore */ }
+}
+
+export function clearPendingUpdate(): void {
+  try {
+    localStorage.removeItem(PENDING_UPDATE_KEY);
+  } catch { /* ignore */ }
+}
+
+/**
+ * Return release notes only when the relaunched app is the exact version that
+ * was downloaded. Mismatched or malformed payloads are stale and are removed.
+ */
+export function getPendingUpdateForVersion(currentVersion: string): CompletedUpdate | null {
+  try {
+    const stored = localStorage.getItem(PENDING_UPDATE_KEY);
+    if (!stored) return null;
+
+    const parsed: unknown = JSON.parse(stored);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('version' in parsed) ||
+      !('notes' in parsed) ||
+      typeof parsed.version !== 'string' ||
+      typeof parsed.notes !== 'string' ||
+      normalizedVersionIdentity(parsed.version) === null ||
+      normalizedVersionIdentity(currentVersion) === null ||
+      normalizedVersionIdentity(parsed.version) !== normalizedVersionIdentity(currentVersion)
+    ) {
+      clearPendingUpdate();
+      return null;
+    }
+
+    return {
+      version: parsed.version,
+      notes: parsed.notes.slice(0, MAX_RELEASE_NOTES_LENGTH),
+    };
+  } catch {
+    clearPendingUpdate();
+    return null;
+  }
+}
+
+function normalizedVersionIdentity(version: string): string | null {
+  if (!parseSemver(version)) return null;
+  return version.trim().replace(/^v/, '');
 }
 
 // --- min_version fetch ---

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -43,6 +43,16 @@ When a new version is available and the current version is above `min_version`:
 2. **Downloading** — Progress bar with percentage. Progress reported via Tauri's `downloadAndInstall` callback.
 3. **Ready** — "Installing and relaunching..." text displayed.
 4. **Relaunch** — App restarts automatically via `@tauri-apps/plugin-process`.
+5. **What's New** — After the relaunched binary confirms that it is the
+   downloaded version, a one-time modal shows that release's features, fixes,
+   and other changes.
+
+Before download begins, the app stores a bounded `{ version, notes }` payload in
+localStorage under `pending-update-release-notes`. The payload is intentionally
+kept until the user dismisses the post-update modal, so an app quit while the
+modal is open does not lose it. A fresh install has no pending payload and never
+shows the modal. A malformed payload or one whose version does not exactly match
+the running app is removed without being displayed.
 
 ### Forced Updates
 
@@ -78,6 +88,21 @@ The updater includes a semver parser (`updater.ts`) that:
 
 Release notes from the manifest are rendered as Markdown using `react-markdown` with `rehype-sanitize` (default sanitization schema). Custom HTML in release notes is stripped by the sanitizer.
 
+The promotion workflow creates the draft GitHub release with generated notes,
+then reads that exact Markdown body into `latest-v2.json`. Manifest generation
+fails if the body is missing or empty. `.github/release.yml` groups merged pull
+requests into **New Features** (`enhancement`), **Bug Fixes** (`bug`), and
+**Other Changes** categories.
+
+The same sanitized notes appear in two places:
+
+- the update-available dialog, before download
+- the one-time What's New dialog, after the updated app relaunches
+
+For a useful customer-facing summary, release pull requests should carry either
+the `enhancement` or `bug` label when applicable. Unlabeled pull requests remain
+visible under Other Changes.
+
 ## Signed Updates
 
 Updates are signed with ed25519. The public key is embedded in `tauri.conf.json` as a base64-encoded minisign public key. The Tauri updater plugin handles signature verification automatically — unsigned or incorrectly signed updates are rejected.
@@ -99,11 +124,17 @@ type UpdateStatus =
 
 The update modal renders for `available`, `downloading`, `ready`, and `error` phases. The `idle`, `checking`, and `up-to-date` phases return null (no modal).
 
+Post-update notes use separate `CompletedUpdate` state rather than adding a
+phase to `UpdateStatus`; this prevents the Settings update checker from treating
+an already-installed release as an available update.
+
 ## Settings Integration
 
 - The "Check for Updates" button in the About section of settings triggers a manual check. It is disabled during `checking` or `downloading` phases.
 - Status text shows: "Checking...", "You're up to date", "vX.Y.Z available", or "Update check failed".
 - Skipped version is stored in localStorage under `skipped-update-version`.
+- Pending post-update notes are stored under `pending-update-release-notes` and
+  removed when dismissed or when the running version does not match.
 
 ## Dependencies
 

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -319,6 +319,7 @@ def write_updater_manifests(
     repository: str,
     bridge_url: str,
     bridge_signature: str,
+    release_notes_path: Path,
     output_dir: Path,
 ) -> tuple[Path, Path]:
     if not re.fullmatch(r"v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", tag):
@@ -328,6 +329,11 @@ def write_updater_manifests(
     bridge_signature = bridge_signature.strip()
     if not bridge_url.startswith("https://") or not bridge_signature:
         raise ArtifactError("bridge updater URL and signature are required")
+    if not release_notes_path.is_file():
+        raise ArtifactError("release notes file is required")
+    release_notes = release_notes_path.read_text(encoding="utf-8").strip()
+    if not release_notes:
+        raise ArtifactError("release notes must not be empty")
 
     validated = json.loads(validated_path.read_text(encoding="utf-8"))
     macos = validated["platforms"]["macos"]
@@ -349,7 +355,7 @@ def write_updater_manifests(
                 "signature": linux["signature"],
             },
         },
-        "notes": f"See release notes at https://github.com/{repository}/releases/tag/{tag}",
+        "notes": release_notes,
     }
     legacy = {
         "version": version,
@@ -411,6 +417,7 @@ def _parser() -> argparse.ArgumentParser:
     manifests.add_argument("--repository", required=True)
     manifests.add_argument("--bridge-url", required=True)
     manifests.add_argument("--bridge-signature", required=True)
+    manifests.add_argument("--release-notes", type=Path, required=True)
     manifests.add_argument("--output-dir", type=Path, required=True)
     return parser
 
@@ -468,6 +475,7 @@ def main() -> None:
                 args.repository,
                 args.bridge_url,
                 args.bridge_signature,
+                args.release_notes,
                 args.output_dir,
             )
             print(f"wrote updater manifests: {modern}, {legacy}")

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -360,6 +360,9 @@ def validate_promotion_policy(workflow: str) -> int:
     assert "release versions differ" in workflow
     assert "already_published=true" in workflow
     assert "contains unexpected asset" in workflow
+    assert 'gh release view "$TAG"' in workflow
+    assert "--json body --jq .body > release-notes.md" in workflow
+    assert "--release-notes release-notes.md" in workflow
     assert workflow.index("scripts/release_artifacts.py validate") < workflow.index(
         "Create automatic release tag"
     )

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -45,12 +45,18 @@ class ReleaseArtifactTests(unittest.TestCase):
     def test_valid_artifacts_and_manifest_signatures_match_sig_assets(self) -> None:
         validated_path = self.root / "validated.json"
         validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        release_notes_path = self.root / "release-notes.md"
+        release_notes_path.write_text(
+            "## New Features\n\n- Added post-update release notes.\n",
+            encoding="utf-8",
+        )
         modern_path, legacy_path = write_updater_manifests(
             validated_path,
             "v1.2.3",
             "owner/repo",
             "https://example.invalid/bridge.app.tar.gz",
             "bridge-signature",
+            release_notes_path,
             self.root / "manifests",
         )
 
@@ -69,6 +75,27 @@ class ReleaseArtifactTests(unittest.TestCase):
         self.assertEqual(
             legacy["platforms"]["linux-x86_64"]["signature"], "linux-signature"
         )
+        self.assertEqual(
+            modern["notes"],
+            "## New Features\n\n- Added post-update release notes.",
+        )
+
+    def test_manifest_generation_requires_nonempty_release_notes(self) -> None:
+        validated_path = self.root / "validated.json"
+        validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        release_notes_path = self.root / "release-notes.md"
+        release_notes_path.write_text(" \n", encoding="utf-8")
+
+        with self.assertRaisesRegex(ArtifactError, "must not be empty"):
+            write_updater_manifests(
+                validated_path,
+                "v1.2.3",
+                "owner/repo",
+                "https://example.invalid/bridge.app.tar.gz",
+                "bridge-signature",
+                release_notes_path,
+                self.root / "manifests",
+            )
 
     def test_commit_sha_mismatch_fails_closed(self) -> None:
         with self.assertRaisesRegex(ArtifactError, "commit_sha mismatch"):


### PR DESCRIPTION
## Summary
- persist the downloaded version and generated release notes before Tauri installs an update
- show a polished, accessible What's New modal only after the relaunched app confirms the exact installed version
- generate categorized GitHub release notes and embed them in the modern updater manifest
- document and test the complete release-notes pipeline

## Validation
- `cd app/src-tauri && cargo test --lib -- --test-threads=1` (640 passed, 5 ignored)
- `cd app && npx tsc --noEmit`
- `cd app && npm test` (576 passed)
- `cd app && npm run build`
- `python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py` (43 passed)
- `python3 scripts/validate_workflow_policy.py`
- native Tauri smoke test: launch, onboarding, main window, Settings, update controls
- browser visual QA: modal content, focus, dismissal, and dark-theme rendering

Closes #379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time “What’s New” dialog after app updates, displaying sanitized release notes.
  * Added accessible dismissal via button, Escape, or backdrop click.
  * Release notes are now included directly in update information and shown consistently before and after installation.
* **Bug Fixes**
  * Prevented stale or invalid update notes from being displayed.
  * Release publishing now validates that release notes are present and non-empty.
* **Documentation**
  * Updated auto-updater documentation with post-update notes behavior and release-note handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->