### PR TITLE
docs: record LaunchServices revocation blocker

### DIFF
--- a/docs/decisions/2026-07-30-capture-helper-phase-0.md
+++ b/docs/decisions/2026-07-30-capture-helper-phase-0.md
@@ -1,7 +1,7 @@
-# Capture-helper Phase 0: managed child proven; TCC rollout still gated
+# Capture-helper Phase 0: managed child proven; external-binary shape blocked
 
-- Status: Provisional
-- Date: 2026-07-30
+- Status: Provisional — alternate packaging/recovery decision required
+- Date: 2026-07-31
 - Issue: #407
 - Parent: #405
 
@@ -75,15 +75,34 @@ reached callbacks while the Murmur identity was denied, showing that the
 platform stream result alone cannot enforce the app's TCC policy in every
 launch context.
 
-The parent therefore snapshots permission before helper spawn and requires a
-provable grant; denied, not-determined, and unknown states create no process.
-Once the helper becomes active, it polls the same AVFoundation authorization
-status used by Murmur's permission UI. Any loss of the proven grant is
-classified as the stable `permission_denied` outcome and runs the existing
-bounded cooperative-cancel/hard-kill teardown. A queued helper failure or
-protocol frame during teardown cannot overwrite that primary outcome. This is
-deliberately stricter than the UI banner: capture fails closed when
-authorization cannot be proven.
+The parent snapshots permission before helper spawn and requires a provable
+grant; denied, not-determined, and unknown states create no process. Once the
+helper becomes active, it polls the same AVFoundation authorization status used
+by Murmur's permission UI. Any observed loss of the proven grant is classified
+as the stable `permission_denied` outcome and runs the existing bounded
+cooperative-cancel/hard-kill teardown. A queued helper failure or protocol
+frame during teardown cannot overwrite that primary outcome.
+
+That active poll is defense in depth, not the macOS revocation contract. The
+merged, signed/notarized LaunchServices run showed that macOS 26.0.1 terminates
+and restarts the real Murmur process when the user disables Murmur while capture
+is active. The direct capture helper subsequently exited and no helper survived.
+The probe could not serialize a terminal result because the parent was
+terminated first. The exact mechanism of the helper exit was not established;
+the helper may simply have observed its parent pipe closing.
+
+This makes the current external-binary shape unsuitable for production capture.
+Audio already delivered into the app's memory cannot survive the forced app
+restart, and a content-free "capture was active" marker cannot satisfy #411's
+requirement to preserve and transcribe that PCM. Issue #407 therefore owns the
+alternate packaging/recovery investigation. Candidates must retain the existing
+privacy boundary while providing a bounded, revocation-safe handoff across the
+forced restart. The protocol work in #408 remains gated until that decision is
+proven; #411 is not a prerequisite for #407.
+
+TCC conclusions are valid only when the bundle is launched through
+LaunchServices. Direct executable and `launchctl submit` contexts produced
+different TCC/capture outcomes and are retained only as diagnostics.
 
 The child-management and runtime signature-validation primitives are generic.
 The local-LLM sidecar now uses the same signature gate; a later focused
@@ -115,13 +134,14 @@ responsible-process attribution. The matrix in
 records expected and actual states without audio, transcripts, device names, or
 paths.
 
-Two non-publishing trusted-main releases have now exercised the installed
+Three non-publishing trusted-main releases have now exercised the installed
 update boundary on Shawn's arm64 macOS 26.0.1 release-gate machine:
 
 - workflow run `30588206915`, source `e8cf2607`, helper 0.1.0/build 1;
 - workflow run `30590132800`, source `a8603c27`, helper 0.1.1/build 2.
+- workflow run `30635340250`, merged source `ab6f7513`, app 0.23.9.
 
-Both artifacts were Developer ID signed, notarized, stapled, accepted by
+All three artifacts were Developer ID signed, notarized, stapled, accepted by
 Gatekeeper after quarantine, and matched their uploaded helper hashes. With an
 existing Murmur grant, the first helper started without a second prompt. The
 same grant then survived a moved bundle, an exact helper `SIGKILL` followed by
@@ -137,23 +157,44 @@ helper. A second clean reset and **Allow** produced first-buffer readiness in
 Settings snapshots taken during the grant and revocation checks each showed
 one Murmur identity.
 
