### PR TITLE
feat: ship device identity with diagnostic logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built with [Tauri 2](https://tauri.app/) (Rust + React), with local transcriptio
 ## Features
 
 - **100% local speech and text** — transcription, text rewriting, and benchmarking all run on-device. Audio and your words never leave the machine
-- **Anonymous diagnostics** — privacy-stripped event logs (timing, errors, pipeline stats — never audio or transcription text) upload to the maintainer for debugging, identified only by a random install ID. Launch with `MURMUR_LOG_SHIPPER=off` to disable
+- **Diagnostics upload** — privacy-stripped event logs (timing, errors, pipeline stats — never audio or transcription text) upload to the maintainer for debugging, tagged with a random install ID, the Mac's device name, and macOS version. Launch with `MURMUR_LOG_SHIPPER=off` to disable
 - **Apple Neural Engine by default** — multilingual Parakeet v3 through Core ML for very low-latency transcription; other engines a click away
 - **Three recording modes** — Hold Down, Double-Tap, or Both (hold and double-tap on the same key)
 - **Clipboard-first output** — text always copied to the clipboard. Optional auto-paste into your focused app, plus optional transcript/audio file output

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -117,13 +117,75 @@ fn read_range(path: &Path, offset: u64, max: u64) -> Option<Vec<u8>> {
     Some(buf)
 }
 
-async fn ship(client: &reqwest::Client, endpoint: &str, install_id: &str, data: Vec<u8>) -> bool {
+/// Device identity shipped alongside every batch so the dashboard can name
+/// the stream ("George's MacBook Pro · macOS 26.0"). Collected once.
+struct DeviceInfo {
+    name: String,
+    os: String,
+    hw: String,
+}
+
+fn sanitize_header(value: &str) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|c| if c.is_ascii_graphic() || c == ' ' { c } else { '?' })
+        .collect();
+    cleaned.trim().chars().take(80).collect()
+}
+
+fn command_stdout(cmd: &str, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new(cmd).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn collect_device_info() -> DeviceInfo {
+    #[cfg(target_os = "macos")]
+    let name = command_stdout("scutil", &["--get", "ComputerName"]);
+    #[cfg(not(target_os = "macos"))]
+    let name: Option<String> = None;
+    let name = name
+        .or_else(|| command_stdout("hostname", &[]))
+        .unwrap_or_else(|| "unknown".into());
+
+    #[cfg(target_os = "macos")]
+    let os = command_stdout("sw_vers", &["--productVersion"])
+        .map(|v| format!("macOS {}", v))
+        .unwrap_or_else(|| "macOS ?".into());
+    #[cfg(not(target_os = "macos"))]
+    let os = std::env::consts::OS.to_string();
+
+    #[cfg(target_os = "macos")]
+    let hw = command_stdout("sysctl", &["-n", "hw.model"]).unwrap_or_default();
+    #[cfg(not(target_os = "macos"))]
+    let hw = String::new();
+
+    DeviceInfo {
+        name: sanitize_header(&name),
+        os: sanitize_header(&os),
+        hw: sanitize_header(&hw),
+    }
+}
+
+async fn ship(
+    client: &reqwest::Client,
+    endpoint: &str,
+    install_id: &str,
+    device: &DeviceInfo,
+    data: Vec<u8>,
+) -> bool {
     let result = client
         .post(endpoint)
         .header("Authorization", format!("Bearer {}", TOKEN))
         .header("X-Install-Id", install_id)
         .header("X-App-Version", env!("CARGO_PKG_VERSION"))
         .header("X-Dev", if cfg!(debug_assertions) { "1" } else { "0" })
+        .header("X-Device-Name", &device.name)
+        .header("X-Os-Version", &device.os)
+        .header("X-Hw-Model", &device.hw)
         .header("Content-Type", "application/x-ndjson")
         .body(data)
         .send()
@@ -131,7 +193,7 @@ async fn ship(client: &reqwest::Client, endpoint: &str, install_id: &str, data: 
     matches!(result, Ok(resp) if resp.status().is_success())
 }
 
-async fn tick(client: &reqwest::Client, endpoint: &str) {
+async fn tick(client: &reqwest::Client, endpoint: &str, device: &DeviceInfo) {
     let (Some(state_file), Some(log)) = (state_path(), jsonl_path()) else {
         return;
     };
@@ -145,7 +207,7 @@ async fn tick(client: &reqwest::Client, endpoint: &str) {
             break;
         };
         if !batch.data.is_empty()
-            && !ship(client, endpoint, &state.install_id, batch.data).await
+            && !ship(client, endpoint, &state.install_id, device, batch.data).await
         {
             break; // endpoint unreachable — offset stays put, retry next tick
         }
@@ -171,8 +233,9 @@ pub fn start() {
             Err(_) => return,
         };
         tokio::time::sleep(std::time::Duration::from_secs(STARTUP_DELAY_SECS)).await;
+        let device = collect_device_info();
         loop {
-            tick(&client, &endpoint).await;
+            tick(&client, &endpoint, &device).await;
             tokio::time::sleep(std::time::Duration::from_secs(TICK_SECS)).await;
         }
     });
@@ -236,6 +299,22 @@ mod tests {
         let batch = next_batch(&log, &dir.join("events.jsonl.1"), 999).unwrap();
         assert!(batch.data.is_empty());
         assert_eq!(batch.next_offset, 0);
+    }
+
+    #[test]
+    fn device_info_is_sanitized_and_present() {
+        let d = collect_device_info();
+        assert!(!d.name.is_empty());
+        assert!(d.name.len() <= 80);
+        assert!(d.name.chars().all(|c| c.is_ascii_graphic() || c == ' '));
+        assert!(d.os.starts_with("macOS") || !d.os.is_empty());
+    }
+
+    #[test]
+    fn sanitize_strips_control_and_truncates() {
+        assert_eq!(sanitize_header("Bob\u{7f}s\nMac"), "Bob?s?Mac");
+        assert_eq!(sanitize_header(&"x".repeat(200)).len(), 80);
+        assert_eq!(sanitize_header("  padded  "), "padded");
     }
 
     #[test]

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -11,8 +11,10 @@ install the app (or receive an auto-update) and logs flow.
   privacy-stripped events shown in the in-app log viewer. Transcription text
   never enters that stream (`telemetry.rs` strips it at the source).
 - Installs are identified by a **random UUID** generated on first run and
-  stored in `shipper_state.json`. Hostname, username, and machine identifiers
-  are never sent.
+  stored in `shipper_state.json`. Each batch also carries the **device name**
+  (`scutil --get ComputerName`), **macOS version**, and **hardware model** so
+  the fleet dashboard can label streams ("George's MacBook Pro · macOS 26.0").
+  Username and any content-bearing identifiers are never sent.
 - Kill switch: launch with `MURMUR_LOG_SHIPPER=off` in the environment.
 
 ## Architecture
@@ -52,6 +54,13 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
 - Exposed at `https://georgenijo.com/murmur/ingest` via a `location` block in
   `/etc/nginx/sites-enabled/georgenijo.com`. Health: `/murmur/healthz`.
 - The ingest token is in fleet secrets: `fleet secret get murmur-log-ingest-token`.
+
+## Fleet dashboard
+
+`https://murmur.georgenijo.com` (Cloudflare Access, george.nijo8@gmail.com
+only) — one row per install stream with device name, OS, version, event count,
+and freshness; click a row for the per-device page (recent warnings/errors on
+top, last 200 events below). Served by the same receiver process.
 
 ## Reading the logs
 


### PR DESCRIPTION
Each batch now carries X-Device-Name (scutil ComputerName), X-Os-Version,
and X-Hw-Model headers, sanitized to printable ASCII and 80 chars, so the
fleet dashboard can label install streams by device instead of bare UUIDs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic uploads now include sanitized device name, macOS version, and hardware model metadata alongside privacy-stripped event logs.
  * Uploads remain associated with a random installation identifier, without sending usernames or content-bearing identifiers.
  * Added a fleet dashboard for viewing installation activity, device metadata, event counts, and freshness.

* **Documentation**
  * Updated feature and privacy documentation to describe diagnostic uploads, metadata handling, the fleet dashboard, and the existing upload-disable option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->