### PR TITLE
fix: fail closed on capture-helper TCC changes

### DIFF
--- a/app/src-tauri/src/capture_helper_probe.rs
+++ b/app/src-tauri/src/capture_helper_probe.rs
@@ -26,6 +26,7 @@ const CANCEL_GRACE: Duration = Duration::from_millis(250);
 pub struct TestCaptureProbeConfig {
     pub helper_path: PathBuf,
     pub scenario_environment: Vec<(String, String)>,
+    pub permission_status_sequence: Vec<String>,
     pub handshake_timeout: Duration,
     pub observe_for: Duration,
     pub cancel_grace: Duration,
@@ -80,6 +81,25 @@ impl SpawnPlan {
             Self::Production { .. } => CANCEL_GRACE,
             #[cfg(any(debug_assertions, feature = "llm-test-support"))]
             Self::Test(config) => config.cancel_grace,
+        }
+    }
+
+    fn microphone_permission_status(&self, test_index: &mut usize) -> String {
+        match self {
+            Self::Production { .. } => {
+                crate::commands::permissions::check_microphone_permission_status()
+            }
+            #[cfg(any(debug_assertions, feature = "llm-test-support"))]
+            Self::Test(config) => {
+                let status = config
+                    .permission_status_sequence
+                    .get(*test_index)
+                    .cloned()
+                    .or_else(|| config.permission_status_sequence.last().cloned())
+                    .unwrap_or_else(|| "granted".to_string());
+                *test_index = test_index.saturating_add(1);
+                status
+            }
         }
     }
 }
@@ -301,6 +321,15 @@ impl CaptureProbeSupervisor {
             ownership.take();
         }
         let started = Instant::now();