-Active revocation exposed the macOS callback-continuation behavior described
-above: the original signed build remained active for the full 120,216 ms
-observation despite TCC changing to denied. The parent-side detector has passed
-its deterministic callback-continuation regression and the complete Rust and
-frontend suites on the release-gate MacBook. The final matrix row remains
-pending one signed/notarized run of that detector; the baseline failure is
-retained in the evidence rather than overwritten.
+The merged artifact passed Gatekeeper, staple, signature, an authoritative
+LaunchServices denied preflight, and LaunchServices control runs. The denied
+preflight returned the stable `permission_denied` result in 70 ms, retained no
+audio, and spawned no helper during a five-second 25 ms polling window. Its
+five-second granted control retained the first callback at 112 ms and settled
+cooperatively; a separate 120,225 ms control retained the first callback at 107
+ms and also left an empty process group.
 
-Until every signed/notarized matrix row passes, this ADR remains Provisional and
-production capture must not move into the helper. Ad-hoc or unsigned behavior
-cannot satisfy that gate.
+The authoritative LaunchServices revocation run began with the exact signed
+parent and helper alive after four seconds. Disabling the visible Murmur entry
+removed the TCC grant, terminated and restarted the parent, and left no helper.
+The helper subsequently exited; this evidence does not distinguish a direct
+system termination from an exit caused by the parent pipe closing. Because the
+parent terminated before stdout could flush, there was no probe outcome. A new
+normal Murmur app was observed in its microphone-denied onboarding screen.
+Murmur's native reset/request flow then restored a user grant and the normal app
+screen without starting a helper.
+
+This differs from two deliberately non-authoritative diagnostics: a direct
+shell launch failed closed before spawn, while a `launchctl submit`
+launchd-submitted context continued after the Murmur toggle changed. The
+different outcomes are consistent with different responsible-process chains,
+but the diagnostic runs did not prove that attribution mechanism. They do prove
+that only the LaunchServices app context is acceptable TCC evidence.
+
+Until alternate packaging or a privacy-preserving recovery handoff survives the
+forced app restart, the runtime-revocation row is blocked and production capture
+must not move into the helper. Ad-hoc, unsigned, direct-shell, or
+launchd-submitted behavior cannot satisfy that gate.
 
 ## Consequences
 
-Hard-kill recovery and exact packaging have an implementation path that later
-audio issues can reuse. TCC durability remains an explicit external release
-gate rather than an inferred property. If the notarized matrix shows a second
-permission identity, repeated prompts, or update instability, the fallback is a
-dedicated bundled app/XPC packaging investigation; silently shipping the
-external-binary shape is not allowed.
+Hard-kill recovery and the signed helper prototype remain reusable evidence, but
+the exact production packaging decision is not complete. #408 and dependent
+issues must not begin until #407 proves an alternate shape that can preserve
+already-delivered PCM across the observed forced restart without weakening
+revocation or privacy guarantees. A dedicated bundled app/XPC service is the
+leading investigation; a volatile recovery handoff is acceptable only if its
+lifetime, access control, cleanup, and swap/crash behavior are explicitly
+bounded and tested. Silently shipping the current external-binary shape or
+moving the problem into #411 is not allowed.

