### PR TITLE
feat: add signed capture LaunchAgent recovery spike

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,18 @@ jobs:
               - '.github/**'
               - 'scripts/validate_workflow_policy.py'
               - 'scripts/release_artifacts.py'
+              - 'scripts/capture_agent_matrix.py'
               - 'tests/test_release_artifacts.py'
               - 'tests/test_workflow_policy.py'
+              - 'tests/test_capture_agent_matrix.py'
 
       - name: Validate workflow policy
         run: |
           python3 scripts/validate_workflow_policy.py
-          python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py
+          python3 -m unittest \
+            tests/test_release_artifacts.py \
+            tests/test_workflow_policy.py \
+            tests/test_capture_agent_matrix.py
 
   typecheck:
     needs: changes
@@ -91,18 +96,29 @@ jobs:
         with:
           workspaces: app/src-tauri
 
-      - name: Stub bundled helpers externalBin for compile checks
-        # tauri.macos.conf.json declares both production helpers as externalBin,
-        # and Tauri's build script requires each file to exist even for cargo
-        # check/test. This job never bundles or ships anything - the release
-        # pipeline builds and signs the real helpers - so exact empty stubs
-        # satisfy the resource check without compiling either helper here.
+      - name: Build capture isolation helpers and stub local-LLM externalBin
+        # PR CI compiles the Swift agent with warnings as errors and builds the
+        # Rust worker protocol. Only the heavyweight local-LLM sidecar is stubbed.
         run: |
-          mkdir -p app/src-tauri/binaries
-          : > app/src-tauri/binaries/murmur-capture-helper-aarch64-apple-darwin
-          : > app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin
-          chmod +x app/src-tauri/binaries/murmur-capture-helper-aarch64-apple-darwin
-          chmod +x app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin
+          cd app/src-tauri
+          mkdir -p binaries
+          xcrun swiftc -warnings-as-errors -parse-as-library \
+            -target arm64-apple-macos14.0 \
+            sidecars/capture-agent/main.swift \
+            -framework Foundation -framework Security \
+            -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist \
+            -Xlinker capture-agent-info.plist \
+            -o binaries/murmur-capture-agent-aarch64-apple-darwin
+          cargo build -p murmur-capture-helper
+          cp target/debug/murmur-capture-helper \
+            binaries/murmur-capture-helper-aarch64-apple-darwin
+          MURMUR_CAPTURE_ROLE=worker \
+            CARGO_TARGET_DIR=target/capture-worker-build \
+            cargo build -p murmur-capture-helper
+          cp target/capture-worker-build/debug/murmur-capture-helper \
+            binaries/murmur-capture-worker-aarch64-apple-darwin
+          : > binaries/murmur-llm-sidecar-aarch64-apple-darwin
+          chmod +x binaries/murmur-llm-sidecar-aarch64-apple-darwin
 
       - name: Compile check
         env:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -208,7 +208,13 @@ jobs:
             --identity "$APPLE_SIGNING_IDENTITY" \
             --main-entitlements app/src-tauri/entitlements.plist \
             --llm-helper-entitlements app/src-tauri/local-llm-sidecar.entitlements.plist \
+            --capture-agent-entitlements app/src-tauri/capture-agent.entitlements.plist \
+            --capture-agent-info-plist app/src-tauri/capture-agent-info.plist \
+            --capture-helper-info-plist app/src-tauri/sidecars/capture/Info.plist \
+            --capture-worker-info-plist app/src-tauri/sidecars/capture/WorkerInfo.plist \
+            --capture-agent-launchd-plist app/src-tauri/macos/com.localdictation.capture-agent.plist \
             --capture-helper-entitlements app/src-tauri/capture-helper.entitlements.plist \
+            --capture-worker-entitlements app/src-tauri/capture-worker.entitlements.plist \
             --expected-team-id "$APPLE_TEAM_ID"
 
           # Notarize + staple the finalized app, then rebuild the DMG and the
@@ -259,7 +265,9 @@ jobs:
           APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
           EXECUTABLE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
           BINARY="$APP/Contents/MacOS/$EXECUTABLE"
+          CAPTURE_AGENT="$APP/Contents/MacOS/murmur-capture-agent"
           CAPTURE_HELPER="$APP/Contents/MacOS/murmur-capture-helper"
+          CAPTURE_WORKER="$APP/Contents/MacOS/murmur-capture-worker"
           EVIDENCE=capture-helper-tcc-evidence
           mkdir -p "$EVIDENCE"
 
@@ -269,6 +277,16 @@ jobs:
             --helper "$CAPTURE_HELPER" \
             --signature-output "$EVIDENCE/signature.json" \
             --entitlements-output "$EVIDENCE/entitlements.plist"
+          python3 scripts/capture_helper_evidence.py collect-signature \
+            --kind capture-agent \
+            --helper "$CAPTURE_AGENT" \
+            --signature-output "$EVIDENCE/agent-signature.json" \
+            --entitlements-output "$EVIDENCE/agent-entitlements.plist"
+          python3 scripts/capture_helper_evidence.py collect-signature \
+            --kind capture-worker \
+            --helper "$CAPTURE_WORKER" \
+            --signature-output "$EVIDENCE/worker-signature.json" \
+            --entitlements-output "$EVIDENCE/worker-entitlements.plist"
 
           set +e
           "$BINARY" --capture-helper-probe > "$EVIDENCE/noninteractive-probe.json"
@@ -309,8 +327,11 @@ jobs:
           # architecture, designated requirement, Team ID, and entitlement digest.
           APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
           HELPER="$APP/Contents/MacOS/murmur-llm-sidecar"
+          CAPTURE_AGENT="$APP/Contents/MacOS/murmur-capture-agent"
           CAPTURE_HELPER="$APP/Contents/MacOS/murmur-capture-helper"
-          if [ ! -f "$HELPER" ] || [ ! -f "$CAPTURE_HELPER" ]; then
+          CAPTURE_WORKER="$APP/Contents/MacOS/murmur-capture-worker"
+          if [ ! -f "$HELPER" ] || [ ! -f "$CAPTURE_AGENT" ] || \
+             [ ! -f "$CAPTURE_HELPER" ] || [ ! -f "$CAPTURE_WORKER" ]; then
             echo "ERROR: finalized bundle is missing a required helper"
             exit 1
           fi
@@ -332,6 +353,24 @@ jobs:
           fi
           codesign -d --entitlements :- --xml "$CAPTURE_HELPER" > "$RUNNER_TEMP/capture-helper-entitlements.xml" 2>/dev/null
           CAPTURE_HELPER_ENT_SHA=$(shasum -a 256 "$RUNNER_TEMP/capture-helper-entitlements.xml" | awk '{print $1}')
+          CAPTURE_AGENT_SHA=$(shasum -a 256 "$CAPTURE_AGENT" | awk '{print $1}')
+          CAPTURE_AGENT_ARCH=$(lipo -archs "$CAPTURE_AGENT" | tr -d ' \n')
+          CAPTURE_AGENT_DR=$(codesign -d -r- "$CAPTURE_AGENT" 2>&1 | sed -n 's/^#* *designated => //p')
+          if [ -z "$CAPTURE_AGENT_DR" ]; then
+            echo "ERROR: could not read the capture agent designated requirement"
+            exit 1
+          fi
+          codesign -d --entitlements :- --xml "$CAPTURE_AGENT" > "$RUNNER_TEMP/capture-agent-entitlements.xml" 2>/dev/null
+          CAPTURE_AGENT_ENT_SHA=$(shasum -a 256 "$RUNNER_TEMP/capture-agent-entitlements.xml" | awk '{print $1}')
+          CAPTURE_WORKER_SHA=$(shasum -a 256 "$CAPTURE_WORKER" | awk '{print $1}')
+          CAPTURE_WORKER_ARCH=$(lipo -archs "$CAPTURE_WORKER" | tr -d ' \n')
+          CAPTURE_WORKER_DR=$(codesign -d -r- "$CAPTURE_WORKER" 2>&1 | sed -n 's/^#* *designated => //p')
+          if [ -z "$CAPTURE_WORKER_DR" ]; then
+            echo "ERROR: could not read the capture worker designated requirement"
+            exit 1
+          fi
+          codesign -d --entitlements :- --xml "$CAPTURE_WORKER" > "$RUNNER_TEMP/capture-worker-entitlements.xml" 2>/dev/null
+          CAPTURE_WORKER_ENT_SHA=$(shasum -a 256 "$RUNNER_TEMP/capture-worker-entitlements.xml" | awk '{print $1}')
 
           python3 scripts/release_artifacts.py record \
             --platform macos \
@@ -344,6 +383,16 @@ jobs:
             --helper-designated-requirement "$HELPER_DR" \
             --helper-team-id "$APPLE_TEAM_ID" \
             --helper-entitlement-sha256 "$HELPER_ENT_SHA" \
+            --capture-agent-sha256 "$CAPTURE_AGENT_SHA" \
+            --capture-agent-arch "$CAPTURE_AGENT_ARCH" \
+            --capture-agent-designated-requirement "$CAPTURE_AGENT_DR" \
+            --capture-agent-team-id "$APPLE_TEAM_ID" \
+            --capture-agent-entitlement-sha256 "$CAPTURE_AGENT_ENT_SHA" \
+            --capture-worker-sha256 "$CAPTURE_WORKER_SHA" \
+            --capture-worker-arch "$CAPTURE_WORKER_ARCH" \
+            --capture-worker-designated-requirement "$CAPTURE_WORKER_DR" \
+            --capture-worker-team-id "$APPLE_TEAM_ID" \
+            --capture-worker-entitlement-sha256 "$CAPTURE_WORKER_ENT_SHA" \
             --capture-helper-sha256 "$CAPTURE_HELPER_SHA" \
             --capture-helper-arch "$CAPTURE_HELPER_ARCH" \
             --capture-helper-designated-requirement "$CAPTURE_HELPER_DR" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,8 @@ jobs:
             --expected-sha '${{ needs.resolve.outputs.source-sha }}' \
             --expected-run-id '${{ needs.resolve.outputs.artifact-run-id }}' \
             --require-macos-helper \
+            --require-macos-capture-agent \
+            --require-macos-capture-worker \
             --require-macos-capture-helper \
             --output validated-release.json
 

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -128,10 +128,17 @@ jobs:
             --identity "$APPLE_SIGNING_IDENTITY" \
             --main-entitlements app/src-tauri/entitlements.plist \
             --helper-entitlements app/src-tauri/local-llm-sidecar.entitlements.plist \
+            --capture-agent-entitlements app/src-tauri/capture-agent.entitlements.plist \
+            --capture-agent-info-plist app/src-tauri/capture-agent-info.plist \
+            --capture-helper-info-plist app/src-tauri/sidecars/capture/Info.plist \
+            --capture-worker-info-plist app/src-tauri/sidecars/capture/WorkerInfo.plist \
+            --capture-agent-launchd-plist app/src-tauri/macos/com.localdictation.capture-agent.plist \
+            --capture-helper-entitlements app/src-tauri/capture-helper.entitlements.plist \
+            --capture-worker-entitlements app/src-tauri/capture-worker.entitlements.plist \
             --expected-team-id "$APPLE_TEAM_ID" \
             | tee "$RUNNER_TEMP/rehearsal-evidence/finalize.log"
 
-      - name: Strict verification of both binaries
+      - name: Strict verification of app and all helpers
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -140,6 +147,9 @@ jobs:
           EXEC=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP/Contents/Info.plist")
           MAIN="$APP/Contents/MacOS/$EXEC"
           HELPER="$APP/Contents/MacOS/murmur-llm-sidecar"
+          CAPTURE_AGENT="$APP/Contents/MacOS/murmur-capture-agent"
+          CAPTURE_HELPER="$APP/Contents/MacOS/murmur-capture-helper"
+          CAPTURE_WORKER="$APP/Contents/MacOS/murmur-capture-worker"
           {
             echo "## codesign --verify --deep --strict"
             codesign --verify --deep --strict --verbose=2 "$APP" 2>&1
@@ -148,18 +158,28 @@ jobs:
             codesign -dvv "$HELPER" 2>&1
             echo "## helper entitlements"
             codesign -d --entitlements :- --xml "$HELPER" 2>/dev/null
+            echo "## capture agent signature"
+            codesign -dvv "$CAPTURE_AGENT" 2>&1
+            echo "## capture helper signature"
+            codesign -dvv "$CAPTURE_HELPER" 2>&1
+            echo "## capture worker signature"
+            codesign -dvv "$CAPTURE_WORKER" 2>&1
             echo "## main entitlements"
             codesign -d --entitlements :- --xml "$MAIN" 2>/dev/null
           } | tee "$LOG"
 
-          # arm64-only helper.
-          test "$(lipo -archs "$HELPER" | tr -d ' \n')" = "arm64"
-          # Hardened runtime on both binaries.
-          codesign -dvv "$HELPER" 2>&1 | grep -qi 'flags=.*runtime'
+          # Every helper is arm64-only and uses hardened runtime.
+          for BINARY in "$HELPER" "$CAPTURE_AGENT" "$CAPTURE_HELPER" "$CAPTURE_WORKER"; do
+            test "$(lipo -archs "$BINARY" | tr -d ' \n')" = "arm64"
+            codesign -dvv "$BINARY" 2>&1 | grep -qi 'flags=.*runtime'
+            codesign -dvv "$BINARY" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID"
+          done
           codesign -dvv "$MAIN" 2>&1 | grep -qi 'flags=.*runtime'
           # Fixed helper identifier and shared Team ID.
           codesign -dvv "$HELPER" 2>&1 | grep -q 'Identifier=com.localdictation.local-llm-sidecar'
-          codesign -dvv "$HELPER" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID"
+          codesign -dvv "$CAPTURE_AGENT" 2>&1 | grep -q 'Identifier=com.localdictation.capture-agent'
+          codesign -dvv "$CAPTURE_HELPER" 2>&1 | grep -q 'Identifier=com.localdictation.capture-helper'
+          codesign -dvv "$CAPTURE_WORKER" 2>&1 | grep -q 'Identifier=com.localdictation.capture-worker'
           codesign -dvv "$MAIN" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID"
           # Helper is sandboxed; main is not.
           codesign -d --entitlements :- --xml "$HELPER" 2>/dev/null | grep -q 'com.apple.security.app-sandbox'

--- a/app/src-tauri/capture-agent-info.plist
+++ b/app/src-tauri/capture-agent-info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>murmur-capture-agent</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.localdictation.capture-agent</string>
+  <key>CFBundleName</key>
+  <string>Murmur Capture Agent</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>__MURMUR_VERSION__</string>
+  <key>CFBundleVersion</key>
+  <string>__MURMUR_VERSION__</string>
+</dict>
+</plist>

--- a/app/src-tauri/capture-agent.entitlements.plist
+++ b/app/src-tauri/capture-agent.entitlements.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+    <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+    <array>
+        <string>com.localdictation.capture-agent.xpc</string>
+    </array>
+    <key>com.apple.security.temporary-exception.mach-register.global-name</key>
+    <array>
+        <string>com.localdictation.capture-agent.xpc</string>
+    </array>
+</dict>
+</plist>

--- a/app/src-tauri/capture-worker.entitlements.plist
+++ b/app/src-tauri/capture-worker.entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
+++ b/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
@@ -5,6 +5,10 @@ pub const PROTOCOL_NAME: &str = "murmur.capture_probe";
 pub const PROTOCOL_VERSION: u16 = 1;
 pub const MAX_FRAME_BYTES: usize = 4 * 1024;
 pub const MAX_NONCE_BYTES: usize = 128;
+pub const SYNTHETIC_FIXTURE: &str = "seq-v1";
+pub const SYNTHETIC_FIXTURE_CHUNKS: u64 = 64;
+pub const SYNTHETIC_FIXTURE_DIGEST: &str =
+    "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -82,6 +86,14 @@ pub enum HelperMessage {
         session_nonce: String,
         callback_count_bucket: String,
     },
+    SyntheticChunk {
+        protocol: String,
+        version: u16,
+        session_nonce: String,
+        fixture: String,
+        fixture_digest: String,
+        sequence: u64,
+    },
     Failure {
         protocol: String,
         version: u16,
@@ -110,6 +122,7 @@ impl HelperMessage {
             | Self::Ready { session_nonce, .. }
             | Self::FirstCallback { session_nonce, .. }
             | Self::CallbackHealth { session_nonce, .. }
+            | Self::SyntheticChunk { session_nonce, .. }
             | Self::Failure { session_nonce, .. }
             | Self::Stopped { session_nonce, .. } => session_nonce,
         }
@@ -148,6 +161,9 @@ pub fn valid_helper_message(message: &HelperMessage, expected_nonce: &str) -> bo
             protocol, version, ..
         }
         | HelperMessage::CallbackHealth {
+            protocol, version, ..
+        }
+        | HelperMessage::SyntheticChunk {
             protocol, version, ..
         }
         | HelperMessage::Failure {
@@ -229,5 +245,15 @@ mod tests {
             read_frame::<HostMessage>(&mut bytes.as_slice()),
             Err(FrameError::TooLarge(_))
         ));
+    }
+
+    #[test]
+    fn synthetic_fixture_contract_is_fixed_and_content_free() {
+        assert_eq!(SYNTHETIC_FIXTURE, "seq-v1");
+        assert_eq!(SYNTHETIC_FIXTURE_CHUNKS, 64);
+        assert_eq!(SYNTHETIC_FIXTURE_DIGEST.len(), 64);
+        assert!(SYNTHETIC_FIXTURE_DIGEST
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit()));
     }
 }

