### PR TITLE
chore(audio): bump capture helper to 0.1.1

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "murmur-capture-helper"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "libc",

--- a/app/src-tauri/sidecars/capture/Cargo.toml
+++ b/app/src-tauri/sidecars/capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur-capture-helper"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/app/src-tauri/sidecars/capture/Info.plist
+++ b/app/src-tauri/sidecars/capture/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.1.1</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import plistlib
 import tempfile
+import tomllib
 import unittest
 
 from scripts.capture_helper_evidence import (
@@ -362,6 +363,23 @@ class ReleaseArtifactTests(unittest.TestCase):
                     "com.apple.security.device.microphone": True,
                 },
             )
+
+    def test_capture_helper_bundle_version_matches_package_revision(self) -> None:
+        capture_helper = (
+            Path(__file__).parents[1] / "app/src-tauri/sidecars/capture"
+        )
+        manifest = tomllib.loads((capture_helper / "Cargo.toml").read_text())
+        with (capture_helper / "Info.plist").open("rb") as handle:
+            info = plistlib.load(handle)
+
+        self.assertEqual(
+            info["CFBundleShortVersionString"],
+            manifest["package"]["version"],
+        )
+        bundle_version = info["CFBundleVersion"]
+        self.assertRegex(bundle_version, r"^[1-9][0-9]*$")
+        # The first signed capture-helper build used bundle version 1.
+        self.assertGreater(int(bundle_version), 1)
 
     def test_capture_probe_requires_complete_confirmed_allowlisted_evidence(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

- bump the capture helper package from 0.1.0 to 0.1.1 and update the exact workspace lockfile entry
- align the embedded signed-helper metadata at short version 0.1.1 and monotonic bundle build 2
- add deterministic coverage preventing Cargo/plist version drift or a non-integer/regressed bundle build
- provide the second helper build revision needed for the TCC application-update survival rehearsal

The optimized local helper hash changed from 520b58a0c0a52e5ce7c0ee11e4652e508efe853f38dbb5bd2ee4ccfb10a4d952 at 0.1.0/build 1 to 071cec6ea6133556eedc35c12ab46d4d3ce85aaaa882688abbd50591e6655914 at 0.1.1/build 2. The built Mach-O embeds the expected 0.1.1 and 2 values. The existing release workflow hashes the finalized bundled capture helper and records it through --capture-helper-sha256, so the notarized release artifact will carry distinct, coherent helper provenance without changing the helper protocol or runtime behavior.

## Validation

- cargo test --manifest-path app/src-tauri/Cargo.toml -p murmur-capture-helper-protocol
- cargo check --manifest-path app/src-tauri/Cargo.toml -p murmur-capture-helper
- cargo build --release --manifest-path app/src-tauri/Cargo.toml -p murmur-capture-helper
- Mach-O embedded __TEXT,__info_plist reports short version 0.1.1 and bundle version 2
- python3 -m unittest tests.test_release_artifacts tests.test_workflow_policy (59 passed)
- python3 scripts/validate_workflow_policy.py
- git diff --check

Refs #407