--- a/docs/evidence/407-capture-helper-phase-0.json
+++ b/docs/evidence/407-capture-helper-phase-0.json
@@ -18,18 +18,18 @@
   "tcc_matrix": [
     {"case": "fresh_install_before_grant", "expected": "single_murmur_prompt", "actual": "passed_one_native_murmur_prompt_after_authorized_reset_2026-07-30"},
     {"case": "grant_through_existing_murmur_flow", "expected": "helper_callbacks_begin_without_second_prompt", "actual": "passed_first_buffer_ready_2175ms_then_helper_probe_no_second_prompt_2026-07-30"},
-    {"case": "permission_denial", "expected": "stable_permission_failure_no_pcm", "actual": "passed_existing_app_flow_no_helper; signed_cli_platform_baseline_reached_callbacks; parent_preflight_signed_validation_pending"},
+    {"case": "permission_denial", "expected": "stable_permission_failure_no_pcm", "actual": "passed_merged_signed_launchservices_preflight_returned_permission_denied_in_70ms_without_helper_or_audio; helper_absence_polled_every_25ms_for_5s_2026-07-31"},
     {"case": "relaunch_after_grant", "expected": "no_second_prompt", "actual": "passed_notarized_helper_probe_no_second_prompt_2026-07-30"},
     {"case": "application_update_helper_changed", "expected": "grant_survives_update", "actual": "passed_notarized_0_1_0_build_1_to_0_1_1_build_2_distinct_helper_sha_2026-07-30"},
     {"case": "application_move_or_reinstall", "expected": "behavior_recorded_without_identity_split", "actual": "passed_notarized_moved_bundle_probe_no_second_prompt_2026-07-30"},
     {"case": "tccutil_reset_test_environment", "expected": "one_new_murmur_prompt", "actual": "passed_exact_bundle_identity_reset_dev_identity_untouched_2026-07-30"},
-    {"case": "runtime_permission_revocation", "expected": "detectable_interruption_despite_platform_callback_behavior", "actual": "baseline_failed_callbacks_continued_120216ms_parent_detector_passed_deterministic_macbook_suite_signed_validation_pending"},
+    {"case": "runtime_permission_revocation", "expected": "detectable_interruption_despite_platform_callback_behavior", "actual": "blocked_on_macos_26_0_1_launchservices_behavior: parent_was_terminated_and_restarted_before_probe_result; helper_subsequently_exited_and_no_helper_survived; helper_exit_mechanism_not_proven; alternate_packaging_or_privacy_preserving_recovery_handoff_required_in_issue_407"},
     {"case": "system_settings_identity", "expected": "single_understandable_murmur_entry", "actual": "passed_single_enabled_murmur_entry_two_fresh_background_snapshots_2026-07-30"},
     {"case": "helper_crash_and_relaunch", "expected": "no_second_prompt_or_identity_change", "actual": "passed_sigkill_confirmed_group_empty_then_fresh_probe_ok_2026-07-30"}
   ],
   "packaging": {
     "expected": "two_exact_helpers_with_split_entitlements_and_fixed_identifiers",
-    "actual": "passed_run_30590132800: app_identifier=com.localdictation; capture_identifier=com.localdictation.capture-helper capture_sha256=2d5b08972a52fafa852fdc12ee51a7abe554d465a8aa1ad110ba9e5c1a550544 capture_entitlement_sha256=43f1f2fe6ef82f876cd216e0ad897f1a56bf5f6564369766b190701cdc10e4d3; llm_identifier=com.localdictation.local-llm-sidecar llm_sha256=132701ccf3989392d88f99b950bb43756edd8a716ea0cfae0d9cf55c2125136e llm_entitlement_sha256=f8b4cfc5e7c5076be716c5a3e37f8f6b03db3f5c47220215175e9ea3cd9ef6f0; matching_team_id=P2U3P8B923; split_entitlements=capture_sandbox_plus_audio_input_and_microphone,llm_sandbox_only,app_audio_input_and_microphone; app_and_dmg_notarization=accepted; app_staple=validated; gatekeeper=accepted; dmg_sha256=e8e1edb886329fb501ece3e480faafb1252d1676a223fde510bd908370e6f9e1; 2026-07-30"
+    "actual": "passed_merged_run_30635340250: source_sha=ab6f7513f0a7c960b08cdfcba8d0034463f4036e app_identifier=com.localdictation; capture_identifier=com.localdictation.capture-helper capture_sha256=d1b87089ffc6a3b8c8665ddab37bf40e7e85d1906dc3333719e5d2b5f62d934e capture_entitlement_sha256=43f1f2fe6ef82f876cd216e0ad897f1a56bf5f6564369766b190701cdc10e4d3; llm_identifier=com.localdictation.local-llm-sidecar llm_sha256=2fa273afc5d1cd198b896d4814fca928c4886a26f9e0442f54468fcafdf5495f llm_entitlement_sha256=f8b4cfc5e7c5076be716c5a3e37f8f6b03db3f5c47220215175e9ea3cd9ef6f0; matching_team_id=P2U3P8B923; split_entitlements=capture_sandbox_plus_audio_input_and_microphone,llm_sandbox_only,app_audio_input_and_microphone; app_and_dmg_notarization=accepted; app_staple=validated; gatekeeper=accepted; dmg_sha256=9ccd2530243b26ce9b3098e665e9a14f72b52708002e9e823c0584a502e060e8; 2026-07-31"
   },
   "trusted_release_evidence": {
     "machine": "shawn_macbook_release_gate",
@@ -51,6 +51,15 @@
       "helper_bundle_version": "2",
       "probe_outcome": "ok"
     },