--- a/app/src-tauri/macos/com.localdictation.capture-agent.plist
+++ b/app/src-tauri/macos/com.localdictation.capture-agent.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.localdictation.capture-agent</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/murmur-capture-agent</string>
+    <key>MachServices</key>
+    <dict>
+        <key>com.localdictation.capture-agent.xpc</key>
+        <true/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/app/src-tauri/sidecars/capture-agent/main.swift
+++ b/app/src-tauri/sidecars/capture-agent/main.swift
@@ -1,0 +1,1525 @@
+import Foundation
+import Security
+import XPC
+import Darwin
+
+private func currentSigningTeamID() -> String? {
+    var runningCode: SecCode?
+    guard SecCodeCopySelf([], &runningCode) == errSecSuccess,
+          let runningCode else {
+        return nil
+    }
+    var staticCode: SecStaticCode?
+    guard SecCodeCopyStaticCode(runningCode, [], &staticCode) == errSecSuccess,
+          let staticCode else {
+        return nil
+    }
+    var information: CFDictionary?
+    let signingInformation = SecCSFlags(rawValue: 1 << 1)
+    guard SecCodeCopySigningInformation(
+        staticCode,
+        signingInformation,
+        &information
+    ) == errSecSuccess,
+    let values = information as? [String: Any] else {
+        return nil
+    }
+    return values[kSecCodeInfoTeamIdentifier as String] as? String
+}
+
+private let agentIdentifier = "com.localdictation.capture-agent"
+private let captureWorkerIdentifier = "com.localdictation.capture-worker"
+private let signingTeamID = currentSigningTeamID() ?? ""
+private let machServiceName = "com.localdictation.capture-agent.xpc"
+private let protocolName = "murmur.capture_probe"
+private let protocolVersion: Int = 1
+private let recoveryTTL: TimeInterval = 30
+private let maxCanaries: UInt64 = 4_096
+private let syntheticFixture = "seq-v1"
+private let syntheticFixtureChunks: UInt64 = 64
+private let syntheticFixtureDigest =
+    "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3"
+private let peerRequirement =
+    "identifier \"\(agentIdentifier)\" and anchor apple generic and " +
+    "certificate leaf[subject.OU] = \"\(signingTeamID)\""
+
+private func disableCoreDumps() {
+    var limit = rlimit(rlim_cur: 0, rlim_max: 0)
+    _ = setrlimit(RLIMIT_CORE, &limit)
+}
+
+private func jsonData(_ value: [String: Any]) -> Data? {
+    try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+}
+
+private func jsonLine(_ value: [String: Any]) {
+    guard let data = jsonData(value), let text = String(data: data, encoding: .utf8) else {
+        return
+    }
+    FileHandle.standardOutput.write(Data((text + "\n").utf8))
+}
+
+private func exactUInt64(_ value: Any?) -> UInt64? {
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) != CFBooleanGetTypeID() else {
+        return nil
+    }
+    let floating = number.doubleValue
+    guard floating.isFinite,
+          floating >= 0,
+          floating.rounded(.towardZero) == floating,
+          floating <= Double(UInt64.max) else {
+        return nil
+    }
+    return number.uint64Value
+}
+
+private func validateCaptureWorker(at executable: URL) -> Bool {
+    var staticCode: SecStaticCode?
+    guard SecStaticCodeCreateWithPath(executable as CFURL, [], &staticCode) == errSecSuccess,
+          let staticCode else {
+        return false
+    }
+    let requirementText =
+        "identifier \"\(captureWorkerIdentifier)\" and anchor apple generic and " +
+        "certificate leaf[subject.OU] = \"\(signingTeamID)\""
+    var requirement: SecRequirement?
+    guard SecRequirementCreateWithString(
+        requirementText as CFString,
+        [],
+        &requirement
+    ) == errSecSuccess, let requirement else {
+        return false
+    }
+    // kSecCSStrictValidate is not imported as a Swift member by every SDK.
+    let strictValidate = SecCSFlags(rawValue: 1 << 4)
+    return SecStaticCodeCheckValidity(staticCode, strictValidate, requirement) == errSecSuccess
+}
+
+private func xpcString(_ object: xpc_object_t, _ key: String) -> String? {
+    key.withCString { rawKey in
+        guard let value = xpc_dictionary_get_string(object, rawKey) else { return nil }
+        return String(cString: value)
+    }
+}
+
+private func setXPCString(_ object: xpc_object_t, _ key: String, _ value: String) {
+    key.withCString { rawKey in
+        value.withCString { rawValue in
+            xpc_dictionary_set_string(object, rawKey, rawValue)
+        }
+    }
+}
+
+private func setXPCUInt64(_ object: xpc_object_t, _ key: String, _ value: UInt64) {
+    key.withCString { rawKey in
+        xpc_dictionary_set_uint64(object, rawKey, value)
+    }
+}
+
+private func setXPCBool(_ object: xpc_object_t, _ key: String, _ value: Bool) {
+    key.withCString { rawKey in
+        xpc_dictionary_set_bool(object, rawKey, value)
+    }
+}
+
+private func dictionary(from object: xpc_object_t) -> [String: Any]? {
+    var result: [String: Any] = [:]
+    for key in [
+        "outcome", "service_status", "agent_instance", "worker_termination", "failure",
+        "claim_id", "synthetic_fixture", "synthetic_digest",
+    ] {
+        let accepted = key.withCString { rawKey -> Bool in
+            guard let value = xpc_dictionary_get_value(object, rawKey) else {
+                return true
+            }
+            guard xpc_get_type(value) == XPC_TYPE_STRING,
+                  let string = xpc_dictionary_get_string(object, rawKey) else {
+                return false
+            }
+            result[key] = String(cString: string)
+            return true
+        }
+        if !accepted { return nil }
+    }
+    for key in [
+        "schema_version", "generation", "agent_pid", "worker_pid",
+        "synthetic_canary_count", "first_callback_ms", "stop_elapsed_ms",
+        "recovery_ttl_ms", "synthetic_first_sequence", "synthetic_last_sequence",
+        "exit_signal",
+    ] {
+        let accepted = key.withCString { rawKey -> Bool in
+            guard let value = xpc_dictionary_get_value(object, rawKey) else {
+                return true
+            }
+            guard xpc_get_type(value) == XPC_TYPE_UINT64 else { return false }
+            result[key] = xpc_dictionary_get_uint64(object, rawKey)
+            return true
+        }
+        if !accepted { return nil }
+    }
+    for key in [
+        "audio_content_retained", "recovered", "agent_survived",
+        "worker_exited", "process_group_empty", "exact_once", "synthetic_complete",
+    ] {
+        let accepted = key.withCString { rawKey -> Bool in
+            guard let value = xpc_dictionary_get_value(object, rawKey) else {
+                return true
+            }
+            guard xpc_get_type(value) == XPC_TYPE_BOOL else { return false }
+            result[key] = xpc_dictionary_get_bool(object, rawKey)
+            return true
+        }
+        if !accepted { return nil }
+    }
+    guard xpc_dictionary_get_count(object) == result.count else { return nil }
+    return result
+}
+
+private func readExactly(_ handle: FileHandle, count: Int) -> Data? {
+    var data = Data()
+    while data.count < count {
+        guard let chunk = try? handle.read(upToCount: count - data.count),
+              !chunk.isEmpty else {
+            return nil
+        }
+        data.append(chunk)
+    }
+    return data
+}
+
+private func readFrame(_ handle: FileHandle) -> [String: Any]? {
+    guard let header = readExactly(handle, count: 4) else { return nil }
+    let length = header.withUnsafeBytes { raw -> UInt32 in
+        raw.loadUnaligned(as: UInt32.self).bigEndian
+    }
+    guard length > 0, length <= 4_096,
+          let body = readExactly(handle, count: Int(length)),
+          let object = try? JSONSerialization.jsonObject(with: body),
+          let dictionary = object as? [String: Any] else {
+        return nil
+    }
+    return dictionary
+}
+
+private func writeFrame(_ value: [String: Any], to handle: FileHandle) -> Bool {
+    guard let body = jsonData(value), !body.isEmpty, body.count <= 4_096 else {
+        return false
+    }
+    var length = UInt32(body.count).bigEndian
+    var framed = Data(bytes: &length, count: 4)
+    framed.append(body)
+    do {
+        try handle.write(contentsOf: framed)
+        return true
+    } catch {
+        return false
+    }
+}
+
+private enum WorkerProtocolState: Equatable {
+    case awaitingEnumeration
+    case awaitingStreamOpen
+    case awaitingReady
+    case awaitingFirstCallbackPhase
+    case awaitingFirstCallback
+    case awaitingActive
+    case active
+    case failed
+    case stopping
+    case stopped
+}
+
+private enum WorkerEvent {
+    case phase
+    case ready
+    case firstCallback(UInt64)
+    case health
+    case syntheticChunk(UInt64)
+    case failure(String)
+    case stopped
+}
+
+private enum WorkerMode: Equatable {
+    case microphone
+    case synthetic
+    case syntheticIgnoreCancel
+
+    var isSynthetic: Bool {
+        self != .microphone
+    }
+}
+
+private struct WorkerEvidence {
+    let canaryCount: UInt64
+    let firstCallbackMS: UInt64
+    let firstSyntheticSequence: UInt64?
+    let lastSyntheticSequence: UInt64?
+}
+
+private struct WorkerTermination {
+    let kind: String
+    let elapsedMS: UInt64
+    let workerExited: Bool
+    let processGroupEmpty: Bool
+    let exitSignal: UInt64
+}
+
+private final class WorkerSession {
+    private let mode: WorkerMode
+    private let process = Process()
+    private let input = Pipe()
+    private let output = Pipe()
+    private let nonce = "agent-\(UUID().uuidString)"
+    private let readerQueue = DispatchQueue(label: "com.localdictation.capture-agent.worker-reader")
+    private let completionQueue = DispatchQueue(label: "com.localdictation.capture-agent.worker-completion")
+    private let stateLock = NSLock()
+    private var completion: ((WorkerTermination) -> Void)?
+    private var stopStarted = DispatchTime.now()
+    private var stoppedFrameSeen = false
+    private var terminationSeen = false
+    private var readerCompleted = false
+    private var completionDelivered = false
+    private var cancelSent = false
+    private var hardKillSent = false
+    private var processGroupOwned = false
+    private var processGroupEmpty = false
+    private var processGroupCheckCompleted = false
+    private var exitSignal: UInt64 = 0
+    private var protocolState = WorkerProtocolState.awaitingEnumeration
+    private var nextSyntheticSequence: UInt64 = 0
+    private var lastHealthRank = 0
+    private var evidenceCanaryCount: UInt64 = 0
+    private var evidenceFirstCallbackMS: UInt64 = 0
+    private var evidenceFirstSyntheticSequence: UInt64?
+    private var evidenceLastSyntheticSequence: UInt64?
+
+    var onReady: ((UInt64) -> Void)?
+    var onCanary: (() -> Void)?
+    var onSyntheticChunk: ((UInt64) -> Void)?
+    var onFailure: ((String) -> Void)?
+
+    var pid: UInt64 {
+        UInt64(process.processIdentifier)
+    }
+
+    init(mode: WorkerMode) {
+        self.mode = mode
+    }
+
+    func start() throws {
+        let executable = URL(fileURLWithPath: CommandLine.arguments[0])
+            .deletingLastPathComponent()
+            .appendingPathComponent("murmur-capture-worker")
+        guard validateCaptureWorker(at: executable) else {
+            throw NSError(domain: agentIdentifier, code: 2)
+        }
+        process.executableURL = executable
+        switch mode {
+        case .microphone:
+            process.arguments = []
+        case .synthetic:
+            process.arguments = ["--synthetic-fixture", syntheticFixture]
+        case .syntheticIgnoreCancel:
+            process.arguments = [
+                "--synthetic-fixture", syntheticFixture, "--ignore-cancel",
+            ]
+        }
+        process.currentDirectoryURL = URL(fileURLWithPath: "/")
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        process.environment = [:]
+        process.terminationHandler = { [weak self] _ in
+            self?.processTerminated()
+        }
+        try process.run()
+        let groupDeadline = DispatchTime.now() + .seconds(1)
+        while process.isRunning,
+              Darwin.getpgid(process.processIdentifier) != process.processIdentifier,
+              DispatchTime.now() < groupDeadline {
+            usleep(1_000)
+        }
+        guard process.isRunning,
+              Darwin.getpgid(process.processIdentifier) == process.processIdentifier else {
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+            throw NSError(domain: agentIdentifier, code: 3)
+        }
+        stateLock.lock()
+        processGroupOwned = true
+        stateLock.unlock()
+
+        let hello: [String: Any] = [
+            "type": "hello",
+            "protocol": protocolName,
+            "version": protocolVersion,
+            "sessionNonce": nonce,
+        ]
+        guard writeFrame(hello, to: input.fileHandleForWriting) else {
+            process.terminate()
+            throw NSError(domain: agentIdentifier, code: 1)
+        }
+
+        readerQueue.async { [weak self] in
+            self?.readLoop()
+        }
+    }
+
+    private func validEnvelope(_ frame: [String: Any], keys: Set<String>) -> Bool {
+        Set(frame.keys) == keys
+            && frame["protocol"] as? String == protocolName
+            && exactUInt64(frame["version"]) == UInt64(protocolVersion)
+            && frame["sessionNonce"] as? String == nonce
+    }
+
+    private func readLoop() {
+        var expectedEOF = false
+        workerFrames: while let frame = readFrame(output.fileHandleForReading) {
+            guard let event = accept(frame) else {
+                onFailure?("protocol")
+                break workerFrames
+            }
+            switch event {
+            case .phase, .ready:
+                continue
+            case .firstCallback(let latency):
+                if mode == .microphone {
+                    onCanary?()
+                }
+                onReady?(latency)
+            case .health:
+                onCanary?()
+            case .syntheticChunk(let sequence):
+                onSyntheticChunk?(sequence)
+            case .failure(let code):
+                onFailure?(code)
+                break workerFrames
+            case .stopped:
+                continue
+            }
+        }
+        stateLock.lock()
+        readerCompleted = true
+        expectedEOF = cancelSent || terminationSeen
+        stateLock.unlock()
+        if !expectedEOF {
+            onFailure?("worker_stdout_eof")
+        }
+        deliverCompletionIfPossible()
+    }
+
+    private func accept(_ frame: [String: Any]) -> WorkerEvent? {
+        guard let type = frame["type"] as? String else { return nil }
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        switch type {
+        case "phase":
+            guard validEnvelope(
+                frame,
+                keys: ["type", "protocol", "version", "sessionNonce", "phase"]
+            ), let phase = frame["phase"] as? String else {
+                return nil
+            }
+            switch (protocolState, phase) {
+            case (.awaitingEnumeration, "enumeration"):
+                protocolState = .awaitingStreamOpen
+            case (.awaitingStreamOpen, "streamOpen"):
+                protocolState = .awaitingReady
+            case (.awaitingFirstCallbackPhase, "awaitingFirstCallback"):
+                protocolState = .awaitingFirstCallback
+            case (.awaitingActive, "active"):
+                protocolState = .active
+            case (_, "stopping")
+                where cancelSent
+                    && protocolState != .failed
+                    && protocolState != .stopping
+                    && protocolState != .stopped:
+                protocolState = .stopping
+            default:
+                return nil
+            }
+            return .phase
+        case "ready":
+            guard protocolState == .awaitingReady,
+                  validEnvelope(
+                      frame,
+                      keys: ["type", "protocol", "version", "sessionNonce"]
+                  ) else {
+                return nil
+            }
+            protocolState = .awaitingFirstCallbackPhase
+            return .ready
+        case "firstCallback":
+            guard protocolState == .awaitingFirstCallback,
+                  validEnvelope(
+                      frame,
+                      keys: [
+                          "type", "protocol", "version", "sessionNonce",
+                          "callbackLatencyMs",
+                      ]
+                  ), let latency = exactUInt64(frame["callbackLatencyMs"]),
+                  latency <= 60_000 else {
+                return nil
+            }
+            protocolState = .awaitingActive
+            evidenceFirstCallbackMS = latency
+            if mode == .microphone {
+                evidenceCanaryCount = min(maxCanaries, evidenceCanaryCount &+ 1)
+            }
+            return .firstCallback(latency)
+        case "callbackHealth":
+            guard protocolState == .active,
+                  validEnvelope(
+                      frame,
+                      keys: [
+                          "type", "protocol", "version", "sessionNonce",
+                          "callbackCountBucket",
+                      ]
+                  ), let bucket = frame["callbackCountBucket"] as? String,
+                  let rank = ["0", "le10", "le100", "le1k", "gt1k"].firstIndex(of: bucket),
+                  rank >= lastHealthRank else {
+                return nil
+            }
+            lastHealthRank = rank
+            evidenceCanaryCount = min(maxCanaries, evidenceCanaryCount &+ 1)
+            return .health
+        case "syntheticChunk":
+            guard mode.isSynthetic,
+                  protocolState == .active,
+                  validEnvelope(
+                      frame,
+                      keys: [
+                          "type", "protocol", "version", "sessionNonce",
+                          "fixture", "fixtureDigest", "sequence",
+                      ]
+                  ),
+                  frame["fixture"] as? String == syntheticFixture,
+                  frame["fixtureDigest"] as? String == syntheticFixtureDigest,
+                  let sequence = exactUInt64(frame["sequence"]),
+                  sequence == nextSyntheticSequence,
+                  sequence < syntheticFixtureChunks else {
+                return nil
+            }
+            nextSyntheticSequence &+= 1
+            if evidenceFirstSyntheticSequence == nil {
+                evidenceFirstSyntheticSequence = sequence
+            }
+            evidenceLastSyntheticSequence = sequence
+            evidenceCanaryCount = min(maxCanaries, evidenceCanaryCount &+ 1)
+            return .syntheticChunk(sequence)
+        case "failure":
+            guard protocolState != .failed,
+                  protocolState != .stopping,
+                  protocolState != .stopped,
+                  validEnvelope(
+                      frame,
+                      keys: ["type", "protocol", "version", "sessionNonce", "code"]
+                  ), let code = frame["code"] as? String,
+                  [
+                      "permissionDenied", "noInputDevice", "enumerationFailed",
+                      "configurationFailed", "streamOpenFailed", "streamStartFailed",
+                      "streamError", "callbackStalled", "invalidMessage", "internal",
+                  ].contains(code) else {
+                return nil
+            }
+            protocolState = .failed
+            return .failure(code)
+        case "stopped":
+            guard cancelSent,
+                  protocolState == .stopping,
+                  validEnvelope(
+                      frame,
+                      keys: ["type", "protocol", "version", "sessionNonce"]
+                  ) else {
+                return nil
+            }
+            protocolState = .stopped
+            stoppedFrameSeen = true
+            return .stopped
+        default:
+            return nil
+        }
+    }
+
+    func evidence() -> WorkerEvidence {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return WorkerEvidence(
+            canaryCount: evidenceCanaryCount,
+            firstCallbackMS: evidenceFirstCallbackMS,
+            firstSyntheticSequence: evidenceFirstSyntheticSequence,
+            lastSyntheticSequence: evidenceLastSyntheticSequence
+        )
+    }
+
+    func stop(completion: @escaping (WorkerTermination) -> Void) {
+        stateLock.lock()
+        self.completion = completion
+        stopStarted = DispatchTime.now()
+        cancelSent = true
+        stateLock.unlock()
+        let cancel: [String: Any] = [
+            "type": "cancel",
+            "protocol": protocolName,
+            "version": protocolVersion,
+            "sessionNonce": nonce,
+        ]
+        _ = writeFrame(cancel, to: input.fileHandleForWriting)
+        completionQueue.asyncAfter(deadline: .now() + .milliseconds(250)) { [weak self] in
+            guard let self, self.process.isRunning else { return }
+            self.stateLock.lock()
+            self.hardKillSent = true
+            let ownsGroup = self.processGroupOwned
+            self.stateLock.unlock()
+            let pid = self.process.processIdentifier
+            if !ownsGroup || Darwin.kill(-pid, SIGKILL) != 0 {
+                _ = Darwin.kill(pid, SIGKILL)
+            }
+        }
+        deliverCompletionIfPossible()
+    }
+
+    private func processTerminated() {
+        stateLock.lock()
+        terminationSeen = true
+        if process.terminationReason == .uncaughtSignal {
+            exitSignal = UInt64(process.terminationStatus)
+        }
+        let wasExpected = completion != nil
+        stateLock.unlock()
+        if !wasExpected {
+            onFailure?("worker_exited")
+        }
+        completionQueue.async { [weak self] in
+            self?.confirmProcessGroupEmpty()
+        }
+    }
+
+    private func confirmProcessGroupEmpty() {
+        let deadline = DispatchTime.now() + .seconds(2)
+        while true {
+            stateLock.lock()
+            let ownsGroup = processGroupOwned
+            stateLock.unlock()
+            let probe = ownsGroup ? Darwin.kill(-process.processIdentifier, 0) : -1
+            if !ownsGroup || (probe != 0 && Darwin.errno == ESRCH) {
+                stateLock.lock()
+                processGroupEmpty = true
+                stateLock.unlock()
+                break
+            }
+            _ = Darwin.kill(-process.processIdentifier, SIGKILL)
+            if DispatchTime.now() >= deadline {
+                break
+            }
+            usleep(5_000)
+        }
+        stateLock.lock()
+        processGroupCheckCompleted = true
+        stateLock.unlock()
+        deliverCompletionIfPossible()
+    }
+
+    private func deliverCompletionIfPossible() {
+        stateLock.lock()
+        guard terminationSeen,
+              readerCompleted,
+              processGroupCheckCompleted,
+              !completionDelivered,
+              let callback = completion else {
+            stateLock.unlock()
+            return
+        }
+        completionDelivered = true
+        let elapsed = DispatchTime.now().uptimeNanoseconds - stopStarted.uptimeNanoseconds
+        let kind = hardKillSent
+            ? (exitSignal == UInt64(SIGKILL) ? "hard_kill" : "kill_unconfirmed")
+            : (stoppedFrameSeen ? "cooperative" : "exited")
+        let termination = WorkerTermination(
+            kind: kind,
+            elapsedMS: elapsed / 1_000_000,
+            workerExited: terminationSeen,
+            processGroupEmpty: processGroupEmpty,
+            exitSignal: exitSignal
+        )
+        stateLock.unlock()
+        completionQueue.async {
+            callback(termination)
+        }
+    }
+}
+
+private struct PendingRecovery {
+    let generation: UInt64
+    let agentPID: UInt64
+    let agentBootNonce: String
+    let workerPID: UInt64
+    let syntheticCanaryCount: UInt64
+    let firstCallbackMS: UInt64
+    let workerTermination: String
+    let workerExited: Bool
+    let processGroupEmpty: Bool
+    let exitSignal: UInt64
+    let stopElapsedMS: UInt64
+    let expiresAt: DispatchTime
+    let syntheticFixture: String?
+    let syntheticDigest: String?
+    let syntheticFirstSequence: UInt64?
+    let syntheticLastSequence: UInt64?
+    var claimID: String?
+    var claimOwner: String?
+}
+
+private struct AcknowledgedTombstone {
+    let recovery: PendingRecovery
+}
+
+private final class AgentState {
+    private let queue = DispatchQueue(label: "com.localdictation.capture-agent.state")
+    // Opaque observation-only fingerprint. It is never used for authorization.
+    private let instanceFingerprint = UUID().uuidString
+    private var generation: UInt64 = 0
+    private var activeLeaseID: String?
+    private var worker: WorkerSession?
+    private var canaryCount: UInt64 = 0
+    private var firstCallbackMS: UInt64 = 0
+    private var startReplySent = false
+    private var pending: PendingRecovery?
+    private var acknowledged: AcknowledgedTombstone?
+    private var expiredGeneration: UInt64?
+    private var activeMode = WorkerMode.microphone
+    private var firstSyntheticSequence: UInt64?
+    private var lastSyntheticSequence: UInt64?
+
+    func handle(peerID: String, peer: xpc_connection_t, request: xpc_object_t) {
+        queue.async {
+            guard xpc_dictionary_get_count(request) == 1 else {
+                self.reply(
+                    peer: peer,
+                    request: request,
+                    fields: ["outcome": "invalid_command", "audio_content_retained": false]
+                )
+                return
+            }
+            switch xpcString(request, "command") {
+            case "start":
+                self.start(
+                    peerID: peerID,
+                    peer: peer,
+                    request: request,
+                    mode: .microphone
+                )
+            case "start_synthetic":
+                self.start(
+                    peerID: peerID,
+                    peer: peer,
+                    request: request,
+                    mode: .synthetic
+                )
+            case "start_synthetic_fault":
+                self.start(
+                    peerID: peerID,
+                    peer: peer,
+                    request: request,
+                    mode: .syntheticIgnoreCancel
+                )
+            case "stop":
+                self.stop(peerID: peerID, peer: peer, request: request)
+            case "recover":
+                self.recover(peerID: peerID, peer: peer, request: request)
+            case "status":
+                self.status(peer: peer, request: request)
+            default:
+                if let command = xpcString(request, "command"),
+                   command.hasPrefix("ack:"),
+                   command.utf8.count <= 132 {
+                    self.ack(
+                        peerID: peerID,
+                        claimID: String(command.dropFirst(4)),
+                        peer: peer,
+                        request: request
+                    )
+                } else {
+                    self.reply(
+                        peer: peer,
+                        request: request,
+                        fields: ["outcome": "invalid_command", "audio_content_retained": false]
+                    )
+                }
+            }
+        }
+    }
+
+    func disconnected(peerID: String) {
+        queue.async {
+            if self.activeLeaseID == peerID {
+                self.interruptActive()
+                return
+            }
+            if self.pending?.claimOwner == peerID {
+                self.pending?.claimOwner = nil
+                self.pending?.claimID = nil
+            }
+        }
+    }
+
+    private func start(
+        peerID: String,
+        peer: xpc_connection_t,
+        request: xpc_object_t,
+        mode: WorkerMode
+    ) {
+        expirePending()
+        guard activeLeaseID == nil, worker == nil, pending == nil else {
+            reply(
+                peer: peer,
+                request: request,
+                fields: ["outcome": "busy", "audio_content_retained": false]
+            )
+            return
+        }
+        generation &+= 1
+        acknowledged = nil
+        expiredGeneration = nil
+        canaryCount = 0
+        firstCallbackMS = 0
+        startReplySent = false
+        activeMode = mode
+        firstSyntheticSequence = nil
+        lastSyntheticSequence = nil
+        activeLeaseID = peerID
+
+        let nextWorker = WorkerSession(mode: mode)
+        worker = nextWorker
+        nextWorker.onCanary = { [weak self] in
+            self?.queue.async {
+                guard let self, self.activeLeaseID == peerID else { return }
+                self.canaryCount = min(maxCanaries, self.canaryCount &+ 1)
+            }
+        }
+        nextWorker.onReady = { [weak self] latency in
+            self?.queue.async {
+                guard let self,
+                      self.activeLeaseID == peerID,
+                      !self.startReplySent else { return }
+                self.startReplySent = true
+                self.firstCallbackMS = latency
+                self.reply(
+                    peer: peer,
+                    request: request,
+                    fields: [
+                        "outcome": "ready",
+                        "generation": self.generation,
+                        "agent_pid": UInt64(getpid()),
+                        "agent_instance": self.instanceFingerprint,
+                        "worker_pid": nextWorker.pid,
+                        "synthetic_canary_count": self.canaryCount,
+                        "first_callback_ms": latency,
+                        "audio_content_retained": false,
+                    ]
+                )
+            }
+        }
+        nextWorker.onSyntheticChunk = { [weak self] sequence in
+            self?.queue.async {
+                guard let self,
+                      self.activeLeaseID == peerID,
+                      self.activeMode.isSynthetic else { return }
+                if self.firstSyntheticSequence == nil {
+                    self.firstSyntheticSequence = sequence
+                }
+                self.lastSyntheticSequence = sequence
+                self.canaryCount = min(maxCanaries, self.canaryCount &+ 1)
+            }
+        }
+        nextWorker.onFailure = { [weak self] failure in
+            self?.queue.async {
+                guard let self, self.activeLeaseID == peerID else { return }
+                if !self.startReplySent {
+                    self.startReplySent = true
+                    self.reply(
+                        peer: peer,
+                        request: request,
+                        fields: [
+                            "outcome": "worker_failed",
+                            "failure": failure,
+                            "audio_content_retained": false,
+                        ]
+                    )
+                }
+                self.interruptActive()
+            }
+        }
+
+        do {
+            try nextWorker.start()
+        } catch {
+            worker = nil
+            activeLeaseID = nil
+            reply(
+                peer: peer,
+                request: request,
+                fields: ["outcome": "worker_spawn_failed", "audio_content_retained": false]
+            )
+        }
+    }
+
+    private func stop(peerID: String, peer: xpc_connection_t, request: xpc_object_t) {
+        guard activeLeaseID == peerID, let activeWorker = worker else {
+            reply(
+                peer: peer,
+                request: request,
+                fields: ["outcome": "not_active", "audio_content_retained": false]
+            )
+            return
+        }
+        let finalGeneration = generation
+        let finalMode = activeMode
+        activeLeaseID = nil
+        activeWorker.stop { termination in
+            let evidence = activeWorker.evidence()
+            self.queue.async {
+                guard self.worker === activeWorker,
+                      self.generation == finalGeneration else { return }
+                self.worker = nil
+                var fields: [String: Any] = [
+                    "outcome": termination.workerExited
+                        && termination.processGroupEmpty
+                        && termination.kind != "kill_unconfirmed"
+                        ? "stopped"
+                        : "stop_failed",
+                    "generation": finalGeneration,
+                    "synthetic_canary_count": evidence.canaryCount,
+                    "worker_termination": termination.kind,
+                    "stop_elapsed_ms": termination.elapsedMS,
+                    "worker_exited": termination.workerExited,
+                    "process_group_empty": termination.processGroupEmpty,
+                    "exit_signal": termination.exitSignal,
+                    "audio_content_retained": false,
+                ]
+                if finalMode.isSynthetic,
+                   let first = evidence.firstSyntheticSequence,
+                   let last = evidence.lastSyntheticSequence {
+                    fields["synthetic_fixture"] = syntheticFixture
+                    fields["synthetic_digest"] = syntheticFixtureDigest
+                    fields["synthetic_first_sequence"] = first
+                    fields["synthetic_last_sequence"] = last
+                    fields["synthetic_complete"] =
+                        first == 0
+                            && last == syntheticFixtureChunks - 1
+                            && evidence.canaryCount == syntheticFixtureChunks
+                }
+                self.reply(
+                    peer: peer,
+                    request: request,
+                    fields: fields
+                )
+            }
+        }
+    }
+
+    private func interruptActive() {
+        guard let activeWorker = worker else {
+            activeLeaseID = nil
+            return
+        }
+        let interrupted = PendingRecovery(
+            generation: generation,
+            agentPID: UInt64(getpid()),
+            agentBootNonce: instanceFingerprint,
+            workerPID: activeWorker.pid,
+            syntheticCanaryCount: canaryCount,
+            firstCallbackMS: firstCallbackMS,
+            workerTermination: "settling",
+            workerExited: false,
+            processGroupEmpty: false,
+            exitSignal: 0,
+            stopElapsedMS: 0,
+            expiresAt: .now() + .milliseconds(Int(recoveryTTL * 1_000)),
+            syntheticFixture: activeMode.isSynthetic ? syntheticFixture : nil,
+            syntheticDigest: activeMode.isSynthetic ? syntheticFixtureDigest : nil,
+            syntheticFirstSequence: firstSyntheticSequence,
+            syntheticLastSequence: lastSyntheticSequence,
+            claimID: nil,
+            claimOwner: nil
+        )
+        activeLeaseID = nil
+        pending = interrupted
+        scheduleExpiry(generation: interrupted.generation, at: interrupted.expiresAt)
+        activeWorker.stop { termination in
+            let evidence = activeWorker.evidence()
+            self.queue.async {
+                guard self.worker === activeWorker,
+                      self.pending?.generation == interrupted.generation else { return }
+                self.worker = nil
+                guard interrupted.expiresAt.uptimeNanoseconds > DispatchTime.now().uptimeNanoseconds else {
+                    self.markExpired(generation: interrupted.generation)
+                    self.pending = nil
+                    return
+                }
+                self.pending = PendingRecovery(
+                    generation: interrupted.generation,
+                    agentPID: interrupted.agentPID,
+                    agentBootNonce: interrupted.agentBootNonce,
+                    workerPID: interrupted.workerPID,
+                    syntheticCanaryCount: evidence.canaryCount,
+                    firstCallbackMS: evidence.firstCallbackMS,
+                    workerTermination: termination.kind,
+                    workerExited: termination.workerExited,
+                    processGroupEmpty: termination.processGroupEmpty,
+                    exitSignal: termination.exitSignal,
+                    stopElapsedMS: termination.elapsedMS,
+                    expiresAt: interrupted.expiresAt,
+                    syntheticFixture: interrupted.syntheticFixture,
+                    syntheticDigest: interrupted.syntheticDigest,
+                    syntheticFirstSequence: evidence.firstSyntheticSequence,
+                    syntheticLastSequence: evidence.lastSyntheticSequence,
+                    claimID: interrupted.claimID,
+                    claimOwner: interrupted.claimOwner
+                )
+            }
+        }
+    }
+
+    private func recover(
+        peerID: String,
+        peer: xpc_connection_t,
+        request: xpc_object_t
+    ) {
+        expirePending()
+        if let tombstone = acknowledged {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "already_acked",
+                    "generation": tombstone.recovery.generation,
+                    "recovered": false,
+                    "exact_once": true,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        if let expiredGeneration {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "expired",
+                    "generation": expiredGeneration,
+                    "recovered": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        if let recovery = pending, recovery.workerTermination == "settling" {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "settling",
+                    "recovered": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        if let recovery = pending,
+           (!recovery.workerExited || !recovery.processGroupEmpty) {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "isolation_failed",
+                    "recovered": false,
+                    "worker_exited": recovery.workerExited,
+                    "process_group_empty": recovery.processGroupEmpty,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        if let recovery = pending,
+           recovery.syntheticFixture != nil,
+           !(recovery.syntheticFirstSequence == 0
+                && recovery.syntheticLastSequence == syntheticFixtureChunks - 1
+                && recovery.syntheticCanaryCount == syntheticFixtureChunks) {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "synthetic_incomplete",
+                    "recovered": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        guard var recovery = pending, recovery.syntheticCanaryCount > 0 else {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "none",
+                    "recovered": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        if let owner = recovery.claimOwner, owner != peerID {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "claim_busy",
+                    "recovered": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        let claimID = recovery.claimID ?? UUID().uuidString
+        if recovery.claimID == nil {
+            recovery.claimID = claimID
+            recovery.claimOwner = peerID
+            pending = recovery
+        }
+        var fields = recoveryFields(recovery)
+        fields["outcome"] = "recovery_offer"
+        fields["claim_id"] = claimID
+        fields["recovered"] = false
+        fields["exact_once"] = false
+        reply(peer: peer, request: request, fields: fields)
+    }
+
+    private func ack(
+        peerID: String,
+        claimID: String,
+        peer: xpc_connection_t,
+        request: xpc_object_t
+    ) {
+        expirePending()
+        if let tombstone = acknowledged,
+           tombstone.recovery.claimID == claimID,
+           tombstone.recovery.claimOwner == peerID {
+            var fields = recoveryFields(tombstone.recovery)
+            fields["outcome"] = "recovery_acked"
+            fields["claim_id"] = claimID
+            fields["recovered"] = true
+            fields["exact_once"] = true
+            reply(peer: peer, request: request, fields: fields)
+            return
+        }
+        guard !claimID.isEmpty,
+              let recovery = pending,
+              recovery.claimID == claimID,
+              recovery.claimOwner == peerID,
+              recovery.workerTermination != "settling" else {
+            reply(
+                peer: peer,
+                request: request,
+                fields: [
+                    "outcome": "claim_rejected",
+                    "recovered": false,
+                    "exact_once": false,
+                    "audio_content_retained": false,
+                ]
+            )
+            return
+        }
+        pending = nil
+        acknowledged = AcknowledgedTombstone(recovery: recovery)
+        scheduleAcknowledgedExpiry(
+            claimID: claimID,
+            at: recovery.expiresAt
+        )
+        var fields = recoveryFields(recovery)
+        fields["outcome"] = "recovery_acked"
+        fields["claim_id"] = claimID
+        fields["recovered"] = true
+        fields["exact_once"] = true
+        reply(peer: peer, request: request, fields: fields)
+    }
+
+    private func recoveryFields(_ recovery: PendingRecovery) -> [String: Any] {
+        var fields: [String: Any] = [
+            "generation": recovery.generation,
+            "agent_pid": recovery.agentPID,
+            "agent_instance": recovery.agentBootNonce,
+            "worker_pid": recovery.workerPID,
+            "synthetic_canary_count": recovery.syntheticCanaryCount,
+            "first_callback_ms": recovery.firstCallbackMS,
+            "worker_termination": recovery.workerTermination,
+            "stop_elapsed_ms": recovery.stopElapsedMS,
+            "recovery_ttl_ms": remainingMilliseconds(until: recovery.expiresAt),
+            "agent_survived": true,
+            "worker_exited": recovery.workerExited,
+            "process_group_empty": recovery.processGroupEmpty,
+            "exit_signal": recovery.exitSignal,
+            "audio_content_retained": false,
+        ]
+        if let fixture = recovery.syntheticFixture,
+           let digest = recovery.syntheticDigest,
+           let first = recovery.syntheticFirstSequence,
+           let last = recovery.syntheticLastSequence {
+            fields["synthetic_fixture"] = fixture
+            fields["synthetic_digest"] = digest
+            fields["synthetic_first_sequence"] = first
+            fields["synthetic_last_sequence"] = last
+            fields["synthetic_complete"] =
+                first == 0
+                    && last == syntheticFixtureChunks - 1
+                    && recovery.syntheticCanaryCount == syntheticFixtureChunks
+        }
+        return fields
+    }
+
+    private func status(peer: xpc_connection_t, request: xpc_object_t) {
+        expirePending()
+        let activeWorkerPID = worker?.pid ?? pending?.workerPID ?? 0
+        let visibleCanaries = activeLeaseID == nil
+            ? (pending?.syntheticCanaryCount ?? 0)
+            : canaryCount
+        reply(
+            peer: peer,
+            request: request,
+            fields: [
+                "outcome": activeLeaseID == nil ? (pending == nil ? "idle" : "pending") : "active",
+                "agent_pid": UInt64(getpid()),
+                "agent_instance": instanceFingerprint,
+                "generation": generation,
+                "worker_pid": activeWorkerPID,
+                "synthetic_canary_count": visibleCanaries,
+                "audio_content_retained": false,
+            ]
+        )
+    }
+
+    private func expirePending() {
+        if let recovery = pending,
+           recovery.expiresAt.uptimeNanoseconds <= DispatchTime.now().uptimeNanoseconds,
+           worker == nil {
+            markExpired(generation: recovery.generation)
+            pending = nil
+        }
+        if let tombstone = acknowledged,
+           tombstone.recovery.expiresAt.uptimeNanoseconds
+            <= DispatchTime.now().uptimeNanoseconds {
+            markExpired(generation: tombstone.recovery.generation)
+            acknowledged = nil
+        }
+    }
+
+    private func remainingMilliseconds(until deadline: DispatchTime) -> UInt64 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard deadline.uptimeNanoseconds > now else { return 0 }
+        return (deadline.uptimeNanoseconds - now) / 1_000_000
+    }
+
+    private func markExpired(generation: UInt64) {
+        expiredGeneration = generation
+    }
+
+    private func scheduleExpiry(generation: UInt64, at deadline: DispatchTime) {
+        queue.asyncAfter(deadline: deadline) {
+            guard self.pending?.generation == generation,
+                  self.worker == nil else {
+                return
+            }
+            self.markExpired(generation: generation)
+            self.pending = nil
+        }
+    }
+
+    private func scheduleAcknowledgedExpiry(claimID: String, at deadline: DispatchTime) {
+        queue.asyncAfter(deadline: deadline) {
+            guard let tombstone = self.acknowledged,
+                  tombstone.recovery.claimID == claimID else { return }
+            self.acknowledged = nil
+            self.markExpired(generation: tombstone.recovery.generation)
+        }
+    }
+
+    private func reply(
+        peer: xpc_connection_t,
+        request: xpc_object_t,
+        fields: [String: Any]
+    ) {
+        guard let response = xpc_dictionary_create_reply(request) else { return }
+        setXPCUInt64(response, "schema_version", 1)
+        for (key, value) in fields {
+            switch value {
+            case let text as String:
+                setXPCString(response, key, text)
+            case let number as UInt64:
+                setXPCUInt64(response, key, number)
+            case let number as Int:
+                setXPCUInt64(response, key, UInt64(number))
+            case let flag as Bool:
+                setXPCBool(response, key, flag)
+            default:
+                continue
+            }
+        }
+        xpc_connection_send_message(peer, response)
+    }
+}
+
+private func applyPeerRequirement(_ connection: xpc_connection_t) -> Bool {
+    peerRequirement.withCString { requirement in
+        xpc_connection_set_peer_code_signing_requirement(connection, requirement) == 0
+    }
+}
+
+private func makeClientConnection() -> xpc_connection_t? {
+    let connection = xpc_connection_create_mach_service(machServiceName, nil, 0)
+    guard applyPeerRequirement(connection) else {
+        xpc_connection_cancel(connection)
+        return nil
+    }
+    xpc_connection_set_event_handler(connection) { _ in }
+    xpc_connection_activate(connection)
+    return connection
+}
+
+private func sendRequest(
+    connection: xpc_connection_t,
+    command: String,
+    timeout: TimeInterval = 8
+) -> xpc_object_t? {
+    let request = xpc_dictionary_create_empty()
+    setXPCString(request, "command", command)
+    let semaphore = DispatchSemaphore(value: 0)
+    let lock = NSLock()
+    var result: xpc_object_t?
+    xpc_connection_send_message_with_reply(connection, request, nil) { reply in
+        lock.lock()
+        result = xpc_get_type(reply) == XPC_TYPE_DICTIONARY ? reply : nil
+        lock.unlock()
+        semaphore.signal()
+    }
+    guard semaphore.wait(timeout: .now() + timeout) == .success else { return nil }
+    lock.lock()
+    defer { lock.unlock() }
+    return result
+}
+
+private func runClient(_ command: String) -> Int32 {
+    guard let connection = makeClientConnection() else {
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "unsupported_os",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let reply = sendRequest(connection: connection, command: command) else {
+        xpc_connection_cancel(connection)
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "xpc_timeout",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let response = dictionary(from: reply) else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    jsonLine(response)
+    xpc_connection_cancel(connection)
+    let allowed: Set<String> = command == "status"
+        ? ["idle", "active", "pending"]
+        : []
+    guard let outcome = response["outcome"] as? String,
+          allowed.contains(outcome) else {
+        return 2
+    }
+    return 0
+}
+
+private func replayEquivalent(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
+    var first = lhs
+    var second = rhs
+    first.removeValue(forKey: "recovery_ttl_ms")
+    second.removeValue(forKey: "recovery_ttl_ms")
+    return NSDictionary(dictionary: first).isEqual(to: second)
+}
+
+private func runRecoveryClient(replayAcknowledgement: Bool) -> Int32 {
+    guard let connection = makeClientConnection() else {
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "unsupported_os",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let reply = sendRequest(connection: connection, command: "recover") else {
+        xpc_connection_cancel(connection)
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "xpc_timeout",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let offer = dictionary(from: reply) else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    jsonLine(offer)
+    if ["recovery_acked", "already_acked"].contains(
+        offer["outcome"] as? String ?? ""
+    ) {
+        xpc_connection_cancel(connection)
+        return 0
+    }
+    guard offer["outcome"] as? String == "recovery_offer" else {
+        xpc_connection_cancel(connection)
+        return ["none", "settling", "expired"].contains(
+            offer["outcome"] as? String ?? ""
+        ) ? 0 : 2
+    }
+    guard let claimID = offer["claim_id"] as? String,
+          !claimID.isEmpty,
+          readLine() == "ack:\(claimID)" else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    var ackReply: xpc_object_t?
+    for _ in 0..<2 {
+        ackReply = sendRequest(connection: connection, command: "ack:\(claimID)")
+        if ackReply != nil { break }
+    }
+    guard let ackReply else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    guard let firstAck = dictionary(from: ackReply),
+          firstAck["outcome"] as? String == "recovery_acked" else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    let ack: [String: Any]
+    if replayAcknowledgement {
+        guard let replayReply = sendRequest(
+            connection: connection,
+            command: "ack:\(claimID)"
+        ),
+        let replay = dictionary(from: replayReply),
+        replay["outcome"] as? String == "recovery_acked",
+        replayEquivalent(firstAck, replay) else {
+            xpc_connection_cancel(connection)
+            return 2
+        }
+        ack = replay
+    } else {
+        ack = firstAck
+    }
+    jsonLine(ack)
+    xpc_connection_cancel(connection)
+    return ack["outcome"] as? String == "recovery_acked" ? 0 : 2
+}
+
+private func runLeaseClient(startCommand: String) -> Int32 {
+    guard let connection = makeClientConnection() else {
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "unsupported_os",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let reply = sendRequest(connection: connection, command: startCommand) else {
+        xpc_connection_cancel(connection)
+        jsonLine([
+            "schema_version": 1,
+            "outcome": "xpc_timeout",
+            "audio_content_retained": false,
+        ])
+        return 2
+    }
+    guard let ready = dictionary(from: reply) else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    jsonLine(ready)
+    guard ready["outcome"] as? String == "ready" else {
+        xpc_connection_cancel(connection)
+        return 2
+    }
+    while let line = readLine() {
+        if line == "stop" {
+            if let stopped = sendRequest(connection: connection, command: "stop"),
+               let response = dictionary(from: stopped) {
+                jsonLine(response)
+            }
+            break
+        }
+    }
+    xpc_connection_cancel(connection)
+    return 0
+}
+
+private func runServer() -> Never {
+    let state = AgentState()
+    let listener = xpc_connection_create_mach_service(
+        machServiceName,
+        nil,
+        UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER)
+    )
+    xpc_connection_set_event_handler(listener) { event in
+        guard xpc_get_type(event) == XPC_TYPE_CONNECTION else { return }
+        let peer = event
+        let peerID = UUID().uuidString
+        guard applyPeerRequirement(peer) else {
+            xpc_connection_cancel(peer)
+            return
+        }
+        xpc_connection_set_event_handler(peer) { request in
+            if xpc_get_type(request) == XPC_TYPE_DICTIONARY {
+                state.handle(peerID: peerID, peer: peer, request: request)
+            } else {
+                state.disconnected(peerID: peerID)
+            }
+        }
+        xpc_connection_activate(peer)
+    }
+    xpc_connection_activate(listener)
+    dispatchMain()
+}
+
+@main
+private struct CaptureAgentMain {
+    static func main() {
+        disableCoreDumps()
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        if arguments.isEmpty {
+            runServer()
+        } else if arguments == ["lease"] {
+            exit(runLeaseClient(startCommand: "start"))
+        } else if arguments == ["lease-synthetic"] {
+            exit(runLeaseClient(startCommand: "start_synthetic"))
+        } else if arguments == ["lease-synthetic-fault"] {
+            exit(runLeaseClient(startCommand: "start_synthetic_fault"))
+        } else if arguments == ["recover"] {
+            exit(runRecoveryClient(replayAcknowledgement: false))
+        } else if arguments == ["recover-replay-ack"] {
+            exit(runRecoveryClient(replayAcknowledgement: true))
+        } else if arguments == ["status"] {
+            exit(runClient("status"))
+        } else {
+            jsonLine([
+                "schema_version": 1,
+                "outcome": "invalid_arguments",
+                "audio_content_retained": false,
+            ])
+            exit(64)
+        }
+    }
+}

--- a/app/src-tauri/sidecars/capture/WorkerInfo.plist
+++ b/app/src-tauri/sidecars/capture/WorkerInfo.plist
@@ -5,13 +5,13 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>
-    <string>murmur-capture-helper</string>
+    <string>murmur-capture-worker</string>
     <key>CFBundleIdentifier</key>
-    <string>com.localdictation.capture-helper</string>
+    <string>com.localdictation.capture-worker</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>Murmur Capture Helper</string>
+    <string>Murmur Capture Worker</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/app/src-tauri/sidecars/capture/build.rs
+++ b/app/src-tauri/sidecars/capture/build.rs
@@ -2,14 +2,31 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=Info.plist");
+    println!("cargo:rerun-if-changed=WorkerInfo.plist");
+    println!("cargo:rerun-if-env-changed=MURMUR_CAPTURE_ROLE");
+    println!("cargo:rerun-if-env-changed=MURMUR_APP_VERSION");
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
         let manifest_dir = PathBuf::from(
             std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set"),
         );
-        let info_plist = manifest_dir.join("Info.plist");
+        let role = std::env::var("MURMUR_CAPTURE_ROLE").unwrap_or_else(|_| "helper".to_string());
+        let template = match role.as_str() {
+            "helper" => manifest_dir.join("Info.plist"),
+            "worker" => manifest_dir.join("WorkerInfo.plist"),
+            _ => panic!("MURMUR_CAPTURE_ROLE must be helper or worker"),
+        };
+        let version = std::env::var("MURMUR_APP_VERSION")
+            .unwrap_or_else(|_| std::env::var("CARGO_PKG_VERSION").unwrap());
+        let payload = std::fs::read_to_string(template)
+            .expect("capture executable Info.plist template is readable")
+            .replace("__MURMUR_VERSION__", &version);
+        let output = PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR is set"))
+            .join(format!("capture-{role}-Info.plist"));
+        std::fs::write(&output, payload)
+            .expect("generated capture executable Info.plist is writable");
         println!(
             "cargo:rustc-link-arg=-Wl,-sectcreate,__TEXT,__info_plist,{}",
-            info_plist.display()
+            output.display()
         );
     }
 }

--- a/app/src-tauri/sidecars/capture/src/main.rs
+++ b/app/src-tauri/sidecars/capture/src/main.rs
@@ -4,7 +4,8 @@ mod supported {
     use cpal::{SampleFormat, Stream, StreamConfig};
     use murmur_capture_helper_protocol::{
         read_frame, valid_host_message, write_frame, CapturePhase, FailureCode, HelperMessage,
-        HostMessage, PROTOCOL_NAME, PROTOCOL_VERSION,
+        HostMessage, PROTOCOL_NAME, PROTOCOL_VERSION, SYNTHETIC_FIXTURE, SYNTHETIC_FIXTURE_CHUNKS,
+        SYNTHETIC_FIXTURE_DIGEST,
     };
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{mpsc, Arc};
@@ -98,8 +99,109 @@ mod supported {
         }
     }
 
-    pub fn run() -> Result<(), ()> {
+    fn establish_process_group() -> Result<(), ()> {
+        let pid = unsafe { libc::getpid() };
+        if unsafe { libc::setpgid(0, 0) } != 0 && unsafe { libc::getpgrp() } != pid {
+            return Err(());
+        }
+        if unsafe { libc::getpgrp() } != pid {
+            return Err(());
+        }
+        Ok(())
+    }
+
+    fn wait_for_cancel(
+        host_rx: &mpsc::Receiver<HostMessage>,
+        stdout: &mut impl std::io::Write,
+        nonce: &str,
+    ) -> Result<(), ()> {
+        match host_rx.recv() {
+            Ok(HostMessage::Cancel {
+                protocol,
+                version,
+                session_nonce,
+            }) if protocol == PROTOCOL_NAME
+                && version == PROTOCOL_VERSION
+                && session_nonce == nonce =>
+            {
+                write_frame(stdout, &message(nonce, CapturePhase::Stopping)).map_err(|_| ())?;
+                write_frame(
+                    stdout,
+                    &HelperMessage::Stopped {
+                        protocol: PROTOCOL_NAME.to_string(),
+                        version: PROTOCOL_VERSION,
+                        session_nonce: nonce.to_string(),
+                    },
+                )
+                .map_err(|_| ())
+            }
+            _ => {
+                write_frame(stdout, &failure(nonce, FailureCode::InvalidMessage))
+                    .map_err(|_| ())?;
+                Err(())
+            }
+        }
+    }
+
+    fn run_synthetic(
+        host_rx: &mpsc::Receiver<HostMessage>,
+        stdout: &mut impl std::io::Write,
+        nonce: &str,
+        ignore_cancel: bool,
+    ) -> Result<(), ()> {
+        for phase in [CapturePhase::Enumeration, CapturePhase::StreamOpen] {
+            write_frame(stdout, &message(nonce, phase)).map_err(|_| ())?;
+        }
+        write_frame(
+            stdout,
+            &HelperMessage::Ready {
+                protocol: PROTOCOL_NAME.to_string(),
+                version: PROTOCOL_VERSION,
+                session_nonce: nonce.to_string(),
+            },
+        )
+        .map_err(|_| ())?;
+        write_frame(stdout, &message(nonce, CapturePhase::AwaitingFirstCallback))
+            .map_err(|_| ())?;
+        write_frame(
+            stdout,
+            &HelperMessage::FirstCallback {
+                protocol: PROTOCOL_NAME.to_string(),
+                version: PROTOCOL_VERSION,
+                session_nonce: nonce.to_string(),
+                callback_latency_ms: 0,
+            },
+        )
+        .map_err(|_| ())?;
+        write_frame(stdout, &message(nonce, CapturePhase::Active)).map_err(|_| ())?;
+        for sequence in 0..SYNTHETIC_FIXTURE_CHUNKS {
+            write_frame(
+                stdout,
+                &HelperMessage::SyntheticChunk {
+                    protocol: PROTOCOL_NAME.to_string(),
+                    version: PROTOCOL_VERSION,
+                    session_nonce: nonce.to_string(),
+                    fixture: SYNTHETIC_FIXTURE.to_string(),
+                    fixture_digest: SYNTHETIC_FIXTURE_DIGEST.to_string(),
+                    sequence,
+                },
+            )
+            .map_err(|_| ())?;
+        }
+        if ignore_cancel {
+            loop {
+                std::thread::park_timeout(Duration::from_secs(60));
+            }
+        }
+        wait_for_cancel(host_rx, stdout, nonce)
+    }
+
+    pub fn run(synthetic: bool, ignore_cancel: bool) -> Result<(), ()> {
         disable_core_dumps();
+        // The worker establishes its own group before reading the host hello or
+        // touching CoreAudio. A parent-side setpgid after Process.run() races
+        // with exec and is permitted to fail with EACCES on macOS.
+        establish_process_group()?;
         let mut stdin = std::io::stdin().lock();
         let mut stdout = std::io::stdout().lock();
         let hello = read_frame::<HostMessage>(&mut stdin).map_err(|_| ())?;
@@ -120,7 +222,15 @@ mod supported {
                     return;
                 }
             }
+            // The agent owns this worker through the stdin pipe. If the agent is
+            // killed while CoreAudio is blocked, the reader thread is still able
+            // to terminate the whole worker immediately on EOF.
+            unsafe { libc::_exit(0) }
         });
+
+        if synthetic {
+            return run_synthetic(&host_rx, &mut stdout, &nonce, ignore_cancel);
+        }
 
         write_frame(&mut stdout, &message(&nonce, CapturePhase::Enumeration)).map_err(|_| ())?;
         let host = cpal::default_host();
@@ -270,8 +380,28 @@ mod supported {
 
 fn main() {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    if supported::run().is_ok() {
-        return;
+    {
+        let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+        let (synthetic, ignore_cancel) = match arguments.as_slice() {
+            [] => (false, false),
+            [flag, fixture]
+                if flag == "--synthetic-fixture"
+                    && fixture == murmur_capture_helper_protocol::SYNTHETIC_FIXTURE =>
+            {
+                (true, false)
+            }
+            [flag, fixture, fault]
+                if flag == "--synthetic-fixture"
+                    && fixture == murmur_capture_helper_protocol::SYNTHETIC_FIXTURE
+                    && fault == "--ignore-cancel" =>
+            {
+                (true, true)
+            }
+            _ => std::process::exit(64),
+        };
+        if supported::run(synthetic, ignore_cancel).is_ok() {
+            return;
+        }
     }
     std::process::exit(70);
 }

--- a/app/src-tauri/src/capture_agent_probe.rs
+++ b/app/src-tauri/src/capture_agent_probe.rs
@@ -1,0 +1,1021 @@
+//! Opt-in LaunchAgent recovery spike for issue #407.
+//!
+//! The production dictation path does not use this module. Signed/notarized
+//! builds expose a narrow CLI so LaunchServices can register the experimental
+//! per-user agent, hold a microphone lease, and claim content-free recovery
+//! evidence after macOS restarts the main application.
+
+use crate::managed_child::{bundled_sibling, ManagedChild};
+use serde_json::{Map, Value};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const CAPTURE_AGENT_NAME: &str = "murmur-capture-agent";
+const CAPTURE_AGENT_IDENTIFIER: &str = "com.localdictation.capture-agent";
+const DEFAULT_OBSERVE: Duration = Duration::from_secs(5);
+const MAX_OBSERVE_SECONDS: u64 = 300;
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+const SERVICE_TRANSITION_TIMEOUT: Duration = Duration::from_secs(15);
+const SERVICE_PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceCommand {
+    Register,
+    Refresh,
+    Status,
+    Unregister,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliRequest {
+    NotRequested,
+    Service(ServiceCommand),
+    Probe(Duration),
+    SyntheticProbe(Duration),
+    SyntheticFaultProbe(Duration),
+    Recover,
+    RecoverReplayAck,
+    Status,
+    Invalid,
+}
+
+fn parse_cli_request(arguments: impl IntoIterator<Item = String>) -> CliRequest {
+    let arguments = arguments.into_iter().collect::<Vec<_>>();
+    match arguments.as_slice() {
+        [] => CliRequest::NotRequested,
+        [flag, command] if flag == "--capture-agent-service" => match command.as_str() {
+            "register" => CliRequest::Service(ServiceCommand::Register),
+            "refresh" => CliRequest::Service(ServiceCommand::Refresh),
+            "status" => CliRequest::Service(ServiceCommand::Status),
+            "unregister" => CliRequest::Service(ServiceCommand::Unregister),
+            _ => CliRequest::Invalid,
+        },
+        [flag] if flag == "--capture-agent-probe" => CliRequest::Probe(DEFAULT_OBSERVE),
+        [flag] if flag == "--capture-agent-synthetic-probe" => {
+            CliRequest::SyntheticProbe(DEFAULT_OBSERVE)
+        }
+        [flag] if flag == "--capture-agent-synthetic-fault-probe" => {
+            CliRequest::SyntheticFaultProbe(DEFAULT_OBSERVE)
+        }
+        [flag, duration_flag, seconds]
+            if flag == "--capture-agent-probe" && duration_flag == "--observe-seconds" =>
+        {
+            match seconds.parse::<u64>() {
+                Ok(seconds @ 1..=MAX_OBSERVE_SECONDS) => {
+                    CliRequest::Probe(Duration::from_secs(seconds))
+                }
+                _ => CliRequest::Invalid,
+            }
+        }
+        [flag, duration_flag, seconds]
+            if flag == "--capture-agent-synthetic-probe"
+                && duration_flag == "--observe-seconds" =>
+        {
+            match seconds.parse::<u64>() {
+                Ok(seconds @ 1..=MAX_OBSERVE_SECONDS) => {
+                    CliRequest::SyntheticProbe(Duration::from_secs(seconds))
+                }
+                _ => CliRequest::Invalid,
+            }
+        }
+        [flag, duration_flag, seconds]
+            if flag == "--capture-agent-synthetic-fault-probe"
+                && duration_flag == "--observe-seconds" =>
+        {
+            match seconds.parse::<u64>() {
+                Ok(seconds @ 1..=MAX_OBSERVE_SECONDS) => {
+                    CliRequest::SyntheticFaultProbe(Duration::from_secs(seconds))
+                }
+                _ => CliRequest::Invalid,
+            }
+        }
+        [flag] if flag == "--capture-agent-recover" => CliRequest::Recover,
+        [flag] if flag == "--capture-agent-recover-replay-ack" => CliRequest::RecoverReplayAck,
+        [flag] if flag == "--capture-agent-status" => CliRequest::Status,
+        [first, ..] if first.starts_with("--capture-agent-") => CliRequest::Invalid,
+        _ => CliRequest::NotRequested,
+    }
+}
+
+fn content_free_error(outcome: &str) -> Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "outcome": outcome,
+        "audio_content_retained": false
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "ServiceManagement", kind = "framework")]
+unsafe extern "C" {}
+
+#[cfg(target_os = "macos")]
+fn service_status_name(status: isize) -> &'static str {
+    match status {
+        0 => "not_registered",
+        1 => "enabled",
+        2 => "requires_approval",
+        3 => "not_found",
+        _ => "unknown",
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn service_response(outcome: &str, status: isize, exit_code: i32) -> (Value, i32) {
+    (
+        serde_json::json!({
+            "schema_version": 1,
+            "outcome": outcome,
+            "service_status": service_status_name(status),
+            "audio_content_retained": false
+        }),
+        exit_code,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn registered_service_pids() -> Result<Vec<u64>, ()> {
+    let (status, exit_code) = run_one_shot(&["status"], &["idle", "active", "pending"]);
+    if exit_code != 0 {
+        return Err(());
+    }
+    let agent_pid = status
+        .get("agent_pid")
+        .and_then(Value::as_u64)
+        .filter(|pid| (2..=i32::MAX as u64).contains(pid))
+        .ok_or(())?;
+    let mut pids = vec![agent_pid];
+    pids.extend(
+        ["worker_pid"]
+            .into_iter()
+            .filter_map(|key| status.get(key).and_then(Value::as_u64))
+            .filter(|pid| (2..=i32::MAX as u64).contains(pid)),
+    );
+    Ok(pids)
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_processes_to_exit(pids: &[u64], timeout: Duration) -> bool {
+    if pids.is_empty() {
+        return true;
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        let any_alive = pids.iter().any(|pid| {
+            let result = unsafe { libc::kill(*pid as i32, 0) };
+            result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+        });
+        if !any_alive {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_service_command(command: ServiceCommand) -> (Value, i32) {
+    use block2::RcBlock;
+    use objc2::msg_send;
+    use objc2::runtime::{AnyClass, AnyObject, Bool};
+    use objc2_foundation::NSString;
+
+    unsafe {
+        let Some(class) = AnyClass::get(c"SMAppService") else {
+            return (content_free_error("service_unavailable"), 2);
+        };
+        let plist_name = NSString::from_str("com.localdictation.capture-agent.plist");
+        let service: *mut AnyObject = msg_send![class, agentServiceWithPlistName: &*plist_name];
+        if service.is_null() {
+            return (content_free_error("service_unavailable"), 2);
+        }
+
+        let mut status: isize = msg_send![service, status];
+        if matches!(status, 3) || !matches!(status, 0..=3) {
+            return service_response("service_error", status, 2);
+        }
+        if command == ServiceCommand::Status {
+            return service_response("service_status", status, 0);
+        }
+
+        let observed_pids = if matches!(
+            command,
+            ServiceCommand::Refresh | ServiceCommand::Unregister
+        ) && status == 1
+        {
+            match registered_service_pids() {
+                Ok(pids) => pids,
+                Err(()) => return service_response("service_error", status, 2),
+            }
+        } else {
+            Vec::new()
+        };
+
+        if matches!(
+            command,
+            ServiceCommand::Refresh | ServiceCommand::Unregister
+        ) && matches!(status, 1 | 2)
+        {
+            let (sender, receiver) = mpsc::sync_channel(1);
+            let completion = RcBlock::new(move |error: *mut AnyObject| {
+                let _ = sender.send(error.is_null());
+            });
+            let _: () = msg_send![service, unregisterWithCompletionHandler: &*completion];
+            if receiver.recv_timeout(SERVICE_TRANSITION_TIMEOUT) != Ok(true) {
+                status = msg_send![service, status];
+                return service_response("service_error", status, 2);
+            }
+            let status_deadline = Instant::now() + SERVICE_PROCESS_EXIT_TIMEOUT;
+            loop {
+                status = msg_send![service, status];
+                if status == 0 || Instant::now() >= status_deadline {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            if status != 0
+                || !wait_for_processes_to_exit(&observed_pids, SERVICE_PROCESS_EXIT_TIMEOUT)
+            {
+                return service_response("service_error", status, 2);
+            }
+        }
+
+        if command == ServiceCommand::Unregister {
+            return service_response(
+                if status == 0 {
+                    "service_status"
+                } else {
+                    "service_error"
+                },
+                status,
+                if status == 0 { 0 } else { 2 },
+            );
+        }
+
+        if status == 0 {
+            let mut error: *mut AnyObject = std::ptr::null_mut();
+            let succeeded: Bool = msg_send![service, registerAndReturnError: &mut error];
+            if !succeeded.as_bool() {
+                status = msg_send![service, status];
+                return service_response("service_error", status, 2);
+            }
+            let status_deadline = Instant::now() + SERVICE_PROCESS_EXIT_TIMEOUT;
+            loop {
+                status = msg_send![service, status];
+                if matches!(status, 1 | 2) || Instant::now() >= status_deadline {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+
+        service_response(
+            if status == 1 {
+                "service_status"
+            } else {
+                "service_error"
+            },
+            status,
+            if status == 1 { 0 } else { 2 },
+        )
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_service_command(_command: ServiceCommand) -> (Value, i32) {
+    (content_free_error("service_unavailable"), 2)
+}
+
+fn allowed_key(key: &str) -> bool {
+    matches!(
+        key,
+        "schema_version"
+            | "outcome"
+            | "service_status"
+            | "agent_instance"
+            | "worker_termination"
+            | "failure"
+            | "generation"
+            | "agent_pid"
+            | "worker_pid"
+            | "synthetic_canary_count"
+            | "first_callback_ms"
+            | "stop_elapsed_ms"
+            | "recovery_ttl_ms"
+            | "audio_content_retained"
+            | "recovered"
+            | "agent_survived"
+            | "worker_exited"
+            | "process_group_empty"
+            | "exit_signal"
+            | "exact_once"
+            | "claim_id"
+            | "synthetic_fixture"
+            | "synthetic_digest"
+            | "synthetic_first_sequence"
+            | "synthetic_last_sequence"
+            | "synthetic_complete"
+    )
+}
+
+fn parse_allowlisted_json(line: &str) -> Result<Map<String, Value>, ()> {
+    if line.len() > 8_192 || line.contains('\0') {
+        return Err(());
+    }
+    let value: Value = serde_json::from_str(line).map_err(|_| ())?;
+    let object = value.as_object().ok_or(())?;
+    if object.keys().any(|key| !allowed_key(key))
+        || object.get("schema_version").and_then(Value::as_u64) != Some(1)
+        || object
+            .get("audio_content_retained")
+            .and_then(Value::as_bool)
+            != Some(false)
+        || object.get("outcome").and_then(Value::as_str).is_none()
+    {
+        return Err(());
+    }
+    Ok(object.clone())
+}
+
+fn has_exact_keys(object: &Map<String, Value>, keys: &[&str]) -> bool {
+    object.len() == keys.len() && keys.iter().all(|key| object.contains_key(*key))
+}
+
+fn valid_common(object: &Map<String, Value>, outcome: &str) -> bool {
+    object.get("schema_version").and_then(Value::as_u64) == Some(1)
+        && object.get("outcome").and_then(Value::as_str) == Some(outcome)
+        && object
+            .get("audio_content_retained")
+            .and_then(Value::as_bool)
+            == Some(false)
+}
+
+fn nonempty_bounded_string(object: &Map<String, Value>, key: &str) -> bool {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty() && value.len() <= 128)
+}
+
+fn valid_worker_termination(object: &Map<String, Value>) -> bool {
+    match (
+        object.get("worker_termination").and_then(Value::as_str),
+        object.get("exit_signal").and_then(Value::as_u64),
+    ) {
+        (Some("cooperative" | "exited"), Some(0)) => true,
+        (Some("hard_kill"), Some(signal)) if signal == libc::SIGKILL as u64 => true,
+        _ => false,
+    }
+}
+
+fn valid_status_response(object: &Map<String, Value>) -> bool {
+    let Some(outcome @ ("idle" | "active" | "pending")) =
+        object.get("outcome").and_then(Value::as_str)
+    else {
+        return false;
+    };
+    has_exact_keys(
+        object,
+        &[
+            "schema_version",
+            "outcome",
+            "agent_pid",
+            "agent_instance",
+            "generation",
+            "worker_pid",
+            "synthetic_canary_count",
+            "audio_content_retained",
+        ],
+    ) && valid_common(object, outcome)
+        && object
+            .get("agent_pid")
+            .and_then(Value::as_u64)
+            .is_some_and(|pid| (2..=i32::MAX as u64).contains(&pid))
+        && nonempty_bounded_string(object, "agent_instance")
+        && object.get("generation").and_then(Value::as_u64).is_some()
+        && object.get("worker_pid").and_then(Value::as_u64).is_some()
+        && object
+            .get("synthetic_canary_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 4_096)
+}
+
+fn valid_ready_response(object: &Map<String, Value>) -> bool {
+    has_exact_keys(
+        object,
+        &[
+            "schema_version",
+            "outcome",
+            "generation",
+            "agent_pid",
+            "agent_instance",
+            "worker_pid",
+            "synthetic_canary_count",
+            "first_callback_ms",
+            "audio_content_retained",
+        ],
+    ) && valid_common(object, "ready")
+        && nonempty_bounded_string(object, "agent_instance")
+        && ["generation", "agent_pid", "worker_pid"].iter().all(|key| {
+            object
+                .get(*key)
+                .and_then(Value::as_u64)
+                .is_some_and(|value| value > 0)
+        })
+        && object
+            .get("synthetic_canary_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 4_096)
+        && object
+            .get("first_callback_ms")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 60_000)
+}
+
+fn valid_stopped_response(object: &Map<String, Value>) -> bool {
+    let mut keys = vec![
+        "schema_version",
+        "outcome",
+        "generation",
+        "synthetic_canary_count",
+        "worker_termination",
+        "stop_elapsed_ms",
+        "worker_exited",
+        "process_group_empty",
+        "exit_signal",
+        "audio_content_retained",
+    ];
+    let has_synthetic = object.contains_key("synthetic_fixture");
+    if has_synthetic {
+        keys.extend([
+            "synthetic_fixture",
+            "synthetic_digest",
+            "synthetic_first_sequence",
+            "synthetic_last_sequence",
+            "synthetic_complete",
+        ]);
+    }
+    has_exact_keys(object, &keys)
+        && valid_common(object, "stopped")
+        && object.get("generation").and_then(Value::as_u64).is_some()
+        && object
+            .get("synthetic_canary_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 4_096)
+        && valid_worker_termination(object)
+        && object
+            .get("stop_elapsed_ms")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 5_000)
+        && object.get("worker_exited").and_then(Value::as_bool) == Some(true)
+        && object.get("process_group_empty").and_then(Value::as_bool) == Some(true)
+        && (!has_synthetic
+            || (object.get("synthetic_fixture").and_then(Value::as_str) == Some("seq-v1")
+                && object.get("synthetic_digest").and_then(Value::as_str)
+                    == Some("9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3")
+                && object
+                    .get("synthetic_first_sequence")
+                    .and_then(Value::as_u64)
+                    == Some(0)
+                && object
+                    .get("synthetic_last_sequence")
+                    .and_then(Value::as_u64)
+                    == Some(63)
+                && object.get("synthetic_complete").and_then(Value::as_bool) == Some(true)
+                && object.get("synthetic_canary_count").and_then(Value::as_u64) == Some(64)))
+}
+
+fn valid_recovery_payload(object: &Map<String, Value>, outcome: &str) -> bool {
+    let mut keys = vec![
+        "schema_version",
+        "outcome",
+        "generation",
+        "agent_pid",
+        "agent_instance",
+        "worker_pid",
+        "synthetic_canary_count",
+        "first_callback_ms",
+        "worker_termination",
+        "stop_elapsed_ms",
+        "recovery_ttl_ms",
+        "agent_survived",
+        "worker_exited",
+        "process_group_empty",
+        "exit_signal",
+        "audio_content_retained",
+        "claim_id",
+        "recovered",
+        "exact_once",
+    ];
+    let has_synthetic = object.contains_key("synthetic_fixture");
+    if has_synthetic {
+        keys.extend([
+            "synthetic_fixture",
+            "synthetic_digest",
+            "synthetic_first_sequence",
+            "synthetic_last_sequence",
+            "synthetic_complete",
+        ]);
+    }
+    has_exact_keys(object, &keys)
+        && valid_common(object, outcome)
+        && ["generation", "agent_pid", "worker_pid"].iter().all(|key| {
+            object
+                .get(*key)
+                .and_then(Value::as_u64)
+                .is_some_and(|value| value > 0)
+        })
+        && nonempty_bounded_string(object, "agent_instance")
+        && nonempty_bounded_string(object, "claim_id")
+        && object
+            .get("synthetic_canary_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| (1..=4_096).contains(&value))
+        && object
+            .get("first_callback_ms")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 60_000)
+        && valid_worker_termination(object)
+        && object
+            .get("stop_elapsed_ms")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 5_000)
+        && object
+            .get("recovery_ttl_ms")
+            .and_then(Value::as_u64)
+            .is_some_and(|value| value <= 30_000)
+        && object.get("agent_survived").and_then(Value::as_bool) == Some(true)
+        && object.get("worker_exited").and_then(Value::as_bool) == Some(true)
+        && object.get("process_group_empty").and_then(Value::as_bool) == Some(true)
+        && object.get("recovered").and_then(Value::as_bool) == Some(outcome == "recovery_acked")
+        && object.get("exact_once").and_then(Value::as_bool) == Some(outcome == "recovery_acked")
+        && (!has_synthetic
+            || (object.get("synthetic_fixture").and_then(Value::as_str) == Some("seq-v1")
+                && object.get("synthetic_digest").and_then(Value::as_str)
+                    == Some("9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3")
+                && object
+                    .get("synthetic_first_sequence")
+                    .and_then(Value::as_u64)
+                    == Some(0)
+                && object
+                    .get("synthetic_last_sequence")
+                    .and_then(Value::as_u64)
+                    == Some(63)
+                && object.get("synthetic_complete").and_then(Value::as_bool) == Some(true)
+                && object.get("synthetic_canary_count").and_then(Value::as_u64) == Some(64)))
+}
+
+fn valid_terminal_recovery_response(object: &Map<String, Value>) -> bool {
+    match object.get("outcome").and_then(Value::as_str) {
+        Some("none" | "settling" | "claim_busy") => {
+            has_exact_keys(
+                object,
+                &[
+                    "schema_version",
+                    "outcome",
+                    "recovered",
+                    "audio_content_retained",
+                ],
+            ) && object.get("recovered").and_then(Value::as_bool) == Some(false)
+        }
+        Some("expired") => {
+            has_exact_keys(
+                object,
+                &[
+                    "schema_version",
+                    "outcome",
+                    "generation",
+                    "recovered",
+                    "audio_content_retained",
+                ],
+            ) && object.get("generation").and_then(Value::as_u64).is_some()
+                && object.get("recovered").and_then(Value::as_bool) == Some(false)
+        }
+        Some("already_acked") => {
+            has_exact_keys(
+                object,
+                &[
+                    "schema_version",
+                    "outcome",
+                    "generation",
+                    "recovered",
+                    "exact_once",
+                    "audio_content_retained",
+                ],
+            ) && object.get("generation").and_then(Value::as_u64).is_some()
+                && object.get("recovered").and_then(Value::as_bool) == Some(false)
+                && object.get("exact_once").and_then(Value::as_bool) == Some(true)
+        }
+        Some("recovery_offer") => valid_recovery_payload(object, "recovery_offer"),
+        Some("recovery_acked") => valid_recovery_payload(object, "recovery_acked"),
+        _ => false,
+    }
+}
+
+fn agent_path() -> Result<std::path::PathBuf, ()> {
+    let path = bundled_sibling(CAPTURE_AGENT_NAME)?;
+    if !cfg!(debug_assertions) {
+        crate::code_signing::validate_bundled_helper(&path, CAPTURE_AGENT_IDENTIFIER)?;
+    }
+    Ok(path)
+}
+
+struct AgentProcess {
+    child: ManagedChild,
+    stdin: std::process::ChildStdin,
+    lines: mpsc::Receiver<String>,
+}
+
+impl AgentProcess {
+    fn spawn(arguments: &[&str]) -> Result<Self, ()> {
+        let path = agent_path()?;
+        let (child, stdin, stdout) =
+            ManagedChild::spawn_with_arguments(&path, arguments, &[]).map_err(|_| ())?;
+        let (sender, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                let read = match (&mut reader).take(8_193).read_line(&mut line) {
+                    Ok(read) => read,
+                    Err(_) => break,
+                };
+                if read == 0 {
+                    break;
+                }
+                if read > 8_192 || !line.ends_with('\n') {
+                    let _ = sender.send(String::new());
+                    break;
+                }
+                line.pop();
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                if sender.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Self {
+            child,
+            stdin,
+            lines,
+        })
+    }
+
+    fn receive(&self, timeout: Duration) -> Result<Map<String, Value>, ()> {
+        let line = self.lines.recv_timeout(timeout).map_err(|_| ())?;
+        parse_allowlisted_json(&line)
+    }
+
+    fn finish(mut self) -> i32 {
+        drop(self.stdin);
+        let deadline = Instant::now() + EXIT_TIMEOUT;
+        let termination = self.child.wait_for_exit(deadline).or_else(|| {
+            self.child
+                .hard_kill_confirmed(Instant::now() + EXIT_TIMEOUT)
+        });
+        termination.and_then(|value| value.exit_code).unwrap_or(2)
+    }
+}
+
+fn run_one_shot(arguments: &[&str], allowed_outcomes: &[&str]) -> (Value, i32) {
+    let process = match AgentProcess::spawn(arguments) {
+        Ok(process) => process,
+        Err(()) => return (content_free_error("agent_spawn_failed"), 2),
+    };
+    let response = match process.receive(RESPONSE_TIMEOUT) {
+        Ok(response)
+            if response
+                .get("outcome")
+                .and_then(Value::as_str)
+                .is_some_and(|outcome| allowed_outcomes.contains(&outcome))
+                && valid_status_response(&response) =>
+        {
+            Value::Object(response)
+        }
+        _ => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    };
+    let exit_code = process.finish();
+    (response, exit_code)
+}
+
+fn run_probe(observe_for: Duration, synthetic: bool, fault: bool) -> (Value, i32) {
+    if !synthetic && crate::commands::permissions::check_microphone_permission_status() != "granted"
+    {
+        return (content_free_error("permission_denied"), 2);
+    }
+    let arguments = if fault {
+        &["lease-synthetic-fault"][..]
+    } else if synthetic {
+        &["lease-synthetic"][..]
+    } else {
+        &["lease"][..]
+    };
+    let mut process = match AgentProcess::spawn(arguments) {
+        Ok(process) => process,
+        Err(()) => return (content_free_error("agent_spawn_failed"), 2),
+    };
+    let ready = match process.receive(RESPONSE_TIMEOUT) {
+        Ok(response) => response,
+        Err(()) => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    };
+    if !valid_ready_response(&ready) {
+        let exit_code = process.finish();
+        return (Value::Object(ready), exit_code.max(2));
+    }
+
+    let deadline = Instant::now() + observe_for;
+    while Instant::now() < deadline {
+        if !synthetic
+            && crate::commands::permissions::check_microphone_permission_status() != "granted"
+        {
+            // Closing the lease client connection is the interruption signal.
+            let _ = process.finish();
+            return (content_free_error("permission_revoked"), 2);
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    if process.stdin.write_all(b"stop\n").is_err() || process.stdin.flush().is_err() {
+        let _ = process.finish();
+        return (content_free_error("agent_stop_failed"), 2);
+    }
+    let stopped = match process.receive(RESPONSE_TIMEOUT) {
+        Ok(response) => response,
+        Err(()) => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    };
+    let exit_code = process.finish();
+    if !valid_stopped_response(&stopped) {
+        return (Value::Object(stopped), exit_code.max(2));
+    }
+
+    let mut combined = ready;
+    combined.insert("outcome".to_string(), Value::String("ok".to_string()));
+    for (key, value) in stopped {
+        if key != "outcome" {
+            combined.insert(key, value);
+        }
+    }
+    (Value::Object(combined), exit_code)
+}
+
+fn immutable_recovery_payload(object: &Map<String, Value>) -> Map<String, Value> {
+    let mut payload = object.clone();
+    for key in ["outcome", "recovered", "exact_once", "recovery_ttl_ms"] {
+        payload.remove(key);
+    }
+    payload
+}
+
+fn run_recover(replay_acknowledgement: bool) -> (Value, i32) {
+    let arguments = if replay_acknowledgement {
+        ["recover-replay-ack"].as_slice()
+    } else {
+        ["recover"].as_slice()
+    };
+    let mut process = match AgentProcess::spawn(arguments) {
+        Ok(process) => process,
+        Err(()) => return (content_free_error("agent_spawn_failed"), 2),
+    };
+    let offer = match process.receive(RESPONSE_TIMEOUT) {
+        Ok(response) if valid_terminal_recovery_response(&response) => response,
+        Ok(_) | Err(()) => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    };
+    match offer.get("outcome").and_then(Value::as_str) {
+        Some("none" | "settling" | "expired" | "already_acked") => {
+            let exit_code = process.finish();
+            return (Value::Object(offer), exit_code);
+        }
+        Some("recovery_acked") => {
+            let exit_code = process.finish();
+            return (Value::Object(offer), exit_code);
+        }
+        Some("recovery_offer") => {}
+        _ => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    }
+    let Some(claim_id) = offer
+        .get("claim_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty() && value.len() <= 128)
+    else {
+        let _ = process.finish();
+        return (content_free_error("agent_protocol_failed"), 2);
+    };
+    if writeln!(process.stdin, "ack:{claim_id}").is_err() || process.stdin.flush().is_err() {
+        let _ = process.finish();
+        return (content_free_error("agent_protocol_failed"), 2);
+    }
+    let mut acknowledged = match process.receive(RESPONSE_TIMEOUT) {
+        Ok(response)
+            if valid_recovery_payload(&response, "recovery_acked")
+                && response.get("claim_id").and_then(Value::as_str) == Some(claim_id)
+                && immutable_recovery_payload(&response) == immutable_recovery_payload(&offer) =>
+        {
+            response
+        }
+        _ => {
+            let _ = process.finish();
+            return (content_free_error("agent_protocol_failed"), 2);
+        }
+    };
+    let exit_code = process.finish();
+    if replay_acknowledgement {
+        acknowledged.insert("ack_replay_verified".to_string(), Value::Bool(true));
+    }
+    (Value::Object(acknowledged), exit_code)
+}
+
+pub fn run_cli_if_requested() -> Option<i32> {
+    let (response, exit_code) = match parse_cli_request(std::env::args().skip(1)) {
+        CliRequest::NotRequested => return None,
+        CliRequest::Invalid => (content_free_error("invalid_arguments"), 64),
+        CliRequest::Service(command) => run_service_command(command),
+        CliRequest::Recover => run_recover(false),
+        CliRequest::RecoverReplayAck => run_recover(true),
+        CliRequest::Status => run_one_shot(&["status"], &["idle", "active", "pending"]),
+        CliRequest::Probe(observe_for) => run_probe(observe_for, false, false),
+        CliRequest::SyntheticProbe(observe_for) => run_probe(observe_for, true, false),
+        CliRequest::SyntheticFaultProbe(observe_for) => run_probe(observe_for, true, true),
+    };
+    println!("{response}");
+    Some(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_is_explicit_strict_and_bounded() {
+        assert_eq!(
+            parse_cli_request(["--capture-agent-probe".to_string()]),
+            CliRequest::Probe(DEFAULT_OBSERVE)
+        );
+        assert_eq!(
+            parse_cli_request([
+                "--capture-agent-probe".to_string(),
+                "--observe-seconds".to_string(),
+                "120".to_string(),
+            ]),
+            CliRequest::Probe(Duration::from_secs(120))
+        );
+        assert_eq!(
+            parse_cli_request([
+                "--capture-agent-service".to_string(),
+                "register".to_string(),
+            ]),
+            CliRequest::Service(ServiceCommand::Register)
+        );
+        assert_eq!(
+            parse_cli_request(["--capture-agent-service".to_string(), "refresh".to_string(),]),
+            CliRequest::Service(ServiceCommand::Refresh)
+        );
+        assert_eq!(
+            parse_cli_request(["--capture-agent-recover".to_string()]),
+            CliRequest::Recover
+        );
+        assert_eq!(
+            parse_cli_request(["--capture-agent-recover-replay-ack".to_string()]),
+            CliRequest::RecoverReplayAck
+        );
+        assert_eq!(
+            parse_cli_request(["--capture-agent-synthetic-fault-probe".to_string()]),
+            CliRequest::SyntheticFaultProbe(DEFAULT_OBSERVE)
+        );
+        for arguments in [
+            vec![
+                "--capture-agent-probe".to_string(),
+                "--observe-seconds".to_string(),
+                "0".to_string(),
+            ],
+            vec![
+                "--capture-agent-probe".to_string(),
+                "--observe-seconds".to_string(),
+                "301".to_string(),
+            ],
+            vec!["--capture-agent-service".to_string(), "enable".to_string()],
+            vec!["--capture-agent-status".to_string(), "extra".to_string()],
+        ] {
+            assert_eq!(parse_cli_request(arguments), CliRequest::Invalid);
+        }
+        assert_eq!(
+            parse_cli_request(["--unrelated".to_string()]),
+            CliRequest::NotRequested
+        );
+    }
+
+    #[test]
+    fn evidence_allowlist_rejects_content_and_unknown_fields() {
+        assert!(parse_allowlisted_json(
+            r#"{"schema_version":1,"outcome":"idle","audio_content_retained":false,"agent_pid":42}"#
+        )
+        .is_ok());
+        for rejected in [
+            r#"{"schema_version":1,"outcome":"idle","audio_content_retained":true}"#,
+            r#"{"schema_version":1,"outcome":"idle","audio_content_retained":false,"pcm":[1]}"#,
+            r#"{"schema_version":1,"outcome":"idle","audio_content_retained":false,"path":"/tmp/x"}"#,
+        ] {
+            assert!(parse_allowlisted_json(rejected).is_err());
+        }
+    }
+
+    #[test]
+    fn response_contracts_are_exact_and_cross_field_checked() {
+        let ready = serde_json::json!({
+            "schema_version": 1,
+            "outcome": "ready",
+            "generation": 7,
+            "agent_pid": 101,
+            "agent_instance": "boot",
+            "worker_pid": 102,
+            "synthetic_canary_count": 64,
+            "first_callback_ms": 0,
+            "audio_content_retained": false
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(valid_ready_response(&ready));
+        let mut mutated = ready.clone();
+        mutated.insert("pcm".into(), serde_json::json!([1]));
+        assert!(!valid_ready_response(&mutated));
+
+        let stopped = serde_json::json!({
+            "schema_version": 1,
+            "outcome": "stopped",
+            "generation": 7,
+            "synthetic_canary_count": 64,
+            "worker_termination": "hard_kill",
+            "stop_elapsed_ms": 260,
+            "worker_exited": true,
+            "process_group_empty": true,
+            "exit_signal": 9,
+            "audio_content_retained": false
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(valid_stopped_response(&stopped));
+        let mut contradictory = stopped.clone();
+        contradictory.insert("exit_signal".into(), Value::from(0));
+        assert!(!valid_stopped_response(&contradictory));
+        let mut unconfirmed = stopped;
+        unconfirmed.insert("process_group_empty".into(), Value::Bool(false));
+        assert!(!valid_stopped_response(&unconfirmed));
+
+        let offer = serde_json::json!({
+            "schema_version": 1,
+            "outcome": "recovery_offer",
+            "generation": 7,
+            "agent_pid": 101,
+            "agent_instance": "boot",
+            "worker_pid": 102,
+            "synthetic_canary_count": 64,
+            "first_callback_ms": 0,
+            "worker_termination": "hard_kill",
+            "stop_elapsed_ms": 260,
+            "recovery_ttl_ms": 29_000,
+            "agent_survived": true,
+            "worker_exited": true,
+            "process_group_empty": true,
+            "exit_signal": 9,
+            "audio_content_retained": false,
+            "claim_id": "claim",
+            "recovered": false,
+            "exact_once": false,
+            "synthetic_fixture": "seq-v1",
+            "synthetic_digest":
+                "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3",
+            "synthetic_first_sequence": 0,
+            "synthetic_last_sequence": 63,
+            "synthetic_complete": true
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(valid_recovery_payload(&offer, "recovery_offer"));
+        let mut incomplete = offer;
+        incomplete.insert("synthetic_last_sequence".into(), Value::from(62));
+        assert!(!valid_recovery_payload(&incomplete, "recovery_offer"));
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod audio_lifecycle;
 // call `benchmark::run` directly with a mock AppHandle; not part of any
 // stable external API.
 pub mod benchmark;
+pub mod capture_agent_probe;
 pub mod capture_helper_probe;
 mod cleanup;
 mod cli_command;

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -2,6 +2,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if let Some(exit_code) = ui_lib::capture_agent_probe::run_cli_if_requested() {
+        std::process::exit(exit_code);
+    }
     if let Some(exit_code) = ui_lib::capture_helper_probe::run_cli_if_requested() {
         std::process::exit(exit_code);
     }

--- a/app/src-tauri/src/managed_child.rs
+++ b/app/src-tauri/src/managed_child.rs
@@ -29,12 +29,32 @@ pub struct ManagedChild {
 }
 
 impl ManagedChild {
+    fn from_spawned_child(child: Child) -> Self {
+        let pid = child.id();
+        Self {
+            child,
+            pid,
+            termination_armed: true,
+            #[cfg(test)]
+            drop_fallback_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+
     pub fn spawn(
         executable: &Path,
         test_environment: &[(String, String)],
     ) -> std::io::Result<(Self, ChildStdin, ChildStdout)> {
+        Self::spawn_with_arguments(executable, &[], test_environment)
+    }
+
+    pub fn spawn_with_arguments(
+        executable: &Path,
+        arguments: &[&str],
+        test_environment: &[(String, String)],
+    ) -> std::io::Result<(Self, ChildStdin, ChildStdout)> {
         let mut command = Command::new(executable);
         command
+            .args(arguments)
             .current_dir("/")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -70,24 +90,13 @@ impl ManagedChild {
         }
 
         let mut child = command.spawn()?;
-        let pid = child.id();
         let stdin = child.stdin.take().ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::BrokenPipe, "missing helper stdin")
         })?;
         let stdout = child.stdout.take().ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::BrokenPipe, "missing helper stdout")
         })?;
-        Ok((
-            Self {
-                child,
-                pid,
-                termination_armed: true,
-                #[cfg(test)]
-                drop_fallback_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            },
-            stdin,
-            stdout,
-        ))
+        Ok((Self::from_spawned_child(child), stdin, stdout))
     }
 
     pub fn pid(&self) -> u32 {

--- a/app/src-tauri/tauri.macos.conf.json
+++ b/app/src-tauri/tauri.macos.conf.json
@@ -2,7 +2,9 @@
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
     "externalBin": [
+      "binaries/murmur-capture-agent",
       "binaries/murmur-capture-helper",
+      "binaries/murmur-capture-worker",
       "binaries/murmur-llm-sidecar"
     ]
   }

--- a/app/src-tauri/tests/capture_helper_spike.rs
+++ b/app/src-tauri/tests/capture_helper_spike.rs
@@ -302,14 +302,13 @@ fn revocation_outcome_survives_a_queued_protocol_failure_during_teardown() {
 }
 
 #[test]
-fn production_capture_helper_has_no_process_spawn_or_daemonization_surface() {
+fn production_capture_helper_has_only_its_required_self_process_group_surface() {
     let source = include_str!("../sidecars/capture/src/main.rs");
     for forbidden in [
         "std::process::Command",
         "libc::fork(",
         "libc::posix_spawn",
         "libc::setsid(",
-        "libc::setpgid(",
         "libc::daemon(",
     ] {
         assert!(
@@ -317,4 +316,13 @@ fn production_capture_helper_has_no_process_spawn_or_daemonization_surface() {
             "capture helper must not contain process escape surface {forbidden:?}"
         );
     }
+    assert_eq!(
+        source.matches("libc::setpgid(").count(),
+        1,
+        "capture helper may establish only its own worker process group"
+    );
+    assert!(
+        source.contains("libc::setpgid(0, 0)"),
+        "capture helper must establish only its own worker process group"
+    );
 }

--- a/docs/decisions/2026-07-30-capture-helper-phase-0.md
+++ b/docs/decisions/2026-07-30-capture-helper-phase-0.md
@@ -193,8 +193,11 @@ Hard-kill recovery and the signed helper prototype remain reusable evidence, but
 the exact production packaging decision is not complete. #408 and dependent
 issues must not begin until #407 proves an alternate shape that can preserve
 already-delivered PCM across the observed forced restart without weakening
-revocation or privacy guarantees. A dedicated bundled app/XPC service is the
-leading investigation; a volatile recovery handoff is acceptable only if its
-lifetime, access control, cleanup, and swap/crash behavior are explicitly
-bounded and tested. Silently shipping the current external-binary shape or
-moving the problem into #411 is not allowed.
+revocation or privacy guarantees. The follow-up provisional shape is a
+per-user LaunchAgent recovery owner plus the existing separately killable
+capture worker; see
+[`2026-07-31-capture-agent-recovery-spike.md`](2026-07-31-capture-agent-recovery-spike.md).
+A volatile recovery handoff is acceptable only if its lifetime, access control,
+cleanup, and swap/crash behavior are explicitly bounded and tested. Silently
+shipping the current external-binary shape or moving the problem into #411 is
+not allowed.

--- a/docs/decisions/2026-07-31-capture-agent-recovery-spike.md
+++ b/docs/decisions/2026-07-31-capture-agent-recovery-spike.md
@@ -1,0 +1,138 @@
+# Capture recovery spike uses a per-user agent plus a killable worker
+
+- Status: Provisional — signed/notarized runtime matrix required
+- Date: 2026-07-31
+- Issue: #407
+- Parent: #405
+
+## Context
+
+The signed direct-child experiment proved deterministic helper termination and
+a single Murmur microphone identity. It also exposed a platform boundary:
+macOS 26.0.1 terminated and restarted the LaunchServices-owned main application
+when Murmur's microphone permission was disabled during active capture. The
+direct child then exited, and PCM already delivered into the main process could
+not survive. That shape cannot satisfy interrupted-recording recovery.
+
+An embedded XPC service is also tied to its containing application's lifetime.
+The alternate spike therefore needs a per-user process whose lifetime is
+independent of one main-app process instance, while preserving the separately
+killable HAL worker.
+
+## Provisional shape
+
+The release bundle now contains a probe-only `murmur-capture-agent` and an
+`SMAppService` LaunchAgent plist under `Contents/Library/LaunchAgents`.
+
+- The per-user agent owns a versioned XPC Mach service and survives client
+  disconnects.
+- Capture code remains outside the agent. The earlier
+  `murmur-capture-helper` keeps its direct-child entitlement policy for the
+  original Phase-0 probe. The agent launches a separately signed
+  `murmur-capture-worker` build of that code with exactly App Sandbox plus
+  sandbox inheritance. Apple requires a `Process` child of a sandboxed parent
+  to inherit its parent's static capabilities, so the agent carries the
+  audio-input capability while a static gate forbids capture APIs in the agent
+  source. The signed TCC matrix must decide whether that inherited-capability
+  shape still produces one understandable Murmur identity.
+- The agent starts that worker with an empty environment, root working
+  directory, bounded framed stdin/stdout, and no persistent storage. The worker
+  establishes and proves its own process group before it reads the first frame
+  or touches CoreAudio, avoiding the post-`exec` `setpgid` race.
+- A client connection is the capture lease. Client invalidation starts
+  cooperative cancellation immediately; after 250 ms the exact worker is
+  group-killed. A result is not accepted until the worker has exited, its
+  reader has drained, and the owned process group is confirmed empty. A fixed
+  signed synthetic fault mode ignores cancel so the matrix exercises and
+  proves the `SIGKILL` path.
+- The deterministic synthetic probe retains a fixed 64-sequence public fixture,
+  its public fixture digest, and callback-derived counts for a 30-second
+  in-memory recovery window. It does not retain PCM, device names, transcripts,
+  paths, or audio-derived content.
+- Recovery is offered with a peer-bound claim ID and remains re-offerable until
+  that client explicitly acknowledges it or the monotonic TTL expires. ACK is
+  idempotent only for the original peer and claim, so a lost ACK response can
+  be retried; the signed matrix deliberately discards the first successful ACK
+  response and verifies a full-payload replay on the same connection. Anonymous
+  later recovery requests receive a no-content
+  `already_acked` tombstone; after the TTL they receive an `expired` tombstone.
+- XPC peers must satisfy an exact fixed-identifier, Apple-anchor, same-Team code
+  signing requirement. The Team ID is derived from the running agent's own
+  signed code, not compiled as a release constant. Requirement installation
+  uses the macOS 12 API, checks its return code, and fails closed. Reply
+  dictionaries are checked on the wire for exact key count and XPC value types
+  before Rust applies its outcome-specific schema and cross-field invariants.
+- Registration, status, and unregistration run in the containing main app,
+  because `SMAppService.agent(plistName:)` resolves the calling app's
+  `Contents/Library/LaunchAgents` directory. The agent cannot register itself.
+  Probe and recovery clients still connect to the agent over XPC. All spike
+  operations are reachable only through explicit CLI arguments, and production
+  dictation remains unchanged.
+- The standalone sandboxed agent and worker Mach-O files each embed their exact
+  role-specific Info.plist identity and app version; macOS refuses to
+  initialize a sandboxed standalone executable without coherent embedded code
+  identity.
+
+The release finalizer installs the exact launchd plist, verifies the agent,
+direct helper, and worker embedded versioned Info.plists, signs the agent and
+inherited worker with fixed identifiers and separate entitlements, verifies
+every helper and the main app with hardened runtime, and records their hashes,
+designated requirements, Team IDs, architectures, and entitlement digests in
+release provenance.
+
+## Acceptance gate
+
+This is packaging and lifecycle instrumentation, not an accepted production
+architecture. A downloaded, notarized, quarantined build must prove all of the
+following through LaunchServices on the release-gate Mac:
+
+- registration yields one understandable Murmur Background Activity item and
+  no additional microphone identity or prompt;
+- the exact agent PID and opaque instance fingerprint survive main-app
+  termination/restart;
+- denied preflight starts no worker;
+- active permission revocation stops the exact worker within the bound while
+  the agent survives and exposes one recoverable interruption;
+- client loss stops a blocked worker and permits one recovery claim, with a
+  second claim returning no content and the post-TTL query returning an
+  explicit expired tombstone;
+- agent and worker are both replaced exactly once across a signed app update;
+- unregistration removes the launchd job and every agent/worker process.
+
+[`scripts/capture_agent_matrix.py`](../../scripts/capture_agent_matrix.py)
+validates the final cross-record artifact. It binds the installed agent and
+worker hashes and Team/identifier facts to the trusted release provenance,
+requires quarantine, notarization, stapling, Gatekeeper, and LaunchServices
+observations, proves the main PID changed during the System Settings
+granted → denied → granted transition, requires exactly one Murmur Background
+Activity and microphone identity with no additional prompt, binds both sides
+of the signed update to distinct trusted workflow provenance, distinguishes
+service refresh from that update, and rejects any residual agent or worker
+after unregistration. Its runtime records additionally cross-check the exact
+agent instance, generation, worker PID, denied-preflight generation, synthetic
+sequence, termination signal, process-group proof, same-peer ACK replay,
+duplicate anonymous claim, and TTL expiry.
+
+Apple may leave a disabled Background Activity row visible after
+unregistration until system maintenance runs. Validation must record that
+behavior and must not use the broad `sfltool resetbtm` command.
+
+If the agent receives a second microphone identity/prompt, does not survive the
+main-app restart, cannot spawn the sandboxed worker, or cannot unregister
+cleanly, this architecture remains blocked. No production routing work in #408
+or #409 may treat this provisional spike as passed.
+
+## Consequences
+
+The process topology is now:
+
+`main app → per-user capture agent → killable capture worker`
+
+The agent is the short-lived volatile recovery owner; the worker is the HAL
+fault boundary. A later production protocol must replace synthetic canaries
+with bounded in-memory PCM ownership, exact-once transcription dispatch, memory
+zeroization, and the full privacy contract owned by #408 and #411.
+
+References: [direct-child ADR](2026-07-30-capture-helper-phase-0.md),
+[Apple SMAppService](https://developer.apple.com/documentation/servicemanagement/smappservice),
+[Apple helper update guidance](https://developer.apple.com/documentation/servicemanagement/updating-helper-executables-from-earlier-versions-of-macos).

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,32 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-07-31: Capture recovery spike uses a per-user agent plus a killable worker (#407)
+
+**Decision:** Probe an `SMAppService` per-user LaunchAgent as the volatile
+recovery owner while retaining the existing sandboxed capture helper as the
+separately killable HAL worker. The client XPC connection is a lease; loss of
+that lease starts bounded worker teardown. The Phase-0 agent retains only
+content-free synthetic canary state in RAM for 30 seconds and production
+dictation remains unchanged.
+
+**Rationale:** macOS terminated/restarted the LaunchServices-owned app during
+active microphone revocation, so a direct child and app-owned PCM cannot survive
+the platform transition. An embedded XPC service shares the app lifetime; a
+per-user agent can survive it without making the persistent process itself the
+unkillable CoreAudio owner.
+
+**Status:** provisional — requires a downloaded signed/notarized registration,
+single-TCC-identity, restart/revocation, exact-once recovery, update, and
+unregistration matrix before #407 can close
+
+**References:** issue #407; ADR
+[`2026-07-31-capture-agent-recovery-spike.md`](2026-07-31-capture-agent-recovery-spike.md);
+direct-child ADR
+[`2026-07-30-capture-helper-phase-0.md`](2026-07-30-capture-helper-phase-0.md)
+
+---
+
 ## 2026-07-30: Capture helper uses a direct managed child; production waits for notarized TCC proof (#407)
 
 **Decision:** Package the Phase-0 `murmur-capture-helper` as an exact signed external binary with a fixed code identity, microphone-only sandbox capabilities, runtime Security.framework validation, nonce-framed private IPC, and direct process-group ownership. Cooperative cancel is bounded at 250 ms before group `SIGKILL`; a new helper is forbidden until direct-PID exit and an empty owned process group are confirmed. The callback retains no PCM and touches atomics only. The helper is probe-only; #409 owns production routing.

--- a/scripts/build_local_llm_sidecar.py
+++ b/scripts/build_local_llm_sidecar.py
@@ -2,16 +2,19 @@
 """Build Murmur's macOS-arm64 bundled helpers for Tauri externalBin.
 
 The historical filename remains the developer prerequisite, but it now builds
-both exact production helpers: the local-LLM sidecar and the Phase-0 capture
-helper. A Tauri bundle must never silently omit either signed executable.
+all exact production helpers: the local-LLM sidecar, Phase-0 capture helper,
+and provisional capture recovery agent. A Tauri bundle must never silently
+omit a signed executable.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from pathlib import Path
 import platform
+import plistlib
 import shutil
 import stat
 import subprocess
@@ -22,14 +25,22 @@ ROOT = Path(__file__).resolve().parents[1]
 TAURI_ROOT = ROOT / "app" / "src-tauri"
 SIDECAR_NAME = "murmur-llm-sidecar"
 CAPTURE_HELPER_NAME = "murmur-capture-helper"
+CAPTURE_AGENT_NAME = "murmur-capture-agent"
+CAPTURE_WORKER_NAME = "murmur-capture-worker"
 TARGET = "aarch64-apple-darwin"
 
 
 def run(command: list[str], *, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, cwd=cwd, text=True, check=True, capture_output=True)
 
-def publish_binary(name: str, profile: str) -> Path:
-    built = TAURI_ROOT / "target" / profile / name
+
+def publish_binary(
+    name: str,
+    profile: str,
+    source_name: str | None = None,
+    built_path: Path | None = None,
+) -> Path:
+    built = built_path or TAURI_ROOT / "target" / profile / (source_name or name)
     if not built.is_file():
         raise SystemExit(f"helper build did not produce {built}")
 
@@ -50,6 +61,50 @@ def publish_binary(name: str, profile: str) -> Path:
     return destination
 
 
+def build_capture_agent(profile: str, env: dict[str, str]) -> None:
+    """Build the probe-only SMAppService launch agent with the system Swift toolchain."""
+    output = TAURI_ROOT / "target" / profile / CAPTURE_AGENT_NAME
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with (TAURI_ROOT / "capture-agent-info.plist").open("rb") as handle:
+        embedded_info_payload = plistlib.load(handle)
+    with (TAURI_ROOT / "tauri.conf.json").open(encoding="utf-8") as handle:
+        app_version = str(json.load(handle)["version"])
+    for key in ("CFBundleShortVersionString", "CFBundleVersion"):
+        embedded_info_payload[key] = app_version
+    embedded_info = output.parent / "capture-agent-info.plist"
+    with embedded_info.open("wb") as handle:
+        plistlib.dump(embedded_info_payload, handle, sort_keys=True)
+    optimization = "-O" if profile == "release" else "-Onone"
+    subprocess.run(
+        [
+            "xcrun",
+            "swiftc",
+            optimization,
+            "-parse-as-library",
+            "-target",
+            "arm64-apple-macos14.0",
+            str(TAURI_ROOT / "sidecars" / "capture-agent" / "main.swift"),
+            "-framework",
+            "Foundation",
+            "-framework",
+            "Security",
+            "-Xlinker",
+            "-sectcreate",
+            "-Xlinker",
+            "__TEXT",
+            "-Xlinker",
+            "__info_plist",
+            "-Xlinker",
+            str(embedded_info),
+            "-o",
+            str(output),
+        ],
+        cwd=TAURI_ROOT,
+        env=env,
+        check=True,
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--release", action="store_true")
@@ -67,11 +122,14 @@ def main() -> int:
         profile = "release"
 
     env = os.environ.copy()
+    with (TAURI_ROOT / "tauri.conf.json").open(encoding="utf-8") as handle:
+        app_version = str(json.load(handle)["version"])
     env.update(
         {
             "LLAMA_BUILD_SHARED_LIBS": "OFF",
             "MACOSX_DEPLOYMENT_TARGET": "14.0",
             "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0",
+            "MURMUR_APP_VERSION": app_version,
         }
     )
     subprocess.run(command, cwd=TAURI_ROOT, env=env, check=True)
@@ -80,15 +138,35 @@ def main() -> int:
     if args.release:
         capture_command.append("--release")
     subprocess.run(capture_command, cwd=TAURI_ROOT, env=env, check=True)
+    worker_target = TAURI_ROOT / "target" / "capture-worker-build"
+    worker_env = env.copy()
+    worker_env.update(
+        {
+            "MURMUR_CAPTURE_ROLE": "worker",
+            "CARGO_TARGET_DIR": str(worker_target),
+        }
+    )
+    subprocess.run(capture_command, cwd=TAURI_ROOT, env=worker_env, check=True)
+    build_capture_agent(profile, env)
 
     llm_destination = publish_binary(SIDECAR_NAME, profile)
     capture_destination = publish_binary(CAPTURE_HELPER_NAME, profile)
+    capture_agent_destination = publish_binary(CAPTURE_AGENT_NAME, profile)
+    capture_worker_destination = publish_binary(
+        CAPTURE_WORKER_NAME,
+        profile,
+        built_path=worker_target / profile / CAPTURE_HELPER_NAME,
+    )
     if args.print_output:
         print(llm_destination)
         print(capture_destination)
+        print(capture_agent_destination)
+        print(capture_worker_destination)
     else:
         print(f"built {llm_destination.relative_to(ROOT)}")
         print(f"built {capture_destination.relative_to(ROOT)}")
+        print(f"built {capture_agent_destination.relative_to(ROOT)}")
+        print(f"built {capture_worker_destination.relative_to(ROOT)}")
     return 0
 
 

--- a/scripts/capture_agent_matrix.py
+++ b/scripts/capture_agent_matrix.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Validate issue #407's content-free signed LaunchAgent runtime matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SYNTHETIC_DIGEST = (
+    "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3"
+)
+REQUIRED_STEPS = (
+    "service_initial",
+    "service_register",
+    "synthetic_cooperative",
+    "synthetic_hard_kill",
+    "continuity_active",
+    "continuity_recovery",
+    "continuity_second_claim",
+    "continuity_expired",
+    "refresh_before",
+    "service_refresh",
+    "refresh_after",
+    "microphone_active",
+    "microphone_recovery",
+    "microphone_denied",
+    "denied_status",
+    "microphone_restored",
+    "update_before",
+    "update_after",
+    "service_unregister",
+)
+
+
+class MatrixError(ValueError):
+    pass
+
+
+def _exact(value: object, keys: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise MatrixError(f"{label} must use the complete exact schema")
+    return value
+
+
+def _uint(value: object, label: str, *, positive: bool = False) -> int:
+    if type(value) is not int or value < (1 if positive else 0):
+        raise MatrixError(f"{label} must be a valid unsigned integer")
+    return value
+
+
+def _common(payload: dict[str, Any], outcome: str) -> None:
+    if payload["schema_version"] != 1 or payload["outcome"] != outcome:
+        raise MatrixError(f"{outcome} schema/outcome mismatch")
+    if payload["audio_content_retained"] is not False:
+        raise MatrixError("runtime evidence must retain no audio content")
+
+
+def _synthetic(payload: dict[str, Any]) -> None:
+    if (
+        payload["synthetic_fixture"] != "seq-v1"
+        or payload["synthetic_digest"] != SYNTHETIC_DIGEST
+        or payload["synthetic_first_sequence"] != 0
+        or payload["synthetic_last_sequence"] != 63
+        or payload["synthetic_canary_count"] != 64
+        or payload["synthetic_complete"] is not True
+    ):
+        raise MatrixError("synthetic sequence evidence is incomplete or contradictory")
+
+
+def validate_service(payload: object, expected_status: str) -> dict[str, Any]:
+    value = _exact(
+        payload,
+        {
+            "schema_version",
+            "outcome",
+            "service_status",
+            "audio_content_retained",
+        },
+        "service evidence",
+    )
+    _common(value, "service_status")
+    if value["service_status"] != expected_status:
+        raise MatrixError(
+            f"service status must be {expected_status!r}, got {value['service_status']!r}"
+        )
+    return value
+
+
+def validate_status(payload: object, expected_outcome: str) -> dict[str, Any]:
+    value = _exact(
+        payload,
+        {
+            "schema_version",
+            "outcome",
+            "agent_pid",
+            "agent_instance",
+            "generation",
+            "worker_pid",
+            "synthetic_canary_count",
+            "audio_content_retained",
+        },
+        "agent status",
+    )
+    _common(value, expected_outcome)
+    _uint(value["agent_pid"], "agent_pid", positive=True)
+    _uint(value["generation"], "generation")
+    _uint(value["worker_pid"], "worker_pid")
+    _uint(value["synthetic_canary_count"], "synthetic_canary_count")
+    if not isinstance(value["agent_instance"], str) or not value["agent_instance"]:
+        raise MatrixError("agent_instance must be non-empty")
+    if expected_outcome == "active" and value["worker_pid"] == 0:
+        raise MatrixError("active status must identify the worker")
+    if expected_outcome == "idle" and value["worker_pid"] != 0:
+        raise MatrixError("idle status must not identify a worker")
+    return value
+
+
+def validate_probe(
+    payload: object,
+    termination: str,
+    *,
+    synthetic: bool,
+) -> dict[str, Any]:
+    keys = {
+        "schema_version",
+        "outcome",
+        "generation",
+        "agent_pid",
+        "agent_instance",
+        "worker_pid",
+        "synthetic_canary_count",
+        "first_callback_ms",
+        "worker_termination",
+        "stop_elapsed_ms",
+        "worker_exited",
+        "process_group_empty",
+        "exit_signal",
+        "audio_content_retained",
+    }
+    if synthetic:
+        keys |= {
+            "synthetic_fixture",
+            "synthetic_digest",
+            "synthetic_first_sequence",
+            "synthetic_last_sequence",
+            "synthetic_complete",
+        }
+    value = _exact(payload, keys, "probe evidence")
+    _common(value, "ok")
+    for key in ("generation", "agent_pid", "worker_pid"):
+        _uint(value[key], key, positive=True)
+    _uint(value["first_callback_ms"], "first_callback_ms")
+    _uint(value["stop_elapsed_ms"], "stop_elapsed_ms")
+    if value["worker_termination"] != termination:
+        raise MatrixError(f"worker termination must be {termination!r}")
+    if value["worker_exited"] is not True or value["process_group_empty"] is not True:
+        raise MatrixError("probe must prove worker exit and an empty process group")
+    expected_signal = 9 if termination == "hard_kill" else 0
+    if value["exit_signal"] != expected_signal:
+        raise MatrixError("worker exit signal contradicts its termination")
+    if synthetic:
+        _synthetic(value)
+    return value
+
+
+def validate_recovery(
+    payload: object,
+    *,
+    synthetic: bool,
+    ack_replay: bool = False,
+) -> dict[str, Any]:
+    keys = {
+        "schema_version",
+        "outcome",
+        "generation",
+        "agent_pid",
+        "agent_instance",
+        "worker_pid",
+        "synthetic_canary_count",
+        "first_callback_ms",
+        "worker_termination",
+        "stop_elapsed_ms",
+        "recovery_ttl_ms",
+        "agent_survived",
+        "worker_exited",
+        "process_group_empty",
+        "exit_signal",
+        "audio_content_retained",
+        "claim_id",
+        "recovered",
+        "exact_once",
+    }
+    if synthetic:
+        keys |= {
+            "synthetic_fixture",
+            "synthetic_digest",
+            "synthetic_first_sequence",
+            "synthetic_last_sequence",
+            "synthetic_complete",
+        }
+    if ack_replay:
+        keys.add("ack_replay_verified")
+    value = _exact(payload, keys, "recovery evidence")
+    _common(value, "recovery_acked")
+    for key in ("generation", "agent_pid", "worker_pid"):
+        _uint(value[key], key, positive=True)
+    _uint(value["first_callback_ms"], "first_callback_ms")
+    _uint(value["stop_elapsed_ms"], "stop_elapsed_ms")
+    _uint(value["recovery_ttl_ms"], "recovery_ttl_ms")
+    termination = value["worker_termination"]
+    signal = value["exit_signal"]
+    if (
+        termination not in {"cooperative", "exited", "hard_kill"}
+        or (termination == "hard_kill" and signal != 9)
+        or (termination != "hard_kill" and signal != 0)
+    ):
+        raise MatrixError("recovery termination contradicts its exit signal")
+    if (
+        value["agent_survived"] is not True
+        or value["worker_exited"] is not True
+        or value["process_group_empty"] is not True
+        or value["recovered"] is not True
+        or value["exact_once"] is not True
+    ):
+        raise MatrixError("recovery lifecycle proof is incomplete")
+    if not isinstance(value["claim_id"], str) or not value["claim_id"]:
+        raise MatrixError("recovery claim ID must be non-empty")
+    if ack_replay and value["ack_replay_verified"] is not True:
+        raise MatrixError("same-peer acknowledgement replay was not verified")
+    if synthetic:
+        _synthetic(value)
+    return value
+
+
+def validate_matrix(payload: object) -> dict[str, Any]:
+    matrix = _exact(
+        payload,
+        {
+            "schema_version",
+            "source_sha",
+            "signed_bundle_artifact",
+            "artifact_provenance",
+            "previous_signed_bundle_artifact",
+            "previous_artifact_provenance",
+            "observations",
+            "records",
+        },
+        "capture-agent matrix",
+    )
+    if matrix["schema_version"] != 1:
+        raise MatrixError("capture-agent matrix schema mismatch")
+    source_sha = matrix["source_sha"]
+    if not isinstance(source_sha, str) or not SHA_RE.fullmatch(source_sha):
+        raise MatrixError("source_sha must be a lowercase 40-character SHA")
+    if matrix["signed_bundle_artifact"] != f"macos-release-{source_sha}":
+        raise MatrixError("signed bundle artifact must bind to source_sha")
+    provenance = _exact(
+        matrix["artifact_provenance"],
+        {
+            "commit_sha",
+            "workflow_run_id",
+            "capture_agent_sha256",
+            "capture_worker_sha256",
+            "capture_agent_identifier",
+            "capture_worker_identifier",
+            "team_id",
+        },
+        "artifact provenance",
+    )
+    if provenance["commit_sha"] != source_sha:
+        raise MatrixError("artifact provenance commit does not match source_sha")
+    _uint(provenance["workflow_run_id"], "workflow_run_id", positive=True)
+    for key in ("capture_agent_sha256", "capture_worker_sha256"):
+        if (
+            not isinstance(provenance[key], str)
+            or re.fullmatch(r"[0-9a-f]{64}", provenance[key]) is None
+        ):
+            raise MatrixError(f"{key} must be a lowercase SHA-256")
+    if provenance["capture_agent_identifier"] != "com.localdictation.capture-agent":
+        raise MatrixError("artifact provenance capture-agent identifier mismatch")
+    if provenance["capture_worker_identifier"] != "com.localdictation.capture-worker":
+        raise MatrixError("artifact provenance capture-worker identifier mismatch")
+    if (
+        not isinstance(provenance["team_id"], str)
+        or re.fullmatch(r"[A-Z0-9]{10}", provenance["team_id"]) is None
+    ):
+        raise MatrixError("artifact provenance Team ID is invalid")
+    previous_provenance = _exact(
+        matrix["previous_artifact_provenance"],
+        {
+            "commit_sha",
+            "workflow_run_id",
+            "capture_agent_sha256",
+            "capture_worker_sha256",
+            "capture_agent_identifier",
+            "capture_worker_identifier",
+            "team_id",
+        },
+        "previous artifact provenance",
+    )
+    previous_sha = previous_provenance["commit_sha"]
+    if (
+        not isinstance(previous_sha, str)
+        or not SHA_RE.fullmatch(previous_sha)
+        or previous_sha == source_sha
+    ):
+        raise MatrixError("previous artifact must identify a distinct source commit")
+    if matrix["previous_signed_bundle_artifact"] != f"macos-release-{previous_sha}":
+        raise MatrixError("previous signed bundle artifact must bind to its commit")
+    previous_run_id = _uint(
+        previous_provenance["workflow_run_id"],
+        "previous workflow_run_id",
+        positive=True,
+    )
+    if previous_run_id == provenance["workflow_run_id"]:
+        raise MatrixError("previous artifact must come from a distinct workflow run")
+    for key in ("capture_agent_sha256", "capture_worker_sha256"):
+        if (
+            not isinstance(previous_provenance[key], str)
+            or re.fullmatch(r"[0-9a-f]{64}", previous_provenance[key]) is None
+        ):
+            raise MatrixError(f"previous {key} must be a lowercase SHA-256")
+    for key in ("capture_agent_identifier", "capture_worker_identifier", "team_id"):
+        if previous_provenance[key] != provenance[key]:
+            raise MatrixError(f"previous artifact {key} does not match current provenance")
+
+    observations = _exact(
+        matrix["observations"],
+        {
+            "notarized",
+            "stapled",
+            "gatekeeper_accepted",
+            "quarantine_applied",
+            "launchservices_opened",
+            "main_pid_before_revocation",
+            "main_pid_after_revocation",
+            "permission_transition",
+            "revocation_trigger",
+            "background_activity_labels",
+            "microphone_identity_labels",
+            "microphone_prompt_count",
+            "additional_microphone_prompt_observed",
+            "previous_source_sha",
+            "previous_capture_agent_sha256",
+            "previous_capture_worker_sha256",
+            "installed_capture_agent_sha256",
+            "installed_capture_worker_sha256",
+            "residual_agent_processes",
+            "residual_worker_processes",
+        },
+        "runtime observations",
+    )
+    for key in (
+        "notarized",
+        "stapled",
+        "gatekeeper_accepted",
+        "quarantine_applied",
+        "launchservices_opened",
+    ):
+        if observations[key] is not True:
+            raise MatrixError(f"{key} must be independently confirmed")
+    before_pid = _uint(
+        observations["main_pid_before_revocation"],
+        "main_pid_before_revocation",
+        positive=True,
+    )
+    after_pid = _uint(
+        observations["main_pid_after_revocation"],
+        "main_pid_after_revocation",
+        positive=True,
+    )
+    if before_pid == after_pid:
+        raise MatrixError("permission revocation did not replace the main process")
+    if observations["permission_transition"] != ["granted", "denied", "granted"]:
+        raise MatrixError("permission transition must prove revoke and restoration")
+    if observations["revocation_trigger"] != "system_settings_microphone_toggle":
+        raise MatrixError("revocation must be triggered through System Settings")
+    if observations["background_activity_labels"] != ["Murmur"]:
+        raise MatrixError("Background Activity must show one Murmur identity")
+    if observations["microphone_identity_labels"] != ["Murmur"]:
+        raise MatrixError("Microphone privacy UI must show one Murmur identity")
+    prompt_count = _uint(
+        observations["microphone_prompt_count"],
+        "microphone_prompt_count",
+    )
+    if prompt_count > 1 or observations["additional_microphone_prompt_observed"] is not False:
+        raise MatrixError("capture agent introduced an additional microphone prompt")
+    if observations["previous_source_sha"] != previous_sha:
+        raise MatrixError("previous runtime source does not match artifact provenance")
+    for key in (
+        "previous_capture_agent_sha256",
+        "previous_capture_worker_sha256",
+        "installed_capture_agent_sha256",
+        "installed_capture_worker_sha256",
+    ):
+        if (
+            not isinstance(observations[key], str)
+            or re.fullmatch(r"[0-9a-f]{64}", observations[key]) is None
+        ):
+            raise MatrixError(f"{key} must be a lowercase SHA-256")
+    if (
+        observations["previous_capture_agent_sha256"]
+        != previous_provenance["capture_agent_sha256"]
+        or observations["previous_capture_worker_sha256"]
+        != previous_provenance["capture_worker_sha256"]
+    ):
+        raise MatrixError("previous installed hashes do not match artifact provenance")
+    if (
+        observations["installed_capture_agent_sha256"]
+        != provenance["capture_agent_sha256"]
+        or observations["installed_capture_worker_sha256"]
+        != provenance["capture_worker_sha256"]
+    ):
+        raise MatrixError("installed helper hashes do not match artifact provenance")
+    if (
+        observations["previous_capture_agent_sha256"]
+        == observations["installed_capture_agent_sha256"]
+        or observations["previous_capture_worker_sha256"]
+        == observations["installed_capture_worker_sha256"]
+    ):
+        raise MatrixError("signed update did not replace both capture executables")
+    if observations["residual_agent_processes"] != 0:
+        raise MatrixError("agent process remains after unregistration")
+    if observations["residual_worker_processes"] != 0:
+        raise MatrixError("worker process remains after unregistration")
+    records = _exact(matrix["records"], set(REQUIRED_STEPS), "matrix records")
+
+    def record(name: str, exit_code: int) -> dict[str, Any]:
+        envelope = _exact(records[name], {"exit_code", "payload"}, name)
+        if envelope["exit_code"] != exit_code:
+            raise MatrixError(f"{name} exit code mismatch")
+        return envelope["payload"]
+
+    validate_service(record("service_initial", 0), "not_registered")
+    validate_service(record("service_register", 0), "enabled")
+    validate_probe(
+        record("synthetic_cooperative", 0),
+        "cooperative",
+        synthetic=True,
+    )
+    validate_probe(
+        record("synthetic_hard_kill", 0),
+        "hard_kill",
+        synthetic=True,
+    )
+
+    continuity_active = validate_status(record("continuity_active", 0), "active")
+    continuity_recovery = validate_recovery(
+        record("continuity_recovery", 0),
+        synthetic=True,
+        ack_replay=True,
+    )
+    for key in ("agent_pid", "agent_instance", "generation", "worker_pid"):
+        if continuity_active[key] != continuity_recovery[key]:
+            raise MatrixError(f"continuity recovery changed {key}")
+    second_claim = _exact(
+        record("continuity_second_claim", 0),
+        {
+            "schema_version",
+            "outcome",
+            "generation",
+            "recovered",
+            "exact_once",
+            "audio_content_retained",
+        },
+        "second recovery claim",
+    )
+    _common(second_claim, "already_acked")
+    if (
+        second_claim["generation"] != continuity_recovery["generation"]
+        or second_claim["recovered"] is not False
+        or second_claim["exact_once"] is not True
+    ):
+        raise MatrixError("second recovery claim exposed or adopted recovery content")
+    expired = _exact(
+        record("continuity_expired", 0),
+        {
+            "schema_version",
+            "outcome",
+            "generation",
+            "recovered",
+            "audio_content_retained",
+        },
+        "expired recovery claim",
+    )
+    _common(expired, "expired")
+    if (
+        expired["generation"] != continuity_recovery["generation"]
+        or expired["recovered"] is not False
+    ):
+        raise MatrixError("expired recovery tombstone contradicts its generation")
+
+    refresh_before = validate_status(record("refresh_before", 0), "idle")
+    validate_service(record("service_refresh", 0), "enabled")
+    refresh_after = validate_status(record("refresh_after", 0), "idle")
+    if refresh_before["agent_pid"] == refresh_after["agent_pid"]:
+        raise MatrixError("service refresh did not replace the agent process")
+    if refresh_before["agent_instance"] == refresh_after["agent_instance"]:
+        raise MatrixError("service refresh did not replace the agent instance")
+
+    microphone_active = validate_status(record("microphone_active", 0), "active")
+    microphone_recovery = validate_recovery(
+        record("microphone_recovery", 0),
+        synthetic=False,
+    )
+    for key in ("agent_pid", "agent_instance", "generation", "worker_pid"):
+        if microphone_active[key] != microphone_recovery[key]:
+            raise MatrixError(f"microphone recovery changed {key}")
+    denied = _exact(
+        record("microphone_denied", 2),
+        {"schema_version", "outcome", "audio_content_retained"},
+        "denied microphone probe",
+    )
+    _common(denied, "permission_denied")
+    denied_status = validate_status(record("denied_status", 0), "idle")
+    for key in ("agent_pid", "agent_instance", "generation"):
+        if denied_status[key] != microphone_recovery[key]:
+            raise MatrixError(f"denied preflight replaced surviving agent {key}")
+    validate_probe(
+        record("microphone_restored", 0),
+        "cooperative",
+        synthetic=False,
+    )
+    update_before = validate_status(record("update_before", 0), "idle")
+    update_after = validate_status(record("update_after", 0), "idle")
+    if update_before["agent_pid"] == update_after["agent_pid"]:
+        raise MatrixError("signed update did not replace the agent process")
+    if update_before["agent_instance"] == update_after["agent_instance"]:
+        raise MatrixError("signed update did not replace the agent instance")
+    validate_service(record("service_unregister", 0), "not_registered")
+    return dict(matrix)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("matrix", type=Path)
+    args = parser.parse_args()
+    try:
+        payload = json.loads(args.matrix.read_text(encoding="utf-8"))
+        validated = validate_matrix(payload)
+    except (OSError, json.JSONDecodeError, MatrixError) as exc:
+        raise SystemExit(f"capture-agent matrix invalid: {exc}") from exc
+    print(json.dumps(validated, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_helper_evidence.py
+++ b/scripts/capture_helper_evidence.py
@@ -15,10 +15,27 @@ from xml.parsers.expat import ExpatError
 
 
 CAPTURE_HELPER_IDENTIFIER = "com.localdictation.capture-helper"
+CAPTURE_AGENT_IDENTIFIER = "com.localdictation.capture-agent"
+CAPTURE_WORKER_IDENTIFIER = "com.localdictation.capture-worker"
 CAPTURE_ENTITLEMENTS = {
     "com.apple.security.app-sandbox": True,
     "com.apple.security.device.audio-input": True,
     "com.apple.security.device.microphone": True,
+}
+CAPTURE_AGENT_ENTITLEMENTS = {
+    "com.apple.security.app-sandbox": True,
+    "com.apple.security.device.audio-input": True,
+    "com.apple.security.device.microphone": True,
+    "com.apple.security.temporary-exception.mach-lookup.global-name": [
+        "com.localdictation.capture-agent.xpc"
+    ],
+    "com.apple.security.temporary-exception.mach-register.global-name": [
+        "com.localdictation.capture-agent.xpc"
+    ],
+}
+CAPTURE_WORKER_ENTITLEMENTS = {
+    "com.apple.security.app-sandbox": True,
+    "com.apple.security.inherit": True,
 }
 PROBE_FIELDS = {
     "schema_version",
@@ -106,7 +123,7 @@ def _nonnegative_int(value: object, label: str) -> int:
 
 
 def _designated_requirement_profile(
-    requirement: str, identifier: str, team_id: str
+    requirement: str, identifier: str, team_id: str, label: str
 ) -> tuple[str, str]:
     """Validate a complete known-safe requirement and return normalized facts."""
 
@@ -133,7 +150,7 @@ def _designated_requirement_profile(
         if pattern.fullmatch(normalized):
             return profile, normalized
     raise EvidenceError(
-        "capture-helper designated requirement is not an exact canonical profile"
+        f"{label} designated requirement is not an exact canonical profile"
     )
 
 
@@ -202,22 +219,26 @@ def structured_signature_evidence(
     designated_requirement_output: str,
     entitlements: dict[str, object],
     architecture: str,
+    *,
+    expected_identifier: str = CAPTURE_HELPER_IDENTIFIER,
+    expected_entitlements: dict[str, object] = CAPTURE_ENTITLEMENTS,
+    label: str = "capture-helper",
 ) -> dict[str, Any]:
     identifier_match = re.search(r"^Identifier=(.+)$", details, re.MULTILINE)
     team_match = re.search(r"^TeamIdentifier=(.+)$", details, re.MULTILINE)
     identifier = identifier_match.group(1).strip() if identifier_match else ""
     team_id = team_match.group(1).strip() if team_match else ""
-    if identifier != CAPTURE_HELPER_IDENTIFIER:
-        raise EvidenceError("capture-helper signature identifier mismatch")
+    if identifier != expected_identifier:
+        raise EvidenceError(f"{label} signature identifier mismatch")
     if not TEAM_ID_RE.fullmatch(team_id):
-        raise EvidenceError("capture-helper Team ID is invalid")
+        raise EvidenceError(f"{label} Team ID is invalid")
     hardened_runtime = "(runtime)" in details or "Runtime Version=" in details
     if not hardened_runtime:
-        raise EvidenceError("capture-helper hardened runtime is missing")
+        raise EvidenceError(f"{label} hardened runtime is missing")
     if architecture.strip() != "arm64":
-        raise EvidenceError("capture-helper architecture must be exactly arm64")
-    if entitlements != CAPTURE_ENTITLEMENTS:
-        raise EvidenceError("capture-helper entitlements differ from the exact policy")
+        raise EvidenceError(f"{label} architecture must be exactly arm64")
+    if entitlements != expected_entitlements:
+        raise EvidenceError(f"{label} entitlements differ from the exact policy")
 
     requirement_match = re.search(
         r"^#*\s*designated\s*=>\s*(.+)$",
@@ -226,7 +247,7 @@ def structured_signature_evidence(
     )
     requirement = requirement_match.group(1).strip() if requirement_match else ""
     requirement_profile, normalized_requirement = _designated_requirement_profile(
-        requirement, CAPTURE_HELPER_IDENTIFIER, team_id
+        requirement, expected_identifier, team_id, label
     )
 
     entitlement_bytes = plistlib.dumps(entitlements, sort_keys=True)
@@ -284,8 +305,17 @@ def extract_entitlements_plist(payload: bytes) -> dict[str, object]:
 
 
 def collect_signature(
-    helper: Path, signature_output: Path, entitlements_output: Path
+    helper: Path,
+    signature_output: Path,
+    entitlements_output: Path,
+    kind: str = "capture-helper",
 ) -> None:
+    policies = {
+        "capture-helper": (CAPTURE_HELPER_IDENTIFIER, CAPTURE_ENTITLEMENTS),
+        "capture-agent": (CAPTURE_AGENT_IDENTIFIER, CAPTURE_AGENT_ENTITLEMENTS),
+        "capture-worker": (CAPTURE_WORKER_IDENTIFIER, CAPTURE_WORKER_ENTITLEMENTS),
+    }
+    identifier, expected_entitlements = policies[kind]
     details_result = _run(["codesign", "-d", "--verbose=4", str(helper)])
     details = (details_result.stdout + details_result.stderr).decode(
         "utf-8", errors="strict"
@@ -301,7 +331,13 @@ def collect_signature(
     entitlements = extract_entitlements_plist(entitlement_payload)
     architecture = _run(["lipo", "-archs", str(helper)]).stdout.decode().strip()
     evidence = structured_signature_evidence(
-        details, requirement, entitlements, architecture
+        details,
+        requirement,
+        entitlements,
+        architecture,
+        expected_identifier=identifier,
+        expected_entitlements=expected_entitlements,
+        label=kind,
     )
     signature_output.write_text(
         json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -344,6 +380,11 @@ def main() -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
     collect = subparsers.add_parser("collect-signature")
     collect.add_argument("--helper", type=Path, required=True)
+    collect.add_argument(
+        "--kind",
+        choices=("capture-helper", "capture-agent", "capture-worker"),
+        default="capture-helper",
+    )
     collect.add_argument("--signature-output", type=Path, required=True)
     collect.add_argument("--entitlements-output", type=Path, required=True)
     validate = subparsers.add_parser("validate-probe")
@@ -356,7 +397,10 @@ def main() -> int:
 
     if args.command == "collect-signature":
         collect_signature(
-            args.helper, args.signature_output, args.entitlements_output
+            args.helper,
+            args.signature_output,
+            args.entitlements_output,
+            args.kind,
         )
     else:
         validate_probe_file(

--- a/scripts/finalize_macos_bundle.py
+++ b/scripts/finalize_macos_bundle.py
@@ -6,13 +6,18 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import plistlib
+import shutil
 import subprocess
 
 
 HELPERS = {
+    "murmur-capture-agent": "com.localdictation.capture-agent",
     "murmur-capture-helper": "com.localdictation.capture-helper",
+    "murmur-capture-worker": "com.localdictation.capture-worker",
     "murmur-llm-sidecar": "com.localdictation.local-llm-sidecar",
 }
+CAPTURE_AGENT_PLIST = "com.localdictation.capture-agent.plist"
+CAPTURE_AGENT_MACH_SERVICE = "com.localdictation.capture-agent.xpc"
 
 
 def run(command: list[str], *, capture: bool = False) -> str:
@@ -129,6 +134,77 @@ def require_exact_macos_executables(
         )
 
 
+def install_capture_agent_plist(app: Path, source: Path) -> Path:
+    with source.open("rb") as handle:
+        payload = plistlib.load(handle)
+    expected = {
+        "Label": "com.localdictation.capture-agent",
+        "BundleProgram": "Contents/MacOS/murmur-capture-agent",
+        "MachServices": {CAPTURE_AGENT_MACH_SERVICE: True},
+        "ProcessType": "Interactive",
+        "ThrottleInterval": 10,
+    }
+    if payload != expected:
+        raise SystemExit(
+            f"capture-agent launchd plist differs: expected={expected!r} actual={payload!r}"
+        )
+    destination = app / "Contents" / "Library" / "LaunchAgents" / CAPTURE_AGENT_PLIST
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination
+
+
+def decode_otool_info_plist(output: str) -> dict[str, object]:
+    payload = bytearray()
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 2:
+            continue
+        try:
+            int(fields[0], 16)
+        except ValueError:
+            continue
+        for word in fields[1:]:
+            if len(word) != 8:
+                raise SystemExit("embedded Info.plist has malformed words")
+            try:
+                payload.extend(bytes.fromhex(word)[::-1])
+            except ValueError as exc:
+                raise SystemExit(
+                    "embedded Info.plist is not hexadecimal"
+                ) from exc
+    try:
+        value = plistlib.loads(bytes(payload).rstrip(b"\0"))
+    except Exception as exc:
+        raise SystemExit("embedded Info.plist is invalid") from exc
+    if not isinstance(value, dict):
+        raise SystemExit("embedded Info.plist is not a dictionary")
+    return value
+
+
+def require_embedded_info(
+    executable: Path,
+    template: Path,
+    app_version: str,
+    label: str,
+) -> None:
+    with template.open("rb") as handle:
+        expected = plistlib.load(handle)
+    for key in ("CFBundleShortVersionString", "CFBundleVersion"):
+        expected[key] = app_version
+    actual = decode_otool_info_plist(
+        run(
+            ["otool", "-X", "-s", "__TEXT", "__info_plist", str(executable)],
+            capture=True,
+        )
+    )
+    if actual != expected:
+        raise SystemExit(
+            f"{label} embedded Info.plist differs: "
+            f"expected={expected!r} actual={actual!r}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--app", type=Path, required=True)
@@ -142,6 +218,12 @@ def main() -> int:
         required=True,
     )
     parser.add_argument("--capture-helper-entitlements", type=Path, required=True)
+    parser.add_argument("--capture-worker-entitlements", type=Path, required=True)
+    parser.add_argument("--capture-agent-entitlements", type=Path, required=True)
+    parser.add_argument("--capture-agent-info-plist", type=Path, required=True)
+    parser.add_argument("--capture-helper-info-plist", type=Path, required=True)
+    parser.add_argument("--capture-worker-info-plist", type=Path, required=True)
+    parser.add_argument("--capture-agent-launchd-plist", type=Path, required=True)
     parser.add_argument("--expected-team-id")
     args = parser.parse_args()
 
@@ -153,18 +235,53 @@ def main() -> int:
     if not info_plist.is_file() or not all(path.is_file() for path in helpers.values()):
         raise SystemExit("app bundle is missing Info.plist or a required helper")
     with info_plist.open("rb") as handle:
-        main_name = plistlib.load(handle).get("CFBundleExecutable")
+        app_info = plistlib.load(handle)
+    main_name = app_info.get("CFBundleExecutable")
+    app_version = str(app_info.get("CFBundleVersion", ""))
+    if not app_version:
+        raise SystemExit("app bundle version is missing")
     main_binary = app / "Contents" / "MacOS" / str(main_name)
     if not main_binary.is_file() or main_binary in helpers.values():
         raise SystemExit("app bundle has an invalid main executable")
     require_exact_macos_executables(app, main_binary, list(helpers.values()))
+    require_embedded_info(
+        helpers["murmur-capture-agent"],
+        args.capture_agent_info_plist,
+        app_version,
+        "capture agent",
+    )
+    require_embedded_info(
+        helpers["murmur-capture-helper"],
+        args.capture_helper_info_plist,
+        app_version,
+        "capture helper",
+    )
+    require_embedded_info(
+        helpers["murmur-capture-worker"],
+        args.capture_worker_info_plist,
+        app_version,
+        "capture worker",
+    )
+    launchd_plist = install_capture_agent_plist(app, args.capture_agent_launchd_plist)
 
     sign_nested_code(app, args.identity, exclude={main_binary, *helpers.values()})
+    sign(
+        helpers["murmur-capture-agent"],
+        args.identity,
+        args.capture_agent_entitlements,
+        HELPERS["murmur-capture-agent"],
+    )
     sign(
         helpers["murmur-capture-helper"],
         args.identity,
         args.capture_helper_entitlements,
         HELPERS["murmur-capture-helper"],
+    )
+    sign(
+        helpers["murmur-capture-worker"],
+        args.identity,
+        args.capture_worker_entitlements,
+        HELPERS["murmur-capture-worker"],
     )
     sign(
         helpers["murmur-llm-sidecar"],
@@ -177,9 +294,19 @@ def main() -> int:
 
     run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app)])
     require_exact(
+        entitlements(helpers["murmur-capture-agent"]),
+        args.capture_agent_entitlements,
+        "capture agent",
+    )
+    require_exact(
         entitlements(helpers["murmur-capture-helper"]),
         args.capture_helper_entitlements,
         "capture helper",
+    )
+    require_exact(
+        entitlements(helpers["murmur-capture-worker"]),
+        args.capture_worker_entitlements,
+        "capture worker",
     )
     require_exact(
         entitlements(helpers["murmur-llm-sidecar"]),
@@ -187,6 +314,9 @@ def main() -> int:
         "local-LLM helper",
     )
     require_exact(entitlements(main_binary), args.main_entitlements, "main executable")
+    with launchd_plist.open("rb") as handle:
+        if plistlib.load(handle)["MachServices"] != {CAPTURE_AGENT_MACH_SERVICE: True}:
+            raise SystemExit("signed bundle capture-agent Mach service differs")
 
     helper_details = {
         name: signature_details(path) for name, path in helpers.items()

--- a/scripts/probe_macos_sidecar_signing.py
+++ b/scripts/probe_macos_sidecar_signing.py
@@ -20,7 +20,9 @@ def main() -> int:
     parser.add_argument(
         "--llm-helper", "--helper", dest="llm_helper", type=Path, required=True
     )
+    parser.add_argument("--capture-agent", type=Path, required=True)
     parser.add_argument("--capture-helper", type=Path, required=True)
+    parser.add_argument("--capture-worker", type=Path, required=True)
     parser.add_argument("--output-app", type=Path)
     args = parser.parse_args()
 
@@ -61,7 +63,9 @@ def main() -> int:
         check=True,
     )
     shutil.copy2(args.llm_helper, macos / "murmur-llm-sidecar")
+    shutil.copy2(args.capture_agent, macos / "murmur-capture-agent")
     shutil.copy2(args.capture_helper, macos / "murmur-capture-helper")
+    shutil.copy2(args.capture_worker, macos / "murmur-capture-worker")
 
     subprocess.run(
         [
@@ -75,8 +79,33 @@ def main() -> int:
             str(ROOT / "app" / "src-tauri" / "entitlements.plist"),
             "--helper-entitlements",
             str(ROOT / "app" / "src-tauri" / "local-llm-sidecar.entitlements.plist"),
+            "--capture-agent-entitlements",
+            str(ROOT / "app" / "src-tauri" / "capture-agent.entitlements.plist"),
+            "--capture-agent-info-plist",
+            str(ROOT / "app" / "src-tauri" / "capture-agent-info.plist"),
+            "--capture-helper-info-plist",
+            str(ROOT / "app" / "src-tauri" / "sidecars" / "capture" / "Info.plist"),
+            "--capture-worker-info-plist",
+            str(
+                ROOT
+                / "app"
+                / "src-tauri"
+                / "sidecars"
+                / "capture"
+                / "WorkerInfo.plist"
+            ),
+            "--capture-agent-launchd-plist",
+            str(
+                ROOT
+                / "app"
+                / "src-tauri"
+                / "macos"
+                / "com.localdictation.capture-agent.plist"
+            ),
             "--capture-helper-entitlements",
             str(ROOT / "app" / "src-tauri" / "capture-helper.entitlements.plist"),
+            "--capture-worker-entitlements",
+            str(ROOT / "app" / "src-tauri" / "capture-worker.entitlements.plist"),
         ],
         check=True,
     )
@@ -84,13 +113,18 @@ def main() -> int:
         "schema_version": 1,
         "app": str(app),
         "helpers": {
+            "capture_agent": str(macos / "murmur-capture-agent"),
             "capture": str(macos / "murmur-capture-helper"),
+            "capture_worker": str(macos / "murmur-capture-worker"),
             "local_llm": str(macos / "murmur-llm-sidecar"),
         },
         "identity": "adhoc",
         "main_sandboxed": False,
         "capture_helper_sandboxed": True,
         "capture_helper_audio_input": True,
+        "capture_worker_inherits_agent_sandbox": True,
+        "capture_agent_sandboxed": True,
+        "capture_agent_audio_input": True,
         "llm_helper_sandboxed": True,
         "result": "passed",
     }

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -16,6 +16,8 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 TEAM_ID_RE = re.compile(r"^[A-Z0-9]{10}$")
 LLM_HELPER_IDENTIFIER = "com.localdictation.local-llm-sidecar"
+CAPTURE_AGENT_IDENTIFIER = "com.localdictation.capture-agent"
+CAPTURE_WORKER_IDENTIFIER = "com.localdictation.capture-worker"
 CAPTURE_HELPER_IDENTIFIER = "com.localdictation.capture-helper"
 HELPER_FIELDS = (
     "sha256",
@@ -161,6 +163,8 @@ def create_provenance(
     commit_sha: str,
     run_id: str | int,
     helper: dict[str, Any] | None = None,
+    capture_agent: dict[str, Any] | None = None,
+    capture_worker: dict[str, Any] | None = None,
     capture_helper: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if platform not in PLATFORM_SUFFIXES:
@@ -216,6 +220,22 @@ def create_provenance(
         payload["capture_helper"] = _require_helper(
             capture_helper, CAPTURE_HELPER_IDENTIFIER, "capture helper"
         )
+    if capture_agent is not None:
+        if platform != "macos":
+            raise ArtifactError(
+                "capture agent provenance is only recorded for macos"
+            )
+        payload["capture_agent"] = _require_helper(
+            capture_agent, CAPTURE_AGENT_IDENTIFIER, "capture agent"
+        )
+    if capture_worker is not None:
+        if platform != "macos":
+            raise ArtifactError(
+                "capture worker provenance is only recorded for macos"
+            )
+        payload["capture_worker"] = _require_helper(
+            capture_worker, CAPTURE_WORKER_IDENTIFIER, "capture worker"
+        )
     (root / "provenance.json").write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
@@ -228,6 +248,8 @@ def validate_platform(
     expected_sha: str,
     expected_run_id: str | int,
     require_helper: bool = False,
+    require_capture_agent: bool = False,
+    require_capture_worker: bool = False,
     require_capture_helper: bool = False,
 ) -> dict[str, Any]:
     expected_sha = _require_sha(expected_sha, "expected commit SHA")
@@ -308,6 +330,33 @@ def validate_platform(
             f"{platform} provenance is missing the required capture helper block"
         )
 
+    capture_agent = payload.get("capture_agent")
+    if capture_agent is not None:
+        if platform != "macos":
+            raise ArtifactError(
+                f"{platform} provenance must not carry a capture_agent block"
+            )
+        payload["capture_agent"] = _require_helper(
+            capture_agent, CAPTURE_AGENT_IDENTIFIER, "capture agent"
+        )
+    elif require_capture_agent:
+        raise ArtifactError(
+            f"{platform} provenance is missing the required capture agent block"
+        )
+    capture_worker = payload.get("capture_worker")
+    if capture_worker is not None:
+        if platform != "macos":
+            raise ArtifactError(
+                f"{platform} provenance must not carry a capture_worker block"
+            )
+        payload["capture_worker"] = _require_helper(
+            capture_worker, CAPTURE_WORKER_IDENTIFIER, "capture worker"
+        )
+    elif require_capture_worker:
+        raise ArtifactError(
+            f"{platform} provenance is missing the required capture worker block"
+        )
+
     payload["signature"] = _signature_text(signature)
     return payload
 
@@ -318,6 +367,8 @@ def validate_release(
     expected_run_id: str | int,
     output: Path | None = None,
     require_macos_helper: bool = False,
+    require_macos_capture_agent: bool = False,
+    require_macos_capture_worker: bool = False,
     require_macos_capture_helper: bool = False,
 ) -> dict[str, Any]:
     platforms = {
@@ -327,6 +378,12 @@ def validate_release(
             expected_sha,
             expected_run_id,
             require_helper=(require_macos_helper and platform == "macos"),
+            require_capture_agent=(
+                require_macos_capture_agent and platform == "macos"
+            ),
+            require_capture_worker=(
+                require_macos_capture_worker and platform == "macos"
+            ),
             require_capture_helper=(
                 require_macos_capture_helper and platform == "macos"
             ),
@@ -443,6 +500,16 @@ def _parser() -> argparse.ArgumentParser:
     record.add_argument("--capture-helper-designated-requirement")
     record.add_argument("--capture-helper-team-id")
     record.add_argument("--capture-helper-entitlement-sha256")
+    record.add_argument("--capture-agent-sha256")
+    record.add_argument("--capture-agent-arch")
+    record.add_argument("--capture-agent-designated-requirement")
+    record.add_argument("--capture-agent-team-id")
+    record.add_argument("--capture-agent-entitlement-sha256")
+    record.add_argument("--capture-worker-sha256")
+    record.add_argument("--capture-worker-arch")
+    record.add_argument("--capture-worker-designated-requirement")
+    record.add_argument("--capture-worker-team-id")
+    record.add_argument("--capture-worker-entitlement-sha256")
 
     validate = subparsers.add_parser("validate")
     validate.add_argument("--artifacts", type=Path, required=True)
@@ -453,6 +520,16 @@ def _parser() -> argparse.ArgumentParser:
         "--require-macos-helper",
         action="store_true",
         help="fail unless the macOS provenance records the local-LLM helper block",
+    )
+    validate.add_argument(
+        "--require-macos-capture-agent",
+        action="store_true",
+        help="fail unless macOS provenance records the capture agent block",
+    )
+    validate.add_argument(
+        "--require-macos-capture-worker",
+        action="store_true",
+        help="fail unless macOS provenance records the capture worker block",
     )
     validate.add_argument(
         "--require-macos-capture-helper",
@@ -507,11 +584,51 @@ def _capture_helper_from_args(args: argparse.Namespace) -> dict[str, Any] | None
     return supplied
 
 
+def _capture_agent_from_args(args: argparse.Namespace) -> dict[str, Any] | None:
+    provided = {
+        "sha256": args.capture_agent_sha256,
+        "architecture": args.capture_agent_arch,
+        "designated_requirement": args.capture_agent_designated_requirement,
+        "team_id": args.capture_agent_team_id,
+        "entitlement_sha256": args.capture_agent_entitlement_sha256,
+    }
+    supplied = {key: value for key, value in provided.items() if value}
+    if not supplied:
+        return None
+    if len(supplied) != len(provided):
+        missing = sorted(set(provided) - set(supplied))
+        raise ArtifactError(
+            f"incomplete capture agent provenance arguments: missing {missing}"
+        )
+    return supplied
+
+
+def _capture_worker_from_args(args: argparse.Namespace) -> dict[str, Any] | None:
+    provided = {
+        "sha256": args.capture_worker_sha256,
+        "architecture": args.capture_worker_arch,
+        "designated_requirement": args.capture_worker_designated_requirement,
+        "team_id": args.capture_worker_team_id,
+        "entitlement_sha256": args.capture_worker_entitlement_sha256,
+    }
+    supplied = {key: value for key, value in provided.items() if value}
+    if not supplied:
+        return None
+    if len(supplied) != len(provided):
+        missing = sorted(set(provided) - set(supplied))
+        raise ArtifactError(
+            f"incomplete capture worker provenance arguments: missing {missing}"
+        )
+    return supplied
+
+
 def main() -> None:
     args = _parser().parse_args()
     try:
         if args.command == "record":
             helper = _helper_from_args(args)
+            capture_agent = _capture_agent_from_args(args)
+            capture_worker = _capture_worker_from_args(args)
             capture_helper = _capture_helper_from_args(args)
             payload = create_provenance(
                 args.platform,
@@ -520,6 +637,8 @@ def main() -> None:
                 args.commit_sha,
                 args.run_id,
                 helper=helper,
+                capture_agent=capture_agent,
+                capture_worker=capture_worker,
                 capture_helper=capture_helper,
             )
             print(
@@ -533,6 +652,8 @@ def main() -> None:
                 args.expected_run_id,
                 args.output,
                 require_macos_helper=args.require_macos_helper,
+                require_macos_capture_agent=args.require_macos_capture_agent,
+                require_macos_capture_worker=args.require_macos_capture_worker,
                 require_macos_capture_helper=args.require_macos_capture_helper,
             )
             print(

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -129,15 +129,23 @@ def validate_ci(ci: str) -> int:
     assert scalar(job_block(ci, "ci-pass"), "if") == CI_PASS_GUARD
     assert "scripts/validate_workflow_policy.py" in ci
     assert "scripts/release_artifacts.py" in ci
+    assert "scripts/capture_agent_matrix.py" in ci
     assert "tests/test_release_artifacts.py" in ci
     assert "tests/test_workflow_policy.py" in ci
-    helper_stubs = named_step_block(
-        ci, "Stub bundled helpers externalBin for compile checks", 6
+    assert "tests/test_capture_agent_matrix.py" in ci
+    capture_build = named_step_block(
+        ci, "Build capture isolation helpers and stub local-LLM externalBin", 6
     )
-    for helper in ("murmur-capture-helper", "murmur-llm-sidecar"):
-        target = f"app/src-tauri/binaries/{helper}-aarch64-apple-darwin"
-        assert helper_stubs.count(f": > {target}") == 1
-        assert helper_stubs.count(f"chmod +x {target}") == 1
+    assert "swiftc -warnings-as-errors" in capture_build
+    assert "sidecars/capture-agent/main.swift" in capture_build
+    assert "cargo build -p murmur-capture-helper" in capture_build
+    assert "MURMUR_CAPTURE_ROLE=worker" in capture_build
+    assert "CARGO_TARGET_DIR=target/capture-worker-build" in capture_build
+    assert "target/capture-worker-build/debug/murmur-capture-helper" in capture_build
+    assert "binaries/murmur-capture-worker-aarch64-apple-darwin" in capture_build
+    llm_target = "binaries/murmur-llm-sidecar-aarch64-apple-darwin"
+    assert capture_build.count(f": > {llm_target}") == 1
+    assert capture_build.count(f"chmod +x {llm_target}") == 1
 
     cases = (
         ("push", "chore: bump version to 0.17.0", False),
@@ -171,11 +179,37 @@ def validate_release_build(workflow: str) -> int:
         "--capture-helper-entitlements app/src-tauri/capture-helper.entitlements.plist"
         in workflow
     )
+    assert (
+        "--capture-agent-entitlements app/src-tauri/capture-agent.entitlements.plist"
+        in workflow
+    )
+    assert "--capture-agent-info-plist app/src-tauri/capture-agent-info.plist" in workflow
+    assert (
+        "--capture-helper-info-plist app/src-tauri/sidecars/capture/Info.plist"
+        in workflow
+    )
+    assert (
+        "--capture-worker-info-plist app/src-tauri/sidecars/capture/WorkerInfo.plist"
+        in workflow
+    )
+    assert (
+        "--capture-worker-entitlements app/src-tauri/capture-worker.entitlements.plist"
+        in workflow
+    )
+    assert (
+        "--capture-agent-launchd-plist "
+        "app/src-tauri/macos/com.localdictation.capture-agent.plist"
+        in workflow
+    )
     assert '--capture-helper-sha256 "$CAPTURE_HELPER_SHA"' in workflow
+    assert '--capture-agent-sha256 "$CAPTURE_AGENT_SHA"' in workflow
+    assert '--capture-worker-sha256 "$CAPTURE_WORKER_SHA"' in workflow
     capture_evidence = named_step_block(
         workflow, "Record capture-helper signing and non-interactive probe evidence", 6
     )
     assert "scripts/capture_helper_evidence.py collect-signature" in capture_evidence
+    assert "--kind capture-agent" in capture_evidence
+    assert "--kind capture-worker" in capture_evidence
     assert "scripts/capture_helper_evidence.py validate-probe" in capture_evidence
     assert '--signed-bundle-artifact "macos-release-$SOURCE_SHA"' in capture_evidence
     assert "signature.json" in capture_evidence
@@ -412,6 +446,8 @@ def validate_promotion_policy(workflow: str) -> int:
     assert "expired == false" in workflow
     assert "scripts/release_artifacts.py validate" in workflow
     assert "--require-macos-capture-helper" in workflow
+    assert "--require-macos-capture-agent" in workflow
+    assert "--require-macos-capture-worker" in workflow
     assert 'at("app/src-tauri/tauri.conf.json")' in workflow
     assert 'at("app/src-tauri/Cargo.toml")' in workflow
     assert 'at("app/src-tauri/Cargo.lock")' in workflow

--- a/tests/test_capture_agent_matrix.py
+++ b/tests/test_capture_agent_matrix.py
@@ -1,0 +1,227 @@
+from copy import deepcopy
+import unittest
+
+from scripts.capture_agent_matrix import MatrixError, validate_matrix
+
+
+class CaptureAgentMatrixTests(unittest.TestCase):
+    def setUp(self) -> None:
+        sha = "a" * 40
+        service = lambda status: {
+            "schema_version": 1,
+            "outcome": "service_status",
+            "service_status": status,
+            "audio_content_retained": False,
+        }
+        status = lambda outcome, agent, instance, generation, worker, count=0: {
+            "schema_version": 1,
+            "outcome": outcome,
+            "agent_pid": agent,
+            "agent_instance": instance,
+            "generation": generation,
+            "worker_pid": worker,
+            "synthetic_canary_count": count,
+            "audio_content_retained": False,
+        }
+        synthetic = {
+            "synthetic_fixture": "seq-v1",
+            "synthetic_digest":
+                "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3",
+            "synthetic_first_sequence": 0,
+            "synthetic_last_sequence": 63,
+            "synthetic_complete": True,
+        }
+        probe = lambda termination, is_synthetic: {
+            "schema_version": 1,
+            "outcome": "ok",
+            "generation": 1,
+            "agent_pid": 100,
+            "agent_instance": "one",
+            "worker_pid": 101,
+            "synthetic_canary_count": 64 if is_synthetic else 2,
+            "first_callback_ms": 1,
+            "worker_termination": termination,
+            "stop_elapsed_ms": 20 if termination == "cooperative" else 260,
+            "worker_exited": True,
+            "process_group_empty": True,
+            "exit_signal": 9 if termination == "hard_kill" else 0,
+            "audio_content_retained": False,
+            **(synthetic if is_synthetic else {}),
+        }
+        recovery = lambda agent, instance, generation, worker, is_synthetic: {
+            "schema_version": 1,
+            "outcome": "recovery_acked",
+            "generation": generation,
+            "agent_pid": agent,
+            "agent_instance": instance,
+            "worker_pid": worker,
+            "synthetic_canary_count": 64 if is_synthetic else 2,
+            "first_callback_ms": 1,
+            "worker_termination": "cooperative",
+            "stop_elapsed_ms": 20,
+            "recovery_ttl_ms": 29_000,
+            "agent_survived": True,
+            "worker_exited": True,
+            "process_group_empty": True,
+            "exit_signal": 0,
+            "audio_content_retained": False,
+            "claim_id": "claim",
+            "recovered": True,
+            "exact_once": True,
+            **(synthetic if is_synthetic else {}),
+        }
+        envelope = lambda payload, code=0: {"exit_code": code, "payload": payload}
+        self.matrix = {
+            "schema_version": 1,
+            "source_sha": sha,
+            "signed_bundle_artifact": f"macos-release-{sha}",
+            "artifact_provenance": {
+                "commit_sha": sha,
+                "workflow_run_id": 123,
+                "capture_agent_sha256": "b" * 64,
+                "capture_worker_sha256": "c" * 64,
+                "capture_agent_identifier": "com.localdictation.capture-agent",
+                "capture_worker_identifier": "com.localdictation.capture-worker",
+                "team_id": "P2U3P8B923",
+            },
+            "previous_signed_bundle_artifact": f"macos-release-{'f' * 40}",
+            "previous_artifact_provenance": {
+                "commit_sha": "f" * 40,
+                "workflow_run_id": 122,
+                "capture_agent_sha256": "d" * 64,
+                "capture_worker_sha256": "e" * 64,
+                "capture_agent_identifier": "com.localdictation.capture-agent",
+                "capture_worker_identifier": "com.localdictation.capture-worker",
+                "team_id": "P2U3P8B923",
+            },
+            "observations": {
+                "notarized": True,
+                "stapled": True,
+                "gatekeeper_accepted": True,
+                "quarantine_applied": True,
+                "launchservices_opened": True,
+                "main_pid_before_revocation": 500,
+                "main_pid_after_revocation": 501,
+                "permission_transition": ["granted", "denied", "granted"],
+                "revocation_trigger": "system_settings_microphone_toggle",
+                "background_activity_labels": ["Murmur"],
+                "microphone_identity_labels": ["Murmur"],
+                "microphone_prompt_count": 1,
+                "additional_microphone_prompt_observed": False,
+                "previous_source_sha": "f" * 40,
+                "previous_capture_agent_sha256": "d" * 64,
+                "previous_capture_worker_sha256": "e" * 64,
+                "installed_capture_agent_sha256": "b" * 64,
+                "installed_capture_worker_sha256": "c" * 64,
+                "residual_agent_processes": 0,
+                "residual_worker_processes": 0,
+            },
+            "records": {
+                "service_initial": envelope(service("not_registered")),
+                "service_register": envelope(service("enabled")),
+                "synthetic_cooperative": envelope(probe("cooperative", True)),
+                "synthetic_hard_kill": envelope(probe("hard_kill", True)),
+                "continuity_active": envelope(
+                    status("active", 100, "one", 2, 102, 64)
+                ),
+                "continuity_recovery": envelope(
+                    {
+                        **recovery(100, "one", 2, 102, True),
+                        "ack_replay_verified": True,
+                    }
+                ),
+                "continuity_second_claim": envelope(
+                    {
+                        "schema_version": 1,
+                        "outcome": "already_acked",
+                        "generation": 2,
+                        "recovered": False,
+                        "exact_once": True,
+                        "audio_content_retained": False,
+                    }
+                ),
+                "continuity_expired": envelope(
+                    {
+                        "schema_version": 1,
+                        "outcome": "expired",
+                        "generation": 2,
+                        "recovered": False,
+                        "audio_content_retained": False,
+                    }
+                ),
+                "refresh_before": envelope(status("idle", 100, "one", 2, 0)),
+                "service_refresh": envelope(service("enabled")),
+                "refresh_after": envelope(status("idle", 200, "two", 0, 0)),
+                "microphone_active": envelope(
+                    status("active", 200, "two", 1, 201, 2)
+                ),
+                "microphone_recovery": envelope(
+                    recovery(200, "two", 1, 201, False)
+                ),
+                "microphone_denied": envelope(
+                    {
+                        "schema_version": 1,
+                        "outcome": "permission_denied",
+                        "audio_content_retained": False,
+                    },
+                    2,
+                ),
+                "denied_status": envelope(status("idle", 200, "two", 1, 0)),
+                "microphone_restored": envelope(probe("cooperative", False)),
+                "update_before": envelope(status("idle", 200, "two", 2, 0)),
+                "update_after": envelope(status("idle", 300, "three", 0, 0)),
+                "service_unregister": envelope(service("not_registered")),
+            },
+        }
+
+    def test_complete_matrix_is_valid(self) -> None:
+        self.assertEqual(validate_matrix(self.matrix), self.matrix)
+
+    def test_cross_record_identity_change_is_rejected(self) -> None:
+        mutated = deepcopy(self.matrix)
+        mutated["records"]["continuity_recovery"]["payload"]["worker_pid"] = 999
+        with self.assertRaises(MatrixError):
+            validate_matrix(mutated)
+
+    def test_unconfirmed_group_and_incomplete_sequence_are_rejected(self) -> None:
+        for step, key, value in (
+            ("synthetic_hard_kill", "process_group_empty", False),
+            ("synthetic_cooperative", "synthetic_last_sequence", 62),
+            ("synthetic_hard_kill", "exit_signal", 0),
+            ("continuity_recovery", "exit_signal", 9),
+        ):
+            mutated = deepcopy(self.matrix)
+            mutated["records"][step]["payload"][key] = value
+            with self.subTest(step=step, key=key):
+                with self.assertRaises(MatrixError):
+                    validate_matrix(mutated)
+
+    def test_denied_preflight_must_not_advance_generation(self) -> None:
+        mutated = deepcopy(self.matrix)
+        mutated["records"]["denied_status"]["payload"]["generation"] = 2
+        with self.assertRaises(MatrixError):
+            validate_matrix(mutated)
+
+    def test_ack_replay_and_prompt_evidence_are_required(self) -> None:
+        for path, value in (
+            (
+                ("records", "continuity_recovery", "payload", "ack_replay_verified"),
+                False,
+            ),
+            (("observations", "additional_microphone_prompt_observed"), True),
+            (("observations", "microphone_prompt_count"), 2),
+        ):
+            mutated = deepcopy(self.matrix)
+            target = mutated
+            for key in path[:-1]:
+                target = target[key]
+            target[path[-1]] = value
+            with self.subTest(path=path):
+                with self.assertRaises(MatrixError):
+                    validate_matrix(mutated)
+
+    def test_previous_runtime_hashes_must_match_previous_provenance(self) -> None:
+        mutated = deepcopy(self.matrix)
+        mutated["observations"]["previous_capture_agent_sha256"] = "9" * 64
+        with self.assertRaises(MatrixError):
+            validate_matrix(mutated)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -9,6 +9,10 @@ import unittest
 
 from scripts.capture_helper_evidence import (
     ALLOWED_PROBE_OUTCOMES,
+    CAPTURE_AGENT_ENTITLEMENTS,
+    CAPTURE_AGENT_IDENTIFIER,
+    CAPTURE_WORKER_ENTITLEMENTS,
+    CAPTURE_WORKER_IDENTIFIER,
     CAPTURE_ENTITLEMENTS,
     EvidenceError,
     PROBE_OUTCOME_CONTRACTS,
@@ -144,6 +148,20 @@ class ReleaseArtifactTests(unittest.TestCase):
             'and certificate leaf[subject.OU] = "ABCDE12345"'
         ),
     }
+    CAPTURE_AGENT = {
+        **HELPER,
+        "designated_requirement": (
+            'identifier "com.localdictation.capture-agent" and anchor apple generic '
+            'and certificate leaf[subject.OU] = "ABCDE12345"'
+        ),
+    }
+    CAPTURE_WORKER = {
+        **HELPER,
+        "designated_requirement": (
+            'identifier "com.localdictation.capture-worker" and anchor apple generic '
+            'and certificate leaf[subject.OU] = "ABCDE12345"'
+        ),
+    }
     CAPTURE_PROBE = {
         "schema_version": 1,
         "outcome": "ok",
@@ -212,6 +230,66 @@ class ReleaseArtifactTests(unittest.TestCase):
                 SHA,
                 RUN_ID,
                 require_macos_capture_helper=True,
+            )
+
+    def test_capture_agent_provenance_is_required_and_validated(self) -> None:
+        macos = self.artifacts / "macos"
+        (macos / "provenance.json").unlink()
+        create_provenance(
+            "macos",
+            "darwin-aarch64",
+            macos,
+            SHA,
+            RUN_ID,
+            capture_agent=self.CAPTURE_AGENT,
+        )
+        result = validate_release(
+            self.artifacts,
+            SHA,
+            RUN_ID,
+            require_macos_capture_agent=True,
+        )
+        self.assertEqual(
+            result["platforms"]["macos"]["capture_agent"], self.CAPTURE_AGENT
+        )
+
+    def test_require_capture_agent_fails_without_block(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "required capture agent"):
+            validate_release(
+                self.artifacts,
+                SHA,
+                RUN_ID,
+                require_macos_capture_agent=True,
+            )
+
+    def test_capture_worker_provenance_is_required_and_validated(self) -> None:
+        macos = self.artifacts / "macos"
+        (macos / "provenance.json").unlink()
+        create_provenance(
+            "macos",
+            "darwin-aarch64",
+            macos,
+            SHA,
+            RUN_ID,
+            capture_worker=self.CAPTURE_WORKER,
+        )
+        result = validate_release(
+            self.artifacts,
+            SHA,
+            RUN_ID,
+            require_macos_capture_worker=True,
+        )
+        self.assertEqual(
+            result["platforms"]["macos"]["capture_worker"], self.CAPTURE_WORKER
+        )
+
+    def test_require_capture_worker_fails_without_block(self) -> None:
+        with self.assertRaisesRegex(ArtifactError, "required capture worker"):
+            validate_release(
+                self.artifacts,
+                SHA,
+                RUN_ID,
+                require_macos_capture_worker=True,
             )
 
     def test_helper_wrong_architecture_fails_closed(self) -> None:
@@ -313,12 +391,18 @@ class ReleaseArtifactTests(unittest.TestCase):
         executable_dir.mkdir(parents=True)
         main = executable_dir / "ui"
         helper = executable_dir / "murmur-llm-sidecar"
+        capture_agent = executable_dir / "murmur-capture-agent"
         capture_helper = executable_dir / "murmur-capture-helper"
+        capture_worker = executable_dir / "murmur-capture-worker"
         main.write_bytes(b"main")
         helper.write_bytes(b"helper")
+        capture_agent.write_bytes(b"capture agent")
         capture_helper.write_bytes(b"capture helper")
+        capture_worker.write_bytes(b"capture worker")
 
-        require_exact_macos_executables(app, main, [capture_helper, helper])
+        require_exact_macos_executables(
+            app, main, [capture_agent, capture_helper, capture_worker, helper]
+        )
 
         for unexpected in ("mock_llm_helper", "murmur-eval"):
             with self.subTest(unexpected=unexpected):
@@ -328,7 +412,7 @@ class ReleaseArtifactTests(unittest.TestCase):
                     SystemExit, "app bundle executables differ"
                 ):
                     require_exact_macos_executables(
-                        app, main, [capture_helper, helper]
+                        app, main, [capture_agent, capture_helper, capture_worker, helper]
                     )
                 extra.unlink()
 
@@ -338,12 +422,100 @@ class ReleaseArtifactTests(unittest.TestCase):
         executable_dir.mkdir(parents=True)
         main = executable_dir / "ui"
         helper = executable_dir / "murmur-llm-sidecar"
+        capture_agent = executable_dir / "murmur-capture-agent"
         capture_helper = executable_dir / "murmur-capture-helper"
+        capture_worker = executable_dir / "murmur-capture-worker"
         main.write_bytes(b"main")
         helper.write_bytes(b"helper")
+        capture_agent.write_bytes(b"capture agent")
+        capture_worker.write_bytes(b"capture worker")
 
         with self.assertRaisesRegex(SystemExit, "app bundle executables differ"):
-            require_exact_macos_executables(app, main, [capture_helper, helper])
+            require_exact_macos_executables(
+                app, main, [capture_agent, capture_helper, capture_worker, helper]
+            )
+
+    def test_capture_agent_identity_entitlements_and_launchd_plist_are_exact(
+        self,
+    ) -> None:
+        self.assertEqual(
+            HELPERS["murmur-capture-agent"],
+            "com.localdictation.capture-agent",
+        )
+        self.assertEqual(
+            HELPERS["murmur-capture-worker"],
+            CAPTURE_WORKER_IDENTIFIER,
+        )
+        self.assertEqual(CAPTURE_WORKER_IDENTIFIER, "com.localdictation.capture-worker")
+        root = Path(__file__).parents[1]
+        with (root / "app/src-tauri/capture-agent.entitlements.plist").open(
+            "rb"
+        ) as handle:
+            self.assertEqual(
+                plistlib.load(handle),
+                {
+                    "com.apple.security.app-sandbox": True,
+                    "com.apple.security.device.audio-input": True,
+                    "com.apple.security.device.microphone": True,
+                    "com.apple.security.temporary-exception.mach-lookup.global-name": [
+                        "com.localdictation.capture-agent.xpc"
+                    ],
+                    "com.apple.security.temporary-exception.mach-register.global-name": [
+                        "com.localdictation.capture-agent.xpc"
+                    ],
+                },
+            )
+
+        agent_source = (
+            root / "app/src-tauri/sidecars/capture-agent/main.swift"
+        ).read_text(encoding="utf-8")
+        for forbidden_capture_api in (
+            "AVFoundation",
+            "AVAudioEngine",
+            "AudioUnit",
+            "AudioQueue",
+            "CoreAudio",
+            "CPAL",
+        ):
+            self.assertNotIn(forbidden_capture_api, agent_source)
+        self.assertIn('"murmur-capture-worker"', agent_source)
+        with (root / "app/src-tauri/capture-worker.entitlements.plist").open(
+            "rb"
+        ) as handle:
+            self.assertEqual(plistlib.load(handle), CAPTURE_WORKER_ENTITLEMENTS)
+        with (
+            root
+            / "app/src-tauri/macos/com.localdictation.capture-agent.plist"
+        ).open("rb") as handle:
+            self.assertEqual(
+                plistlib.load(handle),
+                {
+                    "Label": "com.localdictation.capture-agent",
+                    "BundleProgram": "Contents/MacOS/murmur-capture-agent",
+                    "MachServices": {
+                        "com.localdictation.capture-agent.xpc": True
+                    },
+                    "ProcessType": "Interactive",
+                    "ThrottleInterval": 10,
+                },
+            )
+        with (root / "app/src-tauri/capture-agent-info.plist").open(
+            "rb"
+        ) as handle:
+            self.assertEqual(
+                plistlib.load(handle),
+                {
+                    "CFBundleExecutable": "murmur-capture-agent",
+                    "CFBundleIdentifier": "com.localdictation.capture-agent",
+                    "CFBundleName": "Murmur Capture Agent",
+                    "CFBundlePackageType": "APPL",
+                    "CFBundleShortVersionString": "__MURMUR_VERSION__",
+                    "CFBundleVersion": "__MURMUR_VERSION__",
+                },
+            )
+        build_script = (root / "scripts/build_local_llm_sidecar.py").read_text()
+        self.assertIn('"capture-agent-info.plist"', build_script)
+        self.assertIn('"__info_plist"', build_script)
 
     def test_capture_helper_identity_and_entitlements_are_exact(self) -> None:
         self.assertEqual(
@@ -364,22 +536,32 @@ class ReleaseArtifactTests(unittest.TestCase):
                 },
             )
 
-    def test_capture_helper_bundle_version_matches_package_revision(self) -> None:
+    def test_capture_executable_info_templates_are_role_specific_and_versioned(self) -> None:
         capture_helper = (
             Path(__file__).parents[1] / "app/src-tauri/sidecars/capture"
         )
-        manifest = tomllib.loads((capture_helper / "Cargo.toml").read_text())
         with (capture_helper / "Info.plist").open("rb") as handle:
-            info = plistlib.load(handle)
+            helper_info = plistlib.load(handle)
+        with (capture_helper / "WorkerInfo.plist").open("rb") as handle:
+            worker_info = plistlib.load(handle)
 
+        for info in (helper_info, worker_info):
+            self.assertEqual(info["CFBundleShortVersionString"], "__MURMUR_VERSION__")
+            self.assertEqual(info["CFBundleVersion"], "__MURMUR_VERSION__")
+            self.assertIn("NSMicrophoneUsageDescription", info)
         self.assertEqual(
-            info["CFBundleShortVersionString"],
-            manifest["package"]["version"],
+            helper_info["CFBundleIdentifier"],
+            "com.localdictation.capture-helper",
         )
-        bundle_version = info["CFBundleVersion"]
-        self.assertRegex(bundle_version, r"^[1-9][0-9]*$")
-        # The first signed capture-helper build used bundle version 1.
-        self.assertGreater(int(bundle_version), 1)
+        self.assertEqual(
+            worker_info["CFBundleIdentifier"],
+            "com.localdictation.capture-worker",
+        )
+        self.assertEqual(helper_info["CFBundleExecutable"], "murmur-capture-helper")
+        self.assertEqual(worker_info["CFBundleExecutable"], "murmur-capture-worker")
+        build_script = (capture_helper / "build.rs").read_text()
+        self.assertIn("MURMUR_CAPTURE_ROLE", build_script)
+        self.assertIn("MURMUR_APP_VERSION", build_script)
 
     def test_capture_probe_requires_complete_confirmed_allowlisted_evidence(self) -> None:
         self.assertEqual(
@@ -571,6 +753,36 @@ class ReleaseArtifactTests(unittest.TestCase):
                 "entitlement_sha256",
                 "entitlement_keys",
             },
+        )
+
+    def test_capture_agent_signature_evidence_uses_exact_identity_and_policy(
+        self,
+    ) -> None:
+        team_id = "ABCDE12345"
+        details = (
+            f"Identifier={CAPTURE_AGENT_IDENTIFIER}\n"
+            f"TeamIdentifier={team_id}\n"
+            "flags=0x10000(runtime)\n"
+        )
+        requirement = (
+            f'designated => identifier "{CAPTURE_AGENT_IDENTIFIER}" '
+            "and anchor apple generic "
+            "and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ "
+            "and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ "
+            f'and certificate leaf[subject.OU] = "{team_id}"'
+        )
+        evidence = structured_signature_evidence(
+            details,
+            requirement,
+            CAPTURE_AGENT_ENTITLEMENTS,
+            "arm64",
+            expected_identifier=CAPTURE_AGENT_IDENTIFIER,
+            expected_entitlements=CAPTURE_AGENT_ENTITLEMENTS,
+            label="capture-agent",
+        )
+        self.assertEqual(evidence["identifier"], CAPTURE_AGENT_IDENTIFIER)
+        self.assertEqual(
+            evidence["entitlement_keys"], sorted(CAPTURE_AGENT_ENTITLEMENTS)
         )
 
     def test_signature_evidence_rejects_extra_path_bearing_requirement_clause(

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,11 +18,10 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
-    def test_macos_compile_check_stubs_both_exact_helpers(self) -> None:
+    def test_macos_compile_check_builds_capture_worker(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         mutated = workflow.replace(
-            "          : > app/src-tauri/binaries/"
-            "murmur-capture-helper-aarch64-apple-darwin\n",
+            "          MURMUR_CAPTURE_ROLE=worker \\\n",
             "",
             1,
         )
@@ -138,10 +137,17 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
             "scripts/capture_helper_evidence.py validate-probe",
         ):
             with self.subTest(marker=marker):
-                mutated = workflow.replace(marker, "echo skipped", 1)
+                mutated = workflow.replace(marker, "echo skipped")
                 self.assertNotEqual(workflow, mutated)
                 with self.assertRaises(AssertionError):
                     validate_release_build(mutated)
+
+        without_agent = workflow.replace("--kind capture-agent", "--kind capture-helper", 1)
+        with self.assertRaises(AssertionError):
+            validate_release_build(without_agent)
+        without_worker = workflow.replace("--kind capture-worker", "--kind capture-helper", 1)
+        with self.assertRaises(AssertionError):
+            validate_release_build(without_worker)
 
         leaked = workflow.replace(
             "          # Collect only allowlisted signature facts.",


### PR DESCRIPTION
Refs #407

## Summary
- package a per-user SMAppService LaunchAgent and separately signed killable capture worker
- add strict XPC peer/signature/schema validation, bounded worker-group teardown, monotonic exact-once recovery, and same-peer ACK replay
- bind release packaging/provenance and add the signed MacBook acceptance-matrix validator
- document the provisional architecture and keep production dictation routing unchanged

## Validation
- Shawn MacBook: Swift warnings-as-errors typecheck
- Shawn MacBook: cargo test -- --test-threads=1
- Shawn MacBook: Python unittest discovery (71 passed)
- Shawn MacBook: TypeScript check and Vitest (620 passed)
- Shawn MacBook: workflow policy validation
- Shawn MacBook: production .app build plus Developer ID finalizer and strict codesign verification
- three independent static reviews: no P0/P1 blockers

## Acceptance gate
This PR intentionally leaves #407 open. The architecture remains provisional until the exact merged, trusted, notarized artifact passes the signed Shawn MacBook registration/TCC/revocation/update/unregistration matrix. CodeRabbit approval is waived by the maintainer; required CI checks remain mandatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS capture agent and separately managed capture worker for microphone capture and recovery.
  * Added synthetic capture and fault-testing modes with lifecycle and cancellation handling.
  * Added LaunchAgent installation, status, recovery, and permission-probe workflows.

* **Bug Fixes**
  * Improved macOS packaging, signing, entitlement verification, and release validation for capture components.

* **Documentation**
  * Documented the proposed capture-agent recovery architecture and acceptance criteria.

* **Tests**
  * Expanded validation for capture lifecycle, provenance, signing, recovery, and release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->