+        let mut permission_status_index = 0;
+        let initial_permission_status = self
+            .plan
+            .microphone_permission_status(&mut permission_status_index);
+        if initial_permission_status != "granted" {
+            return Err(CaptureProbeError::HelperFailed(
+                FailureCode::PermissionDenied,
+            ));
+        }
         let helper_path = self.plan.helper_path()?;
         if matches!(self.plan, SpawnPlan::Production { .. }) && !cfg!(debug_assertions) {
             crate::code_signing::validate_bundled_helper(&helper_path, CAPTURE_HELPER_IDENTIFIER)
@@ -365,6 +394,17 @@ impl CaptureProbeSupervisor {
         let mut protocol = HelperProtocol::new();
         let mut result = Ok(());
         loop {
+            if active_seen {
+                let permission_status = self
+                    .plan
+                    .microphone_permission_status(&mut permission_status_index);
+                if permission_status != "granted" {
+                    result = Err(CaptureProbeError::HelperFailed(
+                        FailureCode::PermissionDenied,
+                    ));
+                    break;
+                }
+            }
             let phase_deadline = observe_deadline.unwrap_or(handshake_deadline);
             if Instant::now() >= phase_deadline {
                 if observe_deadline.is_none() {
@@ -415,6 +455,12 @@ impl CaptureProbeSupervisor {
             }
         }
 
+        let preserve_revocation = matches!(
+            result,
+            Err(CaptureProbeError::HelperFailed(
+                FailureCode::PermissionDenied
+            ))
+        );
         let cancel = HostMessage::Cancel {
             protocol: PROTOCOL_NAME.to_string(),
             version: PROTOCOL_VERSION,
@@ -440,17 +486,23 @@ impl CaptureProbeSupervisor {
                         | AcceptedFrame::Health,
                     ) => {}
                     Ok(AcceptedFrame::Failure(code)) => {
-                        result = Err(CaptureProbeError::HelperFailed(code));
+                        if !preserve_revocation {
+                            result = Err(CaptureProbeError::HelperFailed(code));
+                        }
                         break;
                     }
                     Err(()) => {
-                        result = Err(CaptureProbeError::Protocol);
+                        if !preserve_revocation {
+                            result = Err(CaptureProbeError::Protocol);
+                        }
                         break;
                     }
                 },
                 Ok(HelperEvent::Exited) | Err(RecvTimeoutError::Disconnected) => break,
                 Ok(HelperEvent::Protocol) => {
-                    result = Err(CaptureProbeError::Protocol);
+                    if !preserve_revocation {
+                        result = Err(CaptureProbeError::Protocol);
+                    }
                     break;
                 }
                 Err(RecvTimeoutError::Timeout) => continue,

--- a/app/src-tauri/tests/capture_helper_spike.rs
+++ b/app/src-tauri/tests/capture_helper_spike.rs
@@ -24,6 +24,7 @@ fn supervisor_with_environment(
     CaptureProbeSupervisor::for_test(TestCaptureProbeConfig {
         helper_path: helper_path(),
         scenario_environment,
+        permission_status_sequence: Vec::new(),
         handshake_timeout: Duration::from_millis(400),
         observe_for: Duration::from_millis(450),
         cancel_grace: Duration::from_millis(100),
@@ -130,6 +131,7 @@ fn active_observation_window_starts_after_the_complete_handshake() {
             "MOCK_CAPTURE_SCENARIO".to_string(),
             "delayed_active".to_string(),
         )],
+        permission_status_sequence: Vec::new(),
         handshake_timeout: Duration::from_millis(800),
         observe_for: Duration::from_millis(300),
         cancel_grace: Duration::from_millis(100),
@@ -190,6 +192,7 @@ fn rapid_second_start_is_rejected_without_overlapping_helper() {
             "MOCK_CAPTURE_SCENARIO".to_string(),
             "pre_handshake_block".to_string(),
         )],
+        permission_status_sequence: Vec::new(),
         handshake_timeout: Duration::from_millis(400),
         observe_for: Duration::from_millis(450),
         cancel_grace: Duration::from_millis(100),
@@ -206,6 +209,96 @@ fn rapid_second_start_is_rejected_without_overlapping_helper() {
     assert_eq!(evidence.helper_pid, spawned_pid);
     assert_eq!(evidence.termination, "hard_kill");
     assert!(evidence.process_group_empty);
+}
+
+#[test]
+fn live_permission_revocation_is_detected_even_when_callbacks_continue() {
+    let supervisor = CaptureProbeSupervisor::for_test(TestCaptureProbeConfig {
+        helper_path: helper_path(),
+        scenario_environment: vec![("MOCK_CAPTURE_SCENARIO".to_string(), "happy".to_string())],
+        permission_status_sequence: vec!["granted".to_string(), "denied".to_string()],
+        handshake_timeout: Duration::from_millis(400),
+        observe_for: Duration::from_secs(5),
+        cancel_grace: Duration::from_millis(100),
+        spawned_signal: None,
+    });
+
+    let evidence = supervisor.run().unwrap();
+    assert_eq!(evidence.outcome, "permission_denied");
+    assert_eq!(evidence.termination, "cooperative");
+    assert!(evidence.elapsed_ms < 1_000);
+    assert!(evidence.process_group_empty);
+    assert!(!evidence.audio_content_retained);
+}
+
+#[test]
+fn every_non_granted_permission_status_is_rejected_before_the_helper_spawns() {
+    for status in ["denied", "notDetermined", "unknown"] {
+        let (spawned_tx, spawned_rx) = mpsc::channel();
+        let supervisor = CaptureProbeSupervisor::for_test(TestCaptureProbeConfig {
+            helper_path: helper_path(),
+            scenario_environment: vec![("MOCK_CAPTURE_SCENARIO".to_string(), "happy".to_string())],
+            permission_status_sequence: vec![status.to_string()],
+            handshake_timeout: Duration::from_millis(400),
+            observe_for: Duration::from_secs(5),
+            cancel_grace: Duration::from_millis(100),
+            spawned_signal: Some(spawned_tx),
+        });
+
+        assert_eq!(
+            supervisor.run().unwrap_err(),
+            CaptureProbeError::HelperFailed(
+                murmur_capture_helper_protocol::FailureCode::PermissionDenied
+            ),
+            "status={status}"
+        );
+        assert!(spawned_rx.try_recv().is_err(), "status={status}");
+    }
+}
+
+#[test]
+fn every_loss_of_a_proven_grant_interrupts_active_capture() {
+    for status in ["denied", "notDetermined", "unknown"] {
+        let supervisor = CaptureProbeSupervisor::for_test(TestCaptureProbeConfig {
+            helper_path: helper_path(),
+            scenario_environment: vec![("MOCK_CAPTURE_SCENARIO".to_string(), "happy".to_string())],
+            permission_status_sequence: vec!["granted".to_string(), status.to_string()],
+            handshake_timeout: Duration::from_millis(400),
+            observe_for: Duration::from_secs(5),
+            cancel_grace: Duration::from_millis(100),
+            spawned_signal: None,
+        });
+
+        let evidence = supervisor.run().unwrap();
+        assert_eq!(evidence.outcome, "permission_denied", "status={status}");
+        assert_eq!(evidence.termination, "cooperative", "status={status}");
+        assert!(evidence.elapsed_ms < 1_000, "status={status}");
+        assert!(evidence.process_group_empty, "status={status}");
+        assert!(!evidence.audio_content_retained, "status={status}");
+    }
+}
+
+#[test]
+fn revocation_outcome_survives_a_queued_protocol_failure_during_teardown() {
+    let supervisor = CaptureProbeSupervisor::for_test(TestCaptureProbeConfig {
+        helper_path: helper_path(),
+        scenario_environment: vec![(
+            "MOCK_CAPTURE_SCENARIO".to_string(),
+            "phase_regression".to_string(),
+        )],
+        permission_status_sequence: vec!["granted".to_string(), "unknown".to_string()],
+        handshake_timeout: Duration::from_millis(400),
+        observe_for: Duration::from_secs(5),
+        cancel_grace: Duration::from_millis(100),
+        spawned_signal: None,
+    });
+
+    let evidence = supervisor.run().unwrap();
+    assert_eq!(evidence.outcome, "permission_denied");
+    assert_eq!(evidence.termination, "hard_kill");
+    assert!(evidence.elapsed_ms < 1_000);
+    assert!(evidence.process_group_empty);
+    assert!(!evidence.audio_content_retained);
 }
 
 #[test]

--- a/docs/decisions/2026-07-30-capture-helper-phase-0.md
+++ b/docs/decisions/2026-07-30-capture-helper-phase-0.md
@@ -66,6 +66,25 @@ Interactive revocation testing can use
 `--capture-helper-probe --observe-seconds <1..300>`; parsing is exact and the
 upper bound is enforced before the helper starts.
 
+macOS 26.0.1 does not necessarily stop an already-open CoreAudio stream when
+the user revokes microphone permission. A 120-second signed-build baseline
+continued receiving callbacks after the System Settings toggle changed from
+granted to denied, then stopped cooperatively at the requested observation
+deadline. A content-free signed CLI probe launched from the test harness also
+reached callbacks while the Murmur identity was denied, showing that the
+platform stream result alone cannot enforce the app's TCC policy in every
+launch context.
+
+The parent therefore snapshots permission before helper spawn and requires a
+provable grant; denied, not-determined, and unknown states create no process.
+Once the helper becomes active, it polls the same AVFoundation authorization
+status used by Murmur's permission UI. Any loss of the proven grant is
+classified as the stable `permission_denied` outcome and runs the existing
+bounded cooperative-cancel/hard-kill teardown. A queued helper failure or
+protocol frame during teardown cannot overwrite that primary outcome. This is
+deliberately stricter than the UI banner: capture fails closed when
+authorization cannot be proven.
+
 The child-management and runtime signature-validation primitives are generic.
 The local-LLM sidecar now uses the same signature gate; a later focused
 refactor may move its bespoke kill loop onto `ManagedChild` after its inherited
@@ -95,6 +114,36 @@ responsible-process attribution. The matrix in
 [`docs/evidence/407-capture-helper-phase-0.json`](../evidence/407-capture-helper-phase-0.json)
 records expected and actual states without audio, transcripts, device names, or
 paths.
+
+Two non-publishing trusted-main releases have now exercised the installed
+update boundary on Shawn's arm64 macOS 26.0.1 release-gate machine:
+
+- workflow run `30588206915`, source `e8cf2607`, helper 0.1.0/build 1;
+- workflow run `30590132800`, source `a8603c27`, helper 0.1.1/build 2.
+
+Both artifacts were Developer ID signed, notarized, stapled, accepted by
+Gatekeeper after quarantine, and matched their uploaded helper hashes. With an
+existing Murmur grant, the first helper started without a second prompt. The
+same grant then survived a moved bundle, an exact helper `SIGKILL` followed by
+a fresh helper process, and a same-path update whose signed helper SHA changed.
+Two fresh System Settings snapshots showed one enabled `Murmur` microphone
+identity. Every probe confirmed an empty owned process group and
+`audio_content_retained=false`.
+
+An authorized reset of the exact installed identity produced one native Murmur
+prompt. Choosing **Don't Allow** produced a stable denial without starting the
+helper. A second clean reset and **Allow** produced first-buffer readiness in
+2,175 ms. A subsequent helper probe produced no second prompt. Fresh System
+Settings snapshots taken during the grant and revocation checks each showed
+one Murmur identity.
+
+Active revocation exposed the macOS callback-continuation behavior described
+above: the original signed build remained active for the full 120,216 ms
+observation despite TCC changing to denied. The parent-side detector has passed
+its deterministic callback-continuation regression and the complete Rust and
+frontend suites on the release-gate MacBook. The final matrix row remains
+pending one signed/notarized run of that detector; the baseline failure is
+retained in the evidence rather than overwritten.
 
 Until every signed/notarized matrix row passes, this ADR remains Provisional and
 production capture must not move into the helper. Ad-hoc or unsigned behavior

--- a/docs/evidence/407-capture-helper-phase-0.json
+++ b/docs/evidence/407-capture-helper-phase-0.json
@@ -29,7 +29,7 @@
   ],
   "packaging": {
     "expected": "two_exact_helpers_with_split_entitlements_and_fixed_identifiers",
-    "actual": "passed_two_developer_id_notarized_gatekeeper_accepted_releases_2026-07-30"
+    "actual": "passed_run_30590132800: app_identifier=com.localdictation; capture_identifier=com.localdictation.capture-helper capture_sha256=2d5b08972a52fafa852fdc12ee51a7abe554d465a8aa1ad110ba9e5c1a550544 capture_entitlement_sha256=43f1f2fe6ef82f876cd216e0ad897f1a56bf5f6564369766b190701cdc10e4d3; llm_identifier=com.localdictation.local-llm-sidecar llm_sha256=132701ccf3989392d88f99b950bb43756edd8a716ea0cfae0d9cf55c2125136e llm_entitlement_sha256=f8b4cfc5e7c5076be716c5a3e37f8f6b03db3f5c47220215175e9ea3cd9ef6f0; matching_team_id=P2U3P8B923; split_entitlements=capture_sandbox_plus_audio_input_and_microphone,llm_sandbox_only,app_audio_input_and_microphone; app_and_dmg_notarization=accepted; app_staple=validated; gatekeeper=accepted; dmg_sha256=e8e1edb886329fb501ece3e480faafb1252d1676a223fde510bd908370e6f9e1; 2026-07-30"
   },
   "trusted_release_evidence": {
     "machine": "shawn_macbook_release_gate",

--- a/docs/evidence/407-capture-helper-phase-0.json
+++ b/docs/evidence/407-capture-helper-phase-0.json
@@ -16,19 +16,54 @@
     {"case": "invalid_control_frames", "expected": "wrong_nonce_version_malformed_truncated_oversized_duplicate_out_of_order_fail_closed", "actual": "passed_local_deterministic_2026-07-30"}
   ],
   "tcc_matrix": [
-    {"case": "fresh_install_before_grant", "expected": "single_murmur_prompt", "actual": "pending_developer_id_notarized_bundle"},
-    {"case": "grant_through_existing_murmur_flow", "expected": "helper_callbacks_begin_without_second_prompt", "actual": "pending_developer_id_notarized_bundle"},
-    {"case": "permission_denial", "expected": "stable_permission_failure_no_pcm", "actual": "pending_developer_id_notarized_bundle"},
-    {"case": "relaunch_after_grant", "expected": "no_second_prompt", "actual": "pending_developer_id_notarized_bundle"},
-    {"case": "application_update_helper_changed", "expected": "grant_survives_update", "actual": "pending_two_notarized_versions"},
-    {"case": "application_move_or_reinstall", "expected": "behavior_recorded_without_identity_split", "actual": "pending_developer_id_notarized_bundle"},
-    {"case": "tccutil_reset_test_environment", "expected": "one_new_murmur_prompt", "actual": "pending_authorized_test_environment"},
-    {"case": "runtime_permission_revocation", "expected": "stream_error_or_callback_stall_detected", "actual": "pending_interactive_system_settings_change"},
-    {"case": "system_settings_identity", "expected": "single_understandable_murmur_entry", "actual": "pending_interactive_system_settings_inspection"},
-    {"case": "helper_crash_and_relaunch", "expected": "no_second_prompt_or_identity_change", "actual": "pending_developer_id_notarized_bundle"}
+    {"case": "fresh_install_before_grant", "expected": "single_murmur_prompt", "actual": "passed_one_native_murmur_prompt_after_authorized_reset_2026-07-30"},
+    {"case": "grant_through_existing_murmur_flow", "expected": "helper_callbacks_begin_without_second_prompt", "actual": "passed_first_buffer_ready_2175ms_then_helper_probe_no_second_prompt_2026-07-30"},
+    {"case": "permission_denial", "expected": "stable_permission_failure_no_pcm", "actual": "passed_existing_app_flow_no_helper; signed_cli_platform_baseline_reached_callbacks; parent_preflight_signed_validation_pending"},
+    {"case": "relaunch_after_grant", "expected": "no_second_prompt", "actual": "passed_notarized_helper_probe_no_second_prompt_2026-07-30"},
+    {"case": "application_update_helper_changed", "expected": "grant_survives_update", "actual": "passed_notarized_0_1_0_build_1_to_0_1_1_build_2_distinct_helper_sha_2026-07-30"},
+    {"case": "application_move_or_reinstall", "expected": "behavior_recorded_without_identity_split", "actual": "passed_notarized_moved_bundle_probe_no_second_prompt_2026-07-30"},
+    {"case": "tccutil_reset_test_environment", "expected": "one_new_murmur_prompt", "actual": "passed_exact_bundle_identity_reset_dev_identity_untouched_2026-07-30"},
+    {"case": "runtime_permission_revocation", "expected": "detectable_interruption_despite_platform_callback_behavior", "actual": "baseline_failed_callbacks_continued_120216ms_parent_detector_passed_deterministic_macbook_suite_signed_validation_pending"},
+    {"case": "system_settings_identity", "expected": "single_understandable_murmur_entry", "actual": "passed_single_enabled_murmur_entry_two_fresh_background_snapshots_2026-07-30"},
+    {"case": "helper_crash_and_relaunch", "expected": "no_second_prompt_or_identity_change", "actual": "passed_sigkill_confirmed_group_empty_then_fresh_probe_ok_2026-07-30"}
   ],
   "packaging": {
     "expected": "two_exact_helpers_with_split_entitlements_and_fixed_identifiers",
-    "actual": "passed_local_adhoc_split_entitlement_probe_2026-07-30_trusted_release_pending"
+    "actual": "passed_two_developer_id_notarized_gatekeeper_accepted_releases_2026-07-30"
+  },
+  "trusted_release_evidence": {
+    "machine": "shawn_macbook_release_gate",
+    "architecture": "arm64",
+    "macos_version": "26.0.1",
+    "initial": {
+      "source_sha": "e8cf2607f5f69005c349819f641be1a2e046b7cc",
+      "workflow_run_id": 30588206915,
+      "capture_helper_sha256": "0768b2505d51c384d55bfc1ecec97e64e6230af67bf2a10664f407464c53df5c",
+      "helper_short_version": "0.1.0",
+      "helper_bundle_version": "1",
+      "probe_outcome": "ok"
+    },
+    "update": {
+      "source_sha": "a8603c27992870975fe9a2c7a1580012fab9b489",
+      "workflow_run_id": 30590132800,
+      "capture_helper_sha256": "2d5b08972a52fafa852fdc12ee51a7abe554d465a8aa1ad110ba9e5c1a550544",
+      "helper_short_version": "0.1.1",
+      "helper_bundle_version": "2",
+      "probe_outcome": "ok"
+    },
+    "observed_probes": [
+      {"case": "existing_grant", "outcome": "ok", "first_callback_ms": 114, "elapsed_ms": 2339, "termination": "cooperative", "process_group_empty": true},
+      {"case": "fresh_grant_application_flow", "outcome": "ready", "first_callback_ms": 2175, "permission_prompt_count": 1},
+      {"case": "post_grant_helper", "outcome": "ok", "second_prompt": false, "process_group_empty": true},
+      {"case": "denied_signed_cli_platform_baseline", "tcc_status": "denied", "outcome": "ok", "first_callback_ms": 188, "elapsed_ms": 5307, "termination": "cooperative", "process_group_empty": true, "interpretation": "launch_context_did_not_enforce_parent_identity_denial"},
+      {"case": "helper_crash", "outcome": "protocol", "last_phase": "stream_open", "exit_signal": 9, "elapsed_ms": 116, "termination": "exited", "process_group_empty": true},
+      {"case": "fresh_helper_after_crash", "outcome": "ok", "first_callback_ms": 98, "elapsed_ms": 2162, "termination": "cooperative", "process_group_empty": true},
+      {"case": "moved_bundle", "outcome": "ok", "first_callback_ms": 102, "elapsed_ms": 2324, "termination": "cooperative", "process_group_empty": true},
+      {"case": "updated_helper", "outcome": "ok", "first_callback_ms": 167, "elapsed_ms": 2426, "termination": "cooperative", "process_group_empty": true},
+      {"case": "runtime_revocation_platform_baseline", "tcc_transition": "granted_to_denied", "outcome": "ok", "first_callback_ms": 150, "elapsed_ms": 120216, "termination": "cooperative", "process_group_empty": true, "interpretation": "macos_kept_existing_coreaudio_stream_active"},
+      {"case": "runtime_revocation_parent_detector", "outcome": "permission_denied", "validation": "passed_deterministic_macbook_suite_signed_runtime_pending", "process_group_empty": true}
+    ],
+    "gatekeeper": "accepted_notarized_developer_id",
+    "audio_content_retained": false
   }
 }


### PR DESCRIPTION
## Summary

- require a provable microphone grant before the Phase-0 capture helper can spawn
- detect any loss of that grant while active even when CoreAudio callbacks continue
- preserve the primary permission outcome across teardown races
- record the signed TCC matrix results and the observed macOS callback-continuation baselines

Advances #407. The issue remains open until the merged signed/notarized artifact passes denied-preflight and live-revocation validation on Shawn's MacBook.

## Validation

All validation ran on Shawn's MacBook:

- `cargo check`
- `cargo test -- --test-threads=1` (689 passed, 5 ignored unit tests; all integration suites passed)
- `cargo test --test capture_helper_spike -- --test-threads=1` (12 passed)
- `npx tsc --noEmit`
- `npm test -- --run` (620 passed)
- JSON evidence parse with `jq -e`
- independent read-only review with no remaining findings

## Privacy

No audio samples are transported, logged, written, or retained. Evidence is content-free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone permission handling before and during audio capture.
  * Capture now stops safely when microphone access is revoked and reports a clear permission-denied result.
  * Permission errors are preserved even if cleanup encounters an additional failure.

* **Documentation**
  * Added validation results covering microphone prompts, denial, revocation, relaunches, updates, crashes, and notarized release verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->