### PR TITLE
ci: restore measured release build speedups

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -135,6 +135,8 @@ runs:
     # build that predates LINUXDEPLOY_EXCLUDED_LIBRARIES. Seed Tauri's tool cache
     # with a checksum-pinned upstream build so the runner-only CUDA driver stub
     # is available for dependency resolution but cannot enter the AppImage.
+    # Also pre-seed the AppImage plugin and type2 runtime so bundling does not
+    # hit the network mid-job (~0–2m saved on cold packaging).
     - name: Install driver-stub-aware linuxdeploy
       shell: bash
       run: |
@@ -145,6 +147,25 @@ runs:
         curl --fail --location --retry 3 "$LINUXDEPLOY_URL" --output "$LINUXDEPLOY_PATH"
         echo "$LINUXDEPLOY_SHA256  $LINUXDEPLOY_PATH" | sha256sum --check --strict
         chmod +x "$LINUXDEPLOY_PATH"
+
+        PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+        PLUGIN_SHA256="1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a"
+        PLUGIN_PATH="$HOME/.cache/tauri/linuxdeploy-plugin-appimage-x86_64.AppImage"
+        curl --fail --location --retry 3 "$PLUGIN_URL" --output "$PLUGIN_PATH"
+        echo "$PLUGIN_SHA256  $PLUGIN_PATH" | sha256sum --check --strict
+        chmod +x "$PLUGIN_PATH"
+
+        # appimagetool type2 runtime — seed XDG cache so packaging skips download
+        RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64"
+        RUNTIME_SHA256="1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf"
+        RUNTIME_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/appimageify"
+        mkdir -p "$RUNTIME_DIR"
+        RUNTIME_PATH="$RUNTIME_DIR/runtime-x86_64"
+        curl --fail --location --retry 3 "$RUNTIME_URL" --output "$RUNTIME_PATH"
+        echo "$RUNTIME_SHA256  $RUNTIME_PATH" | sha256sum --check --strict
+        chmod +x "$RUNTIME_PATH" || true
+
+        echo "$HOME/.cache/tauri" >> "$GITHUB_PATH"
 
     - name: Save CUDA toolkit cache
       if: steps.cuda-cache.outputs.cache-hit != 'true' && inputs.cuda-cache-save-if == 'true'

--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -163,7 +163,7 @@ runs:
         RUNTIME_PATH="$RUNTIME_DIR/runtime-x86_64"
         curl --fail --location --retry 3 "$RUNTIME_URL" --output "$RUNTIME_PATH"
         echo "$RUNTIME_SHA256  $RUNTIME_PATH" | sha256sum --check --strict
-        chmod +x "$RUNTIME_PATH" || true
+        chmod +x "$RUNTIME_PATH"
 
         echo "$HOME/.cache/tauri" >> "$GITHUB_PATH"
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -333,14 +333,27 @@ jobs:
 
       - name: Free disk space for CUDA release build
         run: |
+          # CUDA + whisper release needs roughly 15–20 GiB free. Always drop the
+          # large unused toolchains (fast). Skip the expensive `docker system
+          # prune` when headroom is already enough (~1m of the ~1.5m step).
+          free_gib() { df -Pk / | awk 'NR==2 {printf "%d", $4/1024/1024}'; }
+          echo "Free space on / before: $(free_gib) GiB"
           sudo rm -rf \
             /usr/local/lib/android \
             /usr/share/dotnet \
             /opt/ghc \
             /usr/local/.ghcup \
             /opt/hostedtoolcache/CodeQL
-          sudo apt-get clean
+          sudo apt-get clean || true
+          FREE_GIB=$(free_gib)
+          echo "Free space on / after toolchain removal: ${FREE_GIB} GiB"
+          if [ "$FREE_GIB" -ge 25 ]; then
+            echo "Skipping docker system prune; sufficient space for CUDA release build"
+            exit 0
+          fi
+          echo "Running docker system prune to free additional space"
           docker system prune --all --force || true
