### PR TITLE
Fix signed capture evidence plist extraction

### DIFF
--- a/scripts/capture_helper_evidence.py
+++ b/scripts/capture_helper_evidence.py
@@ -11,6 +11,7 @@ import plistlib
 import re
 import subprocess
 from typing import Any
+from xml.parsers.expat import ExpatError
 
 
 CAPTURE_HELPER_IDENTIFIER = "com.localdictation.capture-helper"
@@ -248,6 +249,40 @@ def _run(command: list[str]) -> subprocess.CompletedProcess[bytes]:
     return subprocess.run(command, check=True, capture_output=True)
 
 
+def extract_entitlements_plist(payload: bytes) -> dict[str, object]:
+    """Extract exactly one complete XML plist from mixed codesign output."""
+
+    xml_starts = [match.start() for match in re.finditer(br"<\?xml\b", payload)]
+    plist_starts = [
+        match.start() for match in re.finditer(br"<plist(?:\s|>)", payload)
+    ]
+    plist_ends = [
+        match.end() for match in re.finditer(br"</plist\s*>", payload)
+    ]
+    if not xml_starts and not plist_starts and not plist_ends:
+        raise EvidenceError("codesign returned no capture-helper entitlements")
+    if len(xml_starts) != 1 or len(plist_starts) != 1 or len(plist_ends) != 1:
+        raise EvidenceError(
+            "codesign returned ambiguous or incomplete capture-helper entitlements"
+        )
+    xml_start = xml_starts[0]
+    plist_start = plist_starts[0]
+    plist_end = plist_ends[0]
+    if not xml_start < plist_start < plist_end:
+        raise EvidenceError("codesign returned malformed capture-helper entitlements")
+
+    document = payload[xml_start:plist_end]
+    try:
+        entitlements = plistlib.loads(document)
+    except (ExpatError, plistlib.InvalidFileException, TypeError, ValueError) as error:
+        raise EvidenceError(
+            "codesign returned malformed capture-helper entitlements"
+        ) from error
+    if not isinstance(entitlements, dict):
+        raise EvidenceError("capture-helper entitlements plist must contain a dictionary")
+    return entitlements
+
+
 def collect_signature(
     helper: Path, signature_output: Path, entitlements_output: Path
 ) -> None:
@@ -263,10 +298,7 @@ def collect_signature(
         ["codesign", "-d", "--entitlements", ":-", "--xml", str(helper)]
     )
     entitlement_payload = entitlement_result.stdout + entitlement_result.stderr
-    xml_start = entitlement_payload.find(b"<?xml")
-    if xml_start < 0:
-        raise EvidenceError("codesign returned no capture-helper entitlements")
-    entitlements = plistlib.loads(entitlement_payload[xml_start:])
+    entitlements = extract_entitlements_plist(entitlement_payload)
     architecture = _run(["lipo", "-archs", str(helper)]).stdout.decode().strip()
     evidence = structured_signature_evidence(
         details, requirement, entitlements, architecture

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -11,6 +11,7 @@ from scripts.capture_helper_evidence import (
     CAPTURE_ENTITLEMENTS,
     EvidenceError,
     PROBE_OUTCOME_CONTRACTS,
+    extract_entitlements_plist,
     structured_signature_evidence,
     validate_probe_evidence,
 )
@@ -576,6 +577,54 @@ class ReleaseArtifactTests(unittest.TestCase):
             structured_signature_evidence(
                 details, requirement, CAPTURE_ENTITLEMENTS, "arm64"
             )
+
+    def test_entitlements_extraction_bounds_realistic_codesign_noise(self) -> None:
+        runner_path = b"/Users/runner/work/private/repo/murmur-capture-helper"
+        xml = plistlib.dumps(CAPTURE_ENTITLEMENTS, sort_keys=True)
+        payload = (
+            b"Executable="
+            + runner_path
+            + b"\nwarning: codesign diagnostic preamble\n"
+            + xml
+            + b"\nExecutable="
+            + runner_path
+            + b"\nwarning: codesign trailing diagnostic\n"
+        )
+        entitlements = extract_entitlements_plist(payload)
+        self.assertEqual(entitlements, CAPTURE_ENTITLEMENTS)
+        canonical_output = plistlib.dumps(entitlements, sort_keys=True)
+        self.assertNotIn(runner_path, canonical_output)
+        self.assertNotIn(b"codesign", canonical_output)
+
+    def test_entitlements_extraction_rejects_missing_or_incomplete_xml(self) -> None:
+        xml = plistlib.dumps(CAPTURE_ENTITLEMENTS, sort_keys=True)
+        cases = (
+            b"Executable=/Users/runner/work/private/repo/helper\n",
+            xml[: xml.index(b"</plist>")],
+            xml[xml.index(b"<plist") :],
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                with self.assertRaises(EvidenceError):
+                    extract_entitlements_plist(payload)
+
+    def test_entitlements_extraction_rejects_malformed_xml(self) -> None:
+        xml = plistlib.dumps(CAPTURE_ENTITLEMENTS, sort_keys=True)
+        malformed = xml.replace(b"<true/>", b"<true>", 1)
+        with self.assertRaisesRegex(EvidenceError, "malformed"):
+            extract_entitlements_plist(malformed)
+
+    def test_entitlements_extraction_rejects_ambiguous_xml(self) -> None:
+        xml = plistlib.dumps(CAPTURE_ENTITLEMENTS, sort_keys=True)
+        cases = (
+            xml + b"\n" + xml,
+            xml + b"\n<?xml trailing diagnostic",
+            xml + b"\n</plist>",
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(EvidenceError, "ambiguous"):
+                    extract_entitlements_plist(payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- extract exactly one complete XML entitlements plist from mixed `codesign` stdout/stderr by bounding the document from its XML declaration through `</plist>`
- accept content-free codesign preamble/trailing diagnostics without parsing or uploading them
- fail closed on missing declarations, truncated documents, malformed XML, duplicate documents, and ambiguous extra XML/plist markers
- preserve canonical entitlements serialization so runner paths and diagnostic text cannot leak into the evidence artifact

## Release failure

Release run [30587076095](https://github.com/georgenijo/murmur-app/actions/runs/30587076095) built, signed, notarized, stapled, passed Gatekeeper, and passed the signed-app smoke test. The evidence collector then appended stderr diagnostics after the XML document and passed those trailing bytes to `plistlib.loads()`, producing `ExpatError: not well-formed`.

## Validation

- `python3 -m py_compile scripts/capture_helper_evidence.py tests/test_release_artifacts.py`
- `python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py` — 58 passed
- `python3 scripts/validate_workflow_policy.py`
- `git diff --check`

Refs #407
