### PR TITLE
Fix capture helper enumeration build

### DIFF
--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -350,7 +350,7 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
     .map_err(|_| ())?;
     match read_control(&mut stdin, capture_id, nonce)? {
         ProductionHostMessage::Enumerate => {
-            let devices = enumerate()?;
+            let devices = enumerate().map_err(|_| ())?;
             write_production_control(
                 &mut stdout,
                 capture_id,


### PR DESCRIPTION
## Summary
- convert device enumeration failures at the helper command boundary
- restore compilation of the macOS capture helper

## Validation
- build-driven fix for the Rust E0277 failure observed on the MacBook
- no test suites run per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during capture operations to ensure failures are reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->