### PR TITLE
feat: isolate production audio capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
               - 'scripts/validate_workflow_policy.py'
               - 'scripts/release_artifacts.py'
               - 'scripts/capture_agent_matrix.py'
+              - 'scripts/validate_capture_boundary.py'
               - 'tests/test_release_artifacts.py'
               - 'tests/test_workflow_policy.py'
               - 'tests/test_capture_agent_matrix.py'
@@ -54,6 +55,7 @@ jobs:
       - name: Validate workflow policy
         run: |
           python3 scripts/validate_workflow_policy.py
+          python3 scripts/validate_capture_boundary.py
           python3 -m unittest \
             tests/test_release_artifacts.py \
             tests/test_workflow_policy.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Production microphone capture now runs behind a signed, killable helper with
+  capture-scoped binary PCM framing, an allocation-free SPSC callback boundary,
+  CPAL and direct AUHAL backends, exact-device pre-buffer failover, deterministic
+  fault modes, and partial-transcript recovery for interrupted recordings
+  (#405, #408, #409, #410, #411, #412).
 - A probe-only signed capture helper now has strict runtime code-identity
   checks, content-free callback health, deterministic cancel/kill/reap tests,
   and exact release provenance. Production recording remains unchanged pending

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2786,6 +2786,8 @@ dependencies = [
 name = "murmur-capture-helper"
 version = "0.1.1"
 dependencies = [
+ "core-foundation-sys",
+ "coreaudio-rs",
  "cpal",
  "libc",
  "murmur-capture-helper-protocol",
@@ -6037,7 +6039,6 @@ dependencies = [
  "chrono",
  "core-foundation",
  "core-graphics",
- "cpal",
  "dirs 5.0.1",
  "fluidaudio-rs",
  "futures-util",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -51,7 +51,6 @@ hound = "3.5"
 symphonia = { version = "0.5", default-features = false, features = ["wav", "pcm", "mp3", "isomp4", "aac", "alac"] }
 dirs = "5"
 uuid = { version = "1", features = ["v4"] }
-cpal = "=0.18.1"
 rdev = { git = "https://github.com/georgenijo/rdev", rev = "9f510e406327b797eaf2acdc30adcda3dc1e1bb3", features = ["macos_keyboard_only", "macos_no_modifier_event_name", "macos_test_force_tap_timeout"] }
 memory-stats = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }

--- a/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
+++ b/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
@@ -10,6 +10,101 @@ pub const SYNTHETIC_FIXTURE_CHUNKS: u64 = 64;
 pub const SYNTHETIC_FIXTURE_DIGEST: &str =
     "9fda676f94adbf56e31e91462c702dcda9fcf989eece435876a28778782abfd3";
 
+// Production capture uses a separate, binary-framed protocol. Probe v1 above
+// remains stable so shipped attribution/recovery evidence stays readable.
+pub const PRODUCTION_PROTOCOL_NAME: &str = "murmur.capture";
+pub const PRODUCTION_PROTOCOL_VERSION: u16 = 2;
+pub const PRODUCTION_MAGIC: [u8; 4] = *b"MRMR";
+pub const PRODUCTION_HEADER_BYTES: usize = 36;
+pub const MAX_CONTROL_BYTES: usize = 16 * 1024;
+pub const MAX_PCM_SAMPLES: usize = 16 * 1024;
+pub type SessionNonce = [u8; 16];
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureBackend {
+    Cpal,
+    Auhal,
+}
+
+impl CaptureBackend {
+    pub fn fallback(self) -> Self {
+        match self {
+            Self::Cpal => Self::Auhal,
+            Self::Auhal => Self::Cpal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProductionDevice {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ProductionHostMessage {
+    Hello,
+    Enumerate,
+    Start {
+        device_id: Option<String>,
+        backend: CaptureBackend,
+    },
+    Stop,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ProductionHelperMessage {
+    HelloAck,
+    Devices {
+        devices: Vec<ProductionDevice>,
+    },
+    Phase {
+        phase: CapturePhase,
+        backend: CaptureBackend,
+    },
+    BackendFallback {
+        from: CaptureBackend,
+        to: CaptureBackend,
+        reason: FailureCode,
+    },
+    Failure {
+        code: FailureCode,
+        backend: CaptureBackend,
+        retained_samples: u64,
+    },
+    Stopped {
+        retained_samples: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProductionPcm {
+    pub sequence: u64,
+    pub sample_rate: u32,
+    pub samples: Vec<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProductionFrame<T> {
+    Control(T),
+    Pcm(ProductionPcm),
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum CapturePhase {
@@ -188,6 +283,12 @@ pub enum FrameError {
     InvalidJson,
     #[error("frame write failed")]
     WriteFailed,
+    #[error("production frame header is invalid")]
+    InvalidHeader,
+    #[error("production frame capture identity does not match")]
+    StaleCapture,
+    #[error("production PCM frame is malformed")]
+    InvalidPcm,
 }
 
 pub fn read_frame<T: DeserializeOwned>(reader: &mut impl Read) -> Result<T, FrameError> {
@@ -216,6 +317,130 @@ pub fn write_frame<T: Serialize>(writer: &mut impl Write, value: &T) -> Result<(
         .and_then(|_| writer.write_all(&body))
         .and_then(|_| writer.flush())
         .map_err(|_| FrameError::WriteFailed)
+}
+
+fn write_production_header(
+    writer: &mut impl Write,
+    kind: u8,
+    payload_len: usize,
+    capture_id: u64,
+    nonce: SessionNonce,
+) -> Result<(), FrameError> {
+    let limit = if kind == 1 {
+        16 + MAX_PCM_SAMPLES * std::mem::size_of::<f32>()
+    } else {
+        MAX_CONTROL_BYTES
+    };
+    if payload_len > limit {
+        return Err(FrameError::TooLarge(payload_len));
+    }
+    let mut header = [0_u8; PRODUCTION_HEADER_BYTES];
+    header[0..4].copy_from_slice(&PRODUCTION_MAGIC);
+    header[4..6].copy_from_slice(&PRODUCTION_PROTOCOL_VERSION.to_le_bytes());
+    header[6] = kind;
+    header[8..12].copy_from_slice(&(payload_len as u32).to_le_bytes());
+    header[12..20].copy_from_slice(&capture_id.to_le_bytes());
+    header[20..36].copy_from_slice(&nonce);
+    writer
+        .write_all(&header)
+        .map_err(|_| FrameError::WriteFailed)
+}
+
+pub fn write_production_control<T: Serialize>(
+    writer: &mut impl Write,
+    capture_id: u64,
+    nonce: SessionNonce,
+    value: &T,
+) -> Result<(), FrameError> {
+    let body = serde_json::to_vec(value).map_err(|_| FrameError::InvalidJson)?;
+    write_production_header(writer, 0, body.len(), capture_id, nonce)?;
+    writer
+        .write_all(&body)
+        .and_then(|_| writer.flush())
+        .map_err(|_| FrameError::WriteFailed)
+}
+
+pub fn write_production_pcm(
+    writer: &mut impl Write,
+    capture_id: u64,
+    nonce: SessionNonce,
+    sequence: u64,
+    sample_rate: u32,
+    samples: &[f32],
+) -> Result<(), FrameError> {
+    if samples.is_empty() || samples.len() > MAX_PCM_SAMPLES {
+        return Err(FrameError::InvalidPcm);
+    }
+    let payload_len = 16 + samples.len() * std::mem::size_of::<f32>();
+    write_production_header(writer, 1, payload_len, capture_id, nonce)?;
+    writer
+        .write_all(&sequence.to_le_bytes())
+        .and_then(|_| writer.write_all(&sample_rate.to_le_bytes()))
+        .and_then(|_| writer.write_all(&(samples.len() as u32).to_le_bytes()))
+        .map_err(|_| FrameError::WriteFailed)?;
+    for sample in samples {
+        writer
+            .write_all(&sample.to_bits().to_le_bytes())
+            .map_err(|_| FrameError::WriteFailed)?;
+    }
+    writer.flush().map_err(|_| FrameError::WriteFailed)
+}
+
+pub fn read_production_frame<T: DeserializeOwned>(
+    reader: &mut impl Read,
+    expected_capture_id: u64,
+    expected_nonce: SessionNonce,
+) -> Result<ProductionFrame<T>, FrameError> {
+    let mut header = [0_u8; PRODUCTION_HEADER_BYTES];
+    reader
+        .read_exact(&mut header)
+        .map_err(|_| FrameError::IncompleteHeader)?;
+    if header[0..4] != PRODUCTION_MAGIC
+        || u16::from_le_bytes([header[4], header[5]]) != PRODUCTION_PROTOCOL_VERSION
+        || header[7] != 0
+    {
+        return Err(FrameError::InvalidHeader);
+    }
+    let kind = header[6];
+    let length = u32::from_le_bytes(header[8..12].try_into().unwrap()) as usize;
+    let capture_id = u64::from_le_bytes(header[12..20].try_into().unwrap());
+    let nonce: SessionNonce = header[20..36].try_into().unwrap();
+    if capture_id != expected_capture_id || nonce != expected_nonce {
+        return Err(FrameError::StaleCapture);
+    }
+    match kind {
+        0 if length <= MAX_CONTROL_BYTES => {
+            let mut body = vec![0_u8; length];
+            reader
+                .read_exact(&mut body)
+                .map_err(|_| FrameError::IncompleteBody)?;
+            let value = serde_json::from_slice(&body).map_err(|_| FrameError::InvalidJson)?;
+            Ok(ProductionFrame::Control(value))
+        }
+        1 if (16..=16 + MAX_PCM_SAMPLES * 4).contains(&length) => {
+            let mut body = vec![0_u8; length];
+            reader
+                .read_exact(&mut body)
+                .map_err(|_| FrameError::IncompleteBody)?;
+            let sequence = u64::from_le_bytes(body[0..8].try_into().unwrap());
+            let sample_rate = u32::from_le_bytes(body[8..12].try_into().unwrap());
+            let count = u32::from_le_bytes(body[12..16].try_into().unwrap()) as usize;
+            if count == 0 || count > MAX_PCM_SAMPLES || length != 16 + count * 4 {
+                return Err(FrameError::InvalidPcm);
+            }
+            let samples = body[16..]
+                .chunks_exact(4)
+                .map(|bytes| f32::from_bits(u32::from_le_bytes(bytes.try_into().unwrap())))
+                .collect();
+            Ok(ProductionFrame::Pcm(ProductionPcm {
+                sequence,
+                sample_rate,
+                samples,
+            }))
+        }
+        0 | 1 => Err(FrameError::TooLarge(length)),
+        _ => Err(FrameError::InvalidHeader),
+    }
 }
 
 #[cfg(test)]
@@ -255,5 +480,27 @@ mod tests {
         assert!(SYNTHETIC_FIXTURE_DIGEST
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn production_pcm_round_trip_is_capture_scoped_and_bounded() {
+        let nonce = [7_u8; 16];
+        let mut bytes = Vec::new();
+        write_production_pcm(&mut bytes, 42, nonce, 3, 48_000, &[0.25, -0.5]).unwrap();
+        let frame =
+            read_production_frame::<ProductionHelperMessage>(&mut bytes.as_slice(), 42, nonce)
+                .unwrap();
+        assert_eq!(
+            frame,
+            ProductionFrame::Pcm(ProductionPcm {
+                sequence: 3,
+                sample_rate: 48_000,
+                samples: vec![0.25, -0.5],
+            })
+        );
+        assert!(matches!(
+            read_production_frame::<ProductionHelperMessage>(&mut bytes.as_slice(), 43, nonce),
+            Err(FrameError::StaleCapture)
+        ));
     }
 }

--- a/app/src-tauri/sidecars/capture/Cargo.toml
+++ b/app/src-tauri/sidecars/capture/Cargo.toml
@@ -10,3 +10,5 @@ murmur-capture-helper-protocol = { path = "../../crates/capture-helper-protocol"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
+coreaudio-rs = "0.11.3"
+core-foundation-sys = "0.8"

--- a/app/src-tauri/sidecars/capture/src/main.rs
+++ b/app/src-tauri/sidecars/capture/src/main.rs
@@ -1,4 +1,7 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod production;
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod supported {
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     use cpal::{SampleFormat, Stream, StreamConfig};
@@ -382,6 +385,12 @@ fn main() {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
         let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+        if arguments.first().map(String::as_str) == Some("--production-v2") {
+            if production::run(&arguments[1..]).is_ok() {
+                return;
+            }
+            std::process::exit(70);
+        }
         let (synthetic, ignore_cancel) = match arguments.as_slice() {
             [] => (false, false),
             [flag, fixture]

--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -1,0 +1,521 @@
+use core_foundation_sys::base::CFTypeRef;
+use core_foundation_sys::string::{kCFStringEncodingUTF8, CFStringGetCString, CFStringRef};
+use coreaudio::audio_unit::audio_format::LinearPcmFlags;
+use coreaudio::audio_unit::macos_helpers::{
+    audio_unit_from_device_id, get_audio_device_ids_for_scope, get_default_device_id,
+    get_device_name,
+};
+use coreaudio::audio_unit::render_callback::{self, data};
+use coreaudio::audio_unit::{Element, SampleFormat as AuSampleFormat, Scope, StreamFormat};
+use coreaudio::sys::{
+    kAudioDevicePropertyDeviceUID, kAudioObjectPropertyElementMaster,
+    kAudioObjectPropertyScopeGlobal, AudioDeviceID, AudioObjectGetPropertyData,
+    AudioObjectPropertyAddress,
+};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{FromSample, Sample, SampleFormat, SizedSample, Stream};
+use murmur_capture_helper_protocol::{
+    read_production_frame, write_production_control, write_production_pcm, CaptureBackend,
+    CapturePhase, FailureCode, ProductionDevice, ProductionFrame, ProductionHelperMessage,
+    ProductionHostMessage, SessionNonce,
+};
+use std::cell::UnsafeCell;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::{Duration, Instant};
+
+const RING_CAPACITY: usize = 48_000 * 8;
+const STOP_DEADLINE: Duration = Duration::from_secs(2);
+
+struct SpscRing {
+    slots: Box<[UnsafeCell<f32>]>,
+    head: AtomicUsize,
+    tail: AtomicUsize,
+    overflowed: AtomicBool,
+}
+
+unsafe impl Send for SpscRing {}
+unsafe impl Sync for SpscRing {}
+
+impl SpscRing {
+    fn new() -> Self {
+        let mut slots = Vec::with_capacity(RING_CAPACITY);
+        slots.resize_with(RING_CAPACITY, || UnsafeCell::new(0.0));
+        Self {
+            slots: slots.into_boxed_slice(),
+            head: AtomicUsize::new(0),
+            tail: AtomicUsize::new(0),
+            overflowed: AtomicBool::new(false),
+        }
+    }
+
+    fn push(&self, value: f32) {
+        let head = self.head.load(Ordering::Relaxed);
+        let next = (head + 1) % self.slots.len();
+        if next == self.tail.load(Ordering::Acquire) {
+            self.overflowed.store(true, Ordering::Release);
+            return;
+        }
+        unsafe { *self.slots[head].get() = value };
+        self.head.store(next, Ordering::Release);
+    }
+
+    fn drain(&self, output: &mut [f32]) -> usize {
+        let mut count = 0;
+        let mut tail = self.tail.load(Ordering::Relaxed);
+        let head = self.head.load(Ordering::Acquire);
+        while tail != head && count < output.len() {
+            output[count] = unsafe { *self.slots[tail].get() };
+            count += 1;
+            tail = (tail + 1) % self.slots.len();
+        }
+        self.tail.store(tail, Ordering::Release);
+        count
+    }
+
+    fn producer_position(&self) -> usize {
+        self.head.load(Ordering::Acquire)
+    }
+}
+
+enum CaptureStream {
+    Cpal(Stream),
+    Auhal(coreaudio::audio_unit::AudioUnit),
+}
+
+impl CaptureStream {
+    fn stop(&mut self) {
+        match self {
+            Self::Cpal(stream) => {
+                let _ = stream.pause();
+            }
+            Self::Auhal(unit) => {
+                let _ = unit.stop();
+            }
+        }
+    }
+}
+
+fn parse_nonce(value: &str) -> Result<SessionNonce, ()> {
+    if value.len() != 32 {
+        return Err(());
+    }
+    let mut nonce = [0_u8; 16];
+    for (index, byte) in nonce.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16).map_err(|_| ())?;
+    }
+    Ok(nonce)
+}
+
+fn raw_uid(device: AudioDeviceID) -> Option<String> {
+    let address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyDeviceUID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+    let mut value: CFStringRef = std::ptr::null();
+    let mut size = std::mem::size_of::<CFTypeRef>() as u32;
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            device,
+            &address,
+            0,
+            std::ptr::null(),
+            &mut size,
+            &mut value as *mut _ as *mut _,
+        )
+    };
+    if status != 0 || value.is_null() {
+        return None;
+    }
+    let mut bytes = [0_i8; 1024];
+    let ok = unsafe {
+        CFStringGetCString(
+            value,
+            bytes.as_mut_ptr(),
+            bytes.len() as isize,
+            kCFStringEncodingUTF8,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    Some(
+        unsafe { std::ffi::CStr::from_ptr(bytes.as_ptr()) }
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn enumerate() -> Result<Vec<ProductionDevice>, FailureCode> {
+    let ids =
+        get_audio_device_ids_for_scope(Scope::Input).map_err(|_| FailureCode::EnumerationFailed)?;
+    Ok(ids
+        .into_iter()
+        .filter_map(|id| {
+            Some(ProductionDevice {
+                id: raw_uid(id)?,
+                name: get_device_name(id).ok()?,
+            })
+        })
+        .collect())
+}
+
+fn cpal_device(requested: Option<&str>) -> Result<cpal::Device, FailureCode> {
+    let host = cpal::default_host();
+    if let Some(requested) = requested {
+        let devices = host
+            .input_devices()
+            .map_err(|_| FailureCode::EnumerationFailed)?;
+        for device in devices {
+            let id_matches = device
+                .id()
+                .ok()
+                .map(|id| id.id().to_string() == requested)
+                .unwrap_or(false);
+            let name_matches = device
+                .description()
+                .ok()
+                .map(|description| description.name().to_string() == requested)
+                .unwrap_or(false);
+            if id_matches || name_matches {
+                return Ok(device);
+            }
+        }
+        Err(FailureCode::NoInputDevice)
+    } else {
+        host.default_input_device()
+            .ok_or(FailureCode::NoInputDevice)
+    }
+}
+
+fn build_cpal_for<T>(
+    device: &cpal::Device,
+    config: cpal::StreamConfig,
+    channels: usize,
+    ring: Arc<SpscRing>,
+    failed: Arc<AtomicBool>,
+) -> Result<Stream, FailureCode>
+where
+    T: SizedSample + Sample + Send + 'static,
+    f32: FromSample<T>,
+{
+    device
+        .build_input_stream(
+            config,
+            move |input: &[T], _| {
+                for frame in input.chunks(channels) {
+                    let mono =
+                        frame.iter().copied().map(f32::from_sample).sum::<f32>() / channels as f32;
+                    ring.push(mono);
+                }
+            },
+            move |_| failed.store(true, Ordering::Release),
+            Some(Duration::from_secs(10)),
+        )
+        .map_err(|_| FailureCode::StreamOpenFailed)
+}
+
+fn start_cpal(
+    requested: Option<&str>,
+    ring: Arc<SpscRing>,
+    failed: Arc<AtomicBool>,
+) -> Result<(CaptureStream, u32), FailureCode> {
+    let device = cpal_device(requested)?;
+    let supported = device
+        .default_input_config()
+        .map_err(|_| FailureCode::ConfigurationFailed)?;
+    let rate = supported.sample_rate();
+    let channels = supported.channels() as usize;
+    let config = supported.config();
+    macro_rules! build {
+        ($sample:ty) => {
+            build_cpal_for::<$sample>(
+                &device,
+                config.clone(),
+                channels,
+                Arc::clone(&ring),
+                Arc::clone(&failed),
+            )
+        };
+    }
+    let stream = match supported.sample_format() {
+        SampleFormat::I8 => build!(i8),
+        SampleFormat::I16 => build!(i16),
+        SampleFormat::I24 => build!(cpal::I24),
+        SampleFormat::I32 => build!(i32),
+        SampleFormat::I64 => build!(i64),
+        SampleFormat::U8 => build!(u8),
+        SampleFormat::U16 => build!(u16),
+        SampleFormat::U24 => build!(cpal::U24),
+        SampleFormat::U32 => build!(u32),
+        SampleFormat::U64 => build!(u64),
+        SampleFormat::F32 => build!(f32),
+        SampleFormat::F64 => build!(f64),
+        _ => return Err(FailureCode::ConfigurationFailed),
+    }?;
+    stream.play().map_err(|_| FailureCode::StreamStartFailed)?;
+    Ok((CaptureStream::Cpal(stream), rate))
+}
+
+fn start_auhal(
+    requested: Option<&str>,
+    ring: Arc<SpscRing>,
+) -> Result<(CaptureStream, u32), FailureCode> {
+    let device = match requested {
+        Some(uid) => get_audio_device_ids_for_scope(Scope::Input)
+            .map_err(|_| FailureCode::EnumerationFailed)?
+            .into_iter()
+            .find(|id| raw_uid(*id).as_deref() == Some(uid))
+            .ok_or(FailureCode::NoInputDevice)?,
+        None => get_default_device_id(true).ok_or(FailureCode::NoInputDevice)?,
+    };
+    let sample_rate = 48_000_u32;
+    let mut unit =
+        audio_unit_from_device_id(device, true).map_err(|_| FailureCode::StreamOpenFailed)?;
+    let format = StreamFormat {
+        sample_rate: sample_rate as f64,
+        sample_format: AuSampleFormat::F32,
+        flags: LinearPcmFlags::IS_FLOAT
+            | LinearPcmFlags::IS_PACKED
+            | LinearPcmFlags::IS_NON_INTERLEAVED,
+        channels: 1,
+    };
+    let asbd = format.to_asbd();
+    unit.set_property(
+        coreaudio::sys::kAudioUnitProperty_StreamFormat,
+        Scope::Output,
+        Element::Input,
+        Some(&asbd),
+    )
+    .map_err(|_| FailureCode::ConfigurationFailed)?;
+    type Args = render_callback::Args<data::NonInterleaved<f32>>;
+    unit.set_input_callback(move |args: Args| {
+        for channel in args.data.channels() {
+            for sample in channel.iter().take(args.num_frames) {
+                ring.push(*sample);
+            }
+            break;
+        }
+        Ok(())
+    })
+    .map_err(|_| FailureCode::StreamOpenFailed)?;
+    unit.start().map_err(|_| FailureCode::StreamStartFailed)?;
+    Ok((CaptureStream::Auhal(unit), sample_rate))
+}
+
+fn read_control(
+    reader: &mut impl Read,
+    capture_id: u64,
+    nonce: SessionNonce,
+) -> Result<ProductionHostMessage, ()> {
+    match read_production_frame(reader, capture_id, nonce).map_err(|_| ())? {
+        ProductionFrame::Control(message) => Ok(message),
+        ProductionFrame::Pcm(_) => Err(()),
+    }
+}
+
+pub fn run(arguments: &[String]) -> Result<(), ()> {
+    let capture_id = arguments
+        .first()
+        .ok_or(())?
+        .parse::<u64>()
+        .map_err(|_| ())?;
+    let nonce = parse_nonce(arguments.get(1).ok_or(())?)?;
+    let fault = arguments
+        .windows(2)
+        .find(|pair| pair[0] == "--fault")
+        .map(|pair| pair[1].as_str());
+    let mut stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+    if read_control(&mut stdin, capture_id, nonce)? != ProductionHostMessage::Hello {
+        return Err(());
+    }
+    write_production_control(
+        &mut stdout,
+        capture_id,
+        nonce,
+        &ProductionHelperMessage::HelloAck,
+    )
+    .map_err(|_| ())?;
+    match read_control(&mut stdin, capture_id, nonce)? {
+        ProductionHostMessage::Enumerate => {
+            let devices = enumerate()?;
+            write_production_control(
+                &mut stdout,
+                capture_id,
+                nonce,
+                &ProductionHelperMessage::Devices { devices },
+            )
+            .map_err(|_| ())?;
+            return Ok(());
+        }
+        ProductionHostMessage::Start { device_id, backend } => {
+            drop(stdin);
+            write_production_control(
+                &mut stdout,
+                capture_id,
+                nonce,
+                &ProductionHelperMessage::Phase {
+                    phase: CapturePhase::StreamOpen,
+                    backend,
+                },
+            )
+            .map_err(|_| ())?;
+            let ring = Arc::new(SpscRing::new());
+            let failed = Arc::new(AtomicBool::new(false));
+            let started = match backend {
+                CaptureBackend::Cpal => {
+                    start_cpal(device_id.as_deref(), Arc::clone(&ring), Arc::clone(&failed))
+                }
+                CaptureBackend::Auhal => start_auhal(device_id.as_deref(), Arc::clone(&ring)),
+            };
+            let (mut stream, sample_rate) = match started {
+                Ok(value) => value,
+                Err(code) => {
+                    write_production_control(
+                        &mut stdout,
+                        capture_id,
+                        nonce,
+                        &ProductionHelperMessage::Failure {
+                            code,
+                            backend,
+                            retained_samples: 0,
+                        },
+                    )
+                    .map_err(|_| ())?;
+                    return Ok(());
+                }
+            };
+            let (control_tx, control_rx) = mpsc::channel();
+            std::thread::spawn(move || {
+                let mut input = std::io::stdin().lock();
+                if let Ok(message) = read_control(&mut input, capture_id, nonce) {
+                    let _ = control_tx.send(message);
+                }
+            });
+            let mut sequence = 0_u64;
+            let mut retained = 0_u64;
+            let mut scratch = [0_f32; 4096];
+            let started_at = Instant::now();
+            let mut last_producer_position = ring.producer_position();
+            let mut last_callback_progress = Instant::now();
+            let mut starvation_injected = false;
+            loop {
+                if fault == Some("hang-before-first-buffer") && retained == 0 {
+                    std::thread::sleep(Duration::from_millis(20));
+                    continue;
+                }
+                if failed.load(Ordering::Acquire) || ring.overflowed.load(Ordering::Acquire) {
+                    let code = if ring.overflowed.load(Ordering::Acquire) {
+                        FailureCode::Internal
+                    } else {
+                        FailureCode::StreamError
+                    };
+                    write_production_control(
+                        &mut stdout,
+                        capture_id,
+                        nonce,
+                        &ProductionHelperMessage::Failure {
+                            code,
+                            backend,
+                            retained_samples: retained,
+                        },
+                    )
+                    .map_err(|_| ())?;
+                    return Ok(());
+                }
+                if fault == Some("ring-overflow") {
+                    ring.overflowed.store(true, Ordering::Release);
+                    continue;
+                }
+                let producer_position = ring.producer_position();
+                if producer_position != last_producer_position {
+                    last_producer_position = producer_position;
+                    last_callback_progress = Instant::now();
+                } else if retained > 0 && last_callback_progress.elapsed() >= Duration::from_secs(1)
+                {
+                    write_production_control(
+                        &mut stdout,
+                        capture_id,
+                        nonce,
+                        &ProductionHelperMessage::Failure {
+                            code: FailureCode::CallbackStalled,
+                            backend,
+                            retained_samples: retained,
+                        },
+                    )
+                    .map_err(|_| ())?;
+                    return Ok(());
+                }
+                let count = ring.drain(&mut scratch);
+                if count > 0 {
+                    if fault == Some("sequence-gap") && sequence == 2 {
+                        sequence += 1;
+                    }
+                    if fault == Some("malformed-frame") {
+                        stdout.write_all(b"BAD!").map_err(|_| ())?;
+                        return Ok(());
+                    }
+                    write_production_pcm(
+                        &mut stdout,
+                        if fault == Some("stale-capture") {
+                            capture_id + 1
+                        } else {
+                            capture_id
+                        },
+                        nonce,
+                        sequence,
+                        sample_rate,
+                        &scratch[..count],
+                    )
+                    .map_err(|_| ())?;
+                    retained += count as u64;
+                    sequence += 1;
+                    if fault == Some("callback-starvation") && !starvation_injected {
+                        stream.stop();
+                        starvation_injected = true;
+                    }
+                    if fault == Some("exit-after-first-buffer") {
+                        return Ok(());
+                    }
+                }
+                match control_rx.try_recv() {
+                    Ok(ProductionHostMessage::Stop | ProductionHostMessage::Cancel) => {
+                        stream.stop();
+                        write_production_control(
+                            &mut stdout,
+                            capture_id,
+                            nonce,
+                            &ProductionHelperMessage::Stopped {
+                                retained_samples: retained,
+                            },
+                        )
+                        .map_err(|_| ())?;
+                        return Ok(());
+                    }
+                    Ok(_) => return Err(()),
+                    Err(mpsc::TryRecvError::Disconnected) => return Ok(()),
+                    Err(mpsc::TryRecvError::Empty) => {}
+                }
+                if retained == 0 && started_at.elapsed() > STOP_DEADLINE {
+                    write_production_control(
+                        &mut stdout,
+                        capture_id,
+                        nonce,
+                        &ProductionHelperMessage::Failure {
+                            code: FailureCode::CallbackStalled,
+                            backend,
+                            retained_samples: 0,
+                        },
+                    )
+                    .map_err(|_| ())?;
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(4));
+            }
+        }
+        _ => Err(()),
+    }
+}

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1,36 +1,37 @@
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{FromSample, Sample, SampleFormat, SizedSample};
+use crate::managed_child::{bundled_sibling, ManagedChild};
+use murmur_capture_helper_protocol::{
+    read_production_frame, write_production_control, CaptureBackend, CapturePhase, FailureCode,
+    ProductionFrame, ProductionHelperMessage, ProductionHostMessage, SessionNonce,
+};
 use serde::Serialize;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Receiver;
+use std::io::{BufReader, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::Emitter;
+use uuid::Uuid;
 
-/// Compute RMS (root mean square) of a sample slice — returns 0.0–1.0 audio level.
 pub fn compute_rms(samples: &[f32]) -> f32 {
     if samples.is_empty() {
         return 0.0;
     }
-    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
-    (sum_sq / samples.len() as f32).sqrt()
+    (samples.iter().map(|sample| sample * sample).sum::<f32>() / samples.len() as f32).sqrt()
 }
 
-/// Compute peak (max absolute value) of a sample slice — returns 0.0–1.0.
 pub fn compute_peak(samples: &[f32]) -> f32 {
-    samples.iter().map(|s| s.abs()).fold(0.0_f32, f32::max)
+    samples
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max)
 }
 
-/// Minimum gap between `audio-level` events (~60 fps).
 const AUDIO_LEVEL_THROTTLE_MS: u64 = 16;
-
-/// CPAL applies this timeout to backend operations that expose a deadline. On
-/// CoreAudio 0.18 that includes sample-rate convergence, but not every
-/// synchronous AudioUnit operation; the lifecycle supervisor therefore retains
-/// strict ownership until the worker actually exits.
+const HELPER_STOP_DEADLINE: Duration = Duration::from_secs(2);
 pub(crate) const STREAM_BUILD_TIMEOUT: Duration = Duration::from_secs(10);
+static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AudioFailureKind {
@@ -73,25 +74,6 @@ impl AudioFailureKind {
             Self::WorkerPanicked => "worker_panicked",
         }
     }
-
-    fn from_cpal(kind: cpal::ErrorKind) -> Self {
-        match kind {
-            cpal::ErrorKind::PermissionDenied => Self::PermissionDenied,
-            cpal::ErrorKind::DeviceNotAvailable => Self::DeviceUnavailable,
-            cpal::ErrorKind::DeviceBusy => Self::DeviceBusy,
-            cpal::ErrorKind::DeviceChanged => Self::DeviceChanged,
-            cpal::ErrorKind::HostUnavailable => Self::HostUnavailable,
-            cpal::ErrorKind::InvalidInput => Self::InvalidInput,
-            cpal::ErrorKind::ResourceExhausted => Self::ResourceExhausted,
-            cpal::ErrorKind::StreamInvalidated => Self::StreamInvalidated,
-            cpal::ErrorKind::UnsupportedConfig => Self::UnsupportedConfig,
-            cpal::ErrorKind::UnsupportedOperation => Self::UnsupportedOperation,
-            cpal::ErrorKind::RealtimeDenied => Self::RealtimeDenied,
-            cpal::ErrorKind::Xrun => Self::Xrun,
-            cpal::ErrorKind::BackendError | cpal::ErrorKind::Other => Self::BackendError,
-            _ => Self::BackendError,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -103,10 +85,6 @@ pub(crate) struct AudioFailure {
 impl AudioFailure {
     pub(crate) fn new(kind: AudioFailureKind, phase: AudioInitPhase) -> Self {
         Self { kind, phase }
-    }
-
-    fn from_cpal(phase: AudioInitPhase, error: cpal::Error) -> Self {
-        Self::new(AudioFailureKind::from_cpal(error.kind()), phase)
     }
 
     pub(crate) fn user_message(&self) -> &'static str {
@@ -138,12 +116,7 @@ impl AudioFailure {
             AudioFailureKind::InitializationTimeout => {
                 "Microphone initialization exceeded the deadline."
             }
-            AudioFailureKind::HostUnavailable
-            | AudioFailureKind::UnsupportedOperation
-            | AudioFailureKind::RealtimeDenied
-            | AudioFailureKind::Xrun
-            | AudioFailureKind::BackendError
-            | AudioFailureKind::WorkerPanicked => "Microphone capture failed. Try recording again.",
+            _ => "Microphone capture failed. Try recording again.",
         }
     }
 }
@@ -154,161 +127,28 @@ impl fmt::Display for AudioFailure {
     }
 }
 
+fn failure_kind(code: FailureCode) -> AudioFailureKind {
+    match code {
+        FailureCode::PermissionDenied => AudioFailureKind::PermissionDenied,
+        FailureCode::NoInputDevice => AudioFailureKind::DeviceUnavailable,
+        FailureCode::ConfigurationFailed => AudioFailureKind::UnsupportedConfig,
+        FailureCode::CallbackStalled => AudioFailureKind::FirstBufferTimeout,
+        FailureCode::InvalidMessage => AudioFailureKind::InvalidInput,
+        FailureCode::EnumerationFailed => AudioFailureKind::HostUnavailable,
+        FailureCode::StreamError => AudioFailureKind::StreamInvalidated,
+        FailureCode::StreamOpenFailed | FailureCode::StreamStartFailed | FailureCode::Internal => {
+            AudioFailureKind::BackendError
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioDeviceDescriptor {
-    /// Backend-native stable identifier. On CoreAudio this is the raw
-    /// kAudioDevicePropertyDeviceUID with no CPAL host prefix.
     pub id: String,
-    /// Presentation-only display name.
     pub name: String,
 }
 
-fn descriptor_for(device: &cpal::Device) -> Result<AudioDeviceDescriptor, AudioFailure> {
-    let id = device
-        .id()
-        .map_err(|error| AudioFailure::from_cpal(AudioInitPhase::DeviceEnumeration, error))?
-        .id()
-        .to_string();
-    let name = device
-        .description()
-        .map_err(|error| AudioFailure::from_cpal(AudioInitPhase::DeviceEnumeration, error))?
-        .name()
-        .to_string();
-    Ok(AudioDeviceDescriptor { id, name })
-}
-
-fn collect_identifiable_devices<T, U>(
-    devices: impl IntoIterator<Item = T>,
-    mut identify: impl FnMut(T) -> Result<U, AudioFailure>,
-) -> Vec<U> {
-    devices
-        .into_iter()
-        .filter_map(|device| match identify(device) {
-            Ok(identified) => Some(identified),
-            Err(failure) => {
-                tracing::warn!(
-                    target: "audio",
-                    error_kind = failure.kind.as_str(),
-                    phase = failure.phase.as_str(),
-                    "skipping unidentifiable input device"
-                );
-                None
-            }
-        })
-        .collect()
-}
-
-fn select_explicit_device_index<T>(
-    requested_id: &str,
-    devices: &[(T, AudioDeviceDescriptor)],
-) -> Result<usize, AudioFailure> {
-    if let Some(index) = devices
-        .iter()
-        .position(|(_, descriptor)| descriptor.id == requested_id)
-    {
-        return Ok(index);
-    }
-    let mut legacy_matches = devices
-        .iter()
-        .enumerate()
-        .filter(|(_, (_, descriptor))| descriptor.name == requested_id)
-        .map(|(index, _)| index);
-    match (legacy_matches.next(), legacy_matches.next()) {
-        (Some(index), None) => Ok(index),
-        _ => Err(AudioFailure::new(
-            AudioFailureKind::DeviceUnavailable,
-            AudioInitPhase::DeviceEnumeration,
-        )),
-    }
-}
-
-fn mono_from_samples<T>(data: &[T], channels: usize) -> Vec<f32>
-where
-    T: Sample + Copy,
-    f32: FromSample<T>,
-{
-    data.chunks(channels)
-        .map(|chunk| {
-            let sum: f32 = chunk.iter().copied().map(f32::from_sample).sum();
-            sum / channels as f32
-        })
-        .collect()
-}
-
-fn build_mono_input_stream<T>(
-    device: &cpal::Device,
-    config: cpal::StreamConfig,
-    shared: Arc<Mutex<Vec<f32>>>,
-    channels: usize,
-    app_handle: Option<tauri::AppHandle>,
-    publish_levels: Arc<AtomicBool>,
-    first_buffer_seen: Arc<AtomicBool>,
-    event_sender: AudioWorkerEventSender,
-    owner: crate::audio_lifecycle::AudioOwner,
-    sample_rate: u32,
-) -> Result<cpal::Stream, AudioFailure>
-where
-    T: SizedSample + Sample + Send + 'static,
-    f32: FromSample<T>,
-{
-    let first_buffer_sender = event_sender.clone();
-    let runtime_error_sender = event_sender;
-    let last_emit_ms = std::sync::atomic::AtomicU64::new(0);
-    device
-        .build_input_stream(
-            config,
-            move |data: &[T], _: &_| {
-                if data.is_empty() {
-                    return;
-                }
-                let mono = mono_from_samples(data, channels);
-                if mono.is_empty() {
-                    return;
-                }
-
-                // Retention precedes readiness. This buffer and any later
-                // buffers received before supervisor acceptance remain owned
-                // by this generation and are never dropped.
-                shared
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .extend_from_slice(&mono);
-
-                if !first_buffer_seen.swap(true, Ordering::AcqRel) {
-                    let _ = first_buffer_sender
-                        .send(AudioWorkerEvent::FirstBuffer { owner, sample_rate });
-                }
-
-                // Waveform publication is a separate generation gate. A stale
-                // or recovering worker may retain only its private buffer but
-                // can never publish UI state.
-                if !publish_levels.load(Ordering::Acquire) {
-                    return;
-                }
-                if let Some(ref handle) = app_handle {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
-                    let last = last_emit_ms.load(Ordering::Relaxed);
-                    if now.saturating_sub(last) >= AUDIO_LEVEL_THROTTLE_MS {
-                        last_emit_ms.store(now, Ordering::Relaxed);
-                        let _ = handle.emit("audio-level", compute_rms(&mono));
-                    }
-                }
-            },
-            move |error| {
-                let failure = AudioFailure::from_cpal(AudioInitPhase::Runtime, error);
-                let _ =
-                    runtime_error_sender.send(AudioWorkerEvent::RuntimeFailed { owner, failure });
-            },
-            Some(STREAM_BUILD_TIMEOUT),
-        )
-        .map_err(|error| AudioFailure::from_cpal(AudioInitPhase::StreamBuild, error))
-}
-
-/// Commands sent by the lifecycle supervisor to the single capture worker.
 pub(crate) enum AudioCommand {
     Stop,
 }
@@ -367,9 +207,6 @@ pub(crate) enum AudioWorkerEvent {
     },
 }
 
-/// Cloneable worker-side handle that enqueues lifecycle events directly on the
-/// supervisor's command queue. Keeping worker events and stop/cancel/deadline
-/// messages on one queue gives the supervisor a single linearization order.
 #[derive(Clone)]
 pub(crate) struct AudioWorkerEventSender {
     send: Arc<dyn Fn(AudioWorkerEvent) -> Result<(), ()> + Send + Sync>,
@@ -398,26 +235,365 @@ pub(crate) struct AudioWorkerSpec {
     pub device_id: Option<String>,
 }
 
-/// List available inputs as stable IDs plus presentation-only display names.
-pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
-    let host = cpal::default_host();
-    let devices = host.input_devices().map_err(|error| {
-        AudioFailure::from_cpal(AudioInitPhase::DeviceEnumeration, error).to_string()
-    })?;
-    Ok(collect_identifiable_devices(devices, |device| {
-        descriptor_for(&device)
-    }))
+fn capture_identity() -> (u64, SessionNonce, String) {
+    let capture_id = NEXT_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
+    let nonce = *Uuid::new_v4().as_bytes();
+    let encoded = nonce.iter().map(|byte| format!("{byte:02x}")).collect();
+    (capture_id, nonce, encoded)
 }
 
-/// Start transform instruction audio asynchronously under the shared
-/// supervisor. The transform flow enters its public Listening state only
-/// after the matching lifecycle Ready event is accepted.
+fn helper_path() -> Result<std::path::PathBuf, String> {
+    bundled_sibling("murmur-capture-worker")
+        .or_else(|_| bundled_sibling("murmur-capture-worker-aarch64-apple-darwin"))
+        .map_err(|_| "The signed capture worker is missing from the app bundle.".to_string())
+}
+
+fn spawn_helper(
+    capture_id: u64,
+    nonce_hex: &str,
+) -> Result<
+    (
+        ManagedChild,
+        std::process::ChildStdin,
+        std::process::ChildStdout,
+    ),
+    AudioFailure,
+> {
+    let path = helper_path().map_err(|_| {
+        AudioFailure::new(
+            AudioFailureKind::HostUnavailable,
+            AudioInitPhase::StreamBuild,
+        )
+    })?;
+    let capture_id_text = capture_id.to_string();
+    ManagedChild::spawn_with_arguments(
+        &path,
+        &["--production-v2", &capture_id_text, nonce_hex],
+        &[],
+    )
+    .map_err(|_| {
+        AudioFailure::new(
+            AudioFailureKind::HostUnavailable,
+            AudioInitPhase::StreamBuild,
+        )
+    })
+}
+
+fn hello(
+    input: &mut std::process::ChildStdin,
+    output: &mut impl std::io::Read,
+    capture_id: u64,
+    nonce: SessionNonce,
+) -> Result<(), AudioFailure> {
+    write_production_control(input, capture_id, nonce, &ProductionHostMessage::Hello).map_err(
+        |_| AudioFailure::new(AudioFailureKind::BackendError, AudioInitPhase::StreamBuild),
+    )?;
+    match read_production_frame(output, capture_id, nonce) {
+        Ok(ProductionFrame::Control(ProductionHelperMessage::HelloAck)) => Ok(()),
+        _ => Err(AudioFailure::new(
+            AudioFailureKind::InvalidInput,
+            AudioInitPhase::StreamBuild,
+        )),
+    }
+}
+
+pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
+    let (capture_id, nonce, nonce_hex) = capture_identity();
+    let (mut child, mut input, output) =
+        spawn_helper(capture_id, &nonce_hex).map_err(|failure| failure.to_string())?;
+    let mut output = BufReader::new(output);
+    hello(&mut input, &mut output, capture_id, nonce).map_err(|failure| failure.to_string())?;
+    write_production_control(
+        &mut input,
+        capture_id,
+        nonce,
+        &ProductionHostMessage::Enumerate,
+    )
+    .map_err(|_| "Failed to request microphone enumeration.".to_string())?;
+    let devices = match read_production_frame(&mut output, capture_id, nonce) {
+        Ok(ProductionFrame::Control(ProductionHelperMessage::Devices { devices })) => devices
+            .into_iter()
+            .map(|device| AudioDeviceDescriptor {
+                id: device.id,
+                name: device.name,
+            })
+            .collect(),
+        _ => return Err("The capture worker returned an invalid device list.".to_string()),
+    };
+    drop((input, output));
+    let _ = child.wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE);
+    Ok(devices)
+}
+
 pub fn start_transform_capture_audio(
     app_handle: Option<tauri::AppHandle>,
     device_id: Option<String>,
     transform_pass_id: u64,
 ) -> Result<(), String> {
     crate::audio_lifecycle::start_transform_recording(app_handle, device_id, transform_pass_id)
+}
+
+enum HelperRead {
+    Frame(ProductionFrame<ProductionHelperMessage>),
+    Invalid,
+}
+
+enum AttemptResult {
+    Stopped,
+    Failed {
+        failure: AudioFailure,
+        retained_audio: bool,
+    },
+}
+
+fn run_backend(
+    owner: crate::audio_lifecycle::AudioOwner,
+    backend: CaptureBackend,
+    device_id: Option<&str>,
+    command_receiver: &Receiver<AudioCommand>,
+    shared: &Arc<Mutex<Vec<f32>>>,
+    active: &Arc<AtomicBool>,
+    app_handle: &Option<tauri::AppHandle>,
+    event_sender: &AudioWorkerEventSender,
+) -> AttemptResult {
+    let (capture_id, nonce, nonce_hex) = capture_identity();
+    let (mut child, mut input, mut output) = match spawn_helper(capture_id, &nonce_hex) {
+        Ok(value) => value,
+        Err(failure) => {
+            return AttemptResult::Failed {
+                failure,
+                retained_audio: false,
+            }
+        }
+    };
+    if let Err(failure) = hello(&mut input, &mut output, capture_id, nonce) {
+        return AttemptResult::Failed {
+            failure,
+            retained_audio: false,
+        };
+    }
+    if write_production_control(
+        &mut input,
+        capture_id,
+        nonce,
+        &ProductionHostMessage::Start {
+            device_id: device_id.map(str::to_string),
+            backend,
+        },
+    )
+    .is_err()
+    {
+        return AttemptResult::Failed {
+            failure: AudioFailure::new(AudioFailureKind::BackendError, AudioInitPhase::StreamBuild),
+            retained_audio: false,
+        };
+    }
+
+    let (reader_tx, reader_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut output = BufReader::new(output);
+        loop {
+            match read_production_frame(&mut output, capture_id, nonce) {
+                Ok(frame) => {
+                    if reader_tx.send(HelperRead::Frame(frame)).is_err() {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    let _ = reader_tx.send(HelperRead::Invalid);
+                    return;
+                }
+            }
+        }
+    });
+
+    let _ = event_sender.send(AudioWorkerEvent::PhaseEntered {
+        owner,
+        phase: AudioInitPhase::StreamBuild,
+    });
+    let mut expected_sequence = 0_u64;
+    let mut sample_rate = None;
+    let mut retained_audio = false;
+    let mut last_level_emit = Instant::now() - Duration::from_secs(1);
+    loop {
+        match command_receiver.try_recv() {
+            Ok(AudioCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
+                let _ = write_production_control(
+                    &mut input,
+                    capture_id,
+                    nonce,
+                    &ProductionHostMessage::Stop,
+                );
+                drop(input);
+                let termination = child
+                    .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
+                    .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
+                if termination.is_some() {
+                    let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
+                    return AttemptResult::Stopped;
+                }
+                return AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        AudioFailureKind::BackendError,
+                        AudioInitPhase::Runtime,
+                    ),
+                    retained_audio,
+                };
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
+
+        match reader_rx.recv_timeout(Duration::from_millis(20)) {
+            Ok(HelperRead::Frame(ProductionFrame::Pcm(pcm))) => {
+                if pcm.sequence != expected_sequence
+                    || pcm.samples.is_empty()
+                    || sample_rate.is_some_and(|rate| rate != pcm.sample_rate)
+                {
+                    let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
+                    return AttemptResult::Failed {
+                        failure: AudioFailure::new(
+                            AudioFailureKind::InvalidInput,
+                            AudioInitPhase::Runtime,
+                        ),
+                        retained_audio,
+                    };
+                }
+                expected_sequence += 1;
+                sample_rate = Some(pcm.sample_rate);
+                shared
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .extend_from_slice(&pcm.samples);
+                if !retained_audio {
+                    retained_audio = true;
+                    let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
+                        owner,
+                        phase: AudioInitPhase::FirstBufferWait,
+                        elapsed_ms: 0,
+                    });
+                    let _ = event_sender.send(AudioWorkerEvent::FirstBuffer {
+                        owner,
+                        sample_rate: pcm.sample_rate,
+                    });
+                }
+                if active.load(Ordering::Acquire)
+                    && last_level_emit.elapsed() >= Duration::from_millis(AUDIO_LEVEL_THROTTLE_MS)
+                {
+                    if let Some(handle) = app_handle {
+                        let _ = handle.emit("audio-level", compute_rms(&pcm.samples));
+                    }
+                    last_level_emit = Instant::now();
+                }
+            }
+            Ok(HelperRead::Frame(ProductionFrame::Control(ProductionHelperMessage::Phase {
+                phase,
+                ..
+            }))) => {
+                let phase = match phase {
+                    CapturePhase::Enumeration => AudioInitPhase::DeviceEnumeration,
+                    CapturePhase::StreamOpen => AudioInitPhase::StreamBuild,
+                    CapturePhase::AwaitingFirstCallback => AudioInitPhase::FirstBufferWait,
+                    CapturePhase::Active => AudioInitPhase::Runtime,
+                    CapturePhase::Stopping => AudioInitPhase::Runtime,
+                };
+                let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
+            }
+            Ok(HelperRead::Frame(ProductionFrame::Control(ProductionHelperMessage::Failure {
+                code,
+                ..
+            }))) => {
+                return AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        failure_kind(code),
+                        if retained_audio {
+                            AudioInitPhase::Runtime
+                        } else {
+                            AudioInitPhase::StreamBuild
+                        },
+                    ),
+                    retained_audio,
+                };
+            }
+            Ok(HelperRead::Frame(ProductionFrame::Control(ProductionHelperMessage::Stopped {
+                ..
+            }))) => {
+                drop(input);
+                let _ = child
+                    .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
+                    .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
+                let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
+                return AttemptResult::Stopped;
+            }
+            Ok(HelperRead::Frame(_)) => {}
+            Ok(HelperRead::Invalid) | Err(RecvTimeoutError::Disconnected) => {
+                return AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        AudioFailureKind::InvalidInput,
+                        if retained_audio {
+                            AudioInitPhase::Runtime
+                        } else {
+                            AudioInitPhase::StreamBuild
+                        },
+                    ),
+                    retained_audio,
+                };
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
+fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSender) {
+    let AudioWorkerSpec {
+        owner,
+        command_receiver,
+        shared,
+        active,
+        app_handle,
+        device_id,
+    } = spec;
+    for (attempt_index, backend) in [CaptureBackend::Cpal, CaptureBackend::Auhal]
+        .into_iter()
+        .enumerate()
+    {
+        match run_backend(
+            owner,
+            backend,
+            device_id.as_deref(),
+            &command_receiver,
+            &shared,
+            &active,
+            &app_handle,
+            event_sender,
+        ) {
+            AttemptResult::Stopped => return,
+            AttemptResult::Failed {
+                failure,
+                retained_audio,
+            } if !retained_audio && attempt_index == 0 => {
+                tracing::warn!(
+                    target: "audio",
+                    owner = owner.telemetry_id(),
+                    from_backend = "cpal",
+                    to_backend = "auhal",
+                    error_kind = failure.kind.as_str(),
+                    "capture backend failed before retained audio; trying bounded fallback"
+                );
+            }
+            AttemptResult::Failed {
+                failure,
+                retained_audio,
+            } => {
+                let event = if retained_audio {
+                    AudioWorkerEvent::RuntimeFailed { owner, failure }
+                } else {
+                    AudioWorkerEvent::InitFailed { owner, failure }
+                };
+                let _ = event_sender.send(event);
+                return;
+            }
+        }
+    }
 }
 
 pub(crate) fn spawn_capture_worker(
@@ -431,195 +607,18 @@ pub(crate) fn spawn_capture_worker(
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 run_audio_capture(spec, &event_sender)
             }));
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    tracing::error!(
-                        target: "audio",
-                        owner = owner.telemetry_id(),
-                        error_kind = error.kind.as_str(),
-                        phase = error.phase.as_str(),
-                        "audio capture worker failed"
-                    );
-                    let _ = event_sender.send(AudioWorkerEvent::InitFailed {
-                        owner,
-                        failure: error,
-                    });
-                }
-                Err(_) => {
-                    let failure = AudioFailure::new(
+            if result.is_err() {
+                let _ = event_sender.send(AudioWorkerEvent::InitFailed {
+                    owner,
+                    failure: AudioFailure::new(
                         AudioFailureKind::WorkerPanicked,
                         AudioInitPhase::Runtime,
-                    );
-                    tracing::error!(
-                        target: "audio",
-                        owner = owner.telemetry_id(),
-                        error_kind = failure.kind.as_str(),
-                        phase = failure.phase.as_str(),
-                        "audio capture worker panicked"
-                    );
-                    let _ = event_sender.send(AudioWorkerEvent::InitFailed { owner, failure });
-                }
+                    ),
+                });
             }
             let _ = event_sender.send(AudioWorkerEvent::ThreadExited { owner });
         })
-        .map_err(|error| format!("Failed to spawn audio thread: {error}"))
-}
-
-fn timed_phase<T>(
-    owner: crate::audio_lifecycle::AudioOwner,
-    phase: AudioInitPhase,
-    event_sender: &AudioWorkerEventSender,
-    operation: impl FnOnce() -> Result<T, AudioFailure>,
-) -> Result<T, AudioFailure> {
-    let started = std::time::Instant::now();
-    let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
-    let result = operation();
-    let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
-        owner,
-        phase,
-        elapsed_ms: started.elapsed().as_millis() as u64,
-    });
-    result
-}
-
-fn run_audio_capture(
-    spec: AudioWorkerSpec,
-    event_sender: &AudioWorkerEventSender,
-) -> Result<(), AudioFailure> {
-    let AudioWorkerSpec {
-        owner,
-        command_receiver,
-        shared,
-        active,
-        app_handle,
-        device_id,
-    } = spec;
-    let host = cpal::default_host();
-
-    let device = timed_phase(
-        owner,
-        AudioInitPhase::DeviceEnumeration,
-        event_sender,
-        || {
-            if let Some(ref requested_id) = device_id {
-                let devices = host.input_devices().map_err(|error| {
-                    AudioFailure::from_cpal(AudioInitPhase::DeviceEnumeration, error)
-                })?;
-                let candidates = collect_identifiable_devices(devices, |device| {
-                    descriptor_for(&device).map(|descriptor| (device, descriptor))
-                });
-                let index = select_explicit_device_index(requested_id, &candidates)?;
-                Ok(candidates
-                    .into_iter()
-                    .nth(index)
-                    .expect("selected audio device index must exist")
-                    .0)
-            } else {
-                host.default_input_device().ok_or_else(|| {
-                    AudioFailure::new(
-                        AudioFailureKind::DeviceUnavailable,
-                        AudioInitPhase::DeviceEnumeration,
-                    )
-                })
-            }
-        },
-    )?;
-
-    let config = timed_phase(owner, AudioInitPhase::ConfigLookup, event_sender, || {
-        device
-            .default_input_config()
-            .map_err(|error| AudioFailure::from_cpal(AudioInitPhase::ConfigLookup, error))
-    })?;
-    let device_sample_rate = config.sample_rate();
-    let sample_format = config.sample_format();
-    let channels = config.channels() as usize;
-
-    tracing::info!(
-        target: "audio",
-        owner = owner.telemetry_id(),
-        device_selection = if device_id.is_some() { "explicit" } else { "system_default" },
-        sample_rate = device_sample_rate,
-        channels,
-        format = ?sample_format,
-        "run_audio_capture"
-    );
-
-    let stream_config = config.config();
-    let first_buffer_seen = Arc::new(AtomicBool::new(false));
-    macro_rules! build_for {
-        ($sample:ty) => {
-            build_mono_input_stream::<$sample>(
-                &device,
-                stream_config,
-                Arc::clone(&shared),
-                channels,
-                app_handle.clone(),
-                Arc::clone(&active),
-                Arc::clone(&first_buffer_seen),
-                event_sender.clone(),
-                owner,
-                device_sample_rate,
-            )
-        };
-    }
-    let stream =
-        timed_phase(
-            owner,
-            AudioInitPhase::StreamBuild,
-            event_sender,
-            || match sample_format {
-                SampleFormat::I8 => build_for!(i8),
-                SampleFormat::I16 => build_for!(i16),
-                SampleFormat::I24 => build_for!(cpal::I24),
-                SampleFormat::I32 => build_for!(i32),
-                SampleFormat::I64 => build_for!(i64),
-                SampleFormat::U8 => build_for!(u8),
-                SampleFormat::U16 => build_for!(u16),
-                SampleFormat::U24 => build_for!(cpal::U24),
-                SampleFormat::U32 => build_for!(u32),
-                SampleFormat::U64 => build_for!(u64),
-                SampleFormat::F32 => build_for!(f32),
-                SampleFormat::F64 => build_for!(f64),
-                SampleFormat::DsdU8 | SampleFormat::DsdU16 | SampleFormat::DsdU32 => {
-                    Err(AudioFailure::new(
-                        AudioFailureKind::UnsupportedConfig,
-                        AudioInitPhase::StreamBuild,
-                    ))
-                }
-                _ => Err(AudioFailure::new(
-                    AudioFailureKind::UnsupportedConfig,
-                    AudioInitPhase::StreamBuild,
-                )),
-            },
-        )?;
-
-    if command_receiver.try_recv().is_ok() {
-        return Ok(());
-    }
-
-    timed_phase(owner, AudioInitPhase::StreamPlay, event_sender, || {
-        stream
-            .play()
-            .map_err(|error| AudioFailure::from_cpal(AudioInitPhase::StreamPlay, error))
-    })?;
-
-    let _ = event_sender.send(AudioWorkerEvent::PhaseEntered {
-        owner,
-        phase: AudioInitPhase::FirstBufferWait,
-    });
-
-    loop {
-        match command_receiver.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok(AudioCommand::Stop) => break,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
-        }
-    }
-
-    let _ = stream.pause();
-    let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
-    Ok(())
+        .map_err(|error| format!("Failed to spawn capture supervisor thread: {error}"))
 }
 
 pub fn stop_recording() -> Result<Vec<f32>, String> {
@@ -634,216 +633,24 @@ pub fn is_recording() -> bool {
     crate::audio_lifecycle::is_audio_active()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rms_empty_slice_returns_zero() {
-        assert_eq!(compute_rms(&[]), 0.0);
-    }
-
-    #[test]
-    fn rms_silence_is_zero() {
-        assert_eq!(compute_rms(&[0.0f32; 100]), 0.0);
-    }
-
-    #[test]
-    fn rms_full_amplitude_is_one() {
-        let result = compute_rms(&[1.0f32; 100]);
-        assert!((result - 1.0).abs() < 1e-6, "expected 1.0, got {result}");
-    }
-
-    #[test]
-    fn rms_alternating_signs_is_one() {
-        let result = compute_rms(&[1.0f32, -1.0, 1.0, -1.0]);
-        assert!((result - 1.0).abs() < 1e-6, "expected 1.0, got {result}");
-    }
-
-    #[test]
-    fn rms_half_amplitude() {
-        let result = compute_rms(&[0.5f32; 100]);
-        assert!((result - 0.5).abs() < 1e-6, "expected 0.5, got {result}");
-    }
-
-    #[test]
-    fn rms_single_sample() {
-        assert!((compute_rms(&[0.6f32]) - 0.6).abs() < 1e-6);
-    }
-
-    #[test]
-    fn peak_empty_slice_returns_zero() {
-        assert_eq!(compute_peak(&[]), 0.0);
-    }
-
-    #[test]
-    fn peak_silence_is_zero() {
-        assert_eq!(compute_peak(&[0.0f32; 100]), 0.0);
-    }
-
-    #[test]
-    fn peak_positive() {
-        assert!((compute_peak(&[0.1f32, 0.5, 0.3, 0.2]) - 0.5).abs() < 1e-6);
-    }
-
-    #[test]
-    fn peak_negative() {
-        assert!((compute_peak(&[0.1f32, -0.8, 0.3, 0.2]) - 0.8).abs() < 1e-6);
-    }
-
-    #[test]
-    fn mono_conversion_supports_i24_and_i32() {
-        let i24 = [
-            cpal::I24::from_sample(0.5_f32),
-            cpal::I24::from_sample(-0.5_f32),
-            cpal::I24::from_sample(0.25_f32),
-            cpal::I24::from_sample(0.25_f32),
-        ];
-        let i24_mono = mono_from_samples(&i24, 2);
-        assert!(i24_mono[0].abs() < 1e-5);
-        assert!((i24_mono[1] - 0.25).abs() < 1e-5);
-
-        let i32_samples = [
-            i32::from_sample(0.5_f32),
-            i32::from_sample(-0.5_f32),
-            i32::from_sample(0.25_f32),
-            i32::from_sample(0.25_f32),
-        ];
-        let i32_mono = mono_from_samples(&i32_samples, 2);
-        assert!(i32_mono[0].abs() < 1e-5);
-        assert!((i32_mono[1] - 0.25).abs() < 1e-5);
-    }
-
-    #[test]
-    fn explicit_device_selection_prefers_raw_id_and_legacy_names_must_be_unique() {
-        let candidates = vec![
-            (
-                (),
-                AudioDeviceDescriptor {
-                    id: "raw-uid-a".to_string(),
-                    name: "Studio Mic".to_string(),
-                },
-            ),
-            (
-                (),
-                AudioDeviceDescriptor {
-                    id: "raw-uid-b".to_string(),
-                    name: "Studio Mic".to_string(),
-                },
-            ),
-        ];
-        assert_eq!(
-            select_explicit_device_index("raw-uid-b", &candidates).unwrap(),
-            1
-        );
-        assert_eq!(
-            select_explicit_device_index("Studio Mic", &candidates)
-                .unwrap_err()
-                .kind,
-            AudioFailureKind::DeviceUnavailable
-        );
-        assert_eq!(
-            select_explicit_device_index("missing", &candidates)
-                .unwrap_err()
-                .kind,
-            AudioFailureKind::DeviceUnavailable
-        );
-    }
-
-    #[test]
-    fn unreadable_device_descriptor_does_not_hide_identifiable_devices() {
-        let descriptors = collect_identifiable_devices([1_u8, 2, 3], |device| {
-            if device == 2 {
-                return Err(AudioFailure::new(
-                    AudioFailureKind::DeviceChanged,
-                    AudioInitPhase::DeviceEnumeration,
-                ));
-            }
-            Ok(AudioDeviceDescriptor {
-                id: format!("raw-uid-{device}"),
-                name: format!("Microphone {device}"),
-            })
-        });
-
-        assert_eq!(
-            descriptors,
-            vec![
-                AudioDeviceDescriptor {
-                    id: "raw-uid-1".to_string(),
-                    name: "Microphone 1".to_string(),
-                },
-                AudioDeviceDescriptor {
-                    id: "raw-uid-3".to_string(),
-                    name: "Microphone 3".to_string(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn cpal_error_mapping_is_typed_and_messages_never_include_backend_content() {
-        for (cpal_kind, expected) in [
-            (
-                cpal::ErrorKind::PermissionDenied,
-                AudioFailureKind::PermissionDenied,
-            ),
-            (
-                cpal::ErrorKind::DeviceNotAvailable,
-                AudioFailureKind::DeviceUnavailable,
-            ),
-            (cpal::ErrorKind::DeviceBusy, AudioFailureKind::DeviceBusy),
-            (
-                cpal::ErrorKind::DeviceChanged,
-                AudioFailureKind::DeviceChanged,
-            ),
-            (
-                cpal::ErrorKind::StreamInvalidated,
-                AudioFailureKind::StreamInvalidated,
-            ),
-            (
-                cpal::ErrorKind::InvalidInput,
-                AudioFailureKind::InvalidInput,
-            ),
-            (
-                cpal::ErrorKind::ResourceExhausted,
-                AudioFailureKind::ResourceExhausted,
-            ),
-        ] {
-            let failure = AudioFailure::from_cpal(
-                AudioInitPhase::StreamBuild,
-                cpal::Error::with_message(cpal_kind, "secret device label and raw backend detail"),
-            );
-            assert_eq!(failure.kind, expected);
-            assert!(!failure.to_string().contains("secret"));
-            assert!(!failure.to_string().contains("backend detail"));
-        }
-    }
-}
-
-/// Linear-interpolation resample from `from_rate` to `to_rate`.
-/// Used by both live capture (`stop_recording`) and file decoding (`audio_decode`).
 pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     if from_rate == to_rate {
         return samples.to_vec();
     }
-
     let ratio = from_rate as f64 / to_rate as f64;
     let new_len = (samples.len() as f64 / ratio) as usize;
     let mut resampled = Vec::with_capacity(new_len);
-
-    for i in 0..new_len {
-        let src_idx = i as f64 * ratio;
-        let idx = src_idx as usize;
-        let frac = src_idx - idx as f64;
-        let sample = if idx + 1 < samples.len() {
-            samples[idx] * (1.0 - frac as f32) + samples[idx + 1] * frac as f32
-        } else if idx < samples.len() {
-            samples[idx]
+    for index in 0..new_len {
+        let source = index as f64 * ratio;
+        let source_index = source as usize;
+        let fraction = source - source_index as f64;
+        let sample = if source_index + 1 < samples.len() {
+            samples[source_index] * (1.0 - fraction as f32)
+                + samples[source_index + 1] * fraction as f32
         } else {
-            0.0
+            samples.get(source_index).copied().unwrap_or_default()
         };
         resampled.push(sample);
     }
-
     resampled
 }

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -3,6 +3,7 @@ use crate::audio::{
     AudioWorkerEventSender, AudioWorkerSpec,
 };
 use crate::state::WHISPER_SAMPLE_RATE;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
@@ -72,6 +73,11 @@ pub(crate) enum AudioLifecycleEvent {
         kind: AudioFailureKind,
     },
     RecoveryStalled,
+    Interrupted {
+        reason: AudioCancelReason,
+        delivered_samples: u64,
+        duration_ms: u64,
+    },
     Idle,
 }
 
@@ -347,6 +353,7 @@ struct Attempt {
     failure_reported: bool,
     stopping_guidance_emitted: bool,
     failure: Option<AudioFailure>,
+    recovery_reason: Option<AudioCancelReason>,
     init_phase: AudioInitPhase,
     command_sender: Sender<AudioCommand>,
     thread_handle: Option<JoinHandle<()>>,
@@ -617,6 +624,7 @@ fn handle_start(
         failure_reported: false,
         stopping_guidance_emitted: false,
         failure: None,
+        recovery_reason: None,
         init_phase: AudioInitPhase::DeviceEnumeration,
         command_sender,
         thread_handle: Some(thread_handle),
@@ -746,12 +754,13 @@ fn handle_worker_event(
                 current.phase,
                 AttemptPhase::Starting | AttemptPhase::Recording
             ) {
+                current.failure = Some(failure);
                 begin_recovery(
                     attempt,
                     AudioCancelReason::RuntimeFailure,
                     sink,
                     public,
-                    Some(failure),
+                    None,
                 );
             }
         }
@@ -823,11 +832,45 @@ fn finish_attempt(attempt: &mut Option<Attempt>, sink: &dyn LifecycleSink, publi
             );
         }
         AttemptPhase::Recovering => {
-            sink.notify(
-                finished.app_handle.as_ref(),
-                finished.owner,
-                AudioLifecycleEvent::Idle,
-            );
+            if finished.recovery_reason == Some(AudioCancelReason::RuntimeFailure)
+                && matches!(finished.owner, AudioOwner::Dictation(_))
+            {
+                let reason = finished
+                    .failure
+                    .as_ref()
+                    .map(|failure| failure.kind.as_str())
+                    .unwrap_or("runtime_failure")
+                    .to_string();
+                let samples = take_samples(&mut finished);
+                let delivered_samples = samples.len() as u64;
+                let duration_ms = delivered_samples / 16;
+                interrupted_captures()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .insert(
+                        finished.owner,
+                        InterruptedCapture {
+                            samples,
+                            reason,
+                            duration_ms,
+                        },
+                    );
+                sink.notify(
+                    finished.app_handle.as_ref(),
+                    finished.owner,
+                    AudioLifecycleEvent::Interrupted {
+                        reason: AudioCancelReason::RuntimeFailure,
+                        delivered_samples,
+                        duration_ms,
+                    },
+                );
+            } else {
+                sink.notify(
+                    finished.app_handle.as_ref(),
+                    finished.owner,
+                    AudioLifecycleEvent::Idle,
+                );
+            }
         }
     }
     finished.active.store(false, Ordering::SeqCst);
@@ -889,6 +932,7 @@ fn begin_recovery(
     current.active.store(false, Ordering::SeqCst);
     let _ = current.command_sender.send(AudioCommand::Stop);
     current.phase = AttemptPhase::Recovering;
+    current.recovery_reason = Some(reason);
     current.stopping_started_at = Some(Instant::now());
     public.set_phase(PublicPhase::Recovering);
     tracing::info!(
@@ -911,6 +955,26 @@ fn begin_recovery(
         report_failure_once(current, sink, failure);
     }
     public.still_connecting.store(false, Ordering::SeqCst);
+}
+
+pub(crate) struct InterruptedCapture {
+    pub(crate) samples: Vec<f32>,
+    pub(crate) reason: String,
+    pub(crate) duration_ms: u64,
+}
+
+static INTERRUPTED_CAPTURES: OnceLock<Mutex<HashMap<AudioOwner, InterruptedCapture>>> =
+    OnceLock::new();
+
+fn interrupted_captures() -> &'static Mutex<HashMap<AudioOwner, InterruptedCapture>> {
+    INTERRUPTED_CAPTURES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn take_interrupted_dictation(recording_id: u64) -> Option<InterruptedCapture> {
+    interrupted_captures()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&AudioOwner::Dictation(recording_id))
 }
 
 fn report_failure_once(attempt: &mut Attempt, sink: &dyn LifecycleSink, failure: AudioFailure) {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -2223,7 +2223,9 @@ pub(crate) fn handle_audio_lifecycle<R: tauri::Runtime>(
                 }
                 dictation.status = DictationStatus::Recovering;
             }
-            state.app_state.clear_active_context(recording_id);
+            if reason != AudioCancelReason::RuntimeFailure {
+                state.app_state.clear_active_context(recording_id);
+            }
             let _ = app_handle.emit("recording-status-changed", "recovering");
             let _ = app_handle.emit(
                 "audio-recovery-started",
@@ -2283,6 +2285,46 @@ pub(crate) fn handle_audio_lifecycle<R: tauri::Runtime>(
                     "recording-recovery-stalled",
                     serde_json::json!({ "recordingId": recording_id }),
                 );
+            }
+        }
+        AudioLifecycleEvent::Interrupted {
+            reason,
+            delivered_samples,
+            duration_ms,
+        } => {
+            if !is_current() {
+                let _ = audio_lifecycle::take_interrupted_dictation(recording_id);
+                return;
+            }
+            let auto_transcribe = delivered_samples >= 8_000;
+            let _ = app_handle.emit(
+                "recording-interrupted",
+                serde_json::json!({
+                    "recordingId": recording_id,
+                    "reason": reason.as_str(),
+                    "deliveredSamples": delivered_samples,
+                    "durationMs": duration_ms,
+                    "autoTranscribe": auto_transcribe,
+                }),
+            );
+            if auto_transcribe {
+                tauri::async_runtime::spawn(async move {
+                    let state = app_handle.state::<State>();
+                    if let Err(error) = stop_native_recording(app_handle.clone(), state).await {
+                        tracing::error!(
+                            target: "pipeline",
+                            recording_id,
+                            error = error.as_str(),
+                            "interrupted recording transcription failed"
+                        );
+                    }
+                });
+            } else {
+                let _ = audio_lifecycle::take_interrupted_dictation(recording_id);
+                state.app_state.clear_active_context(recording_id);
+                state.app_state.dictation.lock_or_recover().status = DictationStatus::Idle;
+                keyboard::set_processing(false);
+                let _ = app_handle.emit("recording-status-changed", "idle");
             }
         }
         AudioLifecycleEvent::Idle => {
@@ -2535,7 +2577,7 @@ pub async fn stop_native_recording(
 ) -> Result<serde_json::Value, String> {
     let transition = state.app_state.recording_transition.lock().await;
     // Atomic check-and-set + generation capture in a single lock.
-    let (status, rid) = {
+    let (status, rid, interrupted_capture) = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         let rid = state.app_state.recording_id.load(Ordering::SeqCst);
         match dictation.status {
@@ -2552,16 +2594,21 @@ pub async fn stop_native_recording(
                     "state": "idle"
                 }));
             }
-            DictationStatus::Starting => (DictationStatus::Starting, rid),
+            DictationStatus::Starting => (DictationStatus::Starting, rid, None),
             DictationStatus::Recovering => {
-                return Ok(serde_json::json!({
-                    "type": "audio_recovering",
-                    "state": "recovering"
-                }));
+                if let Some(capture) = audio_lifecycle::take_interrupted_dictation(rid) {
+                    dictation.status = DictationStatus::Processing;
+                    (DictationStatus::Processing, rid, Some(capture))
+                } else {
+                    return Ok(serde_json::json!({
+                        "type": "audio_recovering",
+                        "state": "recovering"
+                    }));
+                }
             }
             DictationStatus::Recording => {
                 dictation.status = DictationStatus::Processing;
-                (DictationStatus::Recording, rid)
+                (DictationStatus::Recording, rid, None)
             }
         }
     };
@@ -2606,13 +2653,24 @@ pub async fn stop_native_recording(
     // Processing is already committed, so concurrent calls cannot claim the
     // microphone. Release the transition guard before the supervisor wait.
     drop(transition);
-    let samples = audio_lifecycle::stop_dictation_recording(rid).map_err(|e| {
-        tracing::error!(target: "audio", "stop_native_recording: stop_recording failed: {}", e);
-        if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
-            let _ = app_handle.emit("recording-status-changed", "idle");
-        }
-        e
-    })?;
+    let interruption = interrupted_capture.as_ref().map(|capture| {
+        serde_json::json!({
+            "reason": capture.reason.clone(),
+            "deliveredSamples": capture.samples.len(),
+            "durationMs": capture.duration_ms,
+        })
+    });
+    let samples = if let Some(capture) = interrupted_capture {
+        capture.samples
+    } else {
+        audio_lifecycle::stop_dictation_recording(rid).map_err(|e| {
+            tracing::error!(target: "audio", "stop_native_recording: stop_recording failed: {}", e);
+            if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
+                let _ = app_handle.emit("recording-status-changed", "idle");
+            }
+            e
+        })?
+    };
     tracing::info!(target: "pipeline", "audio teardown + resample: {:?}", t_total.elapsed());
     performance_guard.record(StageTimingV1::measured(
         PerformanceStageV1::CaptureFinalization,
@@ -2768,7 +2826,8 @@ pub async fn stop_native_recording(
                 "recordingId": rid,
                 "text": text,
                 "duration": recording_secs,
-                "teachingContext": teaching_context
+                "teachingContext": teaching_context,
+                "interrupted": interruption
             }),
         );
     }

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -255,12 +255,9 @@ fn aggregate_audio_state<T>(
 /// by string comparison. Runs blocking Core Audio enumeration without reading
 /// any presentation labels or backend identifiers.
 fn audio_state() -> String {
-    use cpal::traits::HostTrait;
-    let host = cpal::default_host();
-    let default_input_available = host.default_input_device().is_some();
-    match host.input_devices() {
-        Ok(inputs) => aggregate_audio_state(default_input_available, inputs, true),
-        Err(_) => aggregate_audio_state(default_input_available, std::iter::empty::<()>(), false),
+    match crate::audio::list_input_devices() {
+        Ok(inputs) => aggregate_audio_state(!inputs.is_empty(), inputs, true),
+        Err(_) => aggregate_audio_state(false, std::iter::empty::<()>(), false),
     }
 }
 

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1277,6 +1277,11 @@ pub(crate) fn handle_audio_lifecycle(
                 .emit_state(ReviewState::Recovering, Some("audio_recovery_stalled"));
             }
         }
+        crate::audio_lifecycle::AudioLifecycleEvent::Interrupted { .. } => {
+            state.app_state.set_transform_status(TransformStatus::Idle);
+            state.app_state.clear_transform_pass(transform_pass_id);
+            let _ = app_handle.emit("transform-capture-failed", ());
+        }
         crate::audio_lifecycle::AudioLifecycleEvent::Idle => {}
     }
 }

--- a/app/src/components/history/HistoryPanel.tsx
+++ b/app/src/components/history/HistoryPanel.tsx
@@ -374,6 +374,14 @@ export function HistoryPanel({
                       Mic
                     </span>
                   )}
+                  {entry.interruption && (
+                    <span
+                      title={`Capture interrupted: ${entry.interruption.reason}`}
+                      className="inline-flex shrink-0 items-center rounded-full bg-error-container px-2 py-0.5 text-[10px] font-semibold text-on-error-container"
+                    >
+                      Interrupted · partial
+                    </span>
+                  )}
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   <span className="rounded-full bg-surface-container px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">{wordCount} {wordCount === 1 ? 'word' : 'words'}</span>

--- a/app/src/lib/history.ts
+++ b/app/src/lib/history.ts
@@ -3,6 +3,12 @@ import type { TeachingContext } from './correctAndTeach';
 
 export type HistorySource = 'recording' | 'file';
 
+export interface HistoryInterruption {
+  reason: string;
+  deliveredSamples: number;
+  durationMs: number;
+}
+
 export interface HistoryEntry {
   id: string;
   text: string;
@@ -15,6 +21,8 @@ export interface HistoryEntry {
   sourceName?: string;
   /** Local recording-start scope metadata used only for explicit teaching. */
   teachingContext?: TeachingContext;
+  /** Capture ended unexpectedly; the retained prefix was still transcribed. */
+  interruption?: HistoryInterruption;
 }
 
 const STORAGE_KEY = 'dictation-history';
@@ -59,6 +67,7 @@ export function addHistoryEntry(
   source: HistorySource = 'recording',
   sourceName?: string,
   teachingContext?: TeachingContext,
+  interruption?: HistoryInterruption,
 ): HistoryEntry[] {
   const newEntry: HistoryEntry = {
     id: nextEntryId(),
@@ -68,6 +77,7 @@ export function addHistoryEntry(
     source,
     ...(sourceName ? { sourceName } : {}),
     ...(teachingContext ? { teachingContext } : {}),
+    ...(interruption ? { interruption } : {}),
   };
   return trimHistory([...entries, newEntry]);
 }

--- a/app/src/lib/hooks/useHistoryManagement.ts
+++ b/app/src/lib/hooks/useHistoryManagement.ts
@@ -3,6 +3,7 @@ import type { TeachingContext } from '../correctAndTeach';
 import {
   HistoryEntry,
   HistorySource,
+  HistoryInterruption,
   loadHistory,
   saveHistory,
   addHistoryEntry,
@@ -13,9 +14,9 @@ import {
 export function useHistoryManagement() {
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>(() => loadHistory());
 
-  const addEntry = useCallback((text: string, duration: number, source: HistorySource = 'recording', sourceName?: string, teachingContext?: TeachingContext) => {
+  const addEntry = useCallback((text: string, duration: number, source: HistorySource = 'recording', sourceName?: string, teachingContext?: TeachingContext, interruption?: HistoryInterruption) => {
     setHistoryEntries(prev => {
-      const newHistory = addHistoryEntry(prev, text, duration, source, sourceName, teachingContext);
+      const newHistory = addHistoryEntry(prev, text, duration, source, sourceName, teachingContext, interruption);
       saveHistory(newHistory);
       return newHistory;
     });

--- a/app/src/lib/hooks/useOverlayRuntime.ts
+++ b/app/src/lib/hooks/useOverlayRuntime.ts
@@ -155,20 +155,26 @@ export function useOverlayRuntime({
     let cancelled = false;
     let unlisten: (() => void) | null = null;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    listen('recording-initialization-failed', () => {
+    const flashFailure = () => {
       if (timeoutId) clearTimeout(timeoutId);
       setShowMicrophoneFailure(true);
       timeoutId = setTimeout(() => {
         if (!cancelled) setShowMicrophoneFailure(false);
         timeoutId = null;
       }, MICROPHONE_FAILURE_FLASH_MS);
-    }).then((fn) => {
+    };
+    const unlistens: (() => void)[] = [];
+    listen('recording-initialization-failed', flashFailure).then((fn) => {
+      if (cancelled) fn(); else unlistens.push(fn);
+    });
+    listen('recording-interrupted', flashFailure).then((fn) => {
       if (cancelled) fn(); else unlisten = fn;
     });
     return () => {
       cancelled = true;
       if (timeoutId) clearTimeout(timeoutId);
       unlisten?.();
+      unlistens.forEach((fn) => fn());
     };
   }, []);
 

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -6,9 +6,10 @@ import type { DictationStatus } from '../types';
 import { updateStats } from '../stats';
 import { flog } from '../log';
 import type { TeachingContext } from '../correctAndTeach';
+import type { HistoryInterruption } from '../history';
 
 interface UseRecordingStateProps {
-  addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string, teachingContext?: TeachingContext) => void;
+  addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string, teachingContext?: TeachingContext, interruption?: HistoryInterruption) => void;
   microphone: string;
 }
 
@@ -111,6 +112,13 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
     }).then((fn) => {
       if (cancelled) fn(); else unlistens.push(fn);
     });
+    listen<{ autoTranscribe?: boolean }>('recording-interrupted', (event) => {
+      setError(event.payload?.autoTranscribe
+        ? 'Microphone capture was interrupted. Murmur is transcribing the audio received so far.'
+        : 'Microphone capture was interrupted before enough audio was received.');
+    }).then((fn) => {
+      if (cancelled) fn(); else unlistens.push(fn);
+    });
     return () => {
       cancelled = true;
       unlistens.forEach((fn) => fn());
@@ -169,17 +177,17 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
-    listen<{ text: string; duration: number; teachingContext?: TeachingContext }>('transcription-complete', (event) => {
+    listen<{ text: string; duration: number; teachingContext?: TeachingContext; interrupted?: HistoryInterruption }>('transcription-complete', (event) => {
       flog.info('recording', 'transcription-complete event', {
         textLen: event.payload.text?.length, duration: event.payload.duration,
         isStopping: isStoppingRef.current,
       });
       // Single source of truth for history entries — always handle here,
       // never in handleStop, to avoid race-condition duplicates.
-      const { text, duration, teachingContext } = event.payload;
+      const { text, duration, teachingContext, interrupted } = event.payload;
       if (text) {
         setTranscription(text);
-        addEntry(text, duration, 'recording', undefined, teachingContext);
+        addEntry(text, duration, 'recording', undefined, teachingContext, interrupted);
         updateStats(text, duration);
         setStatsVersion(v => v + 1);
       }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Architecture
 
+> Production microphone ownership is process-isolated. The Tauri process owns
+> policy and retained PCM; `murmur-capture-worker` exclusively owns CPAL/AUHAL
+> objects and is killable as an exact managed process group. See
+> [the capture-helper ADR](decisions/2026-08-01-production-capture-helper.md).
+
 ## Overview
 
 Murmur is a privacy-first, local-only voice dictation app for macOS. You speak, it transcribes — no cloud, no API keys, no internet. All inference runs on-device: transcription on the Apple Neural Engine (Core ML), the GPU (Metal/whisper.cpp), or CPU (sherpa-onnx), and selected-text rewriting through a signed local-LLM helper process.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,5 +1,10 @@
 # Murmur — Feature Map
 
+Production microphone capture is isolated in a signed, killable helper. Strict
+capture-scoped framing, bounded CPAL-to-AUHAL fallback, and interrupted-prefix
+transcription keep the app responsive without discarding already-delivered
+speech. See [Transcription](features/transcription.md).
+
 Current as of **v0.21.3**. This is the breadth-first inventory of what ships; each area links to its detailed feature doc. For system structure see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---

--- a/docs/decisions/2026-08-01-production-capture-helper.md
+++ b/docs/decisions/2026-08-01-production-capture-helper.md
@@ -1,0 +1,36 @@
+# Production capture is owned by a killable helper
+
+Date: 2026-08-01  
+Status: active  
+Issues: #405, #408, #409, #410, #411, #412
+
+## Decision
+
+The Tauri application process never links CPAL or CoreAudio capture APIs. It
+owns a single signed `murmur-capture-worker` process group and communicates over
+production protocol v2. Every frame carries a monotonic capture ID and a random
+128-bit nonce. Control payloads are bounded JSON; audio is bounded binary mono
+`f32` PCM with a strict sequence and sample rate.
+
+The worker offers two independent macOS capture implementations: CPAL/CoreAudio
+and direct AUHAL. A failed backend may fall back once, and only before the first
+PCM buffer is retained. It must reuse the exact raw device UID. After retained
+audio, any gap, malformed frame, overflow, backend error, stall, or process exit
+terminates capture and preserves the delivered prefix.
+
+The real-time callback only converts to mono and writes into a preallocated
+eight-second SPSC ring. A non-real-time writer drains the ring into protocol
+frames. Audio content is never logged or included in telemetry.
+
+When an unexpected failure leaves at least 500 ms of resampled PCM, Murmur
+automatically transcribes that prefix through the normal clipboard-first
+pipeline and marks the result as interrupted/partial. Shorter prefixes fail
+without transcription. User cancellation remains a distinct discard path.
+
+## Consequences
+
+- A blocked HAL call can be terminated by killing the exact owned process group.
+- The app retains ordering, accumulation, level calculation, deadlines, and
+  transcription policy while the helper exclusively owns macOS audio objects.
+- CI rejects future app-crate CPAL/CoreAudio dependencies and direct HAL source.
+- Device failover cannot silently switch microphones after capture begins.

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,27 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-01: Production HAL ownership moves to a killable capture worker (#405)
+
+**Decision:** Production microphone enumeration and capture run only inside the
+signed managed capture worker over binary protocol v2. The worker exposes CPAL
+and direct AUHAL backends with one exact-device pre-buffer fallback. Callback
+PCM crosses a preallocated SPSC ring; the app validates capture identity,
+sequence, bounds, and sample rate before retaining it. Runtime failure
+transcribes retained prefixes of at least 500 ms and labels them interrupted.
+
+**Rationale:** Process isolation is the only reliable kill boundary for macOS
+HAL operations that can block synchronously. Strict framing and retained-prefix
+handling prevent isolation from trading a wedged app for silent audio loss or
+cross-generation corruption.
+
+**Status:** active
+
+**References:** issues #405, #408, #409, #410, #411, #412; ADR
+[`2026-08-01-production-capture-helper.md`](2026-08-01-production-capture-helper.md)
+
+---
+
 ## 2026-07-31: Capture recovery spike uses a per-user agent plus a killable worker (#407)
 
 **Decision:** Probe an `SMAppService` per-user LaunchAgent as the volatile

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -1,5 +1,20 @@
 # Transcription Pipeline
 
+## Process-isolated capture
+
+Microphone enumeration and streaming execute only in the signed
+`murmur-capture-worker`. Production protocol v2 binds every control and PCM
+frame to a capture ID and nonce and rejects stale, malformed, oversized,
+out-of-sequence, or sample-rate-changing input. The worker callback writes mono
+samples into a preallocated SPSC ring; the parent retains PCM before declaring
+readiness and calculates waveform levels locally.
+
+CPAL is the primary backend and direct AUHAL is the independent fallback. A
+single fallback is allowed only before any audio is retained and must target the
+same raw device UID. Once audio exists, failure ends capture without switching
+devices. Prefixes of at least 500 ms are transcribed normally, remain
+clipboard-first, and are marked **Interrupted · partial** in history.
+
 ## Overview
 
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,5 +1,9 @@
 # Onboarding
 
+Microphone permission is attributed through Murmur's signed capture boundary.
+The bundled capture worker owns the macOS audio objects, while the app owns
+permission guidance, recording state, retained PCM, and transcription.
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 18+

--- a/scripts/validate_capture_boundary.py
+++ b/scripts/validate_capture_boundary.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Fail CI if production HAL ownership leaks back into the Tauri app process."""
+
+from pathlib import Path
+import re
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_MANIFEST = ROOT / "app/src-tauri/Cargo.toml"
+HELPER_MANIFEST = ROOT / "app/src-tauri/sidecars/capture/Cargo.toml"
+APP_SOURCE = ROOT / "app/src-tauri/src"
+
+
+def dependency_names(table: dict) -> set[str]:
+    names: set[str] = set(table.get("dependencies", {}))
+    for value in table.get("target", {}).values():
+        names.update(value.get("dependencies", {}))
+    return names
+
+
+def main() -> None:
+    app = tomllib.loads(APP_MANIFEST.read_text())
+    helper = tomllib.loads(HELPER_MANIFEST.read_text())
+    forbidden = {"cpal", "coreaudio", "coreaudio-rs"}
+    leaked = dependency_names(app) & forbidden
+    if leaked:
+        raise SystemExit(f"app process links forbidden HAL crates: {sorted(leaked)}")
+    missing = {"cpal", "coreaudio-rs"} - dependency_names(helper)
+    if missing:
+        raise SystemExit(f"capture worker is missing backend crates: {sorted(missing)}")
+    pattern = re.compile(
+        r"\b(?:cpal|coreaudio)::|AudioUnit(?:Initialize|Start|Stop)|"
+        r"kAudioOutputUnitProperty_CurrentDevice"
+    )
+    violations: list[str] = []
+    for path in APP_SOURCE.rglob("*.rs"):
+        if path.name in {"capture_helper_probe.rs", "capture_agent_probe.rs"}:
+            continue
+        for number, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+            if pattern.search(line):
+                violations.append(f"{path.relative_to(ROOT)}:{number}")
+    if violations:
+        raise SystemExit("app-process HAL source found:\n" + "\n".join(violations))
+    print("capture boundary valid: production HAL crates are worker-only")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move production microphone enumeration and streaming out of the Tauri process into the signed managed capture worker
- add capture-scoped protocol v2 with bounded control frames, binary mono PCM, strict nonce/sequence/sample-rate validation, and deterministic fault modes
- add preallocated SPSC callback transport plus CPAL and direct AUHAL backends with one exact-device pre-buffer fallback
- preserve and auto-transcribe interrupted prefixes of at least 500 ms, marking partial results in history and overlay feedback
- remove app-process CPAL ownership and add a CI capture-boundary guard plus architecture documentation

## Validation
Not run, per explicit maintainer direction to skip all further testing, CI waiting, and CodeRabbit review and merge this consolidated PR immediately.

Closes #405
Closes #408
Closes #409
Closes #410
Closes #411
Closes #412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production macOS microphone capture with improved device handling and automatic pre-capture fallback.
  * Interrupted recordings now preserve and transcribe sufficient audio as partial results.
  * History displays an “Interrupted · partial” badge with the interruption reason.

* **Bug Fixes**
  * Improved capture failure reporting, recovery, and cleanup.
  * Added validation to prevent stale or malformed capture data from being processed.

* **Documentation**
  * Documented the updated microphone capture architecture, recovery behavior, and transcription handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->