### PR TITLE
Fix production capture worker sandbox crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,12 @@ jobs:
               - 'scripts/validate_workflow_policy.py'
               - 'scripts/release_artifacts.py'
               - 'scripts/capture_agent_matrix.py'
+              - 'scripts/smoke_test_capture_worker.py'
               - 'scripts/validate_capture_boundary.py'
               - 'tests/test_release_artifacts.py'
               - 'tests/test_workflow_policy.py'
               - 'tests/test_capture_agent_matrix.py'
+              - 'tests/test_capture_worker_smoke.py'
 
       - name: Validate workflow policy
         run: |
@@ -59,7 +61,8 @@ jobs:
           python3 -m unittest \
             tests/test_release_artifacts.py \
             tests/test_workflow_policy.py \
-            tests/test_capture_agent_matrix.py
+            tests/test_capture_agent_matrix.py \
+            tests/test_capture_worker_smoke.py
 
   typecheck:
     needs: changes

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -232,6 +232,12 @@ jobs:
           xcrun stapler validate "$APP"
           spctl --assess --type execute -vvv "$APP"
 
+      - name: Smoke test signed capture worker protocol
+        run: |
+          APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
+          CAPTURE_WORKER="$APP/Contents/MacOS/murmur-capture-worker"
+          python3 scripts/smoke_test_capture_worker.py --worker "$CAPTURE_WORKER"
+
       - name: Smoke test signed application
         run: |
           APP=$(find app/src-tauri/target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The signed production capture worker now uses standalone microphone sandbox
+  entitlements instead of invalid inheritance, preventing macOS from terminating
+  it before protocol startup. Release builds execute the final packaged worker's
+  hello/start handshake, and protocol startup failures no longer appear as
+  unsupported microphone configurations or retry another backend (#428).
 - macOS microphone startup now tries the direct AUHAL capture path before CPAL,
   avoiding an unbounded CPAL stream-open stall observed with healthy USB default
   inputs. Content-free phase timings distinguish helper launch, stream open,

--- a/app/src-tauri/capture-worker.entitlements.plist
+++ b/app/src-tauri/capture-worker.entitlements.plist
@@ -4,7 +4,9 @@
 <dict>
   <key>com.apple.security.app-sandbox</key>
   <true/>
-  <key>com.apple.security.inherit</key>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.microphone</key>
   <true/>
 </dict>
 </plist>

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -51,6 +51,7 @@ pub(crate) enum AudioFailureKind {
     RealtimeDenied,
     Xrun,
     BackendError,
+    ProtocolError,
     FirstBufferTimeout,
     InitializationTimeout,
     WorkerPanicked,
@@ -73,6 +74,7 @@ impl AudioFailureKind {
             Self::RealtimeDenied => "realtime_denied",
             Self::Xrun => "xrun",
             Self::BackendError => "backend_error",
+            Self::ProtocolError => "protocol_error",
             Self::FirstBufferTimeout => "first_buffer_timeout",
             Self::InitializationTimeout => "initialization_timeout",
             Self::WorkerPanicked => "worker_panicked",
@@ -124,8 +126,20 @@ impl AudioFailure {
             AudioFailureKind::SignatureInvalid => {
                 "The bundled microphone capture worker failed integrity validation."
             }
+            AudioFailureKind::ProtocolError => {
+                "The bundled microphone capture worker failed to start. Restart Murmur and try again."
+            }
             _ => "Microphone capture failed. Try recording again.",
         }
+    }
+
+    fn permits_backend_fallback(&self) -> bool {
+        !matches!(
+            self.kind,
+            AudioFailureKind::PermissionDenied
+                | AudioFailureKind::ProtocolError
+                | AudioFailureKind::SignatureInvalid
+        )
     }
 }
 
@@ -141,7 +155,7 @@ fn failure_kind(code: FailureCode) -> AudioFailureKind {
         FailureCode::NoInputDevice => AudioFailureKind::DeviceUnavailable,
         FailureCode::ConfigurationFailed => AudioFailureKind::UnsupportedConfig,
         FailureCode::CallbackStalled => AudioFailureKind::FirstBufferTimeout,
-        FailureCode::InvalidMessage => AudioFailureKind::InvalidInput,
+        FailureCode::InvalidMessage => AudioFailureKind::ProtocolError,
         FailureCode::EnumerationFailed => AudioFailureKind::HostUnavailable,
         FailureCode::StreamError => AudioFailureKind::StreamInvalidated,
         FailureCode::StreamOpenFailed | FailureCode::StreamStartFailed | FailureCode::Internal => {
@@ -343,9 +357,9 @@ fn read_control_frame_with_deadline(
                 AudioInitPhase::StreamBuild,
             )
         })?;
-    frame
-        .map(|frame| (frame, output))
-        .map_err(|_| AudioFailure::new(AudioFailureKind::InvalidInput, AudioInitPhase::StreamBuild))
+    frame.map(|frame| (frame, output)).map_err(|_| {
+        AudioFailure::new(AudioFailureKind::ProtocolError, AudioInitPhase::StreamBuild)
+    })
 }
 
 fn hello(
@@ -355,14 +369,14 @@ fn hello(
     nonce: SessionNonce,
 ) -> Result<BufReader<std::process::ChildStdout>, AudioFailure> {
     write_production_control(input, capture_id, nonce, &ProductionHostMessage::Hello).map_err(
-        |_| AudioFailure::new(AudioFailureKind::BackendError, AudioInitPhase::StreamBuild),
+        |_| AudioFailure::new(AudioFailureKind::ProtocolError, AudioInitPhase::StreamBuild),
     )?;
     let (frame, output) =
         read_control_frame_with_deadline(BufReader::new(output), capture_id, nonce)?;
     match frame {
         ProductionFrame::Control(ProductionHelperMessage::HelloAck) => Ok(output),
         _ => Err(AudioFailure::new(
-            AudioFailureKind::InvalidInput,
+            AudioFailureKind::ProtocolError,
             AudioInitPhase::StreamBuild,
         )),
     }
@@ -516,7 +530,10 @@ fn run_backend(
     {
         let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
         return AttemptResult::Failed {
-            failure: AudioFailure::new(AudioFailureKind::BackendError, AudioInitPhase::StreamBuild),
+            failure: AudioFailure::new(
+                AudioFailureKind::ProtocolError,
+                AudioInitPhase::StreamBuild,
+            ),
             retained_audio: false,
         };
     }
@@ -631,7 +648,7 @@ fn run_backend(
                     let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
                     return AttemptResult::Failed {
                         failure: AudioFailure::new(
-                            AudioFailureKind::InvalidInput,
+                            AudioFailureKind::ProtocolError,
                             AudioInitPhase::Runtime,
                         ),
                         retained_audio,
@@ -727,7 +744,7 @@ fn run_backend(
             Ok(HelperRead::Invalid) | Err(RecvTimeoutError::Disconnected) => {
                 return AttemptResult::Failed {
                     failure: AudioFailure::new(
-                        AudioFailureKind::InvalidInput,
+                        AudioFailureKind::ProtocolError,
                         if retained_audio {
                             AudioInitPhase::Runtime
                         } else {
@@ -767,11 +784,7 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
             AttemptResult::Failed {
                 failure,
                 retained_audio,
-            } if !retained_audio
-                && attempt_index == 0
-                && failure.kind != AudioFailureKind::PermissionDenied
-                && failure.kind != AudioFailureKind::SignatureInvalid =>
-            {
+            } if !retained_audio && attempt_index == 0 && failure.permits_backend_fallback() => {
                 tracing::warn!(
                     target: "audio",
                     owner = owner.telemetry_id(),
@@ -873,5 +886,30 @@ mod tests {
             preferred_backends(),
             [CaptureBackend::Cpal, CaptureBackend::Auhal]
         );
+    }
+
+    #[test]
+    fn worker_protocol_failures_are_actionable_and_terminal() {
+        let failure =
+            AudioFailure::new(AudioFailureKind::ProtocolError, AudioInitPhase::StreamBuild);
+
+        assert_eq!(failure.kind.as_str(), "protocol_error");
+        assert_eq!(
+            failure.user_message(),
+            "The bundled microphone capture worker failed to start. Restart Murmur and try again."
+        );
+        assert!(!failure.permits_backend_fallback());
+    }
+
+    #[test]
+    fn device_configuration_failures_still_permit_bounded_backend_fallback() {
+        for kind in [
+            AudioFailureKind::DeviceUnavailable,
+            AudioFailureKind::InvalidInput,
+            AudioFailureKind::UnsupportedConfig,
+            AudioFailureKind::BackendError,
+        ] {
+            assert!(AudioFailure::new(kind, AudioInitPhase::StreamBuild).permits_backend_fallback());
+        }
     }
 }

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,6 +38,10 @@ Each successful build uploads these 30-day artifacts:
 
 Release binaries retain the Tauri bundle-type marker (Cargo release stripping
 is disabled) so the updater can distinguish the deb and AppImage packages.
+After final signing and notarization, the release job launches the exact packaged
+capture worker, completes its production-v2 hello handshake, sends a bounded
+AUHAL start request, and requires the worker's stream-open phase. This catches
+sandbox or entitlement failures that static plist and signature checks cannot.
 
 Each artifact contains `provenance.json` with the exact commit SHA, workflow
 run ID, platform/updater names, sizes, and SHA-256 hashes. Promotion accepts one

--- a/scripts/capture_helper_evidence.py
+++ b/scripts/capture_helper_evidence.py
@@ -35,7 +35,8 @@ CAPTURE_AGENT_ENTITLEMENTS = {
 }
 CAPTURE_WORKER_ENTITLEMENTS = {
     "com.apple.security.app-sandbox": True,
-    "com.apple.security.inherit": True,
+    "com.apple.security.device.audio-input": True,
+    "com.apple.security.device.microphone": True,
 }
 PROBE_FIELDS = {
     "schema_version",

--- a/scripts/smoke_test_capture_worker.py
+++ b/scripts/smoke_test_capture_worker.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Exercise the final signed capture worker's production-v2 startup protocol."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import secrets
+import selectors
+import struct
+import subprocess
+import time
+from typing import BinaryIO
+
+
+MAGIC = b"MRMR"
+PROTOCOL_VERSION = 2
+HEADER_BYTES = 36
+MAX_CONTROL_BYTES = 16 * 1024
+
+
+class SmokeError(RuntimeError):
+    pass
+
+
+def encode_control_frame(
+    capture_id: int, nonce: bytes, message: dict[str, object]
+) -> bytes:
+    if len(nonce) != 16:
+        raise SmokeError("session nonce must contain exactly 16 bytes")
+    payload = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    if len(payload) > MAX_CONTROL_BYTES:
+        raise SmokeError("control payload exceeds the protocol limit")
+    header = struct.pack(
+        "<4sHBBIQ16s",
+        MAGIC,
+        PROTOCOL_VERSION,
+        0,
+        0,
+        len(payload),
+        capture_id,
+        nonce,
+    )
+    return header + payload
+
+
+def _read_exact(stream: BinaryIO, length: int, deadline: float) -> bytes:
+    chunks = bytearray()
+    selector = selectors.DefaultSelector()
+    selector.register(stream, selectors.EVENT_READ)
+    try:
+        while len(chunks) < length:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SmokeError("capture worker response timed out")
+            if not selector.select(remaining):
+                raise SmokeError("capture worker response timed out")
+            chunk = os.read(stream.fileno(), length - len(chunks))
+            if not chunk:
+                raise SmokeError("capture worker closed its protocol pipe")
+            chunks.extend(chunk)
+    finally:
+        selector.close()
+    return bytes(chunks)
+
+
+def read_control_frame(
+    stream: BinaryIO, capture_id: int, nonce: bytes, deadline: float
+) -> dict[str, object]:
+    header = _read_exact(stream, HEADER_BYTES, deadline)
+    magic, version, kind, reserved, length, actual_capture_id, actual_nonce = (
+        struct.unpack("<4sHBBIQ16s", header)
+    )
+    if (
+        magic != MAGIC
+        or version != PROTOCOL_VERSION
+        or kind != 0
+        or reserved != 0
+        or actual_capture_id != capture_id
+        or actual_nonce != nonce
+        or length > MAX_CONTROL_BYTES
+    ):
+        raise SmokeError("capture worker returned an invalid protocol header")
+    payload = _read_exact(stream, length, deadline)
+    try:
+        message = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SmokeError("capture worker returned invalid control JSON") from error
+    if not isinstance(message, dict):
+        raise SmokeError("capture worker returned a non-object control message")
+    return message
+
+
+def terminate_worker(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=2)
+
+
+def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
+    if not worker.is_file() or not os.access(worker, os.X_OK):
+        raise SmokeError("capture worker is missing or not executable")
+    capture_id = secrets.randbits(63) or 1
+    nonce = os.urandom(16)
+    process = subprocess.Popen(
+        [str(worker), "--production-v2", str(capture_id), nonce.hex()],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        if process.stdin is None or process.stdout is None:
+            raise SmokeError("capture worker protocol pipes are unavailable")
+        deadline = time.monotonic() + timeout_seconds
+        process.stdin.write(
+            encode_control_frame(capture_id, nonce, {"type": "hello"})
+        )
+        process.stdin.flush()
+        hello = read_control_frame(process.stdout, capture_id, nonce, deadline)
+        if hello != {"type": "helloAck"}:
+            raise SmokeError("capture worker did not acknowledge protocol hello")
+
+        process.stdin.write(
+            encode_control_frame(
+                capture_id,
+                nonce,
+                {"type": "start", "deviceId": None, "backend": "auhal"},
+            )
+        )
+        process.stdin.flush()
+        phase = read_control_frame(process.stdout, capture_id, nonce, deadline)
+        if phase != {
+            "type": "phase",
+            "phase": "streamOpen",
+            "backend": "auhal",
+        }:
+            raise SmokeError("capture worker did not enter the stream-open phase")
+    finally:
+        terminate_worker(process)
+        for stream in (process.stdin, process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=float, default=5.0)
+    arguments = parser.parse_args()
+    try:
+        smoke_test(arguments.worker, arguments.timeout_seconds)
+    except SmokeError as error:
+        raise SystemExit(f"ERROR: {error}") from error
+    print("signed capture worker production-v2 startup smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -196,6 +196,17 @@ def validate_release_build(workflow: str) -> int:
         "--capture-worker-entitlements app/src-tauri/capture-worker.entitlements.plist"
         in workflow
     )
+    worker_smoke = named_step_block(
+        workflow, "Smoke test signed capture worker protocol", 6
+    )
+    assert "scripts/smoke_test_capture_worker.py" in worker_smoke
+    assert '--worker "$CAPTURE_WORKER"' in worker_smoke
+    assert workflow.index("Finalize, notarize, and repackage") < workflow.index(
+        "Smoke test signed capture worker protocol"
+    )
+    assert workflow.index("Smoke test signed capture worker protocol") < workflow.index(
+        "Smoke test signed application"
+    )
     assert (
         "--capture-agent-launchd-plist "
         "app/src-tauri/macos/com.localdictation.capture-agent.plist"

--- a/tests/test_capture_worker_smoke.py
+++ b/tests/test_capture_worker_smoke.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import tempfile
+import textwrap
+import time
+import unittest
+
+from scripts.smoke_test_capture_worker import (
+    encode_control_frame,
+    read_control_frame,
+    SmokeError,
+    smoke_test,
+)
+
+
+class CaptureWorkerSmokeTests(unittest.TestCase):
+    def test_control_frame_round_trip(self) -> None:
+        capture_id = 42
+        nonce = bytes(range(16))
+        encoded = encode_control_frame(capture_id, nonce, {"type": "helloAck"})
+        read_fd, write_fd = os.pipe()
+        try:
+            os.write(write_fd, encoded)
+        finally:
+            os.close(write_fd)
+        with os.fdopen(read_fd, "rb", buffering=0) as stream:
+            self.assertEqual(
+                read_control_frame(
+                    stream, capture_id, nonce, time.monotonic() + 1
+                ),
+                {"type": "helloAck"},
+            )
+
+    def test_invalid_capture_identity_fails_closed(self) -> None:
+        nonce = bytes(range(16))
+        encoded = encode_control_frame(41, nonce, {"type": "helloAck"})
+        read_fd, write_fd = os.pipe()
+        try:
+            os.write(write_fd, encoded)
+        finally:
+            os.close(write_fd)
+        with os.fdopen(read_fd, "rb", buffering=0) as stream:
+            with self.assertRaisesRegex(SmokeError, "invalid protocol header"):
+                read_control_frame(stream, 42, nonce, time.monotonic() + 1)
+
+    def test_smoke_exercises_hello_and_start(self) -> None:
+        fake_worker = textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import os
+            import struct
+            import sys
+
+            capture_id = int(sys.argv[2])
+            nonce = bytes.fromhex(sys.argv[3])
+
+            def read_frame():
+                header = sys.stdin.buffer.read(36)
+                magic, version, kind, reserved, length, actual_id, actual_nonce = struct.unpack("<4sHBBIQ16s", header)
+                assert (magic, version, kind, reserved, actual_id, actual_nonce) == (b"MRMR", 2, 0, 0, capture_id, nonce)
+                return json.loads(sys.stdin.buffer.read(length))
+
+            def write_frame(message):
+                body = json.dumps(message, separators=(",", ":")).encode()
+                sys.stdout.buffer.write(struct.pack("<4sHBBIQ16s", b"MRMR", 2, 0, 0, len(body), capture_id, nonce) + body)
+                sys.stdout.buffer.flush()
+
+            assert read_frame() == {"type": "hello"}
+            write_frame({"type": "helloAck"})
+            assert read_frame() == {"type": "start", "deviceId": None, "backend": "auhal"}
+            write_frame({"type": "phase", "phase": "streamOpen", "backend": "auhal"})
+            sys.stdin.buffer.read()
+            """
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            worker = Path(directory) / "fake-worker"
+            worker.write_text(fake_worker, encoding="utf-8")
+            worker.chmod(worker.stat().st_mode | stat.S_IXUSR)
+            smoke_test(worker, timeout_seconds=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #428.

## Root cause

v0.24.0 signed `murmur-capture-worker` with `com.apple.security.inherit` even though it is launched as a standalone child of the unsandboxed app. macOS App Sandbox initialization traps the worker before the production-v2 hello acknowledgement, which the app then mislabeled as an unsupported microphone configuration.

## Fix

- sign the worker with standalone app-sandbox, audio-input, and microphone entitlements
- classify worker framing/handshake failures as terminal protocol errors instead of retrying the alternate backend
- launch the exact finalized signed worker during Release Build and require `helloAck` plus AUHAL `streamOpen`
- add cross-platform protocol smoke tests and release-policy coverage

## Validation

- published v0.24.0 worker: new smoke fails with closed protocol pipe
- same published binary re-signed with fixed entitlements: smoke passes
- locally built packaged worker re-signed with fixed entitlements: smoke passes
- Mac mini native dev app: worker spawned, AUHAL `streamOpen`, first PCM retained, warm readiness 216 ms, no stale worker after stop
- `cargo check`
- `cargo test -- --test-threads=1` (682 passed; integrations passed)
- `npx tsc --noEmit`
- `npm test` (620 passed)
- release/workflow/capture-boundary Python checks (76 passed)
- native debug `.app` built; updater archive signing correctly remained unavailable without the CI-only private key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signed macOS capture-worker microphone permissions.
  * Clearer handling of startup and communication failures, preventing misleading microphone errors or inappropriate backend retries.
* **Validation**
  * Release builds now verify the packaged capture worker’s production handshake and stream startup after signing and notarization.
  * Added automated checks for control frames, worker communication, and invalid responses.
* **Documentation**
  * Updated release documentation and changelog with the new validation and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->