### PR TITLE
Fix process-isolated microphone startup latency

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -141,7 +141,7 @@ runs:
       shell: bash
       run: |
         LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-        LINUXDEPLOY_SHA256="e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf"
+        LINUXDEPLOY_SHA256="421ca71d5c69ea97c6309276232990d43df1dcece0edfaa26bbf926ff96ed12e"
         LINUXDEPLOY_PATH="$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage"
         mkdir -p "$(dirname "$LINUXDEPLOY_PATH")"
         curl --fail --location --retry 3 "$LINUXDEPLOY_URL" --output "$LINUXDEPLOY_PATH"
@@ -149,7 +149,7 @@ runs:
         chmod +x "$LINUXDEPLOY_PATH"
 
         PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
-        PLUGIN_SHA256="1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a"
+        PLUGIN_SHA256="a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79"
         PLUGIN_PATH="$HOME/.cache/tauri/linuxdeploy-plugin-appimage-x86_64.AppImage"
         curl --fail --location --retry 3 "$PLUGIN_URL" --output "$PLUGIN_PATH"
         echo "$PLUGIN_SHA256  $PLUGIN_PATH" | sha256sum --check --strict

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ app/tsc
 app/ui@*
 app/src-tauri/binaries/murmur-llm-sidecar-*
 app/src-tauri/binaries/murmur-capture-helper-*
+app/src-tauri/binaries/murmur-capture-agent-*
+app/src-tauri/binaries/murmur-capture-worker-*
 
 # Local-only notes, migrations, scratch work (not tracked)
 local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React). Local transcripti
 
 ```bash
 python3 scripts/build_local_llm_sidecar.py  # Build the bundled macOS helpers FIRST (see note)
-cd app && npm run tauri dev        # Dev with hot reload
+cd app && npm run tauri:dev        # Dev with hot reload and isolated dev bundle/data
 cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
@@ -188,7 +188,7 @@ Read these before working on a feature:
 
 ## MCP Tools
 
-- **Playwright** (`@playwright/mcp`): Browser automation for UI work. When making frontend/UI changes, use `browser_navigate` to `http://localhost:1420` and `browser_take_screenshot` to visually verify your changes. Requires `npm run tauri dev` to be running. Screenshots return inline as images — evaluate them and iterate until the UI looks right.
+- **Playwright** (`@playwright/mcp`): Browser automation for UI work. When making frontend/UI changes, use `browser_navigate` to `http://localhost:1420` and `browser_take_screenshot` to visually verify your changes. Requires `npm run tauri:dev` to be running. Screenshots return inline as images — evaluate them and iterate until the UI looks right.
 
 ## Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS microphone startup now tries the direct AUHAL capture path before CPAL,
