### PR TITLE
feat: add passive update availability poke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (108 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (110 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -60,7 +60,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 108 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 110 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |
 | `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
@@ -73,7 +73,7 @@ Read these before working on a feature:
 | `commands/performance.rs` | Local run history, resource window, clear |
 | `commands/theme.rs` | Main-window-gated, bounded theme-file import/export transport |
 | `commands/transform_diagnostics.rs` | Per-pass attempt records and consented content captures |
-| `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
+| `commands/tray.rs` | Tray icon rendering plus the update-check item, version label, and wake observer |
 | `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window |
 | `commands/native_window.rs` | Shared non-activating window treatment (main-thread dispatched) |
 | `commands/transform_model.rs` | Transform LLM model download/status/remove/reset |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Update availability now stays visible without a backend or disruptive optional-update modal: Murmur performs due-gated checks on macOS wake and foreground activation, adds a native menu-bar check/update action, and keeps a versioned pill beside Record and Transcribe File until the release is installed or skipped.
+
 ## [0.23.9] - 2026-07-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (108 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (110 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -64,7 +64,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 108 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 110 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |
 | `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
@@ -78,7 +78,7 @@ Read these before working on a feature:
 | `commands/performance.rs` | Local run history, resource window, clear |
 | `commands/theme.rs` | Main-window-gated, bounded theme-file import/export transport |
 | `commands/transform_diagnostics.rs` | Per-pass attempt records and consented content captures |
-| `commands/tray.rs` | Tray icon rendering (`make_tray_icon_data`, `update_tray_icon`) |
+| `commands/tray.rs` | Tray icon rendering plus the update-check item, version label, and wake observer |
 | `commands/overlay.rs` | Notch detection, `OverlayGeometry` contract (`geometry_for()`), `set_overlay_expanded`, show/hide/show-main-window |
 | `commands/native_window.rs` | Shared non-activating window treatment (main-thread dispatched) |
 | `commands/transform_model.rs` | Transform LLM model download/status/remove/reset |

--- a/app/src-tauri/src/commands/tray.rs
+++ b/app/src-tauri/src/commands/tray.rs
@@ -1,3 +1,61 @@
+use std::sync::OnceLock;
+use tauri::menu::MenuItem;
+
+static UPDATE_MENU_ITEM: OnceLock<MenuItem<tauri::Wry>> = OnceLock::new();
+
+pub(crate) fn register_tray_update_item(item: MenuItem<tauri::Wry>) {
+    let _ = UPDATE_MENU_ITEM.set(item);
+}
+
+fn update_menu_label(version: Option<&str>) -> Result<String, String> {
+    let Some(version) = version else {
+        return Ok("Check for Updates…".to_string());
+    };
+    let version = version.trim().trim_start_matches('v');
+    if version.is_empty()
+        || version.len() > 64
+        || !version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+'))
+    {
+        return Err("Invalid update version for menu-bar item".to_string());
+    }
+    Ok(format!("Update Murmur to v{version}…"))
+}
+
+#[tauri::command]
+pub fn set_tray_update_available(version: Option<String>) -> Result<(), String> {
+    let label = update_menu_label(version.as_deref())?;
+    if let Some(item) = UPDATE_MENU_ITEM.get() {
+        item.set_text(label).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn register_update_wake_observer(app_handle: tauri::AppHandle) {
+    use objc2_app_kit::{NSWorkspace, NSWorkspaceDidWakeNotification};
+    use objc2_foundation::{NSNotification, NSOperationQueue};
+    use tauri::Emitter;
+
+    let center = NSWorkspace::sharedWorkspace().notificationCenter();
+    let block = block2::RcBlock::new(move |_notification: std::ptr::NonNull<NSNotification>| {
+        let _ = app_handle.emit("updater-background-check-requested", ());
+    });
+    unsafe {
+        let observer = center.addObserverForName_object_queue_usingBlock(
+            Some(NSWorkspaceDidWakeNotification),
+            None,
+            Some(&NSOperationQueue::mainQueue()),
+            &block,
+        );
+        std::mem::forget(observer);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn register_update_wake_observer(_app_handle: tauri::AppHandle) {}
+
 /// Generate 66×66 RGBA pixel data for an audio-bar tray icon (static white).
 /// 66px = 3× resolution for a 22pt menu-bar icon (crisp on Retina).
 /// Draws 5 vertical capsule bars at varying heights (waveform / equalizer style).
@@ -84,5 +142,21 @@ mod tests {
             let idx = (row * SIZE + col) * 4;
             assert_eq!(data[idx + 3], 0, "corner ({row},{col}) alpha should be 0 (transparent)");
         }
+    }
+
+    #[test]
+    fn update_menu_label_tracks_available_version() {
+        assert_eq!(
+            update_menu_label(Some("v0.23.0")).unwrap(),
+            "Update Murmur to v0.23.0…"
+        );
+        assert_eq!(update_menu_label(None).unwrap(), "Check for Updates…");
+    }
+
+    #[test]
+    fn update_menu_label_rejects_unbounded_or_unsafe_versions() {
+        assert!(update_menu_label(Some("")).is_err());
+        assert!(update_menu_label(Some("0.23.0\nQuit Murmur")).is_err());
+        assert!(update_menu_label(Some(&"1".repeat(65))).is_err());
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -92,7 +92,7 @@ use state::AppState;
 use std::sync::{Mutex, MutexGuard};
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 #[cfg(target_os = "macos")]
 use tauri::RunEvent;
 
@@ -331,6 +331,7 @@ pub fn run() {
             commands::benchmark::save_benchmark_report,
             commands::benchmark::open_benchmark_output_folder,
             commands::tray::update_tray_icon,
+            commands::tray::set_tray_update_available,
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
             commands::overlay::set_overlay_expanded,
@@ -464,6 +465,7 @@ pub fn run() {
             // to re-detect notch info and reposition the overlay.
             commands::overlay::register_screen_change_observer(app.handle().clone());
             audio_lifecycle::register_sleep_wake_observer();
+            commands::tray::register_update_wake_observer(app.handle().clone());
 
             // Overwrite the transform-review window's initial size from Rust's
             // COMPACT_W/COMPACT_H so tauri.conf.json's matching literal is only
@@ -473,17 +475,22 @@ pub fn run() {
             // Restore tray icon (removed by PR #63 overlay work).
             let idle_icon_data = commands::tray::make_tray_icon_data();
             let show_item = MenuItemBuilder::with_id("show", "Show Murmur").build(app)?;
+            let update_item =
+                MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?;
             let disabled_item = tauri::menu::CheckMenuItemBuilder::with_id("toggle_disabled", "Disable Murmur")
                 .checked(false)
                 .build(app)?;
             let quit_item = MenuItemBuilder::with_id("quit", "Quit Murmur").build(app)?;
             let tray_menu = MenuBuilder::new(app)
                 .item(&show_item)
+                .item(&update_item)
+                .separator()
                 .item(&disabled_item)
                 .separator()
                 .item(&quit_item)
                 .build()?;
             commands::keyboard::register_tray_disabled_item(disabled_item.clone());
+            commands::tray::register_tray_update_item(update_item);
             let handle = app.handle().clone();
             TrayIconBuilder::with_id("main-tray")
                 .icon(tauri::image::Image::new(&idle_icon_data, 66, 66))
@@ -504,6 +511,13 @@ pub fn run() {
                             if let Err(e) = commands::keyboard::set_app_disabled(app_handle.clone(), new_disabled) {
                                 tracing::warn!(target: "keyboard", "tray disable toggle failed: {}", e);
                             }
+                        }
+                        "check_updates" => {
+                            if let Some(win) = app_handle.get_webview_window("main") {
+                                let _ = win.show();
+                                let _ = win.set_focus();
+                            }
+                            let _ = app_handle.emit("check-for-updates-requested", ());
                         }
                         "quit" => {
                             app_handle.exit(0);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, lazy, Suspense, useCallback, useMemo, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { flog } from './lib/log';
 import { SettingsPanel, SETTINGS_CATEGORIES } from './components/settings';
 import { CommandPalette } from './components/CommandPalette';
@@ -28,6 +29,7 @@ import { useSilenceAutoStop } from './lib/hooks/useSilenceAutoStop';
 import { useAutoUpdater } from './lib/hooks/useAutoUpdater';
 import { UpdateModal } from './components/UpdateModal';
 import { WhatsNewModal } from './components/WhatsNewModal';
+import { UpdateIndicator } from './components/UpdateIndicator';
 import type { CompletedUpdate, UpdateStatus } from './lib/updater';
 import { StatsBar } from './components/StatsBar';
 const ResourceMonitor = lazy(() => import('./components/ResourceMonitor').then(m => ({ default: m.ResourceMonitor })));
@@ -180,12 +182,14 @@ function App() {
   ] : [];
   const [devUpdateStatus, setDevUpdateStatus] = useState<UpdateStatus | null>(null);
   const [devCompletedUpdate, setDevCompletedUpdate] = useState<CompletedUpdate | null>(null);
+  const [devUpdateDialogOpen, setDevUpdateDialogOpen] = useState(false);
 
   const checkForUpdate = useCallback(async () => {
     if (import.meta.env.DEV) {
       devUpdateIndex.current = (devUpdateIndex.current + 1) % (devMockStates.length + 1);
       if (devUpdateIndex.current === 0) {
         setDevUpdateStatus(null);
+        setDevUpdateDialogOpen(false);
         setDevCompletedUpdate({
           version: '0.22.0',
           notes: '## New Features\n\n- Faster local transcription\n- Selected-text transforms\n\n## Bug Fixes\n\n- More reliable microphone startup\n- Smoother overlay behavior',
@@ -193,6 +197,7 @@ function App() {
       } else {
         setDevCompletedUpdate(null);
         setDevUpdateStatus(devMockStates[devUpdateIndex.current - 1]);
+        setDevUpdateDialogOpen(true);
       }
       return;
     }
@@ -200,12 +205,26 @@ function App() {
   }, [updater.checkForUpdate]);
 
   const updateStatus = devUpdateStatus ?? updater.updateStatus;
+  const isUpdateDialogOpen = devUpdateStatus
+    ? devUpdateDialogOpen
+    : updater.isUpdateDialogOpen;
+  const showAvailableUpdate = useCallback(() => {
+    if (devUpdateStatus?.phase === 'available') {
+      setDevUpdateDialogOpen(true);
+      return;
+    }
+    updater.showAvailableUpdate();
+  }, [devUpdateStatus, updater.showAvailableUpdate]);
   const dismissUpdate = useCallback(() => {
-    if (devUpdateStatus) { setDevUpdateStatus(null); return; }
+    if (devUpdateStatus) { setDevUpdateDialogOpen(false); return; }
     updater.dismissUpdate();
   }, [devUpdateStatus, updater.dismissUpdate]);
   const skipVersion = useCallback(() => {
-    if (devUpdateStatus) { setDevUpdateStatus(null); return; }
+    if (devUpdateStatus) {
+      setDevUpdateDialogOpen(false);
+      setDevUpdateStatus(null);
+      return;
+    }
     updater.skipVersion();
   }, [devUpdateStatus, updater.skipVersion]);
   const startDownload = updater.startDownload;
@@ -217,6 +236,39 @@ function App() {
     }
     updater.dismissCompletedUpdate();
   }, [devCompletedUpdate, updater.dismissCompletedUpdate]);
+
+  // The native menu-bar item brings the main window forward and asks the same
+  // updater used by Settings and the command palette to perform a manual check.
+  useEffect(() => {
+    let disposed = false;
+    let unlistenCheck: (() => void) | undefined;
+    listen<unknown>('check-for-updates-requested', () => {
+      void checkForUpdate();
+    })
+      .then((unlisten) => {
+        if (disposed) unlisten();
+        else unlistenCheck = unlisten;
+      })
+      .catch((err) => {
+        flog.warn('updater', 'could not listen for menu-bar update checks', {
+          error: String(err),
+        });
+      });
+    return () => {
+      disposed = true;
+      unlistenCheck?.();
+    };
+  }, [checkForUpdate]);
+
+  // Keep the native menu label in sync with the passive in-app indicator.
+  useEffect(() => {
+    const version = updateStatus.phase === 'available' ? updateStatus.version : null;
+    invoke('set_tray_update_available', { version }).catch((err: unknown) => {
+      flog.warn('updater', 'could not update menu-bar update item', {
+        error: String(err),
+      });
+    });
+  }, [updateStatus]);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [mainTab, setMainTab] = useState<'record' | 'file'>('record');
@@ -410,20 +462,27 @@ function App() {
 
       <div className="flex-1 flex overflow-hidden">
         <main className={`flex-1 flex-col overflow-hidden p-4 gap-4 ${isSettingsOpen ? 'hidden' : 'flex'}`}>
-          <div className="shrink-0 flex gap-1 p-1 self-start bg-surface-container rounded-xl">
-            {(['record', 'file'] as const).map((tab) => (
-              <button
-                key={tab}
-                onClick={() => setMainTab(tab)}
-                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
-                  mainTab === tab
-                    ? 'bg-surface-container-lowest text-on-surface shadow-sm'
-                    : 'text-on-surface-variant hover:text-on-surface'
-                }`}
-              >
-                {tab === 'record' ? 'Record' : 'Transcribe File'}
-              </button>
-            ))}
+          <div className="flex shrink-0 items-center gap-3">
+            <div className="flex gap-1 rounded-xl bg-surface-container p-1">
+              {(['record', 'file'] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setMainTab(tab)}
+                  className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                    mainTab === tab
+                      ? 'bg-surface-container-lowest text-on-surface shadow-sm'
+                      : 'text-on-surface-variant hover:text-on-surface'
+                  }`}
+                >
+                  {tab === 'record' ? 'Record' : 'Transcribe File'}
+                </button>
+              ))}
+            </div>
+            <UpdateIndicator
+              status={updateStatus}
+              onOpen={showAvailableUpdate}
+              onRetryCheck={() => void checkForUpdate()}
+            />
           </div>
 
           {mainTab === 'record' ? (
@@ -487,7 +546,7 @@ function App() {
       />
       {!completedUpdate && (
         <UpdateModal
-          status={updateStatus}
+          status={isUpdateDialogOpen ? updateStatus : { phase: 'idle' }}
           onDownload={startDownload}
           onSkip={skipVersion}
           onDismiss={dismissUpdate}

--- a/app/src/components/UpdateIndicator.test.tsx
+++ b/app/src/components/UpdateIndicator.test.tsx
@@ -1,0 +1,90 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateIndicator } from './UpdateIndicator';
+
+describe('UpdateIndicator', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('keeps an available update actionable after passive discovery', async () => {
+    const onOpen = vi.fn();
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{ phase: 'available', version: 'v0.23.0', notes: '', isForced: false }}
+          onOpen={onOpen}
+          onRetryCheck={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Update available · v0.23.0');
+    await act(async () => container.querySelector('button')?.click());
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('reports manual check progress and success without creating a dead button', async () => {
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{ phase: 'checking' }}
+          onOpen={vi.fn()}
+          onRetryCheck={vi.fn()}
+        />,
+      );
+    });
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('Checking');
+
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{ phase: 'up-to-date' }}
+          onOpen={vi.fn()}
+          onRetryCheck={vi.fn()}
+        />,
+      );
+    });
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('up to date');
+  });
+
+  it('lets a failed check retry the check itself', async () => {
+    const onRetryCheck = vi.fn();
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{ phase: 'error', message: 'offline', isForced: false }}
+          onOpen={vi.fn()}
+          onRetryCheck={onRetryCheck}
+        />,
+      );
+    });
+
+    await act(async () => container.querySelector('button')?.click());
+    expect(onRetryCheck).toHaveBeenCalledOnce();
+  });
+
+  it('stays absent while idle', async () => {
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{ phase: 'idle' }}
+          onOpen={vi.fn()}
+          onRetryCheck={vi.fn()}
+        />,
+      );
+    });
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/app/src/components/UpdateIndicator.tsx
+++ b/app/src/components/UpdateIndicator.tsx
@@ -1,0 +1,60 @@
+import type { UpdateStatus } from '../lib/updater';
+
+interface UpdateIndicatorProps {
+  status: UpdateStatus;
+  onOpen: () => void;
+  onRetryCheck: () => void;
+}
+
+export function UpdateIndicator({ status, onOpen, onRetryCheck }: UpdateIndicatorProps) {
+  if (status.phase === 'checking') {
+    return (
+      <span
+        role="status"
+        className="ml-auto inline-flex items-center gap-2 rounded-full bg-surface-container-low px-3 py-1.5 text-xs font-medium text-on-surface-variant"
+      >
+        <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
+        Checking for updates…
+      </span>
+    );
+  }
+
+  if (status.phase === 'up-to-date') {
+    return (
+      <span
+        role="status"
+        className="ml-auto inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1.5 text-xs font-medium text-success"
+      >
+        <span aria-hidden="true">✓</span>
+        Murmur is up to date
+      </span>
+    );
+  }
+
+  if (status.phase === 'error') {
+    return (
+      <button
+        type="button"
+        onClick={onRetryCheck}
+        className="ml-auto inline-flex items-center gap-2 rounded-full bg-error/10 px-3 py-1.5 text-xs font-semibold text-error transition-colors hover:bg-error/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-error"
+        aria-label="Update check failed. Retry"
+      >
+        Update check failed · Retry
+      </button>
+    );
+  }
+
+  if (status.phase !== 'available') return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="ml-auto inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1.5 text-xs font-semibold text-on-surface transition-colors hover:bg-primary/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      aria-label={`Murmur ${status.version} is available. View update`}
+    >
+      <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
+      Update available · v{status.version.replace(/^v/, '')}
+    </button>
+  );
+}

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -1,0 +1,118 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  check: vi.fn(),
+  getVersion: vi.fn(),
+  relaunch: vi.fn(),
+  isPermissionGranted: vi.fn(),
+  requestPermission: vi.fn(),
+  sendNotification: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: mocks.check }));
+vi.mock('@tauri-apps/api/app', () => ({ getVersion: mocks.getVersion }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: mocks.relaunch }));
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  isPermissionGranted: mocks.isPermissionGranted,
+  requestPermission: mocks.requestPermission,
+  sendNotification: mocks.sendNotification,
+}));
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('../log', () => ({
+  flog: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { useAutoUpdater, type UseAutoUpdaterReturn } from './useAutoUpdater';
+
+describe('useAutoUpdater presentation state', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: UseAutoUpdaterReturn;
+
+  function Harness() {
+    current = useAutoUpdater();
+    return null;
+  }
+
+  beforeEach(async () => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    mocks.getVersion.mockResolvedValue('0.22.1');
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.isPermissionGranted.mockResolvedValue(true);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }));
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root.render(<Harness />));
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps optional availability after Later and can reopen it from the pill', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: 'Release notes',
+      downloadAndInstall: vi.fn(),
+    });
+
+    await act(async () => current.checkForUpdate());
+    expect(current.updateStatus).toMatchObject({
+      phase: 'available',
+      version: '0.23.0',
+      isForced: false,
+    });
+    expect(current.isUpdateDialogOpen).toBe(true);
+
+    await act(async () => current.dismissUpdate());
+    expect(current.updateStatus.phase).toBe('available');
+    expect(current.isUpdateDialogOpen).toBe(false);
+
+    await act(async () => current.showAvailableUpdate());
+    expect(current.isUpdateDialogOpen).toBe(true);
+  });
+
+  it('removes the passive indicator when the user skips that version', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      downloadAndInstall: vi.fn(),
+    });
+
+    await act(async () => current.checkForUpdate());
+    await act(async () => current.skipVersion());
+
+    expect(current.updateStatus.phase).toBe('idle');
+    expect(current.isUpdateDialogOpen).toBe(false);
+    expect(localStorage.getItem('skipped-update-version')).toBe('0.23.0');
+  });
+
+  it('keeps a failed manual check inline instead of opening a broken retry modal', async () => {
+    mocks.check.mockRejectedValue(new Error('offline'));
+
+    await act(async () => current.checkForUpdate());
+
+    expect(current.updateStatus).toMatchObject({
+      phase: 'error',
+      message: 'Error: offline',
+    });
+    expect(current.isUpdateDialogOpen).toBe(false);
+  });
+});

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { getVersion } from '@tauri-apps/api/app';
@@ -21,13 +22,15 @@ import {
   isDueForCheck,
   setLastCheckTimestamp,
   fetchMinVersion,
-  CHECK_INTERVAL_MS,
+  CHECK_TIMER_TICK_MS,
 } from '../updater';
 
 export interface UseAutoUpdaterReturn {
   updateStatus: UpdateStatus;
   completedUpdate: CompletedUpdate | null;
+  isUpdateDialogOpen: boolean;
   checkForUpdate: () => Promise<void>;
+  showAvailableUpdate: () => void;
   startDownload: () => Promise<void>;
   skipVersion: () => void;
   dismissUpdate: () => void;
@@ -37,9 +40,11 @@ export interface UseAutoUpdaterReturn {
 export function useAutoUpdater(): UseAutoUpdaterReturn {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ phase: 'idle' });
   const [completedUpdate, setCompletedUpdate] = useState<CompletedUpdate | null>(null);
+  const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
   const updateRef = useRef<Update | null>(null);
   const isCheckingRef = useRef(false);
   const isForcedRef = useRef(false);
+  const manualPresentationRequestedRef = useRef(false);
 
   // The updater process replaces the app before relaunching, so the release
   // payload is recovered from localStorage and shown only after the installed
@@ -68,13 +73,17 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, []);
 
   const performCheck = useCallback(async (opts: { isBackground: boolean }) => {
-    if (isCheckingRef.current) return;
-    isCheckingRef.current = true;
-
     if (!opts.isBackground) {
       clearSkippedVersion();
+      manualPresentationRequestedRef.current = true;
       setUpdateStatus({ phase: 'checking' });
     }
+    if (isCheckingRef.current) return;
+    isCheckingRef.current = true;
+    isForcedRef.current = false;
+
+    const shouldPresentManualResult = () =>
+      !opts.isBackground || manualPresentationRequestedRef.current;
 
     try {
       const update = await check();
@@ -82,12 +91,12 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
 
       if (!update?.available || !update.version) {
         flog.info('updater', 'no update available');
-        if (!opts.isBackground) {
+        if (shouldPresentManualResult()) {
+          setIsUpdateDialogOpen(false);
           setUpdateStatus({ phase: 'up-to-date' });
           // Reset back to idle after a brief display
           setTimeout(() => setUpdateStatus(s => s.phase === 'up-to-date' ? { phase: 'idle' } : s), 3000);
         }
-        isCheckingRef.current = false;
         return;
       }
 
@@ -101,13 +110,13 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       // If not forced and user previously skipped this version, suppress
       if (!isForced && getSkippedVersion() === update.version) {
         flog.info('updater', 'user skipped this version', { version: update.version });
-        if (!opts.isBackground) {
+        if (shouldPresentManualResult()) {
           setUpdateStatus({ phase: 'idle' });
         }
-        isCheckingRef.current = false;
         return;
       }
 
+      const wasAlreadyAvailable = updateRef.current?.version === update.version;
       updateRef.current = update;
       isForcedRef.current = isForced;
       setUpdateStatus({
@@ -116,9 +125,10 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
         notes: update.body ?? '',
         isForced,
       });
+      setIsUpdateDialogOpen(isForced || shouldPresentManualResult());
 
       // Background check: fire macOS notification
-      if (opts.isBackground) {
+      if (opts.isBackground && !wasAlreadyAvailable) {
         try {
           let permGranted = await isPermissionGranted();
           if (!permGranted) {
@@ -137,16 +147,21 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       }
     } catch (err) {
       flog.error('updater', 'check failed', { error: String(err) });
-      if (!opts.isBackground) {
+      if (shouldPresentManualResult()) {
+        setIsUpdateDialogOpen(false);
         setUpdateStatus({ phase: 'error', message: String(err), isForced: isForcedRef.current });
       }
       // Background errors are silent
     } finally {
       isCheckingRef.current = false;
+      manualPresentationRequestedRef.current = false;
     }
   }, []);
 
-  // On mount: always check on launch, then set up 24h periodic interval.
+  // On mount: always check on launch. A short, inert timer only asks whether
+  // the six-hour network interval is due; native wake events and foreground
+  // activation use the same gate so hidden/sleeping webviews do not strand the
+  // update indicator.
   // Skip entirely in dev — a dev build auto-updating to a prod release would
   // download+relaunch into /Applications, making `tauri dev` impossible.
   useEffect(() => {
@@ -157,18 +172,50 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
 
     performCheck({ isBackground: true });
 
-    const interval = setInterval(() => {
+    const checkIfDue = () => {
       if (isDueForCheck()) {
         performCheck({ isBackground: true });
       }
-    }, CHECK_INTERVAL_MS);
+    };
+    const interval = setInterval(checkIfDue, CHECK_TIMER_TICK_MS);
+    const onFocus = () => checkIfDue();
+    const onVisibilityChange = () => {
+      if (!document.hidden) checkIfDue();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
-    return () => clearInterval(interval);
+    let disposed = false;
+    let unlistenWake: (() => void) | undefined;
+    listen<unknown>('updater-background-check-requested', checkIfDue)
+      .then((unlisten) => {
+        if (disposed) unlisten();
+        else unlistenWake = unlisten;
+      })
+      .catch((err) => {
+        flog.warn('updater', 'could not listen for native wake checks', {
+          error: String(err),
+        });
+      });
+
+    return () => {
+      disposed = true;
+      clearInterval(interval);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      unlistenWake?.();
+    };
   }, [performCheck]);
 
   const checkForUpdate = useCallback(async () => {
     await performCheck({ isBackground: false });
   }, [performCheck]);
+
+  const showAvailableUpdate = useCallback(() => {
+    if (updateStatus.phase === 'available') {
+      setIsUpdateDialogOpen(true);
+    }
+  }, [updateStatus.phase]);
 
   const startDownload = useCallback(async () => {
     const update = updateRef.current;
@@ -224,11 +271,12 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       flog.info('updater', 'version skipped', { version: updateStatus.version });
     }
     updateRef.current = null;
+    setIsUpdateDialogOpen(false);
     setUpdateStatus({ phase: 'idle' });
   }, [updateStatus]);
 
   const dismissUpdate = useCallback(() => {
-    setUpdateStatus({ phase: 'idle' });
+    setIsUpdateDialogOpen(false);
   }, []);
 
   const dismissCompletedUpdate = useCallback(() => {
@@ -239,7 +287,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   return {
     updateStatus,
     completedUpdate,
+    isUpdateDialogOpen,
     checkForUpdate,
+    showAvailableUpdate,
     startDownload,
     skipVersion,
     dismissUpdate,

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -2,7 +2,8 @@ const SKIPPED_VERSION_KEY = 'skipped-update-version';
 const LAST_CHECK_KEY = 'updater-last-check';
 const PENDING_UPDATE_KEY = 'pending-update-release-notes';
 const MAX_RELEASE_NOTES_LENGTH = 50_000;
-export const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+export const CHECK_TIMER_TICK_MS = 15 * 60 * 1000; // 15 minutes
 
 const LATEST_JSON_URL =
   'https://github.com/georgenijo/murmur-app/releases/latest/download/latest-v2.json';

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,7 +132,7 @@ glass surfaces.
 
 | Module | Purpose |
 |--------|---------|
-| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 108 registered commands, setup, tray, run loop |
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 110 registered commands, setup, tray, run loop |
 | `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
 | `audio.rs` | cpal capture worker, phase telemetry, mono mix, 16kHz resample, `audio-level` emission |
 | `audio_lifecycle.rs` | App-lifetime single-owner supervisor; async start, generation cancellation, deadlines, callback quarantine, and background reaping of blocked workers |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -180,7 +180,7 @@ Every transform-key hold is recorded as a content-free `TransformAttemptV1` with
 - macOS 14+ on Apple Silicon (Core ML/ANE); Whisper and CPU Parakeet also build for Linux.
 - Developer ID signed and notarized; hardened runtime; sidecar ships with split entitlements; release finalization fails closed on any unexpected bundle executable.
 - Release builds use `opt-level = "s"`, LTO off, 16 parallel codegen units, and panic abort; stripping remains disabled so Tauri can patch the updater bundle-type marker.
-- **Auto-updater** — [features/auto-updater.md](features/auto-updater.md). Background check on launch and every 24h against `latest-v2.json`, ed25519-signed, min-version enforcement (no skip/dismiss when required), skip/dismiss otherwise, progress and auto-relaunch.
+- **Auto-updater** — [features/auto-updater.md](features/auto-updater.md). Due-gated checks on launch, every six hours, foreground activation, and macOS wake against `latest-v2.json`; passive homepage/menu-bar availability indicators; ed25519 signatures; required-version enforcement; progress and auto-relaunch.
 - **Privacy boundaries**: release `pipeline` events drop all strings; `transform` events are restricted to an explicit stable vocabulary in *all* builds; knowledge content and selected paths are excluded from logs; instructions never enter history or stats; audio and transcripts are written to disk only when the user turns file output on.
 - All local data is inspectable and deletable from within the app.
 
@@ -190,7 +190,7 @@ Every transform-key hold is recorded as a content-free `TransformAttemptV1` with
 
 | Area | Location |
 |------|----------|
-| Rust backend | `app/src-tauri/src/` — 108 Tauri commands |
+| Rust backend | `app/src-tauri/src/` — 110 Tauri commands |
 | Frontend | `app/src/` — React 18 + TypeScript + Tailwind 4 |
 | LLM sidecar | `app/src-tauri/sidecars/local-llm/`, protocol in `crates/local-llm-protocol` |
 | Diagnostics MCP tool | `tools/murmur-diag/` |

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -2,12 +2,22 @@
 
 ## Overview
 
-The app checks for updates on launch and every 24 hours. Updates are downloaded from GitHub Releases, verified with ed25519 signatures, and installed with an automatic relaunch. A `min_version` field in the release manifest enables forced updates that cannot be skipped or dismissed.
+The app checks for updates on launch, every six hours while resident, and when
+the native app resumes or the main window becomes active after a due interval.
+Updates are downloaded from GitHub Releases, verified with ed25519 signatures,
+and installed with an automatic relaunch. A `min_version` field in the release
+manifest enables forced updates that cannot be skipped or dismissed.
 
 ## Update Check Schedule
 
 - **On launch:** A background check runs immediately on mount via the `useAutoUpdater` hook.
-- **Periodic:** Every 24 hours (`CHECK_INTERVAL_MS = 86400000`), gated by `isDueForCheck()` which reads the last check timestamp from localStorage (`updater-last-check`).
+- **Periodic:** Every six hours (`CHECK_INTERVAL_MS = 21600000`), gated by
+  `isDueForCheck()` which reads the last check timestamp from localStorage
+  (`updater-last-check`). A low-cost 15-minute timer only evaluates that local
+  due check; it does not make a network request every tick.
+- **Lifecycle:** Native resume, webview visibility, and main-window focus request
+  the same due-gated background check. Several lifecycle signals therefore
+  still collapse into at most one network request per six-hour interval.
 
 ## Update Source
 
@@ -36,10 +46,14 @@ The manifest contains version information, download URLs, signatures, and an opt
 
 When a new version is available and the current version is above `min_version`:
 
-1. **Available** — Modal shows version number and release notes. Three buttons:
+1. **Available** — Background discovery is passive: the main Record/File row
+   shows an update pill and the menu-bar action changes to the available
+   version. Manual checks open the modal immediately; clicking either passive
+   indicator opens it later. The modal shows version number and release notes
+   with three buttons:
    - "Update Now" — begins download
    - "Skip This Version" — stores the version in localStorage (`skipped-update-version`), suppresses future background checks for that version
-   - "Later" — dismisses the modal without skipping
+   - "Later" — dismisses the modal without skipping; the update pill remains
 2. **Downloading** — Progress bar with percentage. Progress reported via Tauri's `downloadAndInstall` callback.
 3. **Ready** — "Installing and relaunching..." text displayed.
 4. **Relaunch** — App restarts automatically via `@tauri-apps/plugin-process`.
@@ -132,6 +146,12 @@ an already-installed release as an available update.
 
 - The "Check for Updates" button in the About section of settings triggers a manual check. It is disabled during `checking` or `downloading` phases.
 - Status text shows: "Checking...", "You're up to date", "vX.Y.Z available", or "Update check failed".
+- The macOS menu-bar menu exposes the same manual check. It brings the main
+  window forward, reports checking/up-to-date/error status beside the Record
+  tabs, and opens the existing update dialog when a release is available.
+- Optional background updates do not interrupt the user with a modal. A
+  persistent `Update available · vX.Y.Z` pill and versioned menu item remain
+  until the release is installed or explicitly skipped.
 - Skipped version is stored in localStorage under `skipped-update-version`.
 - Pending post-update notes are stored under `pending-update-release-notes` and
   removed when dismissed or when the running version does not match.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -208,6 +208,7 @@ frontend.
 | Command | Parameters | Returns | Description |
 |---------|-----------|---------|-------------|
 | `update_tray_icon` | `_icon_state: String` | `Result<(), String>` | No-op; the tray icon is always the static white waveform. Retained for API compatibility. |
+| `set_tray_update_available` | `version: Option<String>` | `Result<(), String>` | Changes the native menu item between `Check for Updates…` and a bounded, validated `Update Murmur to vX.Y.Z…` label. |
 
 ## Telemetry (`telemetry.rs`)
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -81,6 +81,13 @@ All transform events carry a `transformPassId` where a pass exists, so a delayed
 |-------|---------|--------|---------------|-----------|
 | `app-event` | `AppEvent` | `telemetry.rs` (`TauriEmitterLayer`) | For **every** `tracing` event in the Rust backend. | Log viewer (`useEventStore`). Release `pipeline` strings are stripped; `transform` strings are restricted by key **and** value to an explicit stable vocabulary in all builds. |
 
+## Updater
+
+| Event | Payload | Source | When it fires | Listeners |
+|-------|---------|--------|---------------|-----------|
+| `check-for-updates-requested` | `()` | Native tray menu | The user selects `Check for Updates…` or the versioned update action. The main window is shown and focused first. | Main `App` → manual `checkForUpdate`. |
+| `updater-background-check-requested` | `()` | `commands/tray.rs` | `NSWorkspaceDidWakeNotification` fires after macOS wakes. | `useAutoUpdater`; a local six-hour gate decides whether any network request is due. |
+
 ## Frontend-emitted (window to window)
 
 | Event | Payload | Source | When it fires | Listeners |
@@ -89,7 +96,9 @@ All transform events carry a `transformPassId` where a pass exists, so a delayed
 | `settings-changed` | `()` | `useSettings`, `useOverlaySettingsMirror` | A window mutates persisted settings, so the other windows re-read localStorage. | Main window, overlay. |
 | `open-settings` | `()` | `useOverlaySettingsMirror` | The overlay's quick-settings card asks the main window to open Settings. | Main window (`useOpenSettingsListener`). |
 
-**Dead listener:** `useShowAboutListener` listens for `show-about`, but the tray menu no longer has an About item (it is Show Murmur / Disable Murmur / Quit), so nothing emits it.
+**Dead listener:** `useShowAboutListener` listens for `show-about`, but the tray
+menu has no About item (it is Show Murmur / Check for Updates / Disable Murmur /
+Quit), so nothing emits it.
 
 ---
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -49,9 +49,18 @@ Loads and persists `Settings` to localStorage, pushes the backend-relevant subse
 One-time init sequence on mount: `init_dictation`, then `configure_dictation` with the loaded settings.
 
 ### `useAutoUpdater`
-OTA updates: background check on launch and every 24h, semver comparison, min-version enforcement (forced updates drop Skip/Later), skip/dismiss persistence, download progress, install, and auto-relaunch. Fires a native macOS notification when a background check finds an update.
+OTA updates: due-gated background checks on launch, every six hours, foreground
+activation, and native macOS wake; semver comparison; min-version enforcement
+(forced updates drop Skip/Later); download progress, install, and auto-relaunch.
+Optional background discoveries stay passive as a persistent homepage pill and
+versioned menu-bar action; required or manual discoveries open the dialog. A
+native notification fires only on the first background discovery of a version
+during the process lifetime.
 
-Returns `{updateStatus, checkForUpdate, startDownload, skipVersion, dismissUpdate}`. Reads `min_version` from the `latest-v2.json` channel; persists `skipped-update-version` and `updater-last-check` to localStorage.
+Returns `{updateStatus, isUpdateDialogOpen, checkForUpdate, showAvailableUpdate,
+startDownload, skipVersion, dismissUpdate}`. Reads `min_version` from the
+`latest-v2.json` channel; persists `skipped-update-version` and
+`updater-last-check` to localStorage.
 
 ### `useOpenSettingsListener`
 Listens for `open-settings` from the overlay's gear button and opens the Settings panel — showing the main window isn't enough, since panel visibility is local React state.


### PR DESCRIPTION
## Summary

- check for updates passively at launch, every six hours, on app focus, and after macOS wake
- show an unobtrusive update-available pill next to the recording controls
- add native tray and in-app manual update checks with clear status feedback
- preserve available updates when dismissed with **Later**, support **Skip**, and keep required updates enforced
- document and test the updater behavior

## Why

Users currently learn about a release only after restarting Murmur or manually checking. This adds a lightweight availability poke using the existing GitHub/Tauri updater path—no new backend service or persistent polling process.

## Validation

- `npx tsc --noEmit`
- `npm test` — 65 files / 614 tests passed
- `cargo test -- --test-threads=1` — 667 unit tests passed plus integration suites
- `git diff --check origin/main...HEAD`
- native packaged-app smoke test against release v0.23.9: availability pill, update dialog, and Later behavior verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent update availability indicators near the main recording controls.
  * Added manual update checks from the macOS menu bar, including version-specific labels.
  * Added automatic checks on launch, every six hours, window activation, and macOS wake.
  * Added retry actions and improved handling for background update checks.
* **Bug Fixes**
  * Update dialogs now open, dismiss, and remain available consistently.
* **Documentation**
  * Updated updater behavior, events, commands, architecture, and feature references.
* **Tests**
  * Added coverage for update indicators, status handling, retries, and version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->