### PR TITLE
Explain and prevent translocated updater failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- In-app updates now detect macOS Gatekeeper App Translocation before
+  downloading, explain how to reinstall Murmur from Finder, and distinguish
+  installation failures from update-check failures (#432).
 - The signed production capture worker now uses standalone microphone sandbox
   entitlements instead of invalid inheritance, preventing macOS from terminating
   it before protocol startup. Release builds execute the final packaged worker's

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Built with [Tauri 2](https://tauri.app/) (Rust + React), with local transcriptio
 2. Open the DMG and drag **Murmur** to your Applications folder
 3. Launch the app — the setup assistant walks you through microphone and Accessibility permissions and downloads a model
 
+Launch Murmur from Applications. Running a downloaded copy from its disk image
+or another quarantined location can make macOS mount it read-only, which prevents
+in-app updates. If Murmur reports this condition, quit it and use Finder to move
+or reinstall it in Applications before reopening it.
+
 Requires macOS 14+ on Apple Silicon.
 
 ### Permissions

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -15,3 +15,4 @@ pub mod transform_diagnostics;
 pub mod transform_model;
 pub mod transform_popover;
 pub mod tray;
+pub mod updater;

--- a/app/src-tauri/src/commands/updater.rs
+++ b/app/src-tauri/src/commands/updater.rs
@@ -1,0 +1,48 @@
+use serde::Serialize;
+use std::ffi::OsStr;
+use std::path::Path;
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInstallEnvironment {
+    app_translocated: bool,
+}
+
+fn is_app_translocated(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == OsStr::new("AppTranslocation"))
+}
+
+#[tauri::command]
+pub fn get_update_install_environment() -> Result<UpdateInstallEnvironment, String> {
+    let executable = std::env::current_exe()
+        .map_err(|_| "Could not verify the update installation location".to_string())?;
+    let app_translocated = is_app_translocated(&executable);
+
+    Ok(UpdateInstallEnvironment { app_translocated })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_gatekeeper_app_translocation_path() {
+        let path = Path::new(
+            "/private/var/folders/example/T/AppTranslocation/UUID/d/Murmur.app/Contents/MacOS/ui",
+        );
+        assert!(is_app_translocated(path));
+    }
+
+    #[test]
+    fn accepts_normal_applications_path() {
+        let path = Path::new("/Applications/Murmur.app/Contents/MacOS/ui");
+        assert!(!is_app_translocated(path));
+    }
+
+    #[test]
+    fn does_not_match_similar_component_names() {
+        let path = Path::new("/tmp/MyAppTranslocation/Murmur.app/Contents/MacOS/ui");
+        assert!(!is_app_translocated(path));
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -336,6 +336,7 @@ pub fn run() {
             commands::benchmark::open_benchmark_output_folder,
             commands::tray::update_tray_icon,
             commands::tray::set_tray_update_available,
+            commands::updater::get_update_install_environment,
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
             commands::overlay::set_overlay_expanded,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -175,10 +175,16 @@ function App() {
   // DEV ONLY: cycle through updater and post-update modal states for visual testing
   const devUpdateIndex = useRef(-1);
   const devMockStates: UpdateStatus[] = import.meta.env.DEV ? [
+    {
+      phase: 'error',
+      stage: 'install',
+      message: 'macOS opened Murmur from a read-only security location. Quit Murmur, then use Finder to move or reinstall it in Applications before reopening it and trying the update again.',
+      isForced: false,
+      recovery: 'reinstall',
+    },
     { phase: 'available', version: '0.7.0', notes: '## What\'s New\n- OTA auto-updater\n- Bug fixes\n- Performance improvements', isForced: false },
     { phase: 'available', version: '0.7.0', notes: 'Critical security fix.', isForced: true },
     { phase: 'downloading', version: '0.7.0', progress: 65 },
-    { phase: 'error', message: 'Network request failed: could not resolve host', isForced: false },
   ] : [];
   const [devUpdateStatus, setDevUpdateStatus] = useState<UpdateStatus | null>(null);
   const [devCompletedUpdate, setDevCompletedUpdate] = useState<CompletedUpdate | null>(null);
@@ -209,7 +215,10 @@ function App() {
     ? devUpdateDialogOpen
     : updater.isUpdateDialogOpen;
   const showAvailableUpdate = useCallback(() => {
-    if (devUpdateStatus?.phase === 'available') {
+    if (
+      devUpdateStatus?.phase === 'available' ||
+      (devUpdateStatus?.phase === 'error' && devUpdateStatus.stage === 'install')
+    ) {
       setDevUpdateDialogOpen(true);
       return;
     }

--- a/app/src/components/UpdateIndicator.test.tsx
+++ b/app/src/components/UpdateIndicator.test.tsx
@@ -64,7 +64,7 @@ describe('UpdateIndicator', () => {
     await act(async () => {
       root.render(
         <UpdateIndicator
-          status={{ phase: 'error', message: 'offline', isForced: false }}
+          status={{ phase: 'error', stage: 'check', message: 'offline', isForced: false }}
           onOpen={vi.fn()}
           onRetryCheck={onRetryCheck}
         />,
@@ -73,6 +73,31 @@ describe('UpdateIndicator', () => {
 
     await act(async () => container.querySelector('button')?.click());
     expect(onRetryCheck).toHaveBeenCalledOnce();
+  });
+
+  it('reopens installation guidance instead of retrying update discovery', async () => {
+    const onOpen = vi.fn();
+    const onRetryCheck = vi.fn();
+    await act(async () => {
+      root.render(
+        <UpdateIndicator
+          status={{
+            phase: 'error',
+            stage: 'install',
+            message: 'Move Murmur to Applications',
+            isForced: false,
+            recovery: 'reinstall',
+          }}
+          onOpen={onOpen}
+          onRetryCheck={onRetryCheck}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Update needs attention');
+    await act(async () => container.querySelector('button')?.click());
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onRetryCheck).not.toHaveBeenCalled();
   });
 
   it('stays absent while idle', async () => {

--- a/app/src/components/UpdateIndicator.tsx
+++ b/app/src/components/UpdateIndicator.tsx
@@ -32,14 +32,15 @@ export function UpdateIndicator({ status, onOpen, onRetryCheck }: UpdateIndicato
   }
 
   if (status.phase === 'error') {
+    const installFailed = status.stage === 'install';
     return (
       <button
         type="button"
-        onClick={onRetryCheck}
+        onClick={installFailed ? onOpen : onRetryCheck}
         className="ml-auto inline-flex items-center gap-2 rounded-full bg-error/10 px-3 py-1.5 text-xs font-semibold text-error transition-colors hover:bg-error/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-error"
-        aria-label="Update check failed. Retry"
+        aria-label={installFailed ? 'Update installation needs attention' : 'Update check failed. Retry'}
       >
-        Update check failed · Retry
+        {installFailed ? 'Update needs attention' : 'Update check failed · Retry'}
       </button>
     );
   }

--- a/app/src/components/UpdateModal.tsx
+++ b/app/src/components/UpdateModal.tsx
@@ -24,6 +24,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
   const isDownloading = status.phase === 'downloading';
   const isReady = status.phase === 'ready';
   const isError = status.phase === 'error';
+  const requiresReinstall = isError && status.recovery === 'reinstall';
   const isBusy = isDownloading || isReady;
 
   const version =
@@ -63,7 +64,11 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
           </div>
 
           <h2 className="text-lg font-semibold text-on-surface text-center mb-1">
-            {isForced ? 'Required Update' : 'Update Available'}
+            {requiresReinstall
+              ? 'Reinstall Murmur to Update'
+              : isForced
+                ? 'Required Update'
+                : 'Update Available'}
           </h2>
 
           {version && (
@@ -117,7 +122,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
 
           {/* Action buttons */}
           <div className="flex flex-col gap-2">
-            {(status.phase === 'available' || isError) && (
+            {(status.phase === 'available' || (isError && !requiresReinstall)) && (
               <button
                 onClick={onDownload}
                 className="w-full py-2 px-4 bg-primary hover:bg-primary-dim text-on-primary text-sm font-medium rounded-lg transition-colors"
@@ -143,7 +148,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
               </>
             )}
 
-            {(status.phase === 'available' || isError) && isForced && (
+            {(((status.phase === 'available' || isError) && isForced) || requiresReinstall) && (
               <button
                 onClick={() => exit(0)}
                 className="w-full rounded-lg border border-error/30 bg-surface-container-lowest px-4 py-2 text-sm font-medium text-error transition-colors hover:bg-error/10"

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -776,7 +776,13 @@ export function SettingsPanel({
               <button type="button" onClick={() => void onCheckForUpdate()} disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary disabled:cursor-not-allowed disabled:opacity-50">{updateStatus.phase === 'checking' ? 'Checking…' : 'Check for Updates'}</button>
               {updateStatus.phase === 'up-to-date' && <p className="mt-1.5 text-xs text-success">You’re up to date.</p>}
               {updateStatus.phase === 'available' && <p className="mt-1.5 text-xs text-primary">v{updateStatus.version} available</p>}
-              {updateStatus.phase === 'error' && <p className="mt-1.5 text-xs text-error">Update check failed.</p>}
+              {updateStatus.phase === 'error' && (
+                <p className="mt-1.5 text-xs text-error">
+                  {updateStatus.stage === 'check'
+                    ? 'Update check failed.'
+                    : 'Update installation needs attention.'}
+                </p>
+              )}
             </div>
             {version && <p className="text-center text-xs text-on-surface-variant">Murmur v{version}</p>}
           </SettingsSection>

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   requestPermission: vi.fn(),
   sendNotification: vi.fn(),
   listen: vi.fn(),
+  getUpdateInstallEnvironment: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/plugin-updater', () => ({ check: mocks.check }));
@@ -21,6 +22,9 @@ vi.mock('@tauri-apps/plugin-notification', () => ({
   sendNotification: mocks.sendNotification,
 }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('../updaterEnvironment', () => ({
+  getUpdateInstallEnvironment: mocks.getUpdateInstallEnvironment,
+}));
 vi.mock('../log', () => ({
   flog: {
     info: vi.fn(),
@@ -47,6 +51,7 @@ describe('useAutoUpdater presentation state', () => {
     mocks.getVersion.mockResolvedValue('0.22.1');
     mocks.listen.mockResolvedValue(vi.fn());
     mocks.isPermissionGranted.mockResolvedValue(true);
+    mocks.getUpdateInstallEnvironment.mockResolvedValue({ appTranslocated: false });
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -111,8 +116,52 @@ describe('useAutoUpdater presentation state', () => {
 
     expect(current.updateStatus).toMatchObject({
       phase: 'error',
+      stage: 'check',
       message: 'Error: offline',
     });
     expect(current.isUpdateDialogOpen).toBe(false);
+  });
+
+  it('blocks installation before download when Gatekeeper translocated the app', async () => {
+    const downloadAndInstall = vi.fn();
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall,
+    });
+    mocks.getUpdateInstallEnvironment.mockResolvedValue({ appTranslocated: true });
+
+    await act(async () => current.checkForUpdate());
+    await act(async () => current.startDownload());
+
+    expect(downloadAndInstall).not.toHaveBeenCalled();
+    expect(current.updateStatus).toMatchObject({
+      phase: 'error',
+      stage: 'install',
+      recovery: 'reinstall',
+      isForced: false,
+    });
+    expect(current.updateStatus.phase === 'error' && current.updateStatus.message)
+      .toContain('read-only security location');
+    expect(localStorage.getItem('pending-update-release-notes')).toBeNull();
+    expect(current.isUpdateDialogOpen).toBe(true);
+  });
+
+  it('keeps the normal writable installation path unchanged', async () => {
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall,
+    });
+
+    await act(async () => current.checkForUpdate());
+    await act(async () => current.startDownload());
+
+    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).toHaveBeenCalledOnce();
+    expect(current.updateStatus).toEqual({ phase: 'ready', version: '0.24.2' });
   });
 });

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -24,6 +24,10 @@ import {
   fetchMinVersion,
   CHECK_TIMER_TICK_MS,
 } from '../updater';
+import { getUpdateInstallEnvironment } from '../updaterEnvironment';
+
+const APP_TRANSLOCATION_MESSAGE =
+  'macOS opened Murmur from a read-only security location. Quit Murmur, then use Finder to move or reinstall it in Applications before reopening it and trying the update again.';
 
 export interface UseAutoUpdaterReturn {
   updateStatus: UpdateStatus;
@@ -149,7 +153,12 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       flog.error('updater', 'check failed', { error: String(err) });
       if (shouldPresentManualResult()) {
         setIsUpdateDialogOpen(false);
-        setUpdateStatus({ phase: 'error', message: String(err), isForced: isForcedRef.current });
+        setUpdateStatus({
+          phase: 'error',
+          stage: 'check',
+          message: String(err),
+          isForced: isForcedRef.current,
+        });
       }
       // Background errors are silent
     } finally {
@@ -212,10 +221,13 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, [performCheck]);
 
   const showAvailableUpdate = useCallback(() => {
-    if (updateStatus.phase === 'available') {
+    if (
+      updateStatus.phase === 'available' ||
+      (updateStatus.phase === 'error' && updateStatus.stage === 'install')
+    ) {
       setIsUpdateDialogOpen(true);
     }
-  }, [updateStatus.phase]);
+  }, [updateStatus]);
 
   const startDownload = useCallback(async () => {
     const update = updateRef.current;
@@ -225,11 +237,24 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       updateStatus.phase === 'available' ? updateStatus.version
       : updateRef.current?.version ?? 'unknown';
 
-    setUpdateStatus({ phase: 'downloading', version, progress: 0 });
-    flog.info('updater', 'starting download', { version });
-    setPendingUpdate({ version, notes: update.body ?? '' });
-
     try {
+      const environment = await getUpdateInstallEnvironment();
+      if (environment.appTranslocated) {
+        flog.warn('updater', 'install blocked by macOS App Translocation');
+        setUpdateStatus({
+          phase: 'error',
+          stage: 'install',
+          message: APP_TRANSLOCATION_MESSAGE,
+          isForced: isForcedRef.current,
+          recovery: 'reinstall',
+        });
+        return;
+      }
+
+      setUpdateStatus({ phase: 'downloading', version, progress: 0 });
+      flog.info('updater', 'starting download', { version });
+      setPendingUpdate({ version, notes: update.body ?? '' });
+
       let totalContentLength = 0;
       let totalDownloaded = 0;
 
@@ -261,7 +286,12 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       await relaunch();
     } catch (err) {
       flog.error('updater', 'download/install failed', { error: String(err) });
-      setUpdateStatus({ phase: 'error', message: String(err), isForced: isForcedRef.current });
+      setUpdateStatus({
+        phase: 'error',
+        stage: 'install',
+        message: String(err),
+        isForced: isForcedRef.current,
+      });
     }
   }, [updateStatus]);
 

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -179,5 +179,11 @@ export type UpdateStatus =
   | { phase: 'available'; version: string; notes: string; isForced: boolean }
   | { phase: 'downloading'; version: string; progress: number }
   | { phase: 'ready'; version: string }
-  | { phase: 'error'; message: string; isForced: boolean }
+  | {
+      phase: 'error';
+      stage: 'check' | 'install';
+      message: string;
+      isForced: boolean;
+      recovery?: 'reinstall';
+    }
   | { phase: 'up-to-date' };

--- a/app/src/lib/updaterEnvironment.ts
+++ b/app/src/lib/updaterEnvironment.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface UpdateInstallEnvironment {
+  appTranslocated: boolean;
+}
+
+export async function getUpdateInstallEnvironment(): Promise<UpdateInstallEnvironment> {
+  return await invoke('get_update_install_environment');
+}

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -83,6 +83,17 @@ When the current version is below the `min_version` field from the release manif
 
 If the download or install fails, the modal shows a red error banner with the error message and a "Retry" button. For forced updates in error state, the "Quit" button remains available.
 
+Before downloading, Murmur asks the Rust host whether the current executable is
+running under macOS Gatekeeper's `AppTranslocation` path. A translocated app is
+mounted read-only, so the updater cannot replace its bundle. Murmur blocks the
+download, explains that the user must quit and use Finder to move or reinstall
+Murmur in `/Applications`, and offers a Quit action instead of a futile Retry.
+Normal writable installations continue through the existing updater path.
+
+Check failures and installation failures remain distinct in `UpdateStatus`, so
+the Settings page and homepage indicator do not describe a completed download
+or failed installation as an update-check failure.
+
 ### Background Notifications
 
 When an update is detected during a background check (not user-initiated), a native macOS notification is sent: "Murmur vX.Y.Z is ready to install." This requires notification permission to be granted.
@@ -133,7 +144,13 @@ type UpdateStatus =
   | { phase: 'available'; version: string; notes: string; isForced: boolean }
   | { phase: 'downloading'; version: string; progress: number }
   | { phase: 'ready'; version: string }
-  | { phase: 'error'; message: string; isForced: boolean };
+  | {
+      phase: 'error';
+      stage: 'check' | 'install';
+      message: string;
+      isForced: boolean;
+      recovery?: 'reinstall';
+    };
 ```
 
 The update modal renders for `available`, `downloading`, `ready`, and `error` phases. The `idle`, `checking`, and `up-to-date` phases return null (no modal).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Tauri Commands Reference
 
-The 109 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
+The 110 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
 Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
 
@@ -209,6 +209,12 @@ frontend.
 |---------|-----------|---------|-------------|
 | `update_tray_icon` | `_icon_state: String` | `Result<(), String>` | No-op; the tray icon is always the static white waveform. Retained for API compatibility. |
 | `set_tray_update_available` | `version: Option<String>` | `Result<(), String>` | Changes the native menu item between `Check for Updates…` and a bounded, validated `Update Murmur to vX.Y.Z…` label. |
+
+## Updater (`commands/updater.rs`)
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `get_update_install_environment` | — | `Result<{ appTranslocated: bool }, String>` | Reports whether Gatekeeper launched the current executable through its read-only `AppTranslocation` mount. Does not expose the executable path and fails closed if the current executable cannot be resolved. |
 
 ## Telemetry (`telemetry.rs`)
 


### PR DESCRIPTION
## Summary

- detect macOS Gatekeeper App Translocation before downloading an update
- replace the raw read-only filesystem failure with Finder reinstall guidance and a Quit action
- distinguish update-check failures from installation failures across the modal, homepage indicator, and Settings

## Test plan

- [x] `cargo check`
- [x] `cargo test -- --test-threads=1`
- [x] `npx tsc --noEmit`
- [x] `npm test -- --run`
- [x] Browser visual QA of the recovery modal
- [x] Native debug-bundle smoke test of General → Check for Updates

Closes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented in-app updates from downloading when macOS runs the app from a read-only Gatekeeper location.
  - Added clear relocation or reinstallation guidance for affected installations.
  - Distinguished update-check failures from installation failures, with appropriate retry or recovery actions.

- **Documentation**
  - Updated installation and updater guidance for macOS disk images and quarantined apps.
  - Documented the new update environment check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->