### PR TITLE
fix: harden capture agent launch registration

### DIFF
--- a/app/src-tauri/sidecars/capture-agent/main.swift
+++ b/app/src-tauri/sidecars/capture-agent/main.swift
@@ -3,7 +3,7 @@ import Security
 import XPC
 import Darwin
 
-private func currentSigningTeamID() -> String? {
+private func currentStaticCode() -> SecStaticCode? {
     var runningCode: SecCode?
     guard SecCodeCopySelf([], &runningCode) == errSecSuccess,
           let runningCode else {
@@ -12,6 +12,25 @@ private func currentSigningTeamID() -> String? {
     var staticCode: SecStaticCode?
     guard SecCodeCopyStaticCode(runningCode, [], &staticCode) == errSecSuccess,
           let staticCode else {
+        return nil
+    }
+    return staticCode
+}
+
+private func currentExecutableURL() -> URL? {
+    guard let staticCode = currentStaticCode() else {
+        return nil
+    }
+    var executableURL: CFURL?
+    guard SecCodeCopyPath(staticCode, [], &executableURL) == errSecSuccess,
+          let executableURL else {
+        return nil
+    }
+    return executableURL as URL
+}
+
+private func currentSigningTeamID() -> String? {
+    guard let staticCode = currentStaticCode() else {
         return nil
     }
     var information: CFDictionary?
@@ -308,9 +327,11 @@ private final class WorkerSession {
     }
 
     func start() throws {
-        let executable = URL(fileURLWithPath: CommandLine.arguments[0])
+        guard let executable = currentExecutableURL()?
             .deletingLastPathComponent()
-            .appendingPathComponent("murmur-capture-worker")
+            .appendingPathComponent("murmur-capture-worker") else {
+            throw NSError(domain: agentIdentifier, code: 2)
+        }
         guard validateCaptureWorker(at: executable) else {
             throw NSError(domain: agentIdentifier, code: 2)
         }
@@ -857,10 +878,23 @@ private final class AgentState {
         } catch {
             worker = nil
             activeLeaseID = nil
+            let failure: String
+            let launchError = error as NSError
+            if launchError.domain == agentIdentifier && launchError.code == 2 {
+                failure = "worker_signature_invalid"
+            } else if launchError.domain == agentIdentifier && launchError.code == 3 {
+                failure = "worker_process_group_failed"
+            } else {
+                failure = "worker_launch_failed"
+            }
             reply(
                 peer: peer,
                 request: request,
-                fields: ["outcome": "worker_spawn_failed", "audio_content_retained": false]
+                fields: [
+                    "outcome": "worker_spawn_failed",
+                    "failure": failure,
+                    "audio_content_retained": false,
+                ]
             )
         }
     }

--- a/app/src-tauri/src/capture_agent_probe.rs
+++ b/app/src-tauri/src/capture_agent_probe.rs
@@ -122,6 +122,10 @@ fn service_status_name(status: isize) -> &'static str {
     }
 }
 
+fn should_register_service(command: ServiceCommand, status: isize) -> bool {
+    status == 0 || (status == 3 && command == ServiceCommand::Register)
+}
+
 #[cfg(target_os = "macos")]
 fn service_response(outcome: &str, status: isize, exit_code: i32) -> (Value, i32) {
     (
@@ -180,11 +184,18 @@ fn wait_for_processes_to_exit(pids: &[u64], timeout: Duration) -> bool {
 #[cfg(target_os = "macos")]
 fn run_service_command(command: ServiceCommand) -> (Value, i32) {
     use block2::RcBlock;
-    use objc2::msg_send;
     use objc2::runtime::{AnyClass, AnyObject, Bool};
+    use objc2::{msg_send, MainThreadMarker};
+    use objc2_app_kit::NSApplication;
     use objc2_foundation::NSString;
 
     unsafe {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return (content_free_error("service_unavailable"), 2);
+        };
+        let application = NSApplication::sharedApplication(mtm);
+        application.finishLaunching();
+
         let Some(class) = AnyClass::get(c"SMAppService") else {
             return (content_free_error("service_unavailable"), 2);
         };
@@ -195,11 +206,19 @@ fn run_service_command(command: ServiceCommand) -> (Value, i32) {
         }
 
         let mut status: isize = msg_send![service, status];
-        if matches!(status, 3) || !matches!(status, 0..=3) {
+        if !matches!(status, 0..=3) {
             return service_response("service_error", status, 2);
         }
         if command == ServiceCommand::Status {
-            return service_response("service_status", status, 0);
+            return service_response(
+                if status == 3 {
+                    "service_error"
+                } else {
+                    "service_status"
+                },
+                status,
+                if status == 3 { 2 } else { 0 },
+            );
         }
 
         let observed_pids = if matches!(
@@ -256,7 +275,7 @@ fn run_service_command(command: ServiceCommand) -> (Value, i32) {
             );
         }
 
-        if status == 0 {
+        if should_register_service(command, status) {
             let mut error: *mut AnyObject = std::ptr::null_mut();
             let succeeded: Bool = msg_send![service, registerAndReturnError: &mut error];
             if !succeeded.as_bool() {
@@ -922,6 +941,16 @@ mod tests {
             parse_cli_request(["--unrelated".to_string()]),
             CliRequest::NotRequested
         );
+    }
+
+    #[test]
+    fn only_explicit_register_may_recover_from_not_found() {
+        assert!(should_register_service(ServiceCommand::Register, 0));
+        assert!(should_register_service(ServiceCommand::Register, 3));
+        assert!(should_register_service(ServiceCommand::Refresh, 0));
+        assert!(!should_register_service(ServiceCommand::Refresh, 3));
+        assert!(!should_register_service(ServiceCommand::Unregister, 3));
+        assert!(!should_register_service(ServiceCommand::Status, 3));
     }
 
     #[test]

--- a/docs/decisions/2026-07-31-capture-agent-recovery-spike.md
+++ b/docs/decisions/2026-07-31-capture-agent-recovery-spike.md
@@ -68,6 +68,19 @@ The release bundle now contains a probe-only `murmur-capture-agent` and an
   Probe and recovery clients still connect to the agent over XPC. All spike
   operations are reachable only through explicit CLI arguments, and production
   dictation remains unchanged.
+- On macOS 26.0.1, a valid bundled service can report
+  `SMAppServiceStatus.notFound` before its first registration even though
+  `registerAndReturnError:` immediately succeeds and transitions it to
+  `enabled`. The explicit `status` command preserves that pre-registration
+  result as a content-free error; only an explicit `register` operation may
+  attempt registration from `notFound`, and its returned error/status remains
+  authoritative. The evidence matrix accepts either this exact macOS 26 pair
+  (`notFound`, exit 2) or the older (`notRegistered`, exit 0) pair.
+- launchd supplies the plist's relative `BundleProgram` as `argv[0]`. The agent
+  therefore resolves its own absolute signed executable URL through
+  Security.framework (`SecCodeCopyPath`) before locating its worker sibling;
+  it never derives a security-sensitive path from `argv[0]` or a working
+  directory.
 - The standalone sandboxed agent and worker Mach-O files each embed their exact
   role-specific Info.plist identity and app version; macOS refuses to
   initialize a sandboxed standalone executable without coherent embedded code

--- a/scripts/capture_agent_matrix.py
+++ b/scripts/capture_agent_matrix.py
@@ -91,6 +91,36 @@ def validate_service(payload: object, expected_status: str) -> dict[str, Any]:
     return value
 
 
+def validate_initial_service(envelope: object) -> dict[str, Any]:
+    record = _exact(envelope, {"exit_code", "payload"}, "service_initial")
+    if type(record["exit_code"]) is not int:
+        raise MatrixError("initial service exit_code must be an integer")
+    value = _exact(
+        record["payload"],
+        {
+            "schema_version",
+            "outcome",
+            "service_status",
+            "audio_content_retained",
+        },
+        "initial service evidence",
+    )
+    status = value["service_status"]
+    if status == "not_registered":
+        if record["exit_code"] != 0:
+            raise MatrixError("not_registered initial service status must exit 0")
+        _common(value, "service_status")
+    elif status == "not_found":
+        if record["exit_code"] != 2:
+            raise MatrixError("not_found initial service status must exit 2")
+        _common(value, "service_error")
+    else:
+        raise MatrixError(
+            "initial service status must be 'not_registered' or macOS 26 'not_found'"
+        )
+    return value
+
+
 def validate_status(payload: object, expected_outcome: str) -> dict[str, Any]:
     value = _exact(
         payload,
@@ -436,7 +466,7 @@ def validate_matrix(payload: object) -> dict[str, Any]:
             raise MatrixError(f"{name} exit code mismatch")
         return envelope["payload"]
 
-    validate_service(record("service_initial", 0), "not_registered")
+    validate_initial_service(records["service_initial"])
     validate_service(record("service_register", 0), "enabled")
     validate_probe(
         record("synthetic_cooperative", 0),

--- a/tests/test_capture_agent_matrix.py
+++ b/tests/test_capture_agent_matrix.py
@@ -7,9 +7,9 @@ from scripts.capture_agent_matrix import MatrixError, validate_matrix
 class CaptureAgentMatrixTests(unittest.TestCase):
     def setUp(self) -> None:
         sha = "a" * 40
-        service = lambda status: {
+        service = lambda status, outcome="service_status": {
             "schema_version": 1,
-            "outcome": "service_status",
+            "outcome": outcome,
             "service_status": status,
             "audio_content_retained": False,
         }
@@ -117,7 +117,10 @@ class CaptureAgentMatrixTests(unittest.TestCase):
                 "residual_worker_processes": 0,
             },
             "records": {
-                "service_initial": envelope(service("not_registered")),
+                "service_initial": envelope(
+                    service("not_found", "service_error"),
+                    2,
+                ),
                 "service_register": envelope(service("enabled")),
                 "synthetic_cooperative": envelope(probe("cooperative", True)),
                 "synthetic_hard_kill": envelope(probe("hard_kill", True)),
@@ -176,6 +179,47 @@ class CaptureAgentMatrixTests(unittest.TestCase):
 
     def test_complete_matrix_is_valid(self) -> None:
         self.assertEqual(validate_matrix(self.matrix), self.matrix)
+
+    def test_not_registered_initial_service_status_is_also_valid(self) -> None:
+        mutated = deepcopy(self.matrix)
+        mutated["records"]["service_initial"] = {
+            "exit_code": 0,
+            "payload": {
+                "schema_version": 1,
+                "outcome": "service_status",
+                "service_status": "not_registered",
+                "audio_content_retained": False,
+            },
+        }
+        self.assertEqual(validate_matrix(mutated), mutated)
+
+    def test_initial_service_status_requires_exact_outcome_and_exit_pair(self) -> None:
+        for key, value in (
+            (("exit_code",), 0),
+            (("payload", "outcome"), "service_status"),
+            (("payload", "service_status"), "enabled"),
+        ):
+            mutated = deepcopy(self.matrix)
+            target = mutated["records"]["service_initial"]
+            for part in key[:-1]:
+                target = target[part]
+            target[key[-1]] = value
+            with self.subTest(key=key, value=value):
+                with self.assertRaises(MatrixError):
+                    validate_matrix(mutated)
+
+        mutated = deepcopy(self.matrix)
+        mutated["records"]["service_initial"] = {
+            "exit_code": False,
+            "payload": {
+                "schema_version": 1,
+                "outcome": "service_status",
+                "service_status": "not_registered",
+                "audio_content_retained": False,
+            },
+        }
+        with self.assertRaises(MatrixError):
+            validate_matrix(mutated)
 
     def test_cross_record_identity_change_is_rejected(self) -> None:
         mutated = deepcopy(self.matrix)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -479,6 +479,9 @@ class ReleaseArtifactTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden_capture_api, agent_source)
         self.assertIn('"murmur-capture-worker"', agent_source)
+        self.assertIn("SecCodeCopyPath", agent_source)
+        self.assertIn("currentExecutableURL()", agent_source)
+        self.assertNotIn("CommandLine.arguments[0]", agent_source)
         with (root / "app/src-tauri/capture-worker.entitlements.plist").open(
             "rb"
         ) as handle:


### PR DESCRIPTION
## Summary
- initialize AppKit before using SMAppService and allow an explicit first registration when macOS 26 reports `notFound`
- resolve the launch agent executable through Security.framework instead of launchd relative `argv[0]`, then validate the signed worker sibling
- preserve exact initial-service evidence for both `notRegistered` and the observed macOS 26 `notFound` state
- add fail-closed transition and packaging-policy tests plus the observed platform behavior to the ADR

## Why
The first trusted notarized #407 artifact exposed two runtime-only platform behaviors on Shawn MacBook: a valid never-registered service reported `notFound`, and launchd passed the relative `BundleProgram` as `argv[0]`. Registration itself succeeded, but the relative worker path caused the agent signature gate to fail. This follow-up keeps status fail-closed, confines the status-3 workaround to explicit register, and derives the worker path from the running signed code object.

## MacBook validation
- Python: 73 passed
- workflow policy: passed
- TypeScript: passed
- Vitest: 66 files / 620 tests passed
- Rust: 692 passed, 5 ignored; all integration suites passed
- Swift warnings-as-errors typecheck: passed
- production bundle + Developer ID finalizer: passed
- signed local runtime: service register enabled; deterministic 64-chunk synthetic probe passed with expected digest; cooperative worker exit and empty process group; unregister returned not_registered; launchctl found no residual job
- three independent static reviews: no remaining P0/P1 findings

Refs #407