+  avoiding an unbounded CPAL stream-open stall observed with healthy USB default
+  inputs. Content-free phase timings distinguish helper launch, stream open,
+  first callback, first retained PCM, and stop-to-exit latency (#426).
+
 ### Added
 
 - Production microphone capture now runs behind a signed, killable helper with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Privacy-first macOS voice-to-text app. Tauri 2 (Rust + React). Local transcripti
 
 ```bash
 python3 scripts/build_local_llm_sidecar.py  # Build the bundled macOS helpers FIRST (see note)
-cd app && npm run tauri dev        # Dev with hot reload
+cd app && npm run tauri:dev        # Dev with hot reload and isolated dev bundle/data
 cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
@@ -202,7 +202,7 @@ Read these before working on a feature:
 
 ## MCP Tools
 
-- **Playwright** (`@playwright/mcp`): Browser automation for UI work. When making frontend/UI changes, use `browser_navigate` to `http://localhost:1420` and `browser_take_screenshot` to visually verify your changes. Requires `npm run tauri dev` to be running. Screenshots return inline as images — evaluate them and iterate until the UI looks right.
+- **Playwright** (`@playwright/mcp`): Browser automation for UI work. When making frontend/UI changes, use `browser_navigate` to `http://localhost:1420` and `browser_take_screenshot` to visually verify your changes. Requires `npm run tauri:dev` to be running. Screenshots return inline as images — evaluate them and iterate until the UI looks right.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ python3 scripts/build_local_llm_sidecar.py   # required first on macOS
 
 cd app
 npm install
-npm run tauri dev        # Dev with hot reload
+npm run tauri:dev        # Dev with hot reload and isolated dev bundle/data
 npm run tauri build      # Production .app and .dmg
 ```
 

--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -397,6 +397,16 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
                     return Ok(());
                 }
             };
+            write_production_control(
+                &mut stdout,
+                capture_id,
+                nonce,
+                &ProductionHelperMessage::Phase {
+                    phase: CapturePhase::AwaitingFirstCallback,
+                    backend,
+                },
+            )
+            .map_err(|_| ())?;
             let (control_tx, control_rx) = mpsc::channel();
             std::thread::spawn(move || {
                 let mut input = std::io::stdin().lock();
@@ -460,6 +470,18 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
                 }
                 let count = ring.drain(&mut scratch);
                 if count > 0 {
+                    if retained == 0 {
+                        write_production_control(
+                            &mut stdout,
+                            capture_id,
+                            nonce,
+                            &ProductionHelperMessage::Phase {
+                                phase: CapturePhase::Active,
+                                backend,
+                            },
+                        )
+                        .map_err(|_| ())?;
+                    }
                     if fault == Some("sequence-gap") && sequence == 2 {
                         sequence += 1;
                     }

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io::BufReader;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
-use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tauri::Emitter;
@@ -368,290 +368,17 @@ fn hello(
     }
 }
 
-struct PreparedHelper {
-    child: ManagedChild,
-    input: std::process::ChildStdin,
-    output: BufReader<std::process::ChildStdout>,
-    capture_id: u64,
-    nonce: SessionNonce,
-    prepared_at: Instant,
-}
-
-fn prepare_helper() -> Result<PreparedHelper, AudioFailure> {
-    let total_started = Instant::now();
+pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
     let (capture_id, nonce, nonce_hex) = capture_identity();
-    let (mut child, mut input, output) = spawn_helper(capture_id, &nonce_hex)?;
-    let hello_started = Instant::now();
+    let (mut child, mut input, output) =
+        spawn_helper(capture_id, &nonce_hex).map_err(|failure| failure.to_string())?;
     let output = match hello(&mut input, output, capture_id, nonce) {
         Ok(output) => output,
         Err(failure) => {
             let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
-            return Err(failure);
+            return Err(failure.to_string());
         }
     };
-    tracing::info!(
-        target: "audio",
-        capture_id,
-        hello_ms = hello_started.elapsed().as_millis() as u64,
-        total_ms = total_started.elapsed().as_millis() as u64,
-        "capture helper prepared with microphone closed"
-    );
-    Ok(PreparedHelper {
-        child,
-        input,
-        output,
-        capture_id,
-        nonce,
-        prepared_at: Instant::now(),
-    })
-}
-
-enum CaptureWorkerPoolState {
-    Idle,
-    Preparing,
-    Standby(PreparedHelper),
-    Active,
-    Shutdown,
-}
-
-struct CaptureWorkerPool {
-    state: Mutex<CaptureWorkerPoolState>,
-    changed: Condvar,
-}
-
-impl CaptureWorkerPool {
-    fn new() -> Self {
-        Self {
-            state: Mutex::new(CaptureWorkerPoolState::Idle),
-            changed: Condvar::new(),
-        }
-    }
-
-    fn prewarm(&'static self) {
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if !matches!(*state, CaptureWorkerPoolState::Idle) {
-            return;
-        }
-        *state = CaptureWorkerPoolState::Preparing;
-        drop(state);
-        if thread::Builder::new()
-            .name("murmur-capture-prewarm".to_string())
-            .spawn(move || {
-                let result = prepare_helper();
-                let mut state = self
-                    .state
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                match (&*state, result) {
-                    (CaptureWorkerPoolState::Preparing, Ok(helper)) => {
-                        tracing::info!(
-                            target: "audio",
-                            capture_id = helper.capture_id,
-                            "capture helper standby ready"
-                        );
-                        *state = CaptureWorkerPoolState::Standby(helper);
-                    }
-                    (CaptureWorkerPoolState::Preparing, Err(failure)) => {
-                        tracing::warn!(
-                            target: "audio",
-                            error_kind = failure.kind.as_str(),
-                            "capture helper standby preparation failed; next recording will retry"
-                        );
-                        *state = CaptureWorkerPoolState::Idle;
-                    }
-                    (_, Ok(helper)) => drop(helper),
-                    (_, Err(_)) => {}
-                }
-                self.changed.notify_all();
-            })
-            .is_err()
-        {
-            let mut state = self
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if matches!(*state, CaptureWorkerPoolState::Preparing) {
-                *state = CaptureWorkerPoolState::Idle;
-            }
-            self.changed.notify_all();
-        }
-    }
-
-    fn acquire(&'static self) -> Result<CaptureWorkerLease, AudioFailure> {
-        let wait_started = Instant::now();
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        loop {
-            match &*state {
-                CaptureWorkerPoolState::Idle => {
-                    *state = CaptureWorkerPoolState::Active;
-                    drop(state);
-                    tracing::info!(
-                        target: "audio",
-                        wait_ms = wait_started.elapsed().as_millis() as u64,
-                        source = "cold",
-                        "capture helper lease acquired"
-                    );
-                    return Ok(CaptureWorkerLease {
-                        pool: self,
-                        prepared: None,
-                    });
-                }
-                CaptureWorkerPoolState::Preparing => {
-                    let (next_state, timeout) = self
-                        .changed
-                        .wait_timeout(state, HELPER_CONTROL_DEADLINE)
-                        .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    state = next_state;
-                    if timeout.timed_out()
-                        && matches!(*state, CaptureWorkerPoolState::Preparing)
-                    {
-                        return Err(AudioFailure::new(
-                            AudioFailureKind::InitializationTimeout,
-                            AudioInitPhase::StreamBuild,
-                        ));
-                    }
-                }
-                CaptureWorkerPoolState::Standby(_) => {
-                    let CaptureWorkerPoolState::Standby(mut helper) =
-                        std::mem::replace(&mut *state, CaptureWorkerPoolState::Active)
-                    else {
-                        unreachable!();
-                    };
-                    drop(state);
-                    let alive = matches!(helper.child.try_wait(), Ok(None));
-                    if alive {
-                        tracing::info!(
-                            target: "audio",
-                            capture_id = helper.capture_id,
-                            wait_ms = wait_started.elapsed().as_millis() as u64,
-                            standby_age_ms = helper.prepared_at.elapsed().as_millis() as u64,
-                            source = "standby",
-                            "capture helper lease acquired"
-                        );
-                        return Ok(CaptureWorkerLease {
-                            pool: self,
-                            prepared: Some(helper),
-                        });
-                    }
-                    tracing::warn!(
-                        target: "audio",
-                        capture_id = helper.capture_id,
-                        "capture helper standby exited before acquisition; using cold replacement"
-                    );
-                    drop(helper);
-                    return Ok(CaptureWorkerLease {
-                        pool: self,
-                        prepared: None,
-                    });
-                }
-                CaptureWorkerPoolState::Active => {
-                    return Err(AudioFailure::new(
-                        AudioFailureKind::DeviceBusy,
-                        AudioInitPhase::StreamBuild,
-                    ));
-                }
-                CaptureWorkerPoolState::Shutdown => {
-                    return Err(AudioFailure::new(
-                        AudioFailureKind::HostUnavailable,
-                        AudioInitPhase::StreamBuild,
-                    ));
-                }
-            }
-        }
-    }
-
-    fn release(&'static self) {
-        let should_prewarm = {
-            let mut state = self
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if matches!(*state, CaptureWorkerPoolState::Active) {
-                *state = CaptureWorkerPoolState::Idle;
-                self.changed.notify_all();
-                true
-            } else {
-                false
-            }
-        };
-        if should_prewarm {
-            self.prewarm();
-        }
-    }
-
-    fn shutdown(&'static self) {
-        let previous = {
-            let mut state = self
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            std::mem::replace(&mut *state, CaptureWorkerPoolState::Shutdown)
-        };
-        self.changed.notify_all();
-        if let CaptureWorkerPoolState::Standby(helper) = previous {
-            tracing::info!(
-                target: "audio",
-                capture_id = helper.capture_id,
-                "stopping capture helper standby during app shutdown"
-            );
-            drop(helper);
-        }
-    }
-}
-
-struct CaptureWorkerLease {
-    pool: &'static CaptureWorkerPool,
-    prepared: Option<PreparedHelper>,
-}
-
-impl CaptureWorkerLease {
-    fn take_or_prepare(&mut self) -> Result<PreparedHelper, AudioFailure> {
-        self.prepared.take().map_or_else(prepare_helper, Ok)
-    }
-}
-
-impl Drop for CaptureWorkerLease {
-    fn drop(&mut self) {
-        // Never schedule the replacement while an unused standby is still
-        // alive (for example when TCC was already denied before Start).
-        drop(self.prepared.take());
-        self.pool.release();
-    }
-}
-
-fn capture_worker_pool() -> &'static CaptureWorkerPool {
-    static POOL: OnceLock<CaptureWorkerPool> = OnceLock::new();
-    POOL.get_or_init(CaptureWorkerPool::new)
-}
-
-pub(crate) fn prepare_capture_worker() {
-    capture_worker_pool().prewarm();
-}
-
-pub(crate) fn shutdown_capture_worker() {
-    capture_worker_pool().shutdown();
-}
-
-pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
-    let mut lease = capture_worker_pool()
-        .acquire()
-        .map_err(|failure| failure.to_string())?;
-    let PreparedHelper {
-        mut child,
-        mut input,
-        output,
-        capture_id,
-        nonce,
-        ..
-    } = lease
-        .take_or_prepare()
-        .map_err(|failure| failure.to_string())?;
     if write_production_control(
         &mut input,
         capture_id,
@@ -711,8 +438,29 @@ enum AttemptResult {
     },
 }
 
+fn backend_label(backend: CaptureBackend) -> &'static str {
+    match backend {
+        CaptureBackend::Cpal => "cpal",
+        CaptureBackend::Auhal => "auhal",
+    }
+}
+
+fn preferred_backends() -> [CaptureBackend; 2] {
+    // Direct AUHAL avoids CPAL's synchronous Core Audio stream builder, which
+    // can block indefinitely on otherwise healthy USB default inputs. The
+    // helper remains the hard-kill boundary and CPAL remains the exact-device,
+    // pre-buffer fallback if direct AUHAL cannot configure that device.
+    #[cfg(target_os = "macos")]
+    {
+        [CaptureBackend::Auhal, CaptureBackend::Cpal]
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        [CaptureBackend::Cpal, CaptureBackend::Auhal]
+    }
+}
+
 fn run_backend(
-    lease: &mut CaptureWorkerLease,
     owner: crate::audio_lifecycle::AudioOwner,
     backend: CaptureBackend,
     device_id: Option<&str>,
@@ -734,20 +482,24 @@ fn run_backend(
             retained_audio: false,
         };
     }
-    let PreparedHelper {
-        mut child,
-        mut input,
-        output,
-        capture_id,
-        nonce,
-        ..
-    } = match lease.take_or_prepare() {
+    let (capture_id, nonce, nonce_hex) = capture_identity();
+    let (mut child, mut input, output) = match spawn_helper(capture_id, &nonce_hex) {
         Ok(value) => value,
         Err(failure) => {
             return AttemptResult::Failed {
                 failure,
                 retained_audio: false,
             }
+        }
+    };
+    let output = match hello(&mut input, output, capture_id, nonce) {
+        Ok(output) => output,
+        Err(failure) => {
+            let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
+            return AttemptResult::Failed {
+                failure,
+                retained_audio: false,
+            };
         }
     };
     let start_sent_at = Instant::now();
@@ -771,10 +523,7 @@ fn run_backend(
     tracing::info!(
         target: "audio",
         capture_id,
-        backend = match backend {
-            CaptureBackend::Cpal => "cpal",
-            CaptureBackend::Auhal => "auhal",
-        },
+        backend = backend_label(backend),
         start_write_ms = start_sent_at.elapsed().as_millis() as u64,
         "capture helper start sent"
     );
@@ -927,10 +676,7 @@ fn run_backend(
                 tracing::info!(
                     target: "audio",
                     capture_id,
-                    backend = match backend {
-                        CaptureBackend::Cpal => "cpal",
-                        CaptureBackend::Auhal => "auhal",
-                    },
+                    backend = backend_label(backend),
                     worker_phase = ?phase,
                     start_elapsed_ms = start_sent_at.elapsed().as_millis() as u64,
                     "capture helper phase received"
@@ -998,19 +744,9 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
         app_handle,
         device_id,
     } = spec;
-    let mut lease = match capture_worker_pool().acquire() {
-        Ok(lease) => lease,
-        Err(failure) => {
-            let _ = event_sender.send(AudioWorkerEvent::InitFailed { owner, failure });
-            return;
-        }
-    };
-    for (attempt_index, backend) in [CaptureBackend::Cpal, CaptureBackend::Auhal]
-        .into_iter()
-        .enumerate()
-    {
+    let backends = preferred_backends();
+    for (attempt_index, backend) in backends.into_iter().enumerate() {
         match run_backend(
-            &mut lease,
             owner,
             backend,
             device_id.as_deref(),
@@ -1032,8 +768,8 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
                 tracing::warn!(
                     target: "audio",
                     owner = owner.telemetry_id(),
-                    from_backend = "cpal",
-                    to_backend = "auhal",
+                    from_backend = backend_label(backend),
+                    to_backend = backend_label(backends[1]),
                     error_kind = failure.kind.as_str(),
                     "capture backend failed before retained audio; trying bounded fallback"
                 );
@@ -1111,4 +847,24 @@ pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
         resampled.push(sample);
     }
     resampled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macos_prefers_direct_auhal_with_cpal_fallback() {
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            preferred_backends(),
+            [CaptureBackend::Auhal, CaptureBackend::Cpal]
+        );
+
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(
+            preferred_backends(),
+            [CaptureBackend::Cpal, CaptureBackend::Auhal]
+        );
+    }
 }

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io::BufReader;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tauri::Emitter;
@@ -267,12 +267,15 @@ fn spawn_helper(
     ),
     AudioFailure,
 > {
+    let resolve_started = Instant::now();
     let path = helper_path().map_err(|_| {
         AudioFailure::new(
             AudioFailureKind::HostUnavailable,
             AudioInitPhase::StreamBuild,
         )
     })?;
+    let resolve_ms = resolve_started.elapsed().as_millis() as u64;
+    let signature_started = Instant::now();
     if !cfg!(debug_assertions) {
         crate::code_signing::validate_bundled_helper(&path, CAPTURE_WORKER_IDENTIFIER).map_err(
             |_| {
@@ -283,8 +286,10 @@ fn spawn_helper(
             },
         )?;
     }
+    let signature_ms = signature_started.elapsed().as_millis() as u64;
     let capture_id_text = capture_id.to_string();
-    ManagedChild::spawn_with_arguments(
+    let spawn_started = Instant::now();
+    let child = ManagedChild::spawn_with_arguments(
         &path,
         &["--production-v2", &capture_id_text, nonce_hex],
         &[],
@@ -294,7 +299,16 @@ fn spawn_helper(
             AudioFailureKind::HostUnavailable,
             AudioInitPhase::StreamBuild,
         )
-    })
+    })?;
+    tracing::info!(
+        target: "audio",
+        capture_id,
+        resolve_ms,
+        signature_ms,
+        spawn_ms = spawn_started.elapsed().as_millis() as u64,
+        "capture helper process spawned"
+    );
+    Ok(child)
 }
 
 fn read_control_frame_with_deadline(
@@ -354,17 +368,290 @@ fn hello(
     }
 }
 
-pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
+struct PreparedHelper {
+    child: ManagedChild,
+    input: std::process::ChildStdin,
+    output: BufReader<std::process::ChildStdout>,
+    capture_id: u64,
+    nonce: SessionNonce,
+    prepared_at: Instant,
+}
+
+fn prepare_helper() -> Result<PreparedHelper, AudioFailure> {
+    let total_started = Instant::now();
     let (capture_id, nonce, nonce_hex) = capture_identity();
-    let (mut child, mut input, output) =
-        spawn_helper(capture_id, &nonce_hex).map_err(|failure| failure.to_string())?;
+    let (mut child, mut input, output) = spawn_helper(capture_id, &nonce_hex)?;
+    let hello_started = Instant::now();
     let output = match hello(&mut input, output, capture_id, nonce) {
         Ok(output) => output,
         Err(failure) => {
             let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
-            return Err(failure.to_string());
+            return Err(failure);
         }
     };
+    tracing::info!(
+        target: "audio",
+        capture_id,
+        hello_ms = hello_started.elapsed().as_millis() as u64,
+        total_ms = total_started.elapsed().as_millis() as u64,
+        "capture helper prepared with microphone closed"
+    );
+    Ok(PreparedHelper {
+        child,
+        input,
+        output,
+        capture_id,
+        nonce,
+        prepared_at: Instant::now(),
+    })
+}
+
+enum CaptureWorkerPoolState {
+    Idle,
+    Preparing,
+    Standby(PreparedHelper),
+    Active,
+    Shutdown,
+}
+
+struct CaptureWorkerPool {
+    state: Mutex<CaptureWorkerPoolState>,
+    changed: Condvar,
+}
+
+impl CaptureWorkerPool {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(CaptureWorkerPoolState::Idle),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn prewarm(&'static self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !matches!(*state, CaptureWorkerPoolState::Idle) {
+            return;
+        }
+        *state = CaptureWorkerPoolState::Preparing;
+        drop(state);
+        if thread::Builder::new()
+            .name("murmur-capture-prewarm".to_string())
+            .spawn(move || {
+                let result = prepare_helper();
+                let mut state = self
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                match (&*state, result) {
+                    (CaptureWorkerPoolState::Preparing, Ok(helper)) => {
+                        tracing::info!(
+                            target: "audio",
+                            capture_id = helper.capture_id,
+                            "capture helper standby ready"
+                        );
+                        *state = CaptureWorkerPoolState::Standby(helper);
+                    }
+                    (CaptureWorkerPoolState::Preparing, Err(failure)) => {
+                        tracing::warn!(
+                            target: "audio",
+                            error_kind = failure.kind.as_str(),
+                            "capture helper standby preparation failed; next recording will retry"
+                        );
+                        *state = CaptureWorkerPoolState::Idle;
+                    }
+                    (_, Ok(helper)) => drop(helper),
+                    (_, Err(_)) => {}
+                }
+                self.changed.notify_all();
+            })
+            .is_err()
+        {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if matches!(*state, CaptureWorkerPoolState::Preparing) {
+                *state = CaptureWorkerPoolState::Idle;
+            }
+            self.changed.notify_all();
+        }
+    }
+
+    fn acquire(&'static self) -> Result<CaptureWorkerLease, AudioFailure> {
+        let wait_started = Instant::now();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        loop {
+            match &*state {
+                CaptureWorkerPoolState::Idle => {
+                    *state = CaptureWorkerPoolState::Active;
+                    drop(state);
+                    tracing::info!(
+                        target: "audio",
+                        wait_ms = wait_started.elapsed().as_millis() as u64,
+                        source = "cold",
+                        "capture helper lease acquired"
+                    );
+                    return Ok(CaptureWorkerLease {
+                        pool: self,
+                        prepared: None,
+                    });
+                }
+                CaptureWorkerPoolState::Preparing => {
+                    let (next_state, timeout) = self
+                        .changed
+                        .wait_timeout(state, HELPER_CONTROL_DEADLINE)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    state = next_state;
+                    if timeout.timed_out()
+                        && matches!(*state, CaptureWorkerPoolState::Preparing)
+                    {
+                        return Err(AudioFailure::new(
+                            AudioFailureKind::InitializationTimeout,
+                            AudioInitPhase::StreamBuild,
+                        ));
+                    }
+                }
+                CaptureWorkerPoolState::Standby(_) => {
+                    let CaptureWorkerPoolState::Standby(mut helper) =
+                        std::mem::replace(&mut *state, CaptureWorkerPoolState::Active)
+                    else {
+                        unreachable!();
+                    };
+                    drop(state);
+                    let alive = matches!(helper.child.try_wait(), Ok(None));
+                    if alive {
+                        tracing::info!(
+                            target: "audio",
+                            capture_id = helper.capture_id,
+                            wait_ms = wait_started.elapsed().as_millis() as u64,
+                            standby_age_ms = helper.prepared_at.elapsed().as_millis() as u64,
+                            source = "standby",
+                            "capture helper lease acquired"
+                        );
+                        return Ok(CaptureWorkerLease {
+                            pool: self,
+                            prepared: Some(helper),
+                        });
+                    }
+                    tracing::warn!(
+                        target: "audio",
+                        capture_id = helper.capture_id,
+                        "capture helper standby exited before acquisition; using cold replacement"
+                    );
+                    drop(helper);
+                    return Ok(CaptureWorkerLease {
+                        pool: self,
+                        prepared: None,
+                    });
+                }
+                CaptureWorkerPoolState::Active => {
+                    return Err(AudioFailure::new(
+                        AudioFailureKind::DeviceBusy,
+                        AudioInitPhase::StreamBuild,
+                    ));
+                }
+                CaptureWorkerPoolState::Shutdown => {
+                    return Err(AudioFailure::new(
+                        AudioFailureKind::HostUnavailable,
+                        AudioInitPhase::StreamBuild,
+                    ));
+                }
+            }
+        }
+    }
+
+    fn release(&'static self) {
+        let should_prewarm = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if matches!(*state, CaptureWorkerPoolState::Active) {
+                *state = CaptureWorkerPoolState::Idle;
+                self.changed.notify_all();
+                true
+            } else {
+                false
+            }
+        };
+        if should_prewarm {
+            self.prewarm();
+        }
+    }
+
+    fn shutdown(&'static self) {
+        let previous = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::replace(&mut *state, CaptureWorkerPoolState::Shutdown)
+        };
+        self.changed.notify_all();
+        if let CaptureWorkerPoolState::Standby(helper) = previous {
+            tracing::info!(
+                target: "audio",
+                capture_id = helper.capture_id,
+                "stopping capture helper standby during app shutdown"
+            );
+            drop(helper);
+        }
+    }
+}
+
+struct CaptureWorkerLease {
+    pool: &'static CaptureWorkerPool,
+    prepared: Option<PreparedHelper>,
+}
+
+impl CaptureWorkerLease {
+    fn take_or_prepare(&mut self) -> Result<PreparedHelper, AudioFailure> {
+        self.prepared.take().map_or_else(prepare_helper, Ok)
+    }
+}
+
+impl Drop for CaptureWorkerLease {
+    fn drop(&mut self) {
+        // Never schedule the replacement while an unused standby is still
+        // alive (for example when TCC was already denied before Start).
+        drop(self.prepared.take());
+        self.pool.release();
+    }
+}
+
+fn capture_worker_pool() -> &'static CaptureWorkerPool {
+    static POOL: OnceLock<CaptureWorkerPool> = OnceLock::new();
+    POOL.get_or_init(CaptureWorkerPool::new)
+}
+
+pub(crate) fn prepare_capture_worker() {
+    capture_worker_pool().prewarm();
+}
+
+pub(crate) fn shutdown_capture_worker() {
+    capture_worker_pool().shutdown();
+}
+
+pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
+    let mut lease = capture_worker_pool()
+        .acquire()
+        .map_err(|failure| failure.to_string())?;
+    let PreparedHelper {
+        mut child,
+        mut input,
+        output,
+        capture_id,
+        nonce,
+        ..
+    } = lease
+        .take_or_prepare()
+        .map_err(|failure| failure.to_string())?;
     if write_production_control(
         &mut input,
         capture_id,
@@ -425,6 +712,7 @@ enum AttemptResult {
 }
 
 fn run_backend(
+    lease: &mut CaptureWorkerLease,
     owner: crate::audio_lifecycle::AudioOwner,
     backend: CaptureBackend,
     device_id: Option<&str>,
@@ -446,8 +734,14 @@ fn run_backend(
             retained_audio: false,
         };
     }
-    let (capture_id, nonce, nonce_hex) = capture_identity();
-    let (mut child, mut input, output) = match spawn_helper(capture_id, &nonce_hex) {
+    let PreparedHelper {
+        mut child,
+        mut input,
+        output,
+        capture_id,
+        nonce,
+        ..
+    } = match lease.take_or_prepare() {
         Ok(value) => value,
         Err(failure) => {
             return AttemptResult::Failed {
@@ -456,16 +750,7 @@ fn run_backend(
             }
         }
     };
-    let output = match hello(&mut input, output, capture_id, nonce) {
-        Ok(output) => output,
-        Err(failure) => {
-            let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
-            return AttemptResult::Failed {
-                failure,
-                retained_audio: false,
-            };
-        }
-    };
+    let start_sent_at = Instant::now();
     if write_production_control(
         &mut input,
         capture_id,
@@ -483,6 +768,16 @@ fn run_backend(
             retained_audio: false,
         };
     }
+    tracing::info!(
+        target: "audio",
+        capture_id,
+        backend = match backend {
+            CaptureBackend::Cpal => "cpal",
+            CaptureBackend::Auhal => "auhal",
+        },
+        start_write_ms = start_sent_at.elapsed().as_millis() as u64,
+        "capture helper start sent"
+    );
 
     let (reader_tx, reader_rx) = mpsc::channel();
     thread::spawn(move || {
@@ -502,10 +797,6 @@ fn run_backend(
         }
     });
 
-    let _ = event_sender.send(AudioWorkerEvent::PhaseEntered {
-        owner,
-        phase: AudioInitPhase::StreamBuild,
-    });
     let mut expected_sequence = 0_u64;
     let mut sample_rate = None;
     let mut retained_audio = false;
@@ -514,6 +805,7 @@ fn run_backend(
     loop {
         match command_receiver.try_recv() {
             Ok(AudioCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
+                let stop_started = Instant::now();
                 let _ = write_production_control(
                     &mut input,
                     capture_id,
@@ -525,6 +817,12 @@ fn run_backend(
                     .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
                     .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
                 if termination.is_some() {
+                    tracing::info!(
+                        target: "audio",
+                        capture_id,
+                        stop_to_exit_ms = stop_started.elapsed().as_millis() as u64,
+                        "capture helper stopped and exited"
+                    );
                     let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
                     return AttemptResult::Stopped;
                 }
@@ -597,6 +895,12 @@ fn run_backend(
                     .extend_from_slice(&pcm.samples);
                 if !retained_audio {
                     retained_audio = true;
+                    tracing::info!(
+                        target: "audio",
+                        capture_id,
+                        start_to_first_pcm_ms = start_sent_at.elapsed().as_millis() as u64,
+                        "capture helper first PCM retained"
+                    );
                     let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
                         owner,
                         phase: AudioInitPhase::FirstBufferWait,
@@ -620,6 +924,17 @@ fn run_backend(
                 phase,
                 ..
             }))) => {
+                tracing::info!(
+                    target: "audio",
+                    capture_id,
+                    backend = match backend {
+                        CaptureBackend::Cpal => "cpal",
+                        CaptureBackend::Auhal => "auhal",
+                    },
+                    worker_phase = ?phase,
+                    start_elapsed_ms = start_sent_at.elapsed().as_millis() as u64,
+                    "capture helper phase received"
+                );
                 let phase = match phase {
                     CapturePhase::Enumeration => AudioInitPhase::DeviceEnumeration,
                     CapturePhase::StreamOpen => AudioInitPhase::StreamBuild,
@@ -683,11 +998,19 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
         app_handle,
         device_id,
     } = spec;
+    let mut lease = match capture_worker_pool().acquire() {
+        Ok(lease) => lease,
+        Err(failure) => {
+            let _ = event_sender.send(AudioWorkerEvent::InitFailed { owner, failure });
+            return;
+        }
+    };
     for (attempt_index, backend) in [CaptureBackend::Cpal, CaptureBackend::Auhal]
         .into_iter()
         .enumerate()
     {
         match run_backend(
+            &mut lease,
             owner,
             backend,
             device_id.as_deref(),

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -549,6 +549,7 @@ fn run_backend(
     let mut expected_sequence = 0_u64;
     let mut sample_rate = None;
     let mut retained_audio = false;
+    let mut first_callback_wait_started = None;
     let mut last_level_emit = Instant::now() - Duration::from_secs(1);
     let mut last_permission_check = Instant::now();
     loop {
@@ -653,7 +654,10 @@ fn run_backend(
                     let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
                         owner,
                         phase: AudioInitPhase::FirstBufferWait,
-                        elapsed_ms: 0,
+                        elapsed_ms: first_callback_wait_started
+                            .take()
+                            .map(|started: Instant| started.elapsed().as_millis() as u64)
+                            .unwrap_or_default(),
                     });
                     let _ = event_sender.send(AudioWorkerEvent::FirstBuffer {
                         owner,
@@ -681,6 +685,9 @@ fn run_backend(
                     start_elapsed_ms = start_sent_at.elapsed().as_millis() as u64,
                     "capture helper phase received"
                 );
+                if phase == CapturePhase::AwaitingFirstCallback {
+                    first_callback_wait_started = Some(Instant::now());
+                }
                 let phase = match phase {
                     CapturePhase::Enumeration => AudioInitPhase::DeviceEnumeration,
                     CapturePhase::StreamOpen => AudioInitPhase::StreamBuild,

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -2157,6 +2157,24 @@ mod tests {
         wait_until("runtime-failed worker did not exit", || {
             !supervisor.public.is_active()
         });
+        assert_eq!(
+            sink.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(_, event)| {
+                    matches!(
+                        event,
+                        AudioLifecycleEvent::InitializationFailed {
+                            kind: AudioFailureKind::DeviceBusy,
+                            ..
+                        }
+                    )
+                })
+                .count(),
+            1,
+            "transform runtime failure must be reported exactly once"
+        );
         shutdown(&supervisor);
     }
 

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -754,13 +754,18 @@ fn handle_worker_event(
                 current.phase,
                 AttemptPhase::Starting | AttemptPhase::Recording
             ) {
-                current.failure = Some(failure);
+                current.failure = Some(failure.clone());
+                // Dictation reports a retained prefix through Interrupted at
+                // worker exit. Transform audio has no partial-transcript path,
+                // so preserve its typed, content-free failure before recovery.
+                let report_failure =
+                    matches!(current.owner, AudioOwner::Transform(_)).then_some(failure);
                 begin_recovery(
                     attempt,
                     AudioCancelReason::RuntimeFailure,
                     sink,
                     public,
-                    None,
+                    report_failure,
                 );
             }
         }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -469,7 +469,6 @@ pub fn run() {
             // to re-detect notch info and reposition the overlay.
             commands::overlay::register_screen_change_observer(app.handle().clone());
             audio_lifecycle::register_sleep_wake_observer();
-            audio::prepare_capture_worker();
             commands::tray::register_update_wake_observer(app.handle().clone());
 
             // Overwrite the transform-review window's initial size from Rust's
@@ -573,7 +572,6 @@ pub fn run() {
         // outlives the app (no-op when no child is running).
         #[cfg(target_os = "macos")]
         if let RunEvent::Exit = &_event {
-            audio::shutdown_capture_worker();
             if let Some(state) = _app_handle.try_state::<State>() {
                 state.transform_runtime.shutdown();
             }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -469,6 +469,7 @@ pub fn run() {
             // to re-detect notch info and reposition the overlay.
             commands::overlay::register_screen_change_observer(app.handle().clone());
             audio_lifecycle::register_sleep_wake_observer();
+            audio::prepare_capture_worker();
             commands::tray::register_update_wake_observer(app.handle().clone());
 
             // Overwrite the transform-review window's initial size from Rust's
@@ -572,6 +573,7 @@ pub fn run() {
         // outlives the app (no-op when no child is running).
         #[cfg(target_os = "macos")]
         if let RunEvent::Exit = &_event {
+            audio::shutdown_capture_worker();
             if let Some(state) = _app_handle.try_state::<State>() {
                 state.transform_runtime.shutdown();
             }

--- a/app/src/lib/hooks/useRecordingState.test.tsx
+++ b/app/src/lib/hooks/useRecordingState.test.tsx
@@ -179,6 +179,7 @@ describe('useRecordingState transition ordering', () => {
       'recording',
       undefined,
       { appBundleId: 'com.example.Editor', appLabel: 'Editor' },
+      undefined,
     );
     expect(mocks.updateStats).toHaveBeenCalledTimes(1);
     expect(mocks.updateStats).toHaveBeenCalledWith('one final transcript', 12);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,7 +392,7 @@ Core ML models are managed by FluidAudio under `~/Library/Application Support/Fl
 ```bash
 python3 scripts/build_local_llm_sidecar.py   # once, before anything else on macOS
 cd app && npm install
-cd app && npm run tauri dev                  # hot reload
+cd app && npm run tauri:dev                  # hot reload, isolated dev bundle/data
 cd app && npm run tauri build                # .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1
 cd app && npx tsc --noEmit && npm test

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,7 @@ python3 scripts/build_local_llm_sidecar.py
 cd app && npm install
 
 # 3. Run
-npm run tauri dev
+npm run tauri:dev
 ```
 
 > **Step 1 is not optional on macOS.** `tauri.macos.conf.json` declares the
@@ -38,7 +38,7 @@ LLM is a separate, optional download from **Settings → Transform**.
 
 ```bash
 # Dev
-cd app && npm run tauri dev        # full app, hot reload
+cd app && npm run tauri:dev        # full app, isolated bundle/data, hot reload
 cd app && npm run dev              # frontend only (no Rust backend)
 cd app && npm run tauri build      # production .app and .dmg
 
@@ -66,7 +66,7 @@ cd app/src-tauri && MURMUR_COREML_TEST_WAV=/path/to/16khz-mono.wav \
 Murmur needs **Microphone** and **Accessibility**. Which process needs them
 depends on how you are running it:
 
-- **`npm run tauri dev`** — grant them to your *terminal app* (Ghostty, iTerm,
+- **`npm run tauri:dev`** — grant them to your *terminal app* (Ghostty, iTerm,
   Terminal). Dev builds are re-signed on every rebuild, so granting the dev
   binary itself is futile. Restart the dev server after granting.
 - **A built `.app`** — grant them to the app itself.

--- a/docs/decisions/2026-08-01-production-capture-helper.md
+++ b/docs/decisions/2026-08-01-production-capture-helper.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-01  
 Status: active  
-Issues: #405, #408, #409, #410, #411, #412
+Issues: #405, #408, #409, #410, #411, #412, #426
 
 ## Decision
 
@@ -12,11 +12,18 @@ production protocol v2. Every frame carries a monotonic capture ID and a random
 128-bit nonce. Control payloads are bounded JSON; audio is bounded binary mono
 `f32` PCM with a strict sequence and sample rate.
 
-The worker offers two independent macOS capture implementations: CPAL/CoreAudio
-and direct AUHAL. A failed backend may fall back once, and only before the first
-PCM buffer is retained. It must reuse the exact raw device UID. After retained
-audio, any gap, malformed frame, overflow, backend error, stall, or process exit
-terminates capture and preserves the delivered prefix.
+The worker offers two independent macOS capture implementations: direct AUHAL
+and CPAL/CoreAudio. macOS tries direct AUHAL first because CPAL's synchronous
+stream builder can remain blocked on a healthy USB default input; CPAL remains
+the exact-device fallback. A failed backend may fall back once, and only before
+the first PCM buffer is retained. It must reuse the exact raw device UID. After
+retained audio, any gap, malformed frame, overflow, backend error, stall, or
+process exit terminates capture and preserves the delivered prefix.
+
+The worker reports content-free phases after stream open and immediately before
+the first retained callback. Together with host-side helper launch, first-PCM,
+and stop-to-exit timings, this separates process overhead from HAL/device latency
+without logging microphone content.
 
 The real-time callback only converts to mono and writes into a preallocated
 eight-second SPSC ring. A non-real-time writer drains the ring into protocol

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,26 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-01: macOS capture prefers direct AUHAL before CPAL (#426)
+
+**Decision:** Process-isolated macOS recording tries direct AUHAL first and
+retains CPAL as the exact-device, pre-buffer fallback. The helper reports
+content-free stream-open and first-callback phases so startup regressions can be
+attributed without retaining or logging audio.
+
+**Rationale:** CPAL 0.18.1's synchronous Core Audio stream builder remained
+blocked for more than 30 seconds on a healthy USB system-default microphone.
+The same device consistently retained its first AUHAL PCM in about 180 ms and
+reached app readiness in about 200 ms. Prewarming a microphone-closed helper
+saved only process-launch time and did not affect the blocking HAL call.
+
+**Status:** active
+
+**References:** issue #426; ADR
+[`2026-08-01-production-capture-helper.md`](2026-08-01-production-capture-helper.md)
+
+---
+
 ## 2026-08-01: Production HAL ownership moves to a killable capture worker (#405)
 
 **Decision:** Production microphone enumeration and capture run only inside the

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -30,7 +30,7 @@ gitignored and rebuilt by release CI. The script is a no-op on non-arm64-macOS.
 
 ```bash
 # Full Tauri app with hot reload
-cd app && npm run tauri dev
+cd app && npm run tauri:dev
 
 # Frontend only (no Rust backend)
 cd app && npm run dev
@@ -107,7 +107,7 @@ The app searches these locations in order:
 | **Microphone** | Audio capture — dictation and transform instructions | Prompted in-app by the setup assistant |
 | **Accessibility** | All hotkeys (rdev), auto-paste, and transform selection capture / write-back | System Settings > Privacy & Security > Accessibility |
 
-Under `npm run tauri dev`, grant both to your *terminal app* — dev builds are
+Under `npm run tauri:dev`, grant both to your *terminal app* — dev builds are
 re-signed on each rebuild, so a grant to the dev binary never sticks.
 
 ## Logs

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -328,7 +328,7 @@ def validate_linux_cache_policy(action: str) -> None:
         "linuxdeploy-x86_64.AppImage"
     ) in linuxdeploy
     assert (
-        'LINUXDEPLOY_SHA256="e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf"'
+        'LINUXDEPLOY_SHA256="421ca71d5c69ea97c6309276232990d43df1dcece0edfaa26bbf926ff96ed12e"'
         in linuxdeploy
     )
     assert 'LINUXDEPLOY_PATH="$HOME/.cache/tauri/linuxdeploy-x86_64.AppImage"' in linuxdeploy