+    "merged_detector": {
+      "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e",
+      "workflow_run_id": 30635340250,
+      "app_version": "0.23.9",
+      "capture_helper_sha256": "d1b87089ffc6a3b8c8665ddab37bf40e7e85d1906dc3333719e5d2b5f62d934e",
+      "dmg_sha256": "9ccd2530243b26ce9b3098e665e9a14f72b52708002e9e823c0584a502e060e8",
+      "gatekeeper": "accepted_notarized_developer_id",
+      "staple": "validated"
+    },
     "observed_probes": [
       {"case": "existing_grant", "outcome": "ok", "first_callback_ms": 114, "elapsed_ms": 2339, "termination": "cooperative", "process_group_empty": true},
       {"case": "fresh_grant_application_flow", "outcome": "ready", "first_callback_ms": 2175, "permission_prompt_count": 1},
@@ -61,7 +70,13 @@
       {"case": "moved_bundle", "outcome": "ok", "first_callback_ms": 102, "elapsed_ms": 2324, "termination": "cooperative", "process_group_empty": true},
       {"case": "updated_helper", "outcome": "ok", "first_callback_ms": 167, "elapsed_ms": 2426, "termination": "cooperative", "process_group_empty": true},
       {"case": "runtime_revocation_platform_baseline", "tcc_transition": "granted_to_denied", "outcome": "ok", "first_callback_ms": 150, "elapsed_ms": 120216, "termination": "cooperative", "process_group_empty": true, "interpretation": "macos_kept_existing_coreaudio_stream_active"},
-      {"case": "runtime_revocation_parent_detector", "outcome": "permission_denied", "validation": "passed_deterministic_macbook_suite_signed_runtime_pending", "process_group_empty": true}
+      {"case": "runtime_revocation_parent_detector", "outcome": "permission_denied", "validation": "passed_deterministic_macbook_suite_but_not_observable_before_launchservices_forced_termination", "process_group_empty": true},
+      {"case": "merged_signed_denied_shell_preflight_diagnostic", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "direct_binary_from_ssh", "tcc_status": "denied", "outcome": "permission_denied", "helper_spawned": false, "audio_content_retained": false, "interpretation": "fail_closed_preflight_works_but_shell_responsibility_is_not_authoritative_for_app_tcc"},
+      {"case": "merged_signed_launchservices_denied_preflight", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "open_new_background_wait_with_stdout", "tcc_status": "denied", "outcome": "permission_denied", "open_elapsed_ms": 70, "helper_spawned": false, "helper_poll_interval_ms": 25, "helper_poll_duration_ms": 5000, "audio_content_retained": false, "process_group_empty": true},
+      {"case": "merged_signed_launchservices_control", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "open_new_background_wait_with_stdout", "outcome": "ok", "first_callback_ms": 112, "elapsed_ms": 5224, "termination": "cooperative", "process_group_empty": true},
+      {"case": "merged_signed_launchservices_long_control", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "open_new_background_wait_with_stdout", "outcome": "ok", "first_callback_ms": 107, "elapsed_ms": 120225, "termination": "cooperative", "process_group_empty": true},
+      {"case": "merged_signed_launchservices_active_revocation", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "open_new_background_wait_with_stdout", "tcc_transition": "granted_to_denied", "parent_pid": 49591, "helper_pid": 49593, "active_before_revocation_seconds": 4, "probe_output": "none_parent_terminated_before_serialization", "parent_survived": false, "helper_survived": false, "helper_exit_mechanism": "not_proven_may_have_followed_parent_pipe_close", "termination_confirmed_under_ms": 10900, "new_normal_app_observed_in": "microphone_access_denied_onboarding", "recovery": "permission_reset_then_native_request_restored_auth_value_2_reason_2", "audio_content_retained": false, "interpretation": "authoritative_app_identity_does_not_receive_an_in_process_revocation_result; issue_407_requires_alternate_packaging_or_privacy_preserving_recovery_handoff_before_issue_408"},
+      {"case": "launchctl_submitted_context_rejected_as_tcc_evidence", "source_sha": "ab6f7513f0a7c960b08cdfcba8d0034463f4036e", "launch_context": "launchctl_submit", "tcc_transition": "granted_to_denied", "parent_and_helper_continued": true, "cleanup": "two_exact_submitted_labels_removed_and_no_process_survived", "interpretation": "different_behavior_is_consistent_with_but_does_not_prove_a_different_responsible_process_chain; launchservices_is_the_authoritative_app_context"}
     ],
     "gatekeeper": "accepted_notarized_developer_id",
     "audio_content_retained": false


### PR DESCRIPTION
## Summary
- record the merged signed/notarized #407 TCC matrix on Shawn’s MacBook
- add the authoritative denied LaunchServices preflight
- document that macOS restarts the app on active permission revocation
- keep #408 gated on an alternate packaging/recovery decision owned by #407

## Validation
- `jq empty docs/evidence/407-capture-helper-phase-0.json`
- `git diff --check`
- independent read-only evidence/causality/privacy review
- signed release workflow run 30635340250
- Gatekeeper/staple/signature validation on the MacBook
- LaunchServices granted, denied, long-control, and active-revocation probes on the MacBook

This PR intentionally does not close #407; it records the blocker that the next #407 spike must resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated capture-helper decision records with clearer permission handling, revocation monitoring, denial behavior, and release requirements.
  - Documented the need for alternate packaging or privacy-preserving recovery before production capture support and related protocol work can proceed.

- **Evidence**
  - Refreshed validation records covering permission denial, runtime revocation, packaging, signing, notarization, and supported control scenarios.
  - Clarified unresolved runtime-revocation behavior and excluded invalid test evidence from release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->