### PR TITLE
Fix clipped text in post-update modal

### DIFF
--- a/app/src/components/WhatsNewModal.test.tsx
+++ b/app/src/components/WhatsNewModal.test.tsx
@@ -49,6 +49,31 @@ describe('WhatsNewModal', () => {
     expect(document.activeElement?.textContent).toContain('Start using Murmur');
   });
 
+  it('keeps the header and action visible while only the release notes scroll', async () => {
+    await act(async () => {
+      root.render(
+        <WhatsNewModal
+          update={{
+            version: '0.22.0',
+            notes: Array.from({ length: 30 }, (_, index) => `- Change ${index + 1}`).join('\n'),
+          }}
+          onDismiss={onDismiss}
+        />,
+      );
+    });
+
+    const title = container.querySelector('#whats-new-title') as HTMLHeadingElement;
+    const action = container.querySelector('button') as HTMLButtonElement;
+    const header = title.parentElement?.parentElement;
+    const footer = action.parentElement;
+    const notes = container.querySelector('.overflow-y-auto');
+
+    expect(header?.classList.contains('shrink-0')).toBe(true);
+    expect(footer?.classList.contains('shrink-0')).toBe(true);
+    expect(notes?.contains(title)).toBe(false);
+    expect(notes?.contains(action)).toBe(false);
+  });
+
   it('dismisses from the primary action and Escape', async () => {
     await act(async () => {
       root.render(

--- a/app/src/components/WhatsNewModal.tsx
+++ b/app/src/components/WhatsNewModal.tsx
@@ -66,7 +66,7 @@ export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
         aria-describedby="whats-new-description"
         className="flex max-h-[82vh] w-full max-w-[520px] flex-col overflow-hidden rounded-3xl border border-outline-variant/25 bg-surface-container-lowest shadow-2xl"
       >
-        <div className="relative overflow-hidden border-b border-outline-variant/20 px-6 pb-5 pt-6">
+        <div className="relative shrink-0 overflow-hidden border-b border-outline-variant/20 px-6 pb-5 pt-6">
           <div className="absolute -right-12 -top-16 h-44 w-44 rounded-full bg-primary/10 blur-3xl" />
           <div className="relative">
             <div className="mb-4 flex items-start justify-between gap-4">
@@ -112,7 +112,7 @@ export function WhatsNewModal({ update, onDismiss }: WhatsNewModalProps) {
           )}
         </div>
 
-        <div className="border-t border-outline-variant/20 bg-surface-container-low/45 px-6 py-4">
+        <div className="shrink-0 border-t border-outline-variant/20 bg-surface-container-low/45 px-6 py-4">
           <button
             ref={doneRef}
             type="button"


### PR DESCRIPTION
## Summary
- keep the post-update modal header and footer at their natural height
- constrain scrolling to the release-notes pane
- add regression coverage for long release notes

## Validation
- npm test (602 tests)
- npx tsc --noEmit
- cargo check
- cargo test --lib -- --test-threads=1 (653 passed)
- native debug app smoke test at 720×560 with long 0.22.1 release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “What’s New” modal layout so the header and primary action remain visible while release notes are scrolled.
  * Prevented the title and action button from moving into the scrollable content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->