+          echo "Free space on / after docker prune: $(free_gib) GiB"
 
       - name: Setup minimal Linux release environment
         uses: ./.github/actions/setup-linux-build

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -98,9 +98,11 @@ whisper-rs = { version = "0.15", features = ["cuda"] }
 
 [profile.release]
 panic = "abort"
-codegen-units = 1
-lto = true
+# Parallel codegen without LTO: release CI was dominated by fat LTO + CGU=1
+# (cold Linux cargo ~11m). Hot paths are whisper/CUDA/Metal native code, so
+# Rust LTO bought little runtime while burning link time. Keep strip off so
+# Tauri can still patch the updater bundle-type marker after compilation.
+codegen-units = 16
+lto = false
 opt-level = "s"
-# Tauri patches an embedded bundle-type marker after compilation so the updater
-# can distinguish deb/AppImage packages. Full stripping removes that marker.
 strip = false

--- a/app/src/components/AboutModal.tsx
+++ b/app/src/components/AboutModal.tsx
@@ -44,7 +44,7 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
           </p>
 
           <p className="text-sm text-on-surface mb-4">
-            Privacy-first voice-to-text powered by Whisper AI. All processing happens locally on your device.
+            Privacy-first voice-to-text powered by Whisper AI. All processing happens locally on your device — audio never leaves this Mac.
           </p>
 
           <p className="text-xs text-on-surface-variant">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,8 +393,8 @@ Release finalization **fails closed** on any unexpected executable in the bundle
 ```toml
 [profile.release]
 panic = "abort"
-codegen-units = 1
-lto = true
+codegen-units = 16
+lto = false
 opt-level = "s"
 strip = false   # retain Tauri's updater bundle-type marker
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -179,6 +179,7 @@ Every transform-key hold is recorded as a content-free `TransformAttemptV1` with
 
 - macOS 14+ on Apple Silicon (Core ML/ANE); Whisper and CPU Parakeet also build for Linux.
 - Developer ID signed and notarized; hardened runtime; sidecar ships with split entitlements; release finalization fails closed on any unexpected bundle executable.
+- Release builds use `opt-level = "s"`, LTO off, 16 parallel codegen units, and panic abort; stripping remains disabled so Tauri can patch the updater bundle-type marker.
 - **Auto-updater** — [features/auto-updater.md](features/auto-updater.md). Background check on launch and every 24h against `latest-v2.json`, ed25519-signed, min-version enforcement (no skip/dismiss when required), skip/dismiss otherwise, progress and auto-relaunch.
 - **Privacy boundaries**: release `pipeline` events drop all strings; `transform` events are restricted to an explicit stable vocabulary in *all* builds; knowledge content and selected paths are excluded from logs; instructions never enter history or stats; audio and transcripts are written to disk only when the user turns file output on.
 - All local data is inspectable and deletable from within the app.

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -276,7 +276,10 @@ def validate_linux_cache_policy(action: str) -> None:
         in linuxdeploy
     )
     assert 'LINUXDEPLOY_PATH="$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage"' in linuxdeploy
-    assert "sha256sum --check --strict" in linuxdeploy
+    assert (
+        'echo "$LINUXDEPLOY_SHA256  $LINUXDEPLOY_PATH" | sha256sum --check --strict'
+        in linuxdeploy
+    )
 
     prepare = named_step_block(action, "Prepare CUDA cache restore path", 4)
     assert 'sudo mkdir -p "/usr/local/cuda-${CUDA_MM}"' in prepare

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -280,6 +280,38 @@ def validate_linux_cache_policy(action: str) -> None:
         'echo "$LINUXDEPLOY_SHA256  $LINUXDEPLOY_PATH" | sha256sum --check --strict'
         in linuxdeploy
     )
+    assert (
+        "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/"
+        "download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+    ) in linuxdeploy
+    assert (
+        'PLUGIN_SHA256="1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a"'
+        in linuxdeploy
+    )
+    assert (
+        'PLUGIN_PATH="$HOME/.cache/tauri/'
+        'linuxdeploy-plugin-appimage-x86_64.AppImage"'
+    ) in linuxdeploy
+    assert (
+        'echo "$PLUGIN_SHA256  $PLUGIN_PATH" | sha256sum --check --strict'
+        in linuxdeploy
+    )
+    assert (
+        "https://github.com/AppImage/type2-runtime/releases/download/continuous/"
+        "runtime-x86_64"
+    ) in linuxdeploy
+    assert (
+        'RUNTIME_SHA256="1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf"'
+        in linuxdeploy
+    )
+    assert 'RUNTIME_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/appimageify"' in linuxdeploy
+    assert 'RUNTIME_PATH="$RUNTIME_DIR/runtime-x86_64"' in linuxdeploy
+    assert (
+        'echo "$RUNTIME_SHA256  $RUNTIME_PATH" | sha256sum --check --strict'
+        in linuxdeploy
+    )
+    assert 'chmod +x "$RUNTIME_PATH"' in linuxdeploy
+    assert 'chmod +x "$RUNTIME_PATH" || true' not in linuxdeploy
 
     prepare = named_step_block(action, "Prepare CUDA cache restore path", 4)
     assert 'sudo mkdir -p "/usr/local/cuda-${CUDA_MM}"' in prepare

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -191,7 +191,7 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
     def test_linuxdeploy_override_must_be_checksum_pinned(self) -> None:
         action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
         mutated = action.replace(
-            "sha256sum --check --strict",
+            'echo "$LINUXDEPLOY_SHA256  $LINUXDEPLOY_PATH" | sha256sum --check --strict',
             'echo "linuxdeploy checksum validation skipped"',
             1,
         )

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -198,6 +198,59 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate_linux_cache_policy(mutated)
 
+    def test_appimage_tooling_policy_rejects_mutations(self) -> None:
+        action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
+        mutations = {
+            "plugin URL": (
+                "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/"
+                "download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage",
+                "https://example.invalid/plugin.AppImage",
+            ),
+            "plugin checksum": (
+                "1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a",
+                "0" * 64,
+            ),
+            "plugin path": (
+                "$HOME/.cache/tauri/linuxdeploy-plugin-appimage-x86_64.AppImage",
+                "$HOME/.cache/tauri/untrusted-plugin.AppImage",
+            ),
+            "plugin checksum pipeline": (
+                'echo "$PLUGIN_SHA256  $PLUGIN_PATH" | sha256sum --check --strict',
+                'echo "plugin checksum validation skipped"',
+            ),
+            "runtime URL": (
+                "https://github.com/AppImage/type2-runtime/releases/download/"
+                "continuous/runtime-x86_64",
+                "https://example.invalid/runtime-x86_64",
+            ),
+            "runtime checksum": (
+                "1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf",
+                "0" * 64,
+            ),
+            "runtime directory": (
+                "${XDG_CACHE_HOME:-$HOME/.cache}/appimageify",
+                "$HOME/.cache/untrusted-runtime",
+            ),
+            "runtime path": (
+                "$RUNTIME_DIR/runtime-x86_64",
+                "$RUNTIME_DIR/untrusted-runtime",
+            ),
+            "runtime checksum pipeline": (
+                'echo "$RUNTIME_SHA256  $RUNTIME_PATH" | sha256sum --check --strict',
+                'echo "runtime checksum validation skipped"',
+            ),
+            "runtime executable permission": (
+                'chmod +x "$RUNTIME_PATH"',
+                'chmod +x "$RUNTIME_PATH" || true',
+            ),
+        }
+        for name, (expected, replacement) in mutations.items():
+            with self.subTest(name=name):
+                mutated = action.replace(expected, replacement, 1)
+                self.assertNotEqual(action, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_linux_cache_policy(mutated)
+
     def test_cuda_stub_paths_reject_empty_loader_segments(self) -> None:
         action = (ROOT / ".github/actions/setup-linux-build/action.yml").read_text()
         mutated_action = action.replace(


### PR DESCRIPTION
Closes #305

## Summary

- restore the exact eight non-version portions of `59cde4b` on current `main`
- use 16 release codegen units with LTO disabled while retaining `opt-level = "s"`, panic abort, and `strip = false`
- skip the expensive Docker prune when the Linux runner already has at least 25 GiB free
- checksum-pin and pre-seed the AppImage plugin and type2 runtime
- restore the About privacy copy and update architecture/features documentation
- tighten workflow policy validation around the linuxdeploy checksum command

No version, lockfile, Tauri config, or changelog release entry changed.

## Controlled hosted A/B

Trusted workflow SHA for all four runs: `e6a6ef7f8af4ccd81a7e66bfc5005459772b35f5`.

| Cache/platform | Main build | Candidate build | Build delta | Main job | Candidate job | Job delta |
|---|---:|---:|---:|---:|---:|---:|
| Cold macOS | 492s | 324s | -168s (-34.1%) | 11m49s | 8m04s | -3m45s (-31.7%) |
| Cold Linux | 800s | 570s | -230s (-28.8%) | 16m33s | 13m04s | -3m29s (-21.0%) |
| Warm macOS | 217s | 94s | -123s (-56.7%) | 4m51s | 2m47s | -2m04s (-42.6%) |
| Warm Linux | 266s | 167s | -99s (-37.2%) | 7m37s | 5m13s | -2m24s (-31.5%) |

The warm critical path is Linux. Its job improved from 7m37s to 5m13s, satisfying the issue's merge criterion.

Runs:

- main cold/prime: https://github.com/georgenijo/murmur-app/actions/runs/30398132930
- main warm: https://github.com/georgenijo/murmur-app/actions/runs/30399389254
- candidate cold/prime: https://github.com/georgenijo/murmur-app/actions/runs/30417250319
- candidate warm: https://github.com/georgenijo/murmur-app/actions/runs/30417859403

## Artifact-size sanity check

| Artifact | Main warm | Candidate warm | Delta |
|---|---:|---:|---:|
| macOS main binary | 49,101,392 B | 59,279,392 B | +20.7% |
| macOS app bundle | 55,728,128 B | 66,137,424 B | +18.7% (+10.4 MB) |
| Linux main binary | 79,984,264 B | 94,040,792 B | +17.6% |
| DEB | 38,254,828 B | 40,304,226 B | +5.4% |
| AppImage | 677,951,992 B | 679,627,256 B | +0.25% |

The distributable Linux critical artifact is effectively unchanged, and the macOS app's absolute increase is 10.4 MB. The rehearsal built updater-compatible packages successfully with `strip = false`; the prior exact-profile local smoke recorded in #305 also produced a verified DMG and launched to Murmur Ready.

## Validation

- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests.test_workflow_policy` (43 tests)
- `npx tsc --noEmit`
- `npm test -- --run` (63 files, 577 tests)
- candidate cold and warm hosted rehearsals: macOS build, CUDA/Linux build, frontend unit tests, workflow/artifact policy tests all green
- checksum pins revalidated against the current upstream AppImage plugin and type2 runtime assets

Local Rust compilation reached `whisper-rs-sys` and then stopped because this Linux workstation lacks the repository's minimal CUDA/CMake toolchain. Both candidate hosted CUDA/Linux release builds completed successfully; normal PR CI will additionally run the Rust test lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified in the About section that audio is processed locally and never leaves the Mac.

* **Bug Fixes**
  * Improved Linux release build reliability by preloading and verifying packaging tools before bundling.
  * Reduced unnecessary cleanup during builds when sufficient disk space is available.

* **Documentation**
  * Updated release-build documentation to reflect current compiler and packaging settings.

* **Tests**
  * Strengthened validation of checksummed Linux build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->