### PR TITLE
fix: scope developer vocabulary to technical apps

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -71,12 +71,12 @@ fn whisper_prefix(prompt: &str) -> String {
 /// folder is scanned (and cached) and its identifiers are placed *first* — they're
 /// more specific than the generic built-ins, so they survive Whisper's prompt
 /// truncation. Folder scanning still happens at most once per folder/enable change.
-fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
+fn resolve_code_vocab_prompt(app_state: &AppState, bundle_id: Option<&str>) -> String {
     // Fast path under the lock: feature off => nothing to do.
     let (enabled, folder, cached) = {
         let dictation = app_state.dictation.lock_or_recover();
         (
-            dictation.code_vocab_enabled,
+            dictation.code_vocabulary_enabled_for(bundle_id),
             dictation.code_vocab_folder.clone(),
             dictation.code_vocab_prompt.clone(),
         )
@@ -125,8 +125,12 @@ fn resolve_code_vocab_prompt(app_state: &AppState) -> String {
 
 /// Build the code-vocabulary prompt represented by an already-locked settings
 /// generation. `None` means the folder cache is not ready for this generation.
-fn cached_code_vocab_prompt(dictation: &crate::state::DictationState) -> Option<String> {
-    if !dictation.code_vocab_enabled {
+fn cached_code_vocab_prompt(
+    dictation: &crate::state::DictationState,
+    bundle_id: Option<&str>,
+) -> Option<String> {
+    let enabled_for_context = dictation.code_vocabulary_enabled_for(bundle_id);
+    if !enabled_for_context {
         return Some(String::new());
     }
     let builtin = crate::vocab::builtin_terms_prompt();
@@ -163,9 +167,9 @@ fn resolve_live_context(
         }
     };
     loop {
-        let code_vocab = resolve_code_vocab_prompt(app_state);
+        let code_vocab = resolve_code_vocab_prompt(app_state, bundle_id);
         let dictation = app_state.dictation.lock_or_recover();
-        let Some(current_code_vocab) = cached_code_vocab_prompt(&dictation) else {
+        let Some(current_code_vocab) = cached_code_vocab_prompt(&dictation, bundle_id) else {
             continue;
         };
         if current_code_vocab != code_vocab {
@@ -284,7 +288,7 @@ pub(crate) fn rebuild_correction_matcher(
         }
     }
     let knowledge = app_state.knowledge_replacements.lock_or_recover().clone();
-    let matcher = crate::vocabulary_alias::CorrectionMatcherSet::build_with_knowledge(
+    let matcher = crate::vocabulary_alias::CorrectionMatcherSet::build_with_contextual_code_terms(
         &terms,
         &dictation.vocabulary_entries,
         &dictation.app_profiles,
@@ -3090,7 +3094,9 @@ pub async fn transcribe_file(
     performance_guard.enter(PerformanceStageV1::InferenceDecode);
     let t_transcribe = std::time::Instant::now();
     let sanitized = custom_vocabulary.replace('\0', "");
-    let code_vocab = resolve_code_vocab_prompt(&state.app_state);
+    // Imported files have no frontmost-app context, so developer vocabulary is
+    // not applied. Explicit preferred terms remain in `custom_vocabulary`.
+    let code_vocab = resolve_code_vocab_prompt(&state.app_state, None);
     let prompt = combine_prompts(&sanitized, &code_vocab);
     let mut decode_ms = 0;
     let (text, load_report) = state.app_state.model_runtime.with_ready_backend(
@@ -3509,6 +3515,48 @@ mod tests {
             combine_prompts("", "code dupe Dupe").as_deref(),
             Some("code dupe")
         );
+    }
+
+    #[test]
+    fn cached_code_vocab_prompt_is_empty_outside_explicit_technical_context() {
+        let mut dictation = crate::state::DictationState {
+            code_vocab_enabled: true,
+            code_vocab_folder: "/project".to_string(),
+            code_vocab_prompt: Some("all__ toBe".to_string()),
+            ..crate::state::DictationState::default()
+        };
+        let ordinary = crate::state::AppProfile {
+            bundle_id: "com.example.Chat".to_string(),
+            label: "Chat".to_string(),
+            auto_paste_override: None,
+            cleanup_override: None,
+            cli_formatting_override: None,
+            smart_formatting_override: None,
+            writing_style: None,
+            ide_context_enabled: false,
+            ide_project_roots: Vec::new(),
+        };
+        let mut technical = ordinary.clone();
+        technical.bundle_id = "com.example.Editor".to_string();
+        technical.writing_style = Some(crate::state::WritingStyle::CodeTechnical);
+        dictation.app_profiles = vec![ordinary, technical];
+
+        assert_eq!(
+            cached_code_vocab_prompt(&dictation, None).as_deref(),
+            Some("")
+        );
+        assert_eq!(
+            cached_code_vocab_prompt(&dictation, Some("com.example.Chat")).as_deref(),
+            Some("")
+        );
+        assert_eq!(
+            cached_code_vocab_prompt(&dictation, Some("com.example.Unknown")).as_deref(),
+            Some("")
+        );
+        let technical_prompt =
+            cached_code_vocab_prompt(&dictation, Some("com.example.Editor")).unwrap();
+        assert!(technical_prompt.starts_with("all__ toBe"));
+        assert!(technical_prompt.contains("useEffect"));
     }
 
     #[test]

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -224,7 +224,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
         inputs.bundle_id,
         &global.app_profiles,
     );
-    let code_vocab = global.code_vocab_enabled;
+    let code_vocab = global.code_vocabulary_enabled_for(inputs.bundle_id);
     let source = match (custom_vocab, code_vocab) {
         (false, false) => VocabularySource::None,
         (true, false) => VocabularySource::Custom,
@@ -524,6 +524,68 @@ mod tests {
             assert!(!snapshot.transformations.cleanup_enabled);
             assert!(snapshot.matched_profile.is_none());
         }
+    }
+
+    #[test]
+    fn developer_vocabulary_requires_explicit_technical_app_context() {
+        let mut global = DictationState {
+            code_vocab_enabled: true,
+            ..DictationState::default()
+        };
+        let ordinary = profile("com.example.Chat", None, None);
+        let mut technical = profile("com.example.Editor", None, None);
+        technical.writing_style = Some(WritingStyle::CodeTechnical);
+        let mut indexed = profile("com.example.IDE", None, None);
+        indexed.ide_context_enabled = true;
+        indexed.ide_project_roots = vec!["/project".to_string()];
+        global.app_profiles = vec![ordinary, technical, indexed];
+
+        assert_eq!(
+            resolve_test(&global, None, SessionOverrides::default())
+                .vocabulary
+                .source,
+            VocabularySource::None
+        );
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.example.Chat"),
+                SessionOverrides::default(),
+            )
+            .vocabulary
+            .source,
+            VocabularySource::None
+        );
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.example.Unconfigured"),
+                SessionOverrides::default(),
+            )
+            .vocabulary
+            .source,
+            VocabularySource::None
+        );
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.example.Editor"),
+                SessionOverrides::default(),
+            )
+            .vocabulary
+            .source,
+            VocabularySource::CodeAware
+        );
+        assert_eq!(
+            resolve_test(
+                &global,
+                Some("com.example.IDE"),
+                SessionOverrides::default(),
+            )
+            .vocabulary
+            .source,
+            VocabularySource::CodeAware
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -149,15 +149,31 @@ pub struct AppProfile {
     pub ide_project_roots: Vec<String>,
 }
 
-impl AppProfile {
-    /// Developer vocabulary is intentionally opt-in per destination app.
-    ///
-    /// A technical writing style or local IDE context is an explicit user
-    /// signal. Bundle IDs and app labels are never guessed, so ordinary prose
-    /// apps cannot inherit a globally scanned code vocabulary by accident.
-    pub(crate) fn enables_code_vocabulary(&self) -> bool {
-        self.ide_context_enabled || self.writing_style == Some(WritingStyle::CodeTechnical)
-    }
+/// Resolve the effective technical-context signal for an app profile. A
+/// technical writing style or local IDE context is an explicit user signal;
+/// bundle IDs and app labels are never guessed.
+///
+/// Duplicate profiles retain the resolver's legacy field semantics: IDE
+/// context is owned by the first matching profile, while an absent or
+/// `Inherit` writing style falls through to the next matching profile.
+pub(crate) fn app_profiles_enable_code_vocabulary(
+    app_profiles: &[AppProfile],
+    bundle_id: &str,
+) -> bool {
+    let mut matching = app_profiles
+        .iter()
+        .filter(|profile| profile.bundle_id == bundle_id);
+    let ide_context_enabled = matching
+        .clone()
+        .next()
+        .is_some_and(|profile| profile.ide_context_enabled);
+    let writing_style = matching.find_map(|profile| {
+        profile
+            .writing_style
+            .filter(|style| *style != WritingStyle::Inherit)
+    });
+
+    ide_context_enabled || writing_style == Some(WritingStyle::CodeTechnical)
 }
 
 /// A user-defined voice command: when `phrase` is spoken (matched
@@ -265,13 +281,9 @@ pub struct DictationState {
 impl DictationState {
     pub(crate) fn code_vocabulary_enabled_for(&self, bundle_id: Option<&str>) -> bool {
         self.code_vocab_enabled
-            && bundle_id
-                .and_then(|bundle_id| {
-                    self.app_profiles
-                        .iter()
-                        .find(|profile| profile.bundle_id == bundle_id)
-                })
-                .is_some_and(AppProfile::enables_code_vocabulary)
+            && bundle_id.is_some_and(|bundle_id| {
+                app_profiles_enable_code_vocabulary(&self.app_profiles, bundle_id)
+            })
     }
 }
 

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -149,6 +149,17 @@ pub struct AppProfile {
     pub ide_project_roots: Vec<String>,
 }
 
+impl AppProfile {
+    /// Developer vocabulary is intentionally opt-in per destination app.
+    ///
+    /// A technical writing style or local IDE context is an explicit user
+    /// signal. Bundle IDs and app labels are never guessed, so ordinary prose
+    /// apps cannot inherit a globally scanned code vocabulary by accident.
+    pub(crate) fn enables_code_vocabulary(&self) -> bool {
+        self.ide_context_enabled || self.writing_style == Some(WritingStyle::CodeTechnical)
+    }
+}
+
 /// A user-defined voice command: when `phrase` is spoken (matched
 /// case-insensitively on word boundaries), it is replaced by `replacement`.
 /// Applied after the built-in command set, so users can extend — not override —
@@ -249,6 +260,19 @@ pub struct DictationState {
     /// Tier 2 phonetic / edit-distance "sounds-like" matching. Gated under
     /// `correction_enabled`.
     pub correction_fuzzy: bool,
+}
+
+impl DictationState {
+    pub(crate) fn code_vocabulary_enabled_for(&self, bundle_id: Option<&str>) -> bool {
+        self.code_vocab_enabled
+            && bundle_id
+                .and_then(|bundle_id| {
+                    self.app_profiles
+                        .iter()
+                        .find(|profile| profile.bundle_id == bundle_id)
+                })
+                .is_some_and(AppProfile::enables_code_vocabulary)
+    }
 }
 
 impl Default for DictationState {

--- a/app/src-tauri/src/vocabulary_alias.rs
+++ b/app/src-tauri/src/vocabulary_alias.rs
@@ -41,14 +41,61 @@ impl CorrectionMatcherSet {
         fuzzy: bool,
         include_builtins: bool,
     ) -> Self {
+        Self::build_with_knowledge_policy(
+            base_terms,
+            entries,
+            app_profiles,
+            knowledge,
+            fuzzy,
+            include_builtins,
+            false,
+        )
+    }
+
+    /// Build developer-derived terms only into matchers for profiles carrying
+    /// an explicit technical-context signal. Global/app/project preferred
+    /// spellings and learned replacements keep their existing scopes.
+    pub(crate) fn build_with_contextual_code_terms(
+        base_terms: &[String],
+        entries: &[VocabularyEntry],
+        app_profiles: &[AppProfile],
+        knowledge: &[KnowledgeEntry],
+        fuzzy: bool,
+        include_builtins: bool,
+    ) -> Self {
+        Self::build_with_knowledge_policy(
+            base_terms,
+            entries,
+            app_profiles,
+            knowledge,
+            fuzzy,
+            include_builtins,
+            true,
+        )
+    }
+
+    fn build_with_knowledge_policy(
+        base_terms: &[String],
+        entries: &[VocabularyEntry],
+        app_profiles: &[AppProfile],
+        knowledge: &[KnowledgeEntry],
+        fuzzy: bool,
+        include_builtins: bool,
+        contextual_code_terms: bool,
+    ) -> Self {
         let global_entries = applicable_entries(entries, None, app_profiles);
         let global_learned = applicable_learned_pairs(knowledge, None, None);
+        let global_base_terms = if contextual_code_terms {
+            &[][..]
+        } else {
+            base_terms
+        };
         let global = Arc::new(build_matcher(
-            base_terms,
+            global_base_terms,
             &global_entries,
             &global_learned,
             fuzzy,
-            include_builtins,
+            include_builtins && !contextual_code_terms,
         ));
 
         let mut bundle_ids = app_profiles
@@ -77,12 +124,17 @@ impl CorrectionMatcherSet {
                 let applicable = applicable_entries(entries, Some(&bundle_id), app_profiles);
                 let project_root = unambiguous_project_root(&bundle_id, app_profiles);
                 let learned = applicable_learned_pairs(knowledge, Some(&bundle_id), project_root);
+                let code_terms_enabled = !contextual_code_terms
+                    || app_profiles
+                        .iter()
+                        .find(|profile| profile.bundle_id == bundle_id)
+                        .is_some_and(AppProfile::enables_code_vocabulary);
                 let matcher = Arc::new(build_matcher(
-                    base_terms,
+                    if code_terms_enabled { base_terms } else { &[] },
                     &applicable,
                     &learned,
                     fuzzy,
-                    include_builtins,
+                    include_builtins && code_terms_enabled,
                 ));
                 (bundle_id, matcher)
             })
@@ -697,6 +749,64 @@ mod tests {
         assert_eq!(
             set.select(Some("com.example.Editor")).apply("mer mer"),
             "Murmur"
+        );
+    }
+
+    #[test]
+    fn contextual_code_terms_do_not_leak_into_ordinary_apps() {
+        let ordinary = AppProfile {
+            bundle_id: "com.example.Chat".to_string(),
+            label: "Chat".to_string(),
+            auto_paste_override: None,
+            cleanup_override: None,
+            cli_formatting_override: None,
+            smart_formatting_override: None,
+            writing_style: None,
+            ide_context_enabled: false,
+            ide_project_roots: Vec::new(),
+        };
+        let mut technical = ordinary.clone();
+        technical.bundle_id = "com.example.Editor".to_string();
+        technical.label = "Editor".to_string();
+        technical.writing_style = Some(crate::state::WritingStyle::CodeTechnical);
+        let mut indexed = ordinary.clone();
+        indexed.bundle_id = "com.example.IDE".to_string();
+        indexed.label = "IDE".to_string();
+        indexed.ide_context_enabled = true;
+        indexed.ide_project_roots = vec!["/project".to_string()];
+
+        let preferred = entry("Tauri", &["Tori"]);
+        let terms = vec!["all__".to_string(), "toBe".to_string()];
+        let set = CorrectionMatcherSet::build_with_contextual_code_terms(
+            &terms,
+            &[preferred],
+            &[ordinary, technical, indexed],
+            &[],
+            false,
+            false,
+        );
+        let prose = "Tori will deploy this on all the machines before going to be offline";
+        let ordinary_expected =
+            "Tauri will deploy this on all the machines before going to be offline";
+        let technical_expected =
+            "Tauri will deploy this on all__ the machines before going toBe offline";
+
+        assert_eq!(set.select(None).apply(prose), ordinary_expected);
+        assert_eq!(
+            set.select(Some("com.example.Chat")).apply(prose),
+            ordinary_expected
+        );
+        assert_eq!(
+            set.select(Some("com.example.Unconfigured")).apply(prose),
+            ordinary_expected
+        );
+        assert_eq!(
+            set.select(Some("com.example.Editor")).apply(prose),
+            technical_expected
+        );
+        assert_eq!(
+            set.select(Some("com.example.IDE")).apply(prose),
+            technical_expected
         );
     }
 

--- a/app/src-tauri/src/vocabulary_alias.rs
+++ b/app/src-tauri/src/vocabulary_alias.rs
@@ -125,10 +125,7 @@ impl CorrectionMatcherSet {
                 let project_root = unambiguous_project_root(&bundle_id, app_profiles);
                 let learned = applicable_learned_pairs(knowledge, Some(&bundle_id), project_root);
                 let code_terms_enabled = !contextual_code_terms
-                    || app_profiles
-                        .iter()
-                        .find(|profile| profile.bundle_id == bundle_id)
-                        .is_some_and(AppProfile::enables_code_vocabulary);
+                    || crate::state::app_profiles_enable_code_vocabulary(app_profiles, &bundle_id);
                 let matcher = Arc::new(build_matcher(
                     if code_terms_enabled { base_terms } else { &[] },
                     &applicable,
@@ -807,6 +804,55 @@ mod tests {
         assert_eq!(
             set.select(Some("com.example.IDE")).apply(prose),
             technical_expected
+        );
+    }
+
+    #[test]
+    fn contextual_code_terms_follow_duplicate_profile_resolution() {
+        let mut first = AppProfile {
+            bundle_id: "com.example.Editor".to_string(),
+            label: "first".to_string(),
+            auto_paste_override: None,
+            cleanup_override: None,
+            cli_formatting_override: None,
+            smart_formatting_override: None,
+            writing_style: None,
+            ide_context_enabled: false,
+            ide_project_roots: Vec::new(),
+        };
+        let mut second = first.clone();
+        second.label = "second".to_string();
+        second.writing_style = Some(crate::state::WritingStyle::CodeTechnical);
+
+        let terms = vec!["toBe".to_string()];
+        let set = CorrectionMatcherSet::build_with_contextual_code_terms(
+            &terms,
+            &[],
+            &[first.clone(), second],
+            &[],
+            false,
+            false,
+        );
+        assert_eq!(
+            set.select(Some("com.example.Editor"))
+                .apply("going to be ready"),
+            "going toBe ready"
+        );
+
+        first.ide_context_enabled = true;
+        first.writing_style = Some(crate::state::WritingStyle::Conversational);
+        let set = CorrectionMatcherSet::build_with_contextual_code_terms(
+            &terms,
+            &[],
+            &[first],
+            &[],
+            false,
+            false,
+        );
+        assert_eq!(
+            set.select(Some("com.example.Editor"))
+                .apply("going to be ready"),
+            "going toBe ready"
         );
     }
 

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -700,7 +700,7 @@ export function SettingsPanel({
               <p className="mt-1 mb-3 text-xs text-on-surface-variant">Teach Murmur preferred spellings and exact spoken variants.</p>
               <VocabularyAliasesEditor entries={settings.vocabularyEntries} voiceCommands={settings.voiceCommands} onChange={(vocabularyEntries) => onUpdateSettings({ vocabularyEntries, customVocabulary: vocabularyPrompt(vocabularyEntries) })} />
             </div>
-            <SettingToggle title="Developer Terms" description="Bias recognition toward built-in development terms and, optionally, identifiers from one project folder." checked={settings.codeVocabEnabled} onChange={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })} />
+            <SettingToggle title="Developer Terms" description="Make built-in development terms and an optional project scan available only to apps configured as Code / technical or with Local IDE project context." checked={settings.codeVocabEnabled} onChange={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })} />
             {settings.codeVocabEnabled && (
               <div className="ml-3 space-y-2 border-l border-outline-variant/30 pl-3">
                 <p className="break-all rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs text-on-surface">{settings.codeVocabFolder || 'No folder — built-in developer terms only'}</p>
@@ -709,7 +709,7 @@ export function SettingsPanel({
                   {settings.codeVocabFolder && <button type="button" onClick={clearCodeFolder} className="text-xs font-medium text-on-surface-variant underline hover:text-primary">Clear</button>}
                 </div>
                 <VocabScanStrip status={vocabScan.status} walker={vocabScan.walker} stats={vocabScan.stats} folder={settings.codeVocabFolder} onScan={() => void runVocabScan(settings.codeVocabFolder)} onCancel={vocabScan.cancel} />
-                <p className="text-xs text-on-surface-variant">The selected folder is scanned locally; dependency and build folders are skipped.</p>
+                <p className="text-xs text-on-surface-variant">The selected folder is scanned locally; dependency and build folders are skipped. Unconfigured apps keep ordinary prose vocabulary.</p>
               </div>
             )}
             <SettingToggle title="Apply Preferred Spellings" label="Smart correction" description="Apply names, terms, and developer vocabulary after recognition on every model." checked={settings.correctionEnabled} onChange={() => onUpdateSettings({ correctionEnabled: !settings.correctionEnabled })} />

--- a/docs/features/per-app-profiles.md
+++ b/docs/features/per-app-profiles.md
@@ -32,7 +32,7 @@ profiles and every stored field retain their values across the Settings redesign
 | Inherit | Preserves the current global/profile behavior byte-for-byte. |
 | Conversational | Removes filler and repeated words, tidies capitalization, keeps wording, and disables automatic command formatting. |
 | Polished prose | Applies conversational cleanup, deterministic vocabulary correction, and explicitly cued prose structure. |
-| Code / technical | Preserves technical surface text, enables deterministic vocabulary correction, and enables reviewed command formatting. |
+| Code / technical | Preserves technical surface text, activates enabled developer vocabulary, enables deterministic vocabulary correction, and enables reviewed command formatting. |
 | Verbatim | Bypasses cleanup, spoken commands, correction, prose formatting, and command formatting. |
 | Notes | Removes filler without forcing sentence capitalization, applies deterministic correction, and formats explicitly cued lists, paragraphs, lines, and symbols. |
 
@@ -71,7 +71,7 @@ Context capture is deny-by-default. A profile may explicitly grant only its boun
 
 This policy is separate from delivery. Murmur remains clipboard-first: the completed transcript is still written to the clipboard, and existing auto-paste behavior is unchanged. IDE project context does not change those denials: it reads only user-selected roots through the bounded local index described in [Local IDE Symbols and `@file` Context](ide-context.md). Unmatched profiles and app names that merely look like IDEs remain no-ops.
 
-Writing styles also do not change the ASR model, language, vocabulary inputs, prompt, file-saving behavior, clipboard write, auto-paste timing, or destination. Style telemetry contains only the stable resolved enum plus the existing matched-profile boolean; bundle identifiers, labels, setting values, and transcript content are never logged.
+Writing styles do not change the ASR model, language, file-saving behavior, clipboard write, auto-paste timing, or destination. The explicit Code / technical style activates the globally enabled developer-vocabulary pool for that matching app; Local IDE project context is the other activation signal. Other styles and unmatched apps never receive scanned or built-in developer terms. Preferred spellings retain their own global/app/project scopes. Style telemetry contains only the stable resolved enum plus the existing matched-profile boolean; bundle identifiers, labels, setting values, and transcript content are never logged.
 
 Vocabulary aliases use this same immutable context. Global aliases always apply. Typed app aliases require the matching snapshot bundle identifier; typed project aliases additionally require the matching profile's enabled local project context and configured root. Settings currently creates global aliases first. No alias path re-detects the frontmost app.
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -94,7 +94,7 @@ transcript event, live-preview setting, or model-specific preview behavior.
 
 `run_transcription_pipeline()` remains the single authoritative completion entry point. `start_native_recording` resolves one immutable `DictationContextSnapshot` from the frontmost bundle identifier and current configuration; every live stage receives that snapshot instead of re-reading mutable settings:
 
-1. Capture app identity, matched profile, effective settings, vocabulary version, repository-backed commands, and deny-by-default context permissions at recording start
+1. Capture app identity, matched profile, effective settings, vocabulary version, repository-backed commands, and deny-by-default context permissions at recording start. Built-in/scanned developer terms are included only when the matching profile explicitly selects Code / technical or Local IDE project context.
 2. Confirm the snapshot's model preparation completed (or load synchronously as a fallback)
 3. Run one full-buffer VAD and backend transcription pass with the same snapshot
 4. Run the backend-neutral transcript transformation pipeline from the snapshot's stage settings and resources

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -160,7 +160,7 @@ model-selection side effects.
 
 ## Vocabulary Settings
 
-`vocabularyEntries` is an array of `{ id, written, aliases, enabled, scope }`. `written` is the canonical surface form used by Whisper prompt bias and post-model correction. `aliases` contains exact spoken variants applied locally on every backend. Settings currently creates `{ kind: 'global' }` scopes; typed app/project scopes are selected from the existing immutable dictation context. The legacy `customVocabulary` string is migration-only and is re-derived from enabled global canonical terms.
+`vocabularyEntries` is an array of `{ id, written, aliases, enabled, scope }`. `written` is the canonical surface form used by Whisper prompt bias and post-model correction. `aliases` contains exact spoken variants applied locally on every backend. Settings currently creates `{ kind: 'global' }` scopes; typed app/project scopes are selected from the existing immutable dictation context. The legacy `customVocabulary` string is migration-only and is re-derived from enabled global canonical terms. Built-in and scanned developer terms are a separate pool: the global toggle makes that pool available, while a matching Code / technical profile or Local IDE project-context opt-in activates it for a recording. Unmatched apps never receive that pool.
 
 Aliases are limited to 16 per entry and values to 256 characters. Ambiguous aliases, canonical collisions, Voice Command collisions, and direct or indirect cycles are rejected atomically.
 


### PR DESCRIPTION
## Summary
- scope scanned and built-in developer terms to Code / technical or Local IDE profiles
- preserve global preferred spellings and learned correction scopes
- align Whisper prompts, backend-neutral correction, settings copy, and documentation

## Validation
- cargo check
- cargo test -- --test-threads=1 (656 passed; optional hardware tests ignored)
- npx tsc --noEmit
- npm test (602 passed)
- native macOS debug bundle built and launched successfully

The optional DMG packaging wrapper was stopped after the .app bundle completed because the remote hdiutil packaging step remained open; this does not affect the native app smoke result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Developer vocabulary and technical terms now apply only to apps explicitly configured for Code/technical writing or Local IDE project context.
  - Code-aware corrections and formatting are scoped to eligible app profiles.
  - Imported file transcriptions continue using standard vocabulary only.

- **Documentation**
  - Clarified developer vocabulary availability, profile activation, privacy, and per-app behavior in settings and feature documentation.

- **Bug Fixes**
  - Prevented developer terms from leaking into ordinary or unconfigured app contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->