### PR TITLE
Animate compact history search

### DIFF
--- a/app/src/components/history/HistoryPanel.test.tsx
+++ b/app/src/components/history/HistoryPanel.test.tsx
@@ -34,6 +34,10 @@ describe('HistoryPanel', () => {
   const buttons = () => Array.from(container.querySelectorAll('button'));
   const byText = (text: string) => buttons().find((b) => b.textContent === text);
   const cardText = () => Array.from(container.querySelectorAll('article')).map((a) => a.textContent ?? '');
+  const searchShell = () => container.querySelector('[data-testid="history-search-shell"]') as HTMLDivElement;
+  const searchInput = () => container.querySelector('input[type="search"]') as HTMLInputElement;
+  const searchTrigger = () => container.querySelector('[aria-label="Open transcript search"]') as HTMLButtonElement;
+  const searchClose = () => container.querySelector('[aria-label="Close transcript search"]') as HTMLButtonElement;
 
   async function render(props: Partial<Parameters<typeof HistoryPanel>[0]> = {}) {
     await act(async () => {
@@ -49,11 +53,29 @@ describe('HistoryPanel', () => {
   }
 
   async function type(value: string) {
-    const input = container.querySelector('input[type="search"]') as HTMLInputElement;
+    const input = searchInput();
     const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
     await act(async () => {
       setter.call(input, value);
       input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  async function hoverSearch() {
+    await act(async () => {
+      searchShell().dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: document.body,
+      }));
+    });
+  }
+
+  async function leaveSearch() {
+    await act(async () => {
+      searchShell().dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: document.body,
+      }));
     });
   }
 
@@ -165,7 +187,88 @@ describe('HistoryPanel', () => {
   it('focuses the search box when the focus token changes', async () => {
     await render();
     await render({ focusSearchToken: 1 });
-    expect(document.activeElement).toBe(container.querySelector('input[type="search"]'));
+    expect(document.activeElement).toBe(searchInput());
+    expect(searchShell().dataset.expanded).toBe('true');
+  });
+
+  it('previews on hover and collapses when the pointer leaves', async () => {
+    await render();
+    expect(searchShell().dataset.expanded).toBe('false');
+    expect(searchInput().tabIndex).toBe(-1);
+
+    await hoverSearch();
+    expect(searchShell().dataset.expanded).toBe('true');
+    expect(searchInput().tabIndex).toBe(0);
+
+    await leaveSearch();
+    expect(searchShell().dataset.expanded).toBe('false');
+    expect(searchInput().tabIndex).toBe(-1);
+  });
+
+  it('pins on click and does not collapse when hover ends during input', async () => {
+    await render();
+    await hoverSearch();
+    await act(async () => searchTrigger().click());
+    expect(document.activeElement).toBe(searchInput());
+
+    await leaveSearch();
+    expect(searchShell().dataset.expanded).toBe('true');
+
+    await act(async () => byText('Export ▾')!.focus());
+    expect(searchShell().dataset.expanded).toBe('false');
+  });
+
+  it('keeps a non-empty query visible after focus and hover leave', async () => {
+    await render();
+    await act(async () => searchTrigger().click());
+    await type('tauri');
+    await leaveSearch();
+    await act(async () => byText('Export ▾')!.focus());
+
+    expect(searchShell().dataset.expanded).toBe('true');
+    expect(searchInput().value).toBe('tauri');
+    expect(cardText()).toHaveLength(1);
+  });
+
+  it('Escape clears, collapses, and suppresses hover until a genuine re-entry', async () => {
+    await render();
+    await hoverSearch();
+    await act(async () => searchTrigger().click());
+    await type('tauri');
+
+    await act(async () => {
+      searchInput().dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+      }));
+    });
+    expect(searchInput().value).toBe('');
+    expect(searchShell().dataset.expanded).toBe('false');
+    expect(cardText()).toHaveLength(3);
+
+    // The pointer is still notionally over the control, so Escape must win.
+    await hoverSearch();
+    expect(searchShell().dataset.expanded).toBe('false');
+
+    await leaveSearch();
+    await hoverSearch();
+    expect(searchShell().dataset.expanded).toBe('true');
+  });
+
+  it('the close control clears and collapses the active search', async () => {
+    await render();
+    await act(async () => searchTrigger().click());
+    await type('tauri');
+    await act(async () => searchClose().click());
+
+    expect(searchInput().value).toBe('');
+    expect(searchShell().dataset.expanded).toBe('false');
+    expect(cardText()).toHaveLength(3);
+
+    // This click was keyboard-style with no pointer over the shell, so a new
+    // hover must work immediately rather than requiring a leave/re-entry.
+    await hoverSearch();
+    expect(searchShell().dataset.expanded).toBe('true');
   });
 
   it('uses a disclosure group and restores Export focus on Escape', async () => {

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -47,6 +47,9 @@ export function HistoryPanel({
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [teachingEntry, setTeachingEntry] = useState<HistoryEntry | null>(null);
   const [query, setQuery] = useState('');
+  const [searchHovered, setSearchHovered] = useState(false);
+  const [searchPinned, setSearchPinned] = useState(false);
+  const [searchHoverSuppressed, setSearchHoverSuppressed] = useState(false);
   const [filter, setFilter] = useState<HistoryFilter>('all');
   const [exportOpen, setExportOpen] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -54,6 +57,7 @@ export function HistoryPanel({
   const copyGroupId = useId();
   const saveGroupId = useId();
   const exportPanelId = useId();
+  const searchInputId = useId();
   const searchRef = useRef<HTMLInputElement>(null);
   const exportRef = useRef<HTMLDivElement>(null);
   const exportButtonRef = useRef<HTMLButtonElement>(null);
@@ -69,6 +73,8 @@ export function HistoryPanel({
 
   useEffect(() => {
     if (focusSearchToken === undefined) return;
+    setSearchHoverSuppressed(false);
+    setSearchPinned(true);
     searchRef.current?.focus();
     searchRef.current?.select();
   }, [focusSearchToken]);
@@ -108,6 +114,9 @@ export function HistoryPanel({
     () => sortForDisplay(filterHistory(entries, { query, filter })),
     [entries, query, filter],
   );
+  const searchExpanded = searchPinned
+    || query.length > 0
+    || (searchHovered && !searchHoverSuppressed);
   // Correct-and-Teach only ever targets the newest entry in the whole history,
   // not the first row on screen — sorting and filtering reorder the list.
   const newestId = entries[entries.length - 1]?.id;
@@ -159,6 +168,21 @@ export function HistoryPanel({
     onClear();
   };
 
+  const openSearch = () => {
+    setSearchHoverSuppressed(false);
+    setSearchPinned(true);
+    searchRef.current?.focus();
+  };
+
+  const closeSearch = () => {
+    setQuery('');
+    setSearchPinned(false);
+    // Escape/close must win if the pointer is still sitting on the control,
+    // but a keyboard close elsewhere must not suppress the next fresh hover.
+    setSearchHoverSuppressed(searchHovered);
+    searchRef.current?.blur();
+  };
+
   if (entries.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center text-on-surface-variant">
@@ -174,22 +198,92 @@ export function HistoryPanel({
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="mb-2 shrink-0 space-y-2">
-        <div className="flex items-center gap-2">
-          <div className="relative min-w-0 flex-1">
-            <svg className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-on-surface-variant" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
-            </svg>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <div
+            data-testid="history-search-shell"
+            data-expanded={searchExpanded}
+            className={`relative h-8 shrink-0 overflow-hidden rounded-lg border bg-surface-container-lowest shadow-sm motion-safe:transition-[width,border-color,background-color,box-shadow] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.2,0.86,0.24,1.1)] motion-reduce:transition-none ${
+              searchExpanded
+                ? 'w-[min(24rem,55vw)] border-primary/70 bg-surface-container shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-primary)_10%,transparent)]'
+                : 'w-8 border-outline-variant/30'
+            }`}
+            onMouseEnter={() => setSearchHovered(true)}
+            onMouseLeave={() => {
+              setSearchHovered(false);
+              setSearchHoverSuppressed(false);
+            }}
+            onBlur={(event) => {
+              if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+              setSearchPinned(false);
+            }}
+          >
+            <button
+              type="button"
+              onClick={openSearch}
+              aria-label="Open transcript search"
+              aria-expanded={searchExpanded}
+              aria-controls={searchInputId}
+              className="absolute inset-y-0 left-0 z-10 grid w-8 place-items-center rounded-lg text-on-surface-variant transition-colors hover:text-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary"
+            >
+              <svg className={`h-3.5 w-3.5 motion-safe:transition-[color,transform] motion-safe:duration-300 motion-reduce:transition-none ${searchExpanded ? 'scale-95 text-primary' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
+              </svg>
+            </button>
             <input
+              id={searchInputId}
               ref={searchRef}
               type="search"
               value={query}
+              onFocus={() => setSearchPinned(true)}
               onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => { if (event.key === 'Escape' && query) { event.stopPropagation(); setQuery(''); } }}
+              onKeyDown={(event) => {
+                if (event.key !== 'Escape') return;
+                event.preventDefault();
+                event.stopPropagation();
+                closeSearch();
+              }}
               placeholder="Search transcripts"
               aria-label="Search transcripts"
-              className="w-full rounded-lg border border-on-surface-variant bg-surface-container-lowest py-1.5 pl-8 pr-2 text-sm text-on-surface shadow-sm placeholder:text-on-surface-variant focus:outline-none focus-visible:ring-2 focus-visible:ring-primary [&::-webkit-search-cancel-button]:appearance-none"
+              aria-hidden={!searchExpanded}
+              tabIndex={searchExpanded ? 0 : -1}
+              className={`absolute inset-0 h-full w-full border-0 bg-transparent py-1.5 pl-8 pr-8 text-sm text-on-surface outline-none placeholder:text-on-surface-variant [&::-webkit-search-cancel-button]:appearance-none motion-safe:transition-[opacity,transform] motion-safe:duration-200 motion-reduce:transition-none ${
+                searchExpanded
+                  ? 'translate-x-0 opacity-100'
+                  : '-translate-x-1.5 opacity-0 pointer-events-none'
+              }`}
             />
+            <button
+              type="button"
+              onClick={closeSearch}
+              aria-label="Close transcript search"
+              aria-hidden={!searchExpanded}
+              tabIndex={searchExpanded ? 0 : -1}
+              className={`absolute right-1 top-1 z-10 grid h-6 w-6 place-items-center rounded-md bg-on-surface/5 text-sm leading-none text-on-surface-variant transition-[opacity,color,background-color] hover:bg-on-surface/10 hover:text-on-surface focus:outline-none focus-visible:ring-1 focus-visible:ring-primary ${
+                searchExpanded ? 'opacity-100' : 'pointer-events-none opacity-0'
+              }`}
+            >
+              ×
+            </button>
           </div>
+
+          {HISTORY_FILTER_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={filter === option.value}
+              onClick={() => setFilter(option.value)}
+              className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${filter === option.value ? 'bg-primary text-on-primary' : 'bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container'}`}
+            >
+              {option.label}
+            </button>
+          ))}
+
+          <span className="ml-auto text-[11px] text-on-surface-variant">
+            {visible.length === entries.length
+              ? `${entries.length} ${entries.length === 1 ? 'entry' : 'entries'}`
+              : `${visible.length} of ${entries.length}`}
+          </span>
+
           <div ref={exportRef} className="relative shrink-0">
             <button
               ref={exportButtonRef}
@@ -248,25 +342,6 @@ export function HistoryPanel({
               </div>
             )}
           </div>
-        </div>
-
-        <div className="flex items-center gap-1.5">
-          {HISTORY_FILTER_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              aria-pressed={filter === option.value}
-              onClick={() => setFilter(option.value)}
-              className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${filter === option.value ? 'bg-primary text-on-primary' : 'bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container'}`}
-            >
-              {option.label}
-            </button>
-          ))}
-          <span className="ml-auto text-[11px] text-on-surface-variant">
-            {visible.length === entries.length
-              ? `${entries.length} ${entries.length === 1 ? 'entry' : 'entries'}`
-              : `${visible.length} of ${entries.length}`}
-          </span>
         </div>
 
         {notice && (

--- a/docs/features/history-workspace.md
+++ b/docs/features/history-workspace.md
@@ -8,13 +8,18 @@ Everything here is local. History lives in `localStorage` under `dictation-histo
 
 ## Search
 
-The search box filters as you type.
+Search rests as a compact icon so it does not dominate the history toolbar. Hover previews the field; clicking the icon, focusing the input, or invoking the app-wide search shortcut pins it open. An active non-empty query also keeps the field visible after focus leaves.
+
+- Leaving a hover-only preview collapses it.
+- Leaving while the input is focused does not collapse it or steal focus.
+- Clicking elsewhere collapses an empty search; a non-empty search remains visible so an active filter is never hidden.
+- Escape or the close button clears the query, releases focus, and collapses the field. If the pointer is still over the field, hover is suppressed until it genuinely leaves so the just-closed field cannot immediately reopen.
+- Motion uses the app's reduced-motion contract; width and content transitions are removed when reduced motion is requested.
 
 - Matching is case-insensitive and searches the transcript text plus, for imported files, the source file name.
 - Multiple words are **ANDed** — `tauri release` keeps only entries containing both. Narrowing a query never widens the result set.
 - Matches are highlighted in place. `matchSegments` splits an entry into alternating plain/matched runs, merging overlapping and adjacent ranges so two tokens that overlap (`there` and `here` in "therein") produce one highlight rather than nested ones. Original casing is preserved, and the segments always reassemble to the original text exactly.
 - Highlight ranges are capped per entry, so a one-character query cannot emit thousands of spans for a long transcript.
-- Escape clears the query when it is non-empty.
 
 ## Filters
 


### PR DESCRIPTION
## What changed

- replace the always-expanded history search field with a compact icon that animates open on hover
- pin the field while focused, invoked from the keyboard, or carrying an active query
- make Escape and the close control clear and collapse without immediately reopening beneath the pointer
- preserve accessible tab/ARIA behavior and reduced-motion support
- move filters, count, and export into the compact history toolbar
- document the interaction contract

## Validation

- `npm test` — 607 tests passed
- `npx tsc --noEmit`
- `npm run build`
- browser automation confirmed the 32px → 384px expansion and hover/focus/query/Escape transitions