### PR TITLE
fix: bound capture backend failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Microphone initialization now gives AUHAL and CPAL separate bounded attempts,
+  requires confirmed helper termination before fallback, honors Stop between
+  attempts, suspends active deadlines during a pending macOS permission prompt,
+  and reports privacy-safe setup sub-phases for root-cause attribution. This is
+  a capture-contract repair, not a claim that the underlying Core Audio hang is
+  eliminated (#436).
 - In-app updates now detect macOS Gatekeeper App Translocation before
   downloading, explain how to reinstall Murmur from Finder, and distinguish
   installation failures from update-check failures (#432).

--- a/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
+++ b/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
@@ -13,7 +13,7 @@ pub const SYNTHETIC_FIXTURE_DIGEST: &str =
 // Production capture uses a separate, binary-framed protocol. Probe v1 above
 // remains stable so shipped attribution/recovery evidence stays readable.
 pub const PRODUCTION_PROTOCOL_NAME: &str = "murmur.capture";
-pub const PRODUCTION_PROTOCOL_VERSION: u16 = 2;
+pub const PRODUCTION_PROTOCOL_VERSION: u16 = 3;
 pub const PRODUCTION_MAGIC: [u8; 4] = *b"MRMR";
 pub const PRODUCTION_HEADER_BYTES: usize = 36;
 pub const MAX_CONTROL_BYTES: usize = 16 * 1024;
@@ -77,6 +77,11 @@ pub enum ProductionHelperMessage {
         phase: CapturePhase,
         backend: CaptureBackend,
     },
+    SetupStep {
+        backend: CaptureBackend,
+        step: CaptureSetupStep,
+        transition: SetupTransition,
+    },
     BackendFallback {
         from: CaptureBackend,
         to: CaptureBackend,
@@ -90,6 +95,50 @@ pub enum ProductionHelperMessage {
     Stopped {
         retained_samples: u64,
     },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum CaptureSetupStep {
+    DeviceResolution,
+    AudioUnitCreation,
+    FormatConfiguration,
+    CallbackInstallation,
+    DefaultConfig,
+    StreamBuild,
+    StreamStart,
+    AwaitingFirstCallback,
+}
+
+impl CaptureSetupStep {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DeviceResolution => "device_resolution",
+            Self::AudioUnitCreation => "audio_unit_creation",
+            Self::FormatConfiguration => "format_configuration",
+            Self::CallbackInstallation => "callback_installation",
+            Self::DefaultConfig => "default_config",
+            Self::StreamBuild => "stream_build",
+            Self::StreamStart => "stream_start",
+            Self::AwaitingFirstCallback => "awaiting_first_callback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SetupTransition {
+    Entered,
+    Completed,
+}
+
+impl SetupTransition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Entered => "entered",
+            Self::Completed => "completed",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -502,5 +551,28 @@ mod tests {
             read_production_frame::<ProductionHelperMessage>(&mut bytes.as_slice(), 43, nonce),
             Err(FrameError::StaleCapture)
         ));
+    }
+
+    #[test]
+    fn production_setup_telemetry_is_typed_and_content_free() {
+        let nonce = [9_u8; 16];
+        let message = ProductionHelperMessage::SetupStep {
+            backend: CaptureBackend::Auhal,
+            step: CaptureSetupStep::AudioUnitCreation,
+            transition: SetupTransition::Entered,
+        };
+        let mut bytes = Vec::new();
+        write_production_control(&mut bytes, 7, nonce, &message).unwrap();
+        assert_eq!(
+            read_production_frame::<ProductionHelperMessage>(&mut bytes.as_slice(), 7, nonce)
+                .unwrap(),
+            ProductionFrame::Control(message.clone())
+        );
+
+        let serialized = serde_json::to_string(&message).unwrap();
+        assert!(!serialized.contains("deviceId"));
+        assert!(!serialized.contains("deviceName"));
+        assert!(!serialized.contains("uid"));
+        assert!(!serialized.contains("error"));
     }
 }

--- a/app/src-tauri/sidecars/capture/src/main.rs
+++ b/app/src-tauri/sidecars/capture/src/main.rs
@@ -385,7 +385,7 @@ fn main() {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
         let arguments = std::env::args().skip(1).collect::<Vec<_>>();
-        if arguments.first().map(String::as_str) == Some("--production-v2") {
+        if arguments.first().map(String::as_str) == Some("--production-v3") {
             if production::run(&arguments[1..]).is_ok() {
                 return;
             }

--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -16,8 +16,8 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{FromSample, Sample, SampleFormat, SizedSample, Stream};
 use murmur_capture_helper_protocol::{
     read_production_frame, write_production_control, write_production_pcm, CaptureBackend,
-    CapturePhase, FailureCode, ProductionDevice, ProductionFrame, ProductionHelperMessage,
-    ProductionHostMessage, SessionNonce,
+    CapturePhase, CaptureSetupStep, FailureCode, ProductionDevice, ProductionFrame,
+    ProductionHelperMessage, ProductionHostMessage, SessionNonce, SetupTransition,
 };
 use std::cell::UnsafeCell;
 use std::io::{Read, Write};
@@ -230,11 +230,19 @@ fn start_cpal(
     requested: Option<&str>,
     ring: Arc<SpscRing>,
     failed: Arc<AtomicBool>,
+    emit: &mut impl FnMut(CaptureSetupStep, SetupTransition) -> Result<(), FailureCode>,
 ) -> Result<(CaptureStream, u32), FailureCode> {
+    emit(CaptureSetupStep::DeviceResolution, SetupTransition::Entered)?;
     let device = cpal_device(requested)?;
+    emit(
+        CaptureSetupStep::DeviceResolution,
+        SetupTransition::Completed,
+    )?;
+    emit(CaptureSetupStep::DefaultConfig, SetupTransition::Entered)?;
     let supported = device
         .default_input_config()
         .map_err(|_| FailureCode::ConfigurationFailed)?;
+    emit(CaptureSetupStep::DefaultConfig, SetupTransition::Completed)?;
     let rate = supported.sample_rate();
     let channels = supported.channels() as usize;
     let config = supported.config();
@@ -249,6 +257,7 @@ fn start_cpal(
             )
         };
     }
+    emit(CaptureSetupStep::StreamBuild, SetupTransition::Entered)?;
     let stream = match supported.sample_format() {
         SampleFormat::I8 => build!(i8),
         SampleFormat::I16 => build!(i16),
@@ -264,14 +273,19 @@ fn start_cpal(
         SampleFormat::F64 => build!(f64),
         _ => return Err(FailureCode::ConfigurationFailed),
     }?;
+    emit(CaptureSetupStep::StreamBuild, SetupTransition::Completed)?;
+    emit(CaptureSetupStep::StreamStart, SetupTransition::Entered)?;
     stream.play().map_err(|_| FailureCode::StreamStartFailed)?;
+    emit(CaptureSetupStep::StreamStart, SetupTransition::Completed)?;
     Ok((CaptureStream::Cpal(stream), rate))
 }
 
 fn start_auhal(
     requested: Option<&str>,
     ring: Arc<SpscRing>,
+    emit: &mut impl FnMut(CaptureSetupStep, SetupTransition) -> Result<(), FailureCode>,
 ) -> Result<(CaptureStream, u32), FailureCode> {
+    emit(CaptureSetupStep::DeviceResolution, SetupTransition::Entered)?;
     let device = match requested {
         Some(uid) => get_audio_device_ids_for_scope(Scope::Input)
             .map_err(|_| FailureCode::EnumerationFailed)?
@@ -280,9 +294,21 @@ fn start_auhal(
             .ok_or(FailureCode::NoInputDevice)?,
         None => get_default_device_id(true).ok_or(FailureCode::NoInputDevice)?,
     };
+    emit(
+        CaptureSetupStep::DeviceResolution,
+        SetupTransition::Completed,
+    )?;
     let sample_rate = 48_000_u32;
+    emit(
+        CaptureSetupStep::AudioUnitCreation,
+        SetupTransition::Entered,
+    )?;
     let mut unit =
         audio_unit_from_device_id(device, true).map_err(|_| FailureCode::StreamOpenFailed)?;
+    emit(
+        CaptureSetupStep::AudioUnitCreation,
+        SetupTransition::Completed,
+    )?;
     let format = StreamFormat {
         sample_rate: sample_rate as f64,
         sample_format: AuSampleFormat::F32,
@@ -292,6 +318,10 @@ fn start_auhal(
         channels: 1,
     };
     let asbd = format.to_asbd();
+    emit(
+        CaptureSetupStep::FormatConfiguration,
+        SetupTransition::Entered,
+    )?;
     unit.set_property(
         coreaudio::sys::kAudioUnitProperty_StreamFormat,
         Scope::Output,
@@ -299,7 +329,15 @@ fn start_auhal(
         Some(&asbd),
     )
     .map_err(|_| FailureCode::ConfigurationFailed)?;
+    emit(
+        CaptureSetupStep::FormatConfiguration,
+        SetupTransition::Completed,
+    )?;
     type Args = render_callback::Args<data::NonInterleaved<f32>>;
+    emit(
+        CaptureSetupStep::CallbackInstallation,
+        SetupTransition::Entered,
+    )?;
     unit.set_input_callback(move |args: Args| {
         for channel in args.data.channels() {
             for sample in channel.iter().take(args.num_frames) {
@@ -310,7 +348,13 @@ fn start_auhal(
         Ok(())
     })
     .map_err(|_| FailureCode::StreamOpenFailed)?;
+    emit(
+        CaptureSetupStep::CallbackInstallation,
+        SetupTransition::Completed,
+    )?;
+    emit(CaptureSetupStep::StreamStart, SetupTransition::Entered)?;
     unit.start().map_err(|_| FailureCode::StreamStartFailed)?;
+    emit(CaptureSetupStep::StreamStart, SetupTransition::Completed)?;
     Ok((CaptureStream::Auhal(unit), sample_rate))
 }
 
@@ -374,12 +418,31 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
             .map_err(|_| ())?;
             let ring = Arc::new(SpscRing::new());
             let failed = Arc::new(AtomicBool::new(false));
-            let started = match backend {
-                CaptureBackend::Cpal => {
-                    start_cpal(device_id.as_deref(), Arc::clone(&ring), Arc::clone(&failed))
-                }
-                CaptureBackend::Auhal => start_auhal(device_id.as_deref(), Arc::clone(&ring)),
+            let mut emit_setup = |step: CaptureSetupStep, transition: SetupTransition| {
+                write_production_control(
+                    &mut stdout,
+                    capture_id,
+                    nonce,
+                    &ProductionHelperMessage::SetupStep {
+                        backend,
+                        step,
+                        transition,
+                    },
+                )
+                .map_err(|_| FailureCode::Internal)
             };
+            let started = match backend {
+                CaptureBackend::Cpal => start_cpal(
+                    device_id.as_deref(),
+                    Arc::clone(&ring),
+                    Arc::clone(&failed),
+                    &mut emit_setup,
+                ),
+                CaptureBackend::Auhal => {
+                    start_auhal(device_id.as_deref(), Arc::clone(&ring), &mut emit_setup)
+                }
+            };
+            drop(emit_setup);
             let (mut stream, sample_rate) = match started {
                 Ok(value) => value,
                 Err(code) => {
@@ -401,9 +464,31 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
                 &mut stdout,
                 capture_id,
                 nonce,
+                &ProductionHelperMessage::SetupStep {
+                    backend,
+                    step: CaptureSetupStep::AwaitingFirstCallback,
+                    transition: SetupTransition::Entered,
+                },
+            )
+            .map_err(|_| ())?;
+            write_production_control(
+                &mut stdout,
+                capture_id,
+                nonce,
                 &ProductionHelperMessage::Phase {
                     phase: CapturePhase::AwaitingFirstCallback,
                     backend,
+                },
+            )
+            .map_err(|_| ())?;
+            write_production_control(
+                &mut stdout,
+                capture_id,
+                nonce,
+                &ProductionHelperMessage::SetupStep {
+                    backend,
+                    step: CaptureSetupStep::AwaitingFirstCallback,
+                    transition: SetupTransition::Completed,
                 },
             )
             .map_err(|_| ())?;

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -32,6 +32,13 @@ const AUDIO_LEVEL_THROTTLE_MS: u64 = 16;
 const HELPER_STOP_DEADLINE: Duration = Duration::from_secs(2);
 const HELPER_CONTROL_DEADLINE: Duration = Duration::from_secs(3);
 const PERMISSION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+pub(crate) const TCC_PROMPT_WATCHDOG: Duration = Duration::from_secs(120);
+const AUHAL_ATTEMPT_BUDGET: Duration = Duration::from_secs(8);
+const CPAL_ATTEMPT_BUDGET: Duration = Duration::from_secs(16);
+const COOPERATIVE_STOP_GRACE: Duration = Duration::from_millis(250);
+const CAPTURE_TERMINATION_BUDGET: Duration = Duration::from_secs(2);
+const CAPTURE_PROTOCOL_RESERVE: Duration = Duration::from_secs(2);
+const CAPTURE_ACTIVE_BUDGET: Duration = Duration::from_secs(30);
 const CAPTURE_WORKER_IDENTIFIER: &str = "com.localdictation.capture-worker";
 pub(crate) const STREAM_BUILD_TIMEOUT: Duration = Duration::from_secs(10);
 static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
@@ -54,6 +61,8 @@ pub(crate) enum AudioFailureKind {
     ProtocolError,
     FirstBufferTimeout,
     InitializationTimeout,
+    PermissionPromptTimeout,
+    TerminationUnconfirmed,
     WorkerPanicked,
     SignatureInvalid,
 }
@@ -77,6 +86,8 @@ impl AudioFailureKind {
             Self::ProtocolError => "protocol_error",
             Self::FirstBufferTimeout => "first_buffer_timeout",
             Self::InitializationTimeout => "initialization_timeout",
+            Self::PermissionPromptTimeout => "permission_prompt_timeout",
+            Self::TerminationUnconfirmed => "termination_unconfirmed",
             Self::WorkerPanicked => "worker_panicked",
             Self::SignatureInvalid => "signature_invalid",
         }
@@ -123,6 +134,12 @@ impl AudioFailure {
             AudioFailureKind::InitializationTimeout => {
                 "Microphone initialization exceeded the deadline."
             }
+            AudioFailureKind::PermissionPromptTimeout => {
+                "Microphone permission was not decided before the prompt deadline."
+            }
+            AudioFailureKind::TerminationUnconfirmed => {
+                "The microphone worker could not be stopped safely. Restart Murmur before trying again."
+            }
             AudioFailureKind::SignatureInvalid => {
                 "The bundled microphone capture worker failed integrity validation."
             }
@@ -137,6 +154,8 @@ impl AudioFailure {
         !matches!(
             self.kind,
             AudioFailureKind::PermissionDenied
+                | AudioFailureKind::PermissionPromptTimeout
+                | AudioFailureKind::TerminationUnconfirmed
                 | AudioFailureKind::ProtocolError
                 | AudioFailureKind::SignatureInvalid
         )
@@ -208,6 +227,16 @@ pub(crate) enum AudioWorkerEvent {
         owner: crate::audio_lifecycle::AudioOwner,
         phase: AudioInitPhase,
         elapsed_ms: u64,
+    },
+    PermissionPromptPending {
+        owner: crate::audio_lifecycle::AudioOwner,
+    },
+    PermissionPromptResolved {
+        owner: crate::audio_lifecycle::AudioOwner,
+    },
+    TerminationUnconfirmed {
+        owner: crate::audio_lifecycle::AudioOwner,
+        failure: AudioFailure,
     },
     FirstBuffer {
         owner: crate::audio_lifecycle::AudioOwner,
@@ -305,7 +334,7 @@ fn spawn_helper(
     let spawn_started = Instant::now();
     let child = ManagedChild::spawn_with_arguments(
         &path,
-        &["--production-v2", &capture_id_text, nonce_hex],
+        &["--production-v3", &capture_id_text, nonce_hex],
         &[],
     )
     .map_err(|_| {
@@ -446,16 +475,159 @@ enum HelperRead {
 
 enum AttemptResult {
     Stopped,
+    TerminalHandled,
     Failed {
         failure: AudioFailure,
         retained_audio: bool,
     },
 }
 
+#[derive(Debug)]
+struct ActiveAttemptClock {
+    started_at: Instant,
+    paused_at: Option<Instant>,
+    paused_total: Duration,
+}
+
+impl ActiveAttemptClock {
+    fn new(now: Instant) -> Self {
+        Self {
+            started_at: now,
+            paused_at: None,
+            paused_total: Duration::ZERO,
+        }
+    }
+
+    fn pause(&mut self, now: Instant) {
+        if self.paused_at.is_none() {
+            self.paused_at = Some(now);
+        }
+    }
+
+    fn resume(&mut self, now: Instant) {
+        if let Some(paused_at) = self.paused_at.take() {
+            self.paused_total += now.saturating_duration_since(paused_at);
+        }
+    }
+
+    fn elapsed(&self, now: Instant) -> Duration {
+        let current_pause = self
+            .paused_at
+            .map(|paused_at| now.saturating_duration_since(paused_at))
+            .unwrap_or_default();
+        now.saturating_duration_since(self.started_at)
+            .saturating_sub(self.paused_total)
+            .saturating_sub(current_pause)
+    }
+}
+
+fn begin_permission_prompt_pause(
+    prompt_started: &mut Option<Instant>,
+    clock: &mut ActiveAttemptClock,
+    owner: crate::audio_lifecycle::AudioOwner,
+    event_sender: &AudioWorkerEventSender,
+    now: Instant,
+) {
+    if prompt_started.is_none() {
+        *prompt_started = Some(now);
+        clock.pause(now);
+        let _ = event_sender.send(AudioWorkerEvent::PermissionPromptPending { owner });
+    }
+}
+
+fn end_permission_prompt_pause(
+    prompt_started: &mut Option<Instant>,
+    clock: &mut ActiveAttemptClock,
+    owner: crate::audio_lifecycle::AudioOwner,
+    event_sender: &AudioWorkerEventSender,
+    now: Instant,
+) {
+    if prompt_started.take().is_some() {
+        clock.resume(now);
+        let _ = event_sender.send(AudioWorkerEvent::PermissionPromptResolved { owner });
+    }
+}
+
 fn backend_label(backend: CaptureBackend) -> &'static str {
     match backend {
         CaptureBackend::Cpal => "cpal",
         CaptureBackend::Auhal => "auhal",
+    }
+}
+
+fn backend_attempt_budget(backend: CaptureBackend) -> Duration {
+    match backend {
+        CaptureBackend::Auhal => AUHAL_ATTEMPT_BUDGET,
+        CaptureBackend::Cpal => CPAL_ATTEMPT_BUDGET,
+    }
+}
+
+fn terminate_helper(
+    mut child: ManagedChild,
+    mut input: Option<std::process::ChildStdin>,
+    capture_id: u64,
+    nonce: SessionNonce,
+    control: Option<ProductionHostMessage>,
+) -> Result<(), ManagedChild> {
+    if let (Some(input), Some(control)) = (input.as_mut(), control) {
+        let _ = write_production_control(input, capture_id, nonce, &control);
+    }
+    drop(input);
+    let deadline = Instant::now() + CAPTURE_TERMINATION_BUDGET;
+    let cooperative_deadline = std::cmp::min(deadline, Instant::now() + COOPERATIVE_STOP_GRACE);
+    if child.wait_for_exit(cooperative_deadline).is_some()
+        || child.hard_kill_confirmed(deadline).is_some()
+    {
+        Ok(())
+    } else {
+        Err(child)
+    }
+}
+
+fn quarantine_unconfirmed_child(
+    mut child: ManagedChild,
+    owner: crate::audio_lifecycle::AudioOwner,
+    event_sender: &AudioWorkerEventSender,
+    phase: AudioInitPhase,
+) {
+    let failure = AudioFailure::new(AudioFailureKind::TerminationUnconfirmed, phase);
+    let _ = event_sender.send(AudioWorkerEvent::TerminationUnconfirmed { owner, failure });
+    tracing::error!(
+        target: "audio",
+        owner = owner.telemetry_id(),
+        helper_pid = child.pid(),
+        error_kind = AudioFailureKind::TerminationUnconfirmed.as_str(),
+        "capture helper termination could not be confirmed; retaining ownership"
+    );
+    while child
+        .hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE)
+        .is_none()
+    {
+        tracing::warn!(
+            target: "audio",
+            owner = owner.telemetry_id(),
+            helper_pid = child.pid(),
+            "capture helper remains under recovery ownership"
+        );
+    }
+}
+
+fn terminate_or_quarantine(
+    child: ManagedChild,
+    input: Option<std::process::ChildStdin>,
+    capture_id: u64,
+    nonce: SessionNonce,
+    control: Option<ProductionHostMessage>,
+    owner: crate::audio_lifecycle::AudioOwner,
+    event_sender: &AudioWorkerEventSender,
+    phase: AudioInitPhase,
+) -> bool {
+    match terminate_helper(child, input, capture_id, nonce, control) {
+        Ok(()) => true,
+        Err(child) => {
+            quarantine_unconfirmed_child(child, owner, event_sender, phase);
+            false
+        }
     }
 }
 
@@ -474,6 +646,13 @@ fn preferred_backends() -> [CaptureBackend; 2] {
     }
 }
 
+fn stop_requested_between_attempts(command_receiver: &Receiver<AudioCommand>) -> bool {
+    matches!(
+        command_receiver.try_recv(),
+        Ok(AudioCommand::Stop) | Err(mpsc::TryRecvError::Disconnected)
+    )
+}
+
 fn run_backend(
     owner: crate::audio_lifecycle::AudioOwner,
     backend: CaptureBackend,
@@ -484,10 +663,11 @@ fn run_backend(
     app_handle: &Option<tauri::AppHandle>,
     event_sender: &AudioWorkerEventSender,
 ) -> AttemptResult {
-    // A first-ever/not-reset grant must be allowed to reach the worker's
-    // device open so macOS can show the TCC prompt. Only a genuine denial is
-    // terminal before spawn.
-    if crate::commands::permissions::check_microphone_permission_status() == "denied" {
+    let started_at = Instant::now();
+    let mut clock = ActiveAttemptClock::new(started_at);
+    let mut permission_prompt_started = None;
+    let permission_status = crate::commands::permissions::check_microphone_permission_status();
+    if permission_status == "denied" {
         return AttemptResult::Failed {
             failure: AudioFailure::new(
                 AudioFailureKind::PermissionDenied,
@@ -496,20 +676,55 @@ fn run_backend(
             retained_audio: false,
         };
     }
+    if permission_status == "notDetermined" {
+        begin_permission_prompt_pause(
+            &mut permission_prompt_started,
+            &mut clock,
+            owner,
+            event_sender,
+            started_at,
+        );
+    }
+
     let (capture_id, nonce, nonce_hex) = capture_identity();
-    let (mut child, mut input, output) = match spawn_helper(capture_id, &nonce_hex) {
+    let (child, mut input, output) = match spawn_helper(capture_id, &nonce_hex) {
         Ok(value) => value,
         Err(failure) => {
+            end_permission_prompt_pause(
+                &mut permission_prompt_started,
+                &mut clock,
+                owner,
+                event_sender,
+                Instant::now(),
+            );
             return AttemptResult::Failed {
                 failure,
                 retained_audio: false,
-            }
+            };
         }
     };
     let output = match hello(&mut input, output, capture_id, nonce) {
         Ok(output) => output,
         Err(failure) => {
-            let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
+            end_permission_prompt_pause(
+                &mut permission_prompt_started,
+                &mut clock,
+                owner,
+                event_sender,
+                Instant::now(),
+            );
+            if !terminate_or_quarantine(
+                child,
+                Some(input),
+                capture_id,
+                nonce,
+                None,
+                owner,
+                event_sender,
+                AudioInitPhase::StreamBuild,
+            ) {
+                return AttemptResult::TerminalHandled;
+            }
             return AttemptResult::Failed {
                 failure,
                 retained_audio: false,
@@ -528,7 +743,25 @@ fn run_backend(
     )
     .is_err()
     {
-        let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
+        end_permission_prompt_pause(
+            &mut permission_prompt_started,
+            &mut clock,
+            owner,
+            event_sender,
+            Instant::now(),
+        );
+        if !terminate_or_quarantine(
+            child,
+            Some(input),
+            capture_id,
+            nonce,
+            None,
+            owner,
+            event_sender,
+            AudioInitPhase::StreamBuild,
+        ) {
+            return AttemptResult::TerminalHandled;
+        }
         return AttemptResult::Failed {
             failure: AudioFailure::new(
                 AudioFailureKind::ProtocolError,
@@ -568,22 +801,30 @@ fn run_backend(
     let mut retained_audio = false;
     let mut first_callback_wait_started = None;
     let mut last_level_emit = Instant::now() - Duration::from_secs(1);
-    let mut last_permission_check = Instant::now();
+    let mut last_permission_check = Instant::now() - PERMISSION_POLL_INTERVAL;
+    let mut current_phase = AudioInitPhase::StreamBuild;
+    let attempt_budget = backend_attempt_budget(backend);
     loop {
         match command_receiver.try_recv() {
             Ok(AudioCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
                 let stop_started = Instant::now();
-                let _ = write_production_control(
-                    &mut input,
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    stop_started,
+                );
+                if terminate_or_quarantine(
+                    child,
+                    Some(input),
                     capture_id,
                     nonce,
-                    &ProductionHostMessage::Stop,
-                );
-                drop(input);
-                let termination = child
-                    .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
-                    .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
-                if termination.is_some() {
+                    Some(ProductionHostMessage::Stop),
+                    owner,
+                    event_sender,
+                    current_phase,
+                ) {
                     tracing::info!(
                         target: "audio",
                         capture_id,
@@ -593,19 +834,14 @@ fn run_backend(
                     let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
                     return AttemptResult::Stopped;
                 }
-                return AttemptResult::Failed {
-                    failure: AudioFailure::new(
-                        AudioFailureKind::BackendError,
-                        AudioInitPhase::Runtime,
-                    ),
-                    retained_audio,
-                };
+                return AttemptResult::TerminalHandled;
             }
             Err(mpsc::TryRecvError::Empty) => {}
         }
 
         if last_permission_check.elapsed() >= PERMISSION_POLL_INTERVAL {
-            last_permission_check = Instant::now();
+            let now = Instant::now();
+            last_permission_check = now;
             // During active capture, denied and not-determined both mean the
             // grant is no longer in force (not-determined is what a TCC reset
             // can expose). "unknown" is a transient probe failure and must not
@@ -614,29 +850,128 @@ fn run_backend(
                 crate::commands::permissions::check_microphone_permission_status();
             let permission_lost = permission_status == "denied"
                 || (retained_audio && permission_status == "notDetermined");
+            if !retained_audio && permission_status == "notDetermined" {
+                begin_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    now,
+                );
+            } else if permission_status == "granted" {
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    now,
+                );
+            }
+            let permission_prompt_timed_out = permission_prompt_started.is_some_and(|started| {
+                now.saturating_duration_since(started) >= TCC_PROMPT_WATCHDOG
+            });
             if permission_lost {
-                let _ = write_production_control(
-                    &mut input,
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    now,
+                );
+                let phase = if retained_audio {
+                    AudioInitPhase::Runtime
+                } else {
+                    current_phase
+                };
+                if !terminate_or_quarantine(
+                    child,
+                    Some(input),
                     capture_id,
                     nonce,
-                    &ProductionHostMessage::Cancel,
-                );
-                drop(input);
-                let _ = child
-                    .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
-                    .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
+                    Some(ProductionHostMessage::Cancel),
+                    owner,
+                    event_sender,
+                    phase,
+                ) {
+                    return AttemptResult::TerminalHandled;
+                }
                 return AttemptResult::Failed {
-                    failure: AudioFailure::new(
-                        AudioFailureKind::PermissionDenied,
-                        if retained_audio {
-                            AudioInitPhase::Runtime
-                        } else {
-                            AudioInitPhase::StreamBuild
-                        },
-                    ),
+                    failure: AudioFailure::new(AudioFailureKind::PermissionDenied, phase),
                     retained_audio,
                 };
             }
+            if permission_prompt_timed_out {
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    now,
+                );
+                if !terminate_or_quarantine(
+                    child,
+                    Some(input),
+                    capture_id,
+                    nonce,
+                    Some(ProductionHostMessage::Cancel),
+                    owner,
+                    event_sender,
+                    current_phase,
+                ) {
+                    return AttemptResult::TerminalHandled;
+                }
+                return AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        AudioFailureKind::PermissionPromptTimeout,
+                        current_phase,
+                    ),
+                    retained_audio: false,
+                };
+            }
+        }
+
+        let now = Instant::now();
+        if !retained_audio && clock.elapsed(now) >= attempt_budget {
+            end_permission_prompt_pause(
+                &mut permission_prompt_started,
+                &mut clock,
+                owner,
+                event_sender,
+                now,
+            );
+            let failure = AudioFailure::new(
+                if current_phase == AudioInitPhase::FirstBufferWait {
+                    AudioFailureKind::FirstBufferTimeout
+                } else {
+                    AudioFailureKind::InitializationTimeout
+                },
+                current_phase,
+            );
+            tracing::warn!(
+                target: "audio",
+                capture_id,
+                backend = backend_label(backend),
+                active_elapsed_ms = clock.elapsed(now).as_millis() as u64,
+                attempt_budget_ms = attempt_budget.as_millis() as u64,
+                error_kind = failure.kind.as_str(),
+                "capture backend exceeded its active initialization budget"
+            );
+            if !terminate_or_quarantine(
+                child,
+                Some(input),
+                capture_id,
+                nonce,
+                Some(ProductionHostMessage::Stop),
+                owner,
+                event_sender,
+                current_phase,
+            ) {
+                return AttemptResult::TerminalHandled;
+            }
+            return AttemptResult::Failed {
+                failure,
+                retained_audio: false,
+            };
         }
 
         match reader_rx.recv_timeout(Duration::from_millis(20)) {
@@ -645,7 +980,25 @@ fn run_backend(
                     || pcm.samples.is_empty()
                     || sample_rate.is_some_and(|rate| rate != pcm.sample_rate)
                 {
-                    let _ = child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE);
+                    end_permission_prompt_pause(
+                        &mut permission_prompt_started,
+                        &mut clock,
+                        owner,
+                        event_sender,
+                        Instant::now(),
+                    );
+                    if !terminate_or_quarantine(
+                        child,
+                        Some(input),
+                        capture_id,
+                        nonce,
+                        Some(ProductionHostMessage::Cancel),
+                        owner,
+                        event_sender,
+                        AudioInitPhase::Runtime,
+                    ) {
+                        return AttemptResult::TerminalHandled;
+                    }
                     return AttemptResult::Failed {
                         failure: AudioFailure::new(
                             AudioFailureKind::ProtocolError,
@@ -662,6 +1015,14 @@ fn run_backend(
                     .extend_from_slice(&pcm.samples);
                 if !retained_audio {
                     retained_audio = true;
+                    current_phase = AudioInitPhase::Runtime;
+                    end_permission_prompt_pause(
+                        &mut permission_prompt_started,
+                        &mut clock,
+                        owner,
+                        event_sender,
+                        Instant::now(),
+                    );
                     tracing::info!(
                         target: "audio",
                         capture_id,
@@ -712,43 +1073,136 @@ fn run_backend(
                     CapturePhase::Active => AudioInitPhase::Runtime,
                     CapturePhase::Stopping => AudioInitPhase::Runtime,
                 };
+                current_phase = phase;
                 let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
+            }
+            Ok(HelperRead::Frame(ProductionFrame::Control(
+                ProductionHelperMessage::SetupStep {
+                    backend: reported_backend,
+                    step,
+                    transition,
+                },
+            ))) => {
+                if reported_backend != backend {
+                    end_permission_prompt_pause(
+                        &mut permission_prompt_started,
+                        &mut clock,
+                        owner,
+                        event_sender,
+                        Instant::now(),
+                    );
+                    if !terminate_or_quarantine(
+                        child,
+                        Some(input),
+                        capture_id,
+                        nonce,
+                        Some(ProductionHostMessage::Cancel),
+                        owner,
+                        event_sender,
+                        current_phase,
+                    ) {
+                        return AttemptResult::TerminalHandled;
+                    }
+                    return AttemptResult::Failed {
+                        failure: AudioFailure::new(AudioFailureKind::ProtocolError, current_phase),
+                        retained_audio,
+                    };
+                }
+                tracing::info!(
+                    target: "audio",
+                    capture_id,
+                    backend = backend_label(backend),
+                    setup_step = step.as_str(),
+                    setup_transition = transition.as_str(),
+                    "capture helper setup step"
+                );
             }
             Ok(HelperRead::Frame(ProductionFrame::Control(ProductionHelperMessage::Failure {
                 code,
                 ..
             }))) => {
+                let phase = if retained_audio {
+                    AudioInitPhase::Runtime
+                } else {
+                    current_phase
+                };
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    Instant::now(),
+                );
+                if !terminate_or_quarantine(
+                    child,
+                    Some(input),
+                    capture_id,
+                    nonce,
+                    None,
+                    owner,
+                    event_sender,
+                    phase,
+                ) {
+                    return AttemptResult::TerminalHandled;
+                }
                 return AttemptResult::Failed {
-                    failure: AudioFailure::new(
-                        failure_kind(code),
-                        if retained_audio {
-                            AudioInitPhase::Runtime
-                        } else {
-                            AudioInitPhase::StreamBuild
-                        },
-                    ),
+                    failure: AudioFailure::new(failure_kind(code), phase),
                     retained_audio,
                 };
             }
             Ok(HelperRead::Frame(ProductionFrame::Control(ProductionHelperMessage::Stopped {
                 ..
             }))) => {
-                drop(input);
-                let _ = child
-                    .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
-                    .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    Instant::now(),
+                );
+                if !terminate_or_quarantine(
+                    child,
+                    Some(input),
+                    capture_id,
+                    nonce,
+                    None,
+                    owner,
+                    event_sender,
+                    current_phase,
+                ) {
+                    return AttemptResult::TerminalHandled;
+                }
                 let _ = event_sender.send(AudioWorkerEvent::StreamStopped { owner });
                 return AttemptResult::Stopped;
             }
             Ok(HelperRead::Frame(_)) => {}
             Ok(HelperRead::Invalid) | Err(RecvTimeoutError::Disconnected) => {
+                end_permission_prompt_pause(
+                    &mut permission_prompt_started,
+                    &mut clock,
+                    owner,
+                    event_sender,
+                    Instant::now(),
+                );
+                if !terminate_or_quarantine(
+                    child,
+                    Some(input),
+                    capture_id,
+                    nonce,
+                    None,
+                    owner,
+                    event_sender,
+                    current_phase,
+                ) {
+                    return AttemptResult::TerminalHandled;
+                }
                 return AttemptResult::Failed {
                     failure: AudioFailure::new(
                         AudioFailureKind::ProtocolError,
                         if retained_audio {
                             AudioInitPhase::Runtime
                         } else {
-                            AudioInitPhase::StreamBuild
+                            current_phase
                         },
                     ),
                     retained_audio,
@@ -759,32 +1213,28 @@ fn run_backend(
     }
 }
 
-fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSender) {
-    let AudioWorkerSpec {
-        owner,
-        command_receiver,
-        shared,
-        active,
-        app_handle,
-        device_id,
-    } = spec;
-    let backends = preferred_backends();
+fn run_capture_backend_sequence(
+    owner: crate::audio_lifecycle::AudioOwner,
+    command_receiver: &Receiver<AudioCommand>,
+    event_sender: &AudioWorkerEventSender,
+    backends: [CaptureBackend; 2],
+    mut run_attempt: impl FnMut(CaptureBackend) -> AttemptResult,
+) {
     for (attempt_index, backend) in backends.into_iter().enumerate() {
-        match run_backend(
-            owner,
-            backend,
-            device_id.as_deref(),
-            &command_receiver,
-            &shared,
-            &active,
-            &app_handle,
-            event_sender,
-        ) {
-            AttemptResult::Stopped => return,
+        match run_attempt(backend) {
+            AttemptResult::Stopped | AttemptResult::TerminalHandled => return,
             AttemptResult::Failed {
                 failure,
                 retained_audio,
             } if !retained_audio && attempt_index == 0 && failure.permits_backend_fallback() => {
+                if stop_requested_between_attempts(command_receiver) {
+                    tracing::info!(
+                        target: "audio",
+                        owner = owner.telemetry_id(),
+                        "capture fallback suppressed by stop between backend attempts"
+                    );
+                    return;
+                }
                 tracing::warn!(
                     target: "audio",
                     owner = owner.telemetry_id(),
@@ -798,6 +1248,17 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
                 failure,
                 retained_audio,
             } => {
+                if !retained_audio && attempt_index == 1 {
+                    tracing::error!(
+                        target: "audio",
+                        owner = owner.telemetry_id(),
+                        primary_backend = backend_label(backends[0]),
+                        fallback_backend = backend_label(backend),
+                        fallback_exhausted = true,
+                        error_kind = failure.kind.as_str(),
+                        "both capture backend attempts failed before first PCM"
+                    );
+                }
                 let event = if retained_audio {
                     AudioWorkerEvent::RuntimeFailed { owner, failure }
                 } else {
@@ -808,6 +1269,42 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
             }
         }
     }
+}
+
+fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSender) {
+    let AudioWorkerSpec {
+        owner,
+        command_receiver,
+        shared,
+        active,
+        app_handle,
+        device_id,
+    } = spec;
+    tracing::info!(
+        target: "audio",
+        owner = owner.telemetry_id(),
+        active_budget_ms = CAPTURE_ACTIVE_BUDGET.as_millis() as u64,
+        protocol_reserve_ms = CAPTURE_PROTOCOL_RESERVE.as_millis() as u64,
+        "capture backend budget contract started"
+    );
+    run_capture_backend_sequence(
+        owner,
+        &command_receiver,
+        event_sender,
+        preferred_backends(),
+        |backend| {
+            run_backend(
+                owner,
+                backend,
+                device_id.as_deref(),
+                &command_receiver,
+                &shared,
+                &active,
+                &app_handle,
+                event_sender,
+            )
+        },
+    );
 }
 
 pub(crate) fn spawn_capture_worker(
@@ -911,5 +1408,183 @@ mod tests {
         ] {
             assert!(AudioFailure::new(kind, AudioInitPhase::StreamBuild).permits_backend_fallback());
         }
+    }
+
+    #[test]
+    fn capture_budget_split_leaves_the_decided_protocol_reserve() {
+        assert_eq!(
+            AUHAL_ATTEMPT_BUDGET
+                + CAPTURE_TERMINATION_BUDGET
+                + CPAL_ATTEMPT_BUDGET
+                + CAPTURE_TERMINATION_BUDGET
+                + CAPTURE_PROTOCOL_RESERVE,
+            CAPTURE_ACTIVE_BUDGET
+        );
+    }
+
+    #[test]
+    fn active_attempt_clock_excludes_only_the_pending_prompt_interval() {
+        let started = Instant::now();
+        let mut clock = ActiveAttemptClock::new(started);
+        clock.pause(started + Duration::from_secs(2));
+        assert_eq!(
+            clock.elapsed(started + Duration::from_secs(40)),
+            Duration::from_secs(2)
+        );
+        clock.resume(started + Duration::from_secs(42));
+        assert_eq!(
+            clock.elapsed(started + Duration::from_secs(45)),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn permission_and_unconfirmed_termination_never_permit_fallback() {
+        for kind in [
+            AudioFailureKind::PermissionDenied,
+            AudioFailureKind::PermissionPromptTimeout,
+            AudioFailureKind::TerminationUnconfirmed,
+        ] {
+            assert!(
+                !AudioFailure::new(kind, AudioInitPhase::StreamBuild).permits_backend_fallback()
+            );
+        }
+    }
+
+    #[test]
+    fn stop_is_consumed_before_a_fallback_attempt_can_spawn() {
+        let (sender, receiver) = mpsc::channel();
+        assert!(!stop_requested_between_attempts(&receiver));
+        sender.send(AudioCommand::Stop).unwrap();
+        assert!(stop_requested_between_attempts(&receiver));
+    }
+
+    #[test]
+    fn confirmed_primary_timeout_advances_once_to_successful_fallback() {
+        let (_command_sender, command_receiver) = mpsc::channel();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured_events = Arc::clone(&events);
+        let event_sender = AudioWorkerEventSender::new(move |event| {
+            captured_events.lock().unwrap().push(event);
+            Ok(())
+        });
+        let mut calls = Vec::new();
+
+        run_capture_backend_sequence(
+            crate::audio_lifecycle::AudioOwner::Dictation(1),
+            &command_receiver,
+            &event_sender,
+            [CaptureBackend::Auhal, CaptureBackend::Cpal],
+            |backend| {
+                calls.push(backend);
+                if backend == CaptureBackend::Auhal {
+                    // Failed is emitted by the production runner only after
+                    // terminate_or_quarantine positively confirms exit.
+                    AttemptResult::Failed {
+                        failure: AudioFailure::new(
+                            AudioFailureKind::InitializationTimeout,
+                            AudioInitPhase::StreamBuild,
+                        ),
+                        retained_audio: false,
+                    }
+                } else {
+                    AttemptResult::Stopped
+                }
+            },
+        );
+
+        assert_eq!(calls, vec![CaptureBackend::Auhal, CaptureBackend::Cpal]);
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn unconfirmed_primary_termination_never_reaches_fallback() {
+        let (_command_sender, command_receiver) = mpsc::channel();
+        let event_sender = AudioWorkerEventSender::new(|_| Ok(()));
+        let mut calls = Vec::new();
+        run_capture_backend_sequence(
+            crate::audio_lifecycle::AudioOwner::Dictation(2),
+            &command_receiver,
+            &event_sender,
+            [CaptureBackend::Auhal, CaptureBackend::Cpal],
+            |backend| {
+                calls.push(backend);
+                AttemptResult::TerminalHandled
+            },
+        );
+        assert_eq!(calls, vec![CaptureBackend::Auhal]);
+    }
+
+    #[test]
+    fn two_backend_timeouts_emit_one_terminal_initialization_failure() {
+        let (_command_sender, command_receiver) = mpsc::channel();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured_events = Arc::clone(&events);
+        let event_sender = AudioWorkerEventSender::new(move |event| {
+            captured_events.lock().unwrap().push(event);
+            Ok(())
+        });
+        let mut calls = Vec::new();
+        run_capture_backend_sequence(
+            crate::audio_lifecycle::AudioOwner::Dictation(3),
+            &command_receiver,
+            &event_sender,
+            [CaptureBackend::Auhal, CaptureBackend::Cpal],
+            |backend| {
+                calls.push(backend);
+                AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        AudioFailureKind::InitializationTimeout,
+                        AudioInitPhase::StreamBuild,
+                    ),
+                    retained_audio: false,
+                }
+            },
+        );
+
+        assert_eq!(calls, vec![CaptureBackend::Auhal, CaptureBackend::Cpal]);
+        assert!(matches!(
+            events.lock().unwrap().as_slice(),
+            [AudioWorkerEvent::InitFailed {
+                failure: AudioFailure {
+                    kind: AudioFailureKind::InitializationTimeout,
+                    ..
+                },
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn retained_pcm_disables_fallback() {
+        let (_command_sender, command_receiver) = mpsc::channel();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured_events = Arc::clone(&events);
+        let event_sender = AudioWorkerEventSender::new(move |event| {
+            captured_events.lock().unwrap().push(event);
+            Ok(())
+        });
+        let mut calls = Vec::new();
+        run_capture_backend_sequence(
+            crate::audio_lifecycle::AudioOwner::Dictation(4),
+            &command_receiver,
+            &event_sender,
+            [CaptureBackend::Auhal, CaptureBackend::Cpal],
+            |backend| {
+                calls.push(backend);
+                AttemptResult::Failed {
+                    failure: AudioFailure::new(
+                        AudioFailureKind::StreamInvalidated,
+                        AudioInitPhase::Runtime,
+                    ),
+                    retained_audio: true,
+                }
+            },
+        );
+        assert_eq!(calls, vec![CaptureBackend::Auhal]);
+        assert!(matches!(
+            events.lock().unwrap().as_slice(),
+            [AudioWorkerEvent::RuntimeFailed { .. }]
+        ));
     }
 }

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -193,6 +193,7 @@ impl PublicState {
 struct SupervisorConfig {
     still_connecting_after: Duration,
     hard_deadline: Duration,
+    tcc_prompt_watchdog: Duration,
     recovery_guidance_after: Duration,
 }
 
@@ -201,6 +202,7 @@ impl Default for SupervisorConfig {
         Self {
             still_connecting_after: STILL_CONNECTING_AFTER,
             hard_deadline: HARD_INITIALIZATION_DEADLINE,
+            tcc_prompt_watchdog: audio::TCC_PROMPT_WATCHDOG,
             recovery_guidance_after: RECOVERY_GUIDANCE_AFTER,
         }
     }
@@ -347,6 +349,8 @@ struct Attempt {
     origin: String,
     phase: AttemptPhase,
     accepted_at: Instant,
+    tcc_pending_since: Option<Instant>,
+    tcc_paused_total: Duration,
     ready_at: Option<Instant>,
     stopping_started_at: Option<Instant>,
     still_connecting_emitted: bool,
@@ -362,6 +366,18 @@ struct Attempt {
     sample_rate: u32,
     start_response: Option<Sender<Result<(), AudioStartError>>>,
     stop_response: Option<Sender<Result<Vec<f32>, String>>>,
+}
+
+impl Attempt {
+    fn active_initialization_elapsed(&self, now: Instant) -> Duration {
+        let current_pause = self
+            .tcc_pending_since
+            .map(|started| now.saturating_duration_since(started))
+            .unwrap_or_default();
+        now.saturating_duration_since(self.accepted_at)
+            .saturating_sub(self.tcc_paused_total)
+            .saturating_sub(current_pause)
+    }
 }
 
 #[derive(Clone)]
@@ -465,10 +481,15 @@ fn deadline_wait(attempt: Option<&Attempt>, config: SupervisorConfig) -> Duratio
     };
     let now = Instant::now();
     let deadline = match attempt.phase {
-        AttemptPhase::Starting if !attempt.still_connecting_emitted => {
-            attempt.accepted_at + config.still_connecting_after
+        AttemptPhase::Starting if attempt.tcc_pending_since.is_some() => {
+            attempt.tcc_pending_since.unwrap_or(now) + config.tcc_prompt_watchdog
         }
-        AttemptPhase::Starting => attempt.accepted_at + config.hard_deadline,
+        AttemptPhase::Starting if !attempt.still_connecting_emitted => {
+            attempt.accepted_at + attempt.tcc_paused_total + config.still_connecting_after
+        }
+        AttemptPhase::Starting => {
+            attempt.accepted_at + attempt.tcc_paused_total + config.hard_deadline
+        }
         AttemptPhase::Stopping if !attempt.stopping_guidance_emitted => {
             attempt.stopping_started_at.unwrap_or(now) + config.recovery_guidance_after
         }
@@ -618,6 +639,8 @@ fn handle_start(
         origin: request.origin,
         phase: AttemptPhase::Starting,
         accepted_at: Instant::now(),
+        tcc_pending_since: None,
+        tcc_paused_total: Duration::ZERO,
         ready_at: None,
         stopping_started_at: None,
         still_connecting_emitted: false,
@@ -648,6 +671,9 @@ fn handle_worker_event(
     let owner = match &event {
         AudioWorkerEvent::PhaseEntered { owner, .. }
         | AudioWorkerEvent::PhaseExited { owner, .. }
+        | AudioWorkerEvent::PermissionPromptPending { owner }
+        | AudioWorkerEvent::PermissionPromptResolved { owner }
+        | AudioWorkerEvent::TerminationUnconfirmed { owner, .. }
         | AudioWorkerEvent::FirstBuffer { owner, .. }
         | AudioWorkerEvent::InitFailed { owner, .. }
         | AudioWorkerEvent::RuntimeFailed { owner, .. }
@@ -673,6 +699,42 @@ fn handle_worker_event(
     }
 
     match event {
+        AudioWorkerEvent::PermissionPromptPending { .. } => {
+            if current.phase == AttemptPhase::Starting && current.tcc_pending_since.is_none() {
+                current.tcc_pending_since = Some(Instant::now());
+                tracing::info!(
+                    target: "audio",
+                    owner = owner.telemetry_id(),
+                    owner_kind = owner.kind(),
+                    "microphone permission prompt pending; initialization deadlines suspended"
+                );
+            }
+        }
+        AudioWorkerEvent::PermissionPromptResolved { .. } => {
+            if let Some(started) = current.tcc_pending_since.take() {
+                let paused = started.elapsed();
+                current.tcc_paused_total += paused;
+                tracing::info!(
+                    target: "audio",
+                    owner = owner.telemetry_id(),
+                    owner_kind = owner.kind(),
+                    prompt_pending_ms = paused.as_millis() as u64,
+                    "microphone permission prompt resolved; initialization deadlines resumed"
+                );
+            }
+        }
+        AudioWorkerEvent::TerminationUnconfirmed { failure, .. } => {
+            if let Some(response) = current.start_response.take() {
+                let _ = response.send(Err(AudioStartError::InitializationFailed(failure.clone())));
+            }
+            begin_recovery(
+                attempt,
+                AudioCancelReason::RuntimeFailure,
+                sink,
+                public,
+                Some(failure),
+            );
+        }
         AudioWorkerEvent::PhaseEntered { phase, .. } => {
             current.init_phase = phase;
             tracing::info!(
@@ -1015,8 +1077,27 @@ fn handle_deadlines_at(
     let Some(current) = attempt.as_ref() else {
         return;
     };
-    let elapsed = now.saturating_duration_since(current.accepted_at);
+    let elapsed = current.active_initialization_elapsed(now);
+    let permission_prompt_timed_out = current.phase == AttemptPhase::Starting
+        && current.tcc_pending_since.is_some_and(|started| {
+            now.saturating_duration_since(started) >= config.tcc_prompt_watchdog
+        });
+    if permission_prompt_timed_out {
+        let phase = current.init_phase;
+        begin_recovery(
+            attempt,
+            AudioCancelReason::HardDeadline,
+            sink,
+            public,
+            Some(AudioFailure::new(
+                AudioFailureKind::PermissionPromptTimeout,
+                phase,
+            )),
+        );
+        return;
+    }
     let should_emit_still_connecting = current.phase == AttemptPhase::Starting
+        && current.tcc_pending_since.is_none()
         && !current.still_connecting_emitted
         && elapsed >= config.still_connecting_after;
     if should_emit_still_connecting {
@@ -2245,6 +2326,116 @@ mod tests {
     }
 
     #[test]
+    fn pending_tcc_prompt_suspends_active_deadline_and_cancel_stays_responsive() {
+        let (supervisor, gate, _, sink, _) =
+            harness(AudioInitPhase::StreamBuild, SupervisorConfig::default());
+        let owner = AudioOwner::Dictation(96);
+        assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
+        supervisor
+            .sender
+            .send(SupervisorMessage::Worker(
+                AudioWorkerEvent::PermissionPromptPending { owner },
+            ))
+            .unwrap();
+
+        check_deadlines(
+            &supervisor,
+            HARD_INITIALIZATION_DEADLINE + Duration::from_secs(10),
+        );
+        assert!(supervisor.public.is_active());
+        assert!(!sink.events.lock().unwrap().iter().any(|(_, event)| {
+            matches!(event, AudioLifecycleEvent::InitializationFailed { .. })
+        }));
+
+        assert_eq!(cancel(&supervisor, owner).recv().unwrap(), Ok(true));
+        gate.open();
+        wait_until("TCC-pending cancellation did not release ownership", || {
+            !supervisor.public.is_active()
+        });
+        shutdown(&supervisor);
+    }
+
+    #[test]
+    fn pending_tcc_prompt_has_a_separate_bounded_watchdog() {
+        let config = SupervisorConfig {
+            tcc_prompt_watchdog: Duration::from_secs(3),
+            ..SupervisorConfig::default()
+        };
+        let (supervisor, gate, _, sink, _) = harness(AudioInitPhase::StreamBuild, config);
+        let owner = AudioOwner::Dictation(97);
+        assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
+        supervisor
+            .sender
+            .send(SupervisorMessage::Worker(
+                AudioWorkerEvent::PermissionPromptPending { owner },
+            ))
+            .unwrap();
+
+        check_deadlines(&supervisor, Duration::from_secs(4));
+        assert!(sink.events.lock().unwrap().iter().any(|(_, event)| {
+            matches!(
+                event,
+                AudioLifecycleEvent::InitializationFailed {
+                    kind: AudioFailureKind::PermissionPromptTimeout,
+                    ..
+                }
+            )
+        }));
+        assert!(supervisor.public.is_active());
+
+        gate.open();
+        wait_until("TCC watchdog recovery did not release ownership", || {
+            !supervisor.public.is_active()
+        });
+        shutdown(&supervisor);
+    }
+
+    #[test]
+    fn unconfirmed_termination_fails_closed_and_retains_exclusive_ownership() {
+        let (supervisor, gate, spawn_count, sink, _) =
+            harness(AudioInitPhase::StreamBuild, SupervisorConfig::default());
+        let owner = AudioOwner::Dictation(98);
+        assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
+        supervisor
+            .sender
+            .send(SupervisorMessage::Worker(
+                AudioWorkerEvent::TerminationUnconfirmed {
+                    owner,
+                    failure: AudioFailure::new(
+                        AudioFailureKind::TerminationUnconfirmed,
+                        AudioInitPhase::StreamBuild,
+                    ),
+                },
+            ))
+            .unwrap();
+
+        wait_until("unconfirmed termination did not enter recovery", || {
+            sink.events.lock().unwrap().iter().any(|(_, event)| {
+                matches!(
+                    event,
+                    AudioLifecycleEvent::InitializationFailed {
+                        kind: AudioFailureKind::TerminationUnconfirmed,
+                        ..
+                    }
+                )
+            })
+        });
+        assert_eq!(
+            start(&supervisor, AudioOwner::Dictation(99))
+                .recv()
+                .unwrap(),
+            Err(AudioStartError::AudioRecovering)
+        );
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 1);
+
+        gate.open();
+        wait_until("unconfirmed termination recovery did not finish", || {
+            !supervisor.public.is_active()
+        });
+        shutdown(&supervisor);
+    }
+
+    #[test]
     fn stopping_deadline_surfaces_guidance_without_detaching_the_worker() {
         let gate = Gate::closed();
         let sink = Arc::new(RecordingSink::default());
@@ -2254,6 +2445,7 @@ mod tests {
             SupervisorConfig {
                 still_connecting_after: Duration::from_secs(1),
                 hard_deadline: Duration::from_secs(2),
+                tcc_prompt_watchdog: Duration::from_secs(120),
                 recovery_guidance_after: Duration::from_millis(5),
             },
         );

--- a/docs/decisions/2026-08-01-production-capture-helper.md
+++ b/docs/decisions/2026-08-01-production-capture-helper.md
@@ -2,13 +2,13 @@
 
 Date: 2026-08-01  
 Status: active  
-Issues: #405, #408, #409, #410, #411, #412, #426
+Issues: #405, #408, #409, #410, #411, #412, #426, #436
 
 ## Decision
 
 The Tauri application process never links CPAL or CoreAudio capture APIs. It
 owns a single signed `murmur-capture-worker` process group and communicates over
-production protocol v2. Every frame carries a monotonic capture ID and a random
+production protocol v3. Every frame carries a monotonic capture ID and a random
 128-bit nonce. Control payloads are bounded JSON; audio is bounded binary mono
 `f32` PCM with a strict sequence and sample rate.
 
@@ -16,14 +16,29 @@ The worker offers two independent macOS capture implementations: direct AUHAL
 and CPAL/CoreAudio. macOS tries direct AUHAL first because CPAL's synchronous
 stream builder can remain blocked on a healthy USB default input; CPAL remains
 the exact-device fallback. A failed backend may fall back once, and only before
-the first PCM buffer is retained. It must reuse the exact raw device UID. After
+the first PCM buffer is retained. The primary helper process group must be
+positively confirmed empty and Stop must still be absent before the fallback is
+spawned. If termination cannot be confirmed, Murmur retains recovery ownership,
+rejects competing starts, and never opens the alternate backend. The fallback
+must reuse the exact raw device UID. After
 retained audio, any gap, malformed frame, overflow, backend error, stall, or
 process exit terminates capture and preserves the delivered prefix.
 
-The worker reports content-free phases after stream open and immediately before
-the first retained callback. Together with host-side helper launch, first-PCM,
-and stop-to-exit timings, this separates process overhead from HAL/device latency
-without logging microphone content.
+The worker reports content-free setup transitions around AUHAL device
+resolution, AudioUnit creation, format configuration, callback installation,
+stream start, and the transition to awaiting the first callback. CPAL reports
+the comparable device-resolution, default-config, stream-build, stream-start,
+and callback-wait transitions. Together with host-side helper launch, first-PCM,
+and stop-to-exit timings, this localizes a blocked HAL operation without logging
+device identity, raw backend errors, or microphone content.
+
+Initialization uses one decided 30-second active-time contract: 8 seconds for
+AUHAL through first PCM, 2 seconds for confirmed AUHAL termination, 16 seconds
+for CPAL through first PCM, 2 seconds for confirmed CPAL termination, and 2
+seconds of protocol/scheduler reserve. Time spent while macOS reports a genuine
+pending TCC prompt (`notDetermined`) is excluded from those active deadlines.
+The prompt has its own 120-second wall-clock watchdog; denial and user Stop
+remain immediate.
 
 The real-time callback only converts to mono and writes into a preallocated
 eight-second SPSC ring. A non-real-time writer drains the ring into protocol
@@ -41,3 +56,5 @@ without transcription. User cancellation remains a distinct discard path.
   transcription policy while the helper exclusively owns macOS audio objects.
 - CI rejects future app-crate CPAL/CoreAudio dependencies and direct HAL source.
 - Device failover cannot silently switch microphones after capture begins.
+- This repairs the bounded-fallback contract and adds attribution evidence. It
+  does not claim to remove the underlying Core Audio hang.

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,28 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-03: Capture fallback uses fixed active budgets and confirmed teardown (#436)
+
+**Decision:** AUHAL and CPAL receive separate 8-second and 16-second
+initialization budgets inside one 30-second active-time contract. Each backend
+has a 2-second confirmed-termination budget, with 2 seconds reserved for
+protocol scheduling. CPAL can start only after AUHAL's process group is proven
+empty and a final Stop check passes. Pending TCC prompt time is excluded from
+active deadlines but bounded by a separate 120-second watchdog. Protocol v3
+reports privacy-safe setup sub-phases.
+
+**Rationale:** A global Stop at 30 seconds previously converted a hung primary
+attempt into cancellation before the alternate backend was tried. The repaired
+contract makes failover deterministic and leaves enough evidence to locate the
+underlying AUHAL or CPAL hang without claiming to eliminate it.
+
+**Status:** active
+
+**References:** issue #436; ADR
+[`2026-08-01-production-capture-helper.md`](2026-08-01-production-capture-helper.md)
+
+---
+
 ## 2026-08-03: Diagnostics move into the main Performance page (#435)
 
 **Decision:** The local model-comparison page is named **Benchmark**.
@@ -49,7 +71,7 @@ saved only process-launch time and did not affect the blocking HAL call.
 ## 2026-08-01: Production HAL ownership moves to a killable capture worker (#405)
 
 **Decision:** Production microphone enumeration and capture run only inside the
-signed managed capture worker over binary protocol v2. The worker exposes CPAL
+signed managed capture worker over binary protocol v3. The worker exposes CPAL
 and direct AUHAL backends with one exact-device pre-buffer fallback. Callback
 PCM crosses a preallocated SPSC ring; the app validates capture identity,
 sequence, bounds, and sample rate before retaining it. Runtime failure

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -3,15 +3,16 @@
 ## Process-isolated capture
 
 Microphone enumeration and streaming execute only in the signed
-`murmur-capture-worker`. Production protocol v2 binds every control and PCM
+`murmur-capture-worker`. Production protocol v3 binds every control and PCM
 frame to a capture ID and nonce and rejects stale, malformed, oversized,
 out-of-sequence, or sample-rate-changing input. The worker callback writes mono
 samples into a preallocated SPSC ring; the parent retains PCM before declaring
 readiness and calculates waveform levels locally.
 
-CPAL is the primary backend and direct AUHAL is the independent fallback. A
+Direct AUHAL is the primary backend and CPAL is the independent fallback. A
 single fallback is allowed only before any audio is retained and must target the
-same raw device UID. Once audio exists, failure ends capture without switching
+same raw device UID. The fallback starts only after the primary process group is
+confirmed empty and a final Stop check passes. Once audio exists, failure ends capture without switching
 devices. Prefixes of at least 500 ms are transcribed normally, remain
 clipboard-first, and are marked **Interrupted · partial** in history.
 
@@ -25,16 +26,8 @@ Transcription processing is local. Network access occurs for model setup and may
 
 ## Audio Capture (`audio.rs`)
 
-> **Phase-0 boundary (#407):** the bundle contains a probe-only signed capture
-> helper used to validate TCC attribution and hard-kill recovery. Production
-> dictation and transform capture still use the in-process lifecycle below.
-> Runtime-revocation rehearsals may extend the content-free observation window
-> after its complete Active handshake with `--observe-seconds 1..300`; this
-> does not route production audio through the helper.
-> No routing changes belong to this spike; see
-> [the decision record](../decisions/2026-07-30-capture-helper-phase-0.md).
-
-- Uses CPAL 0.18.1 to record on a background thread. `system_default` resolves
+- Uses direct AUHAL first and CPAL 0.18.1 as a single pre-buffer fallback inside
+  a signed, process-isolated capture worker. `system_default` resolves
   the live OS default; an explicit selection is the backend-native stable ID
   (`kAudioDevicePropertyDeviceUID` on CoreAudio), never a display name.
   Display names are presentation-only. A missing/ambiguous explicit selection
@@ -48,8 +41,11 @@ Transcription processing is local. Network access occurs for model setup and may
   Core Audio. The worker reports device enumeration, config lookup, stream
   build, play, first-buffer wait, stop, runtime failure, and exit events back to
   the supervisor.
-- `Starting` emits a still-connecting signal after 5 seconds and hard-cancels
-  after 30 seconds. `stream.play()` means only that start was requested:
+- `Starting` emits a still-connecting signal after 5 seconds and has a
+  30-second active-time contract: AUHAL 8s, AUHAL termination 2s, CPAL 16s,
+  CPAL termination 2s, and 2s reserve. A genuine pending macOS TCC prompt
+  suspends active deadlines and has a separate 120-second watchdog. Denial and
+  Stop remain immediate. `stream.play()` means only that start was requested:
   `Recording` is reached only after the callback has retained a nonempty mono
   buffer. Play-success with no callback fails as `first_buffer_timeout`, so a
   successful zero-sample recording cannot begin.
@@ -63,6 +59,13 @@ Transcription processing is local. Network access occurs for model setup and may
   If one blocks, Murmur retains exclusive ownership rather than detaching the
   worker or accepting a competing retry. Process isolation is the final fault
   boundary.
+- Protocol v3 emits stable entered/completed setup-step constants around AUHAL
+  device resolution, AudioUnit creation, format configuration, callback
+  installation, stream start, and callback wait, plus comparable CPAL steps.
+  These events contain no device label, UID, raw backend error, or content.
+- A timed-out backend can advance only after its owned helper process group is
+  positively confirmed empty. Unconfirmed termination leaves the lifecycle in
+  exclusive recovery and suppresses fallback and new starts.
 - CPAL errors are reduced immediately to stable content-free kinds
   (`permission_denied`, `device_unavailable`, `device_busy`, `device_changed`,
   `stream_invalidated`, `invalid_input`, `resource_exhausted`, and bounded

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,7 +39,7 @@ Each successful build uploads these 30-day artifacts:
 Release binaries retain the Tauri bundle-type marker (Cargo release stripping
 is disabled) so the updater can distinguish the deb and AppImage packages.
 After final signing and notarization, the release job launches the exact packaged
-capture worker, completes its production-v2 hello handshake, sends a bounded
+capture worker, completes its production-v3 hello handshake, sends a bounded
 AUHAL start request, and requires the worker's stream-open phase. This catches
 sandbox or entitlement failures that static plist and signature checks cannot.
 

--- a/scripts/smoke_test_capture_worker.py
+++ b/scripts/smoke_test_capture_worker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Exercise the final signed capture worker's production-v2 startup protocol."""
+"""Exercise the final signed capture worker's production-v3 startup protocol."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from typing import BinaryIO
 
 
 MAGIC = b"MRMR"
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
 HEADER_BYTES = 36
 MAX_CONTROL_BYTES = 16 * 1024
 
@@ -110,7 +110,7 @@ def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
     capture_id = secrets.randbits(63) or 1
     nonce = os.urandom(16)
     process = subprocess.Popen(
-        [str(worker), "--production-v2", str(capture_id), nonce.hex()],
+        [str(worker), "--production-v3", str(capture_id), nonce.hex()],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -158,7 +158,7 @@ def main() -> int:
         smoke_test(arguments.worker, arguments.timeout_seconds)
     except SmokeError as error:
         raise SystemExit(f"ERROR: {error}") from error
-    print("signed capture worker production-v2 startup smoke passed")
+    print("signed capture worker production-v3 startup smoke passed")
     return 0
 
 

--- a/tests/test_capture_worker_smoke.py
+++ b/tests/test_capture_worker_smoke.py
@@ -61,12 +61,12 @@ class CaptureWorkerSmokeTests(unittest.TestCase):
             def read_frame():
                 header = sys.stdin.buffer.read(36)
                 magic, version, kind, reserved, length, actual_id, actual_nonce = struct.unpack("<4sHBBIQ16s", header)
-                assert (magic, version, kind, reserved, actual_id, actual_nonce) == (b"MRMR", 2, 0, 0, capture_id, nonce)
+                assert (magic, version, kind, reserved, actual_id, actual_nonce) == (b"MRMR", 3, 0, 0, capture_id, nonce)
                 return json.loads(sys.stdin.buffer.read(length))
 
             def write_frame(message):
                 body = json.dumps(message, separators=(",", ":")).encode()
-                sys.stdout.buffer.write(struct.pack("<4sHBBIQ16s", b"MRMR", 2, 0, 0, len(body), capture_id, nonce) + body)
+                sys.stdout.buffer.write(struct.pack("<4sHBBIQ16s", b"MRMR", 3, 0, 0, len(body), capture_id, nonce) + body)
                 sys.stdout.buffer.flush()
 
             assert read_frame() == {"type": "hello"}


### PR DESCRIPTION
Closes #436

## Summary

- upgrades the production capture protocol to v3 with privacy-safe AUHAL and CPAL setup-step telemetry
- enforces the decided 30-second active initialization budget: AUHAL 8s, AUHAL termination 2s, CPAL 16s, CPAL termination 2s, protocol reserve 2s
- suspends active deadlines while the macOS microphone permission prompt is pending, with a separate 120-second watchdog
- fails closed when helper termination cannot be confirmed, retaining ownership and preventing fallback or retry until the process group is gone
- checks Stop between attempts and permits fallback only before the first retained PCM frame
- documents this as a capture-contract repair plus instrumentation; device enumeration hygiene remains follow-up #437

## Validation

- `cargo check`
- `cargo test -- --test-threads=1` — 696 library tests passed, 5 ignored; all integration/helper/sidecar suites passed
- `npx tsc --noEmit`
- `npm test` — 66 files, 620 tests passed
- `python3 scripts/validate_capture_boundary.py`
- `python3 scripts/validate_workflow_policy.py`
- production-v3 signed capture-worker startup smoke
- native debug-app smoke: a real pending TCC prompt remained connecting beyond 93 seconds without consuming the active budget; telemetry localized the stall to `audio_unit_creation`; Cancel returned the UI to Ready and confirmed helper teardown in 261ms without spawning fallback

## Scope note

This repairs the bounded failover and lifecycle contract and makes a repeat stall diagnosable. A post-release test on the affected Mac is still required to identify or confirm the underlying AUHAL/CPAL device-specific cause.