### PR TITLE
fix: report device state under the persisted install id

### DIFF
--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -317,11 +317,15 @@ pub fn start() {
         tokio::time::sleep(std::time::Duration::from_secs(STARTUP_DELAY_SECS)).await;
         let device = collect_device_info();
         let state_endpoint = endpoint.replace("/ingest", "/state");
-        let state_install_id = state_path().map(|p| load_state(&p).install_id);
         let mut last_snapshot: Option<String> = None;
         loop {
             tick(&client, &endpoint, &device).await;
             // Event-driven device/state snapshot: POST only when it changes.
+            // The install id is re-read after tick(): the first tick persists
+            // it, so a fresh install reports state under its real identity
+            // instead of a throwaway UUID.
+            let state_install_id =
+                state_path().filter(|p| p.exists()).map(|p| load_state(&p).install_id);
             if let Some(install_id) = &state_install_id {
                 let snap = tokio::task::spawn_blocking(audio_state)
                     .await


### PR DESCRIPTION
On a fresh install the state snapshot captured a throwaway UUID before
the first tick persisted the real one, splitting a device's events and
state across two identities. Re-read the id after each tick instead.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