@@ -341,7 +341,7 @@ def validate_linux_cache_policy(action: str) -> None:
         "download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
     ) in linuxdeploy
     assert (
-        'PLUGIN_SHA256="1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a"'
+        'PLUGIN_SHA256="a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79"'
         in linuxdeploy
     )
     assert (

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -248,7 +248,7 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
                 "https://example.invalid/plugin.AppImage",
             ),
             "plugin checksum": (
-                "1da16a46fa5e058ae740e7c35ed0d36d86cb869ac9cc8a5fd9a1847d7978d99a",
+                "a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79",
                 "0" * 64,
             ),
             "plugin path": (


### PR DESCRIPTION
Closes #426

## What changed
- prefer direct AUHAL on macOS, with CPAL retained as the exact-device pre-buffer fallback
- remove the ineffective microphone-closed helper prewarm design
- add content-free helper spawn, stream-open, first-callback, first-PCM, and stop-to-exit timings
- preserve exactly-once typed failures for transform-owned runtime capture errors
- correct the documented isolated dev command (`npm run tauri:dev`)

## Mac mini measurement
- CPAL/system-default USB path: blocked beyond the 30 s initialization deadline
- AUHAL readiness, 10-run warmed sample: 194-208 ms (median about 200 ms)
- final stable run: 192 ms
- final-run breakdown: 163 ms stream open, 10 ms first callback, about 19 ms helper/IPC

All native/hard measurements were performed on the Mac mini.

## Validation
- `cargo check`
- `cargo test -- --test-threads=1` (680 passed, 5 ignored; integration suites passed)
- `npx tsc --noEmit`
- `npm test -- --run` (620 passed)
- production `.app`, `.dmg`, and updater archive built locally; updater signing step correctly stopped without a private release key
- Claude Fable 5 review completed; actionable timing/test coverage feedback addressed