### PR TITLE
Refresh capture helper lockfile

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -722,6 +722,17 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-rs"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
@@ -735,6 +746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
 name = "cpal"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +762,7 @@ checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
 dependencies = [
  "alsa",
  "block2",
- "coreaudio-rs",
+ "coreaudio-rs 0.14.2",
  "dasp_sample",
  "jni 0.22.4",
  "js-sys",
@@ -2787,7 +2807,7 @@ name = "murmur-capture-helper"
 version = "0.1.1"
 dependencies = [
  "core-foundation-sys",
- "coreaudio-rs",
+ "coreaudio-rs 0.11.3",
  "cpal",
  "libc",
  "murmur-capture-helper-protocol",


### PR DESCRIPTION
## Summary
- record the capture helper CoreAudio dependency in Cargo.lock
- keep macOS helper builds clean and reproducible

## Validation
- lockfile exactly matches Cargo output from the MacBook build
- no test suites run per request