### PR TITLE
fix: bypass slow AX no-value paste fallback

### DIFF
--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -345,6 +345,23 @@ fn focused_field_state() -> FocusedFieldState {
             tracing::warn!(target: "pipeline", "focused_field_state: native AX query timed out; allowing paste");
             return FocusedFieldState::Unknown;
         }
+        Err(native_err)
+            if should_bypass_osascript_for_no_value(
+                &native_err,
+                frontmost_application_is_finder(),
+            ) =>
+        {
+            // kAXErrorNoValue means the target app exposes no focused AX
+            // element. Apps with web-backed editors can report this even while
+            // their editor accepts Cmd+V. The compatibility query reaches the
+            // same AX subsystem through System Events and adds process-launch
+            // latency without improving the answer, so preserve the existing
+            // fail-open behavior immediately. Finder remains on the fallback
+            // path because its desktop/file views are the reason this safety
+            // check exists.
+            tracing::warn!(target: "pipeline", "focused_field_state: native AX query returned no focused element; allowing paste without osascript fallback");
+            return FocusedFieldState::Unknown;
+        }
         Err(native_err) => {
             tracing::warn!(target: "pipeline", "focused_field_state: native AX query failed: {}; falling back to osascript", native_err);
             match focused_role_osascript() {
@@ -364,6 +381,30 @@ fn is_native_ax_timeout(error: &str) -> bool {
     // kAXErrorCannotComplete is returned when the target app does not answer
     // within the per-element messaging timeout.
     error.contains("returned -25204")
+}
+
+#[cfg(target_os = "macos")]
+fn is_native_ax_no_value(error: &str) -> bool {
+    // kAXErrorNoValue is returned when the requested attribute exists but the
+    // target app currently supplies no value for it.
+    error.contains("returned -25212")
+}
+
+#[cfg(target_os = "macos")]
+fn should_bypass_osascript_for_no_value(error: &str, frontmost_is_finder: Option<bool>) -> bool {
+    is_native_ax_no_value(error) && frontmost_is_finder == Some(false)
+}
+
+#[cfg(target_os = "macos")]
+fn frontmost_application_is_finder() -> Option<bool> {
+    use objc2_app_kit::NSWorkspace;
+
+    let application = NSWorkspace::sharedWorkspace().frontmostApplication()?;
+    Some(
+        application
+            .bundleIdentifier()
+            .is_some_and(|bundle_id| bundle_id.to_string() == "com.apple.finder"),
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -996,6 +1037,31 @@ mod focus_tests {
             "AX focused-element query returned -25204"
         ));
         assert!(!is_native_ax_timeout("AX role query returned -25205"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ax_no_value_detection_matches_no_value_only() {
+        assert!(is_native_ax_no_value(
+            "AX focused-element query returned -25212"
+        ));
+        assert!(!is_native_ax_no_value(
+            "AX focused-element query returned -25204"
+        ));
+        assert!(!is_native_ax_no_value("AX role query returned -25205"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ax_no_value_bypasses_osascript_except_for_finder_or_unknown_target() {
+        let error = "AX focused-element query returned -25212";
+        assert!(should_bypass_osascript_for_no_value(error, Some(false)));
+        assert!(!should_bypass_osascript_for_no_value(error, Some(true)));
+        assert!(!should_bypass_osascript_for_no_value(error, None));
+        assert!(!should_bypass_osascript_for_no_value(
+            "AX role query returned -25205",
+            Some(false)
+        ));
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/features/text-injection.md
+++ b/docs/features/text-injection.md
@@ -17,7 +17,7 @@ When `auto_paste` is enabled in settings:
 1. Copy text to clipboard
 2. Check `AXIsProcessTrusted()` — if accessibility not granted, stop here (text is still in clipboard)
 3. Wait for the configurable delay (default 50ms) for window focus to settle
-4. Resolve the frontmost process with `NSWorkspace` and query its focused element role with the macOS Accessibility API. If the native query fails with a non-timeout error, fall back to the previous System Events `osascript` query. Native AX timeout (`-25204`) returns `Unknown` immediately and skips the fallback (allow-paste).
+4. Resolve the frontmost process with `NSWorkspace` and query its focused element role with the macOS Accessibility API. Native AX timeout (`-25204`) returns `Unknown` immediately and skips the fallback (allow-paste). A native no-value response (`-25212`) also skips the fallback for non-Finder apps because web-backed editors can accept Cmd+V without exposing a focused AX element; Finder retains the compatibility query so its desktop/file-view guard remains effective. Other native failures fall back to the previous System Events `osascript` query.
 5. Skip auto-paste only when the focused role is on the confirmed non-editable denylist; unknown roles still allow paste
 6. Post Command-modified `V` key-down and key-up events through the CoreGraphics HID event tap. If event construction fails, fall back to the previous System Events `osascript` paste
 7. If the paste attempt reports a failure, wait 100ms and retry once
@@ -29,7 +29,7 @@ The clipboard write (`arboard::set_text()` → `NSPasteboard`) is synchronous, s
 
 ### Configurable Delay
 
-The paste delay is configurable via a range slider in the settings panel (10–500ms, step 10ms). The slider appears when auto-paste is enabled. The value is sent to the Rust backend via `configure_dictation` and clamped to the 10–500 range.
+The paste delay is configurable via a range slider in the settings panel (10–500ms, step 10ms). The slider appears when auto-paste is enabled. The value is sent to the Rust backend via `configure_dictation` and clamped to the 10–500 range. This configured delay is one component of the broader **Clipboard / paste** performance stage, which also measures the clipboard write, focus safety query, Cmd+V event, and small dispatch overhead.
 
 ### Retry Behavior
 


### PR DESCRIPTION
## Summary

- Treat macOS Accessibility error `-25212` (`kAXErrorNoValue`) as an immediate fail-open result for non-Finder applications.
- Avoid launching the System Events AppleScript compatibility query when web-backed editors accept Cmd+V but expose no focused AX element.
- Preserve the compatibility query for Finder so the existing desktop/file-view `.textClipping` protection remains effective.
- Clarify that the configured Paste Delay is only one component of the broader Clipboard / paste performance stage.

## Root cause

Production 0.23.1 logs from the affected Mac consistently showed the native focused-element query returning `-25212`. Murmur classified only `-25204` as an immediate allow-paste result, so `-25212` launched `osascript` on every transcription. That fallback consumed 118–156 ms while returning no more useful focus information, raising median Clipboard / paste latency from about 15 ms to 148 ms even though the configured delay remained 10 ms.

## Expected impact

For the observed non-Finder `-25212` path, remove roughly 133 ms per completed transcription. The replacement `NSWorkspace` Finder classification measured 0.0002 ms median, 0.0002 ms p95, and 0.5370 ms maximum across 1,000 iterations on the affected MacBook.

## Validation

- [x] `cargo check`
- [x] `cargo test -- --test-threads=1` — 660 passed, 5 ignored
- [x] `npx tsc --noEmit`
- [x] `npm test -- --run` — 607 passed
- [x] Regression tests cover `-25212` detection and preserve the Finder/unknown-target fallback
- [x] Native debug bundle built successfully (packaging stopped only at the expected missing updater private key after producing the `.app`)
- [ ] Native auto-paste smoke test — waiting for macOS Accessibility permission for the isolated `Local Dictation Dev` bundle
