### PR TITLE
Fix flaky sidecar cancellation integration test

### DIFF
--- a/app/src-tauri/tests/llm_sidecar_integration.rs
+++ b/app/src-tauri/tests/llm_sidecar_integration.rs
@@ -360,7 +360,15 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
     // the blocking loop, and clear busy promptly — aborting only the outer
     // tokio future is not enough (BusyGuard lives in spawn_blocking).
     let fixture = fixture_model();
-    let sidecar = sidecar("slow_honor_cancel", &fixture);
+    let receipt_marker = fixture._dir.path().join("transform-received");
+    let sidecar = Arc::new(LlmSidecar::for_test(config_with(
+        "slow_honor_cancel",
+        &fixture,
+        vec![(
+            "MOCK_TRANSFORM_RECEIPT_FILE".to_string(),
+            receipt_marker.to_string_lossy().into_owned(),
+        )],
+    )));
 
     let s = Arc::clone(&sidecar);
     let handle = tokio::spawn(async move {
@@ -373,16 +381,20 @@ async fn cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears()
         .await
     });
 
-    // Wait until the in-flight slot is claimed.
-    let mut claimed = false;
+    // `busy` is claimed before model verification, helper spawn, and the Ready
+    // handshake. Wait for the mock's receipt marker so this test cannot race
+    // startup cancellation (which correctly reaps a partially started helper).
+    let mut received = false;
     for _ in 0..100 {
-        if sidecar.is_transform_busy() {
-            claimed = true;
+        if receipt_marker.exists() {
+            received = true;
             break;
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
-    assert!(claimed, "transform never became busy");
+    assert!(received, "helper never received the Transform request");
+    assert!(sidecar.is_transform_busy());
+    assert!(sidecar.has_live_child());
 
     let started = std::time::Instant::now();
     // Cancel the CURRENT in-flight request via the supervisor entry point;

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -22,7 +22,9 @@
 //! - `wrong_version_on_startup_phase` — a later startup completion has a bad version
 //!
 //! The real supervisor spawns with `env_clear`, so these vars only exist for the
-//! mock via the supervisor's test-only constructor.
+//! mock via the supervisor's test-only constructor. Tests may also set
+//! `MOCK_TRANSFORM_RECEIPT_FILE` to create a synchronization marker after the
+//! helper receives a Transform frame.
 
 use std::io::Write;
 use std::sync::mpsc;
@@ -224,6 +226,9 @@ fn main() {
                     PhaseState::Completed,
                     Some(0),
                 );
+                if let Ok(path) = std::env::var("MOCK_TRANSFORM_RECEIPT_FILE") {
+                    let _ = std::fs::write(path, b"received");
+                }
                 match scenario.as_str() {
                     "crash_on_transform" => std::process::exit(101),
                     "malformed_on_transform" => {


### PR DESCRIPTION
## What changed

- added a test-only mock-helper receipt marker for Transform frames
- changed `cooperative_cancel_mid_request_helper_receives_cancel_and_busy_clears` to wait for that marker before cancelling
- asserted the helper is busy and resident at the proven mid-request barrier

## Root cause

The test used `is_transform_busy()` as if it meant the helper was processing a Transform request. The busy flag is actually claimed before model verification, process spawn, and the Ready handshake. Under full-suite timing, cancellation could land during startup; the supervisor correctly reaped the partially initialized helper, but the test then incorrectly asserted that it remained resident.

The receipt marker makes the test exercise the contract it names: request-level cooperative cancellation after the helper has received Transform.

## Validation

- reproduced the unfixed failure on repeated full-suite run 2
- fixed targeted test: 100 consecutive passes
- complete `cargo test -- --test-threads=1`: 20 consecutive passes (653 library tests, 21 sidecar integrations, and remaining integration targets per run)
- `rustfmt --edition 2021 --check` on both changed Rust files
- `git diff --check`

Closes #386