### PR TITLE
Polish embedded Settings layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- Settings now uses the full workspace below the status bar: dashboard usage
+  cards hide while Settings is open, and Performance begins directly with its
+  diagnostics tabs instead of repeating a page title (#441).
 - Settings now separates the local model **Benchmark** from an embedded
   **Performance** diagnostics workspace. Events, resource charts, run history,
   transform diagnostics, and report comparison live in the main window;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -462,7 +462,7 @@ function App() {
 
       <PermissionsBanner />
 
-      <StatsBar statsVersion={combinedStatsVersion} />
+      <StatsBar statsVersion={combinedStatsVersion} hidden={isSettingsOpen} />
 
       <div className="flex-1 flex overflow-hidden">
         <main className={`flex-1 flex-col overflow-hidden p-4 gap-4 ${isSettingsOpen ? 'hidden' : 'flex'}`}>

--- a/app/src/components/StatsBar.test.tsx
+++ b/app/src/components/StatsBar.test.tsx
@@ -1,0 +1,33 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { StatsBar } from './StatsBar';
+
+describe('StatsBar settings visibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('is visible in the main dashboard', async () => {
+    await act(async () => root.render(<StatsBar statsVersion={0} />));
+
+    expect((container.querySelector('[data-testid="stats-bar"]') as HTMLDivElement).hidden).toBe(false);
+  });
+
+  it('leaves the settings workspace free of usage cards', async () => {
+    await act(async () => root.render(<StatsBar statsVersion={0} hidden />));
+
+    expect((container.querySelector('[data-testid="stats-bar"]') as HTMLDivElement).hidden).toBe(true);
+  });
+});

--- a/app/src/components/StatsBar.tsx
+++ b/app/src/components/StatsBar.tsx
@@ -4,16 +4,17 @@ import type { DictationStats } from '../lib/stats';
 
 interface StatsBarProps {
   statsVersion: number;
+  hidden?: boolean;
 }
 
-export function StatsBar({ statsVersion }: StatsBarProps) {
+export function StatsBar({ statsVersion, hidden = false }: StatsBarProps) {
   const [stats, setStats] = useState<DictationStats>(() => loadStats());
   useEffect(() => { setStats(loadStats()); }, [statsVersion]);
   const wpm = getWPM(stats);
   const tokens = getApproxTokens(stats);
 
   return (
-    <div className="grid shrink-0 grid-cols-4 gap-2 bg-background px-4 py-3">
+    <div data-testid="stats-bar" hidden={hidden} className="grid shrink-0 grid-cols-4 gap-2 bg-background px-4 py-3">
       <StatCard label="Total Words" value={stats.totalWords.toLocaleString()} icon="words" />
       <StatCard label="Avg WPM" value={wpm > 0 ? wpm.toLocaleString() : '—'} icon="speed" />
       <StatCard label="Recordings" value={stats.totalRecordings.toLocaleString()} icon="recordings" />

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -85,6 +85,7 @@ describe('SettingsPanel information architecture', () => {
     const nav = container.querySelector('nav[aria-label="Settings pages"]') as HTMLElement;
     expect(Array.from(nav.querySelectorAll('button')).slice(1).map((button) => button.textContent)).toEqual(SETTINGS_CATEGORIES.map((category) => category.label));
     expect(nav.querySelector('[aria-current="page"]')?.textContent).toBe('Recording');
+    expect(container.querySelector('h1')?.textContent).toBe('Recording');
     expect(container.textContent).toContain('Microphone');
   });
 
@@ -103,6 +104,15 @@ describe('SettingsPanel information architecture', () => {
       expect(button.getAttribute('aria-current')).toBe('page');
     }
     expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+
+  it('starts Performance at the diagnostics workspace without a redundant page heading', async () => {
+    const button = Array.from(container.querySelectorAll('nav button')).find((item) => item.textContent === 'Performance') as HTMLButtonElement;
+    await act(async () => button.click());
+
+    expect(container.textContent).toContain('Diagnostics workspace');
+    expect(Array.from(container.querySelectorAll('h1')).some((heading) => heading.textContent === 'Performance')).toBe(false);
+    expect(container.textContent).not.toContain('Live diagnostics, recorded runs, transforms, and reports');
   });
 });
 

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -478,11 +478,7 @@ export function SettingsPanel({
         {activeCat === 'performance' ? (
           <div className="flex h-full min-h-0 flex-col">
             {configureError && <p role="alert" className="mx-4 mt-4 shrink-0 rounded-lg bg-error/10 px-3 py-2 text-xs text-error">{configureError}</p>}
-            <div className="shrink-0 px-4 pt-4">
-              <h1 className="text-base font-semibold text-on-surface">Performance</h1>
-              <p className="mt-0.5 text-xs text-on-surface-variant">Live diagnostics, recorded runs, transforms, and reports</p>
-            </div>
-            <div className="min-h-0 flex-1 pt-3">
+            <div className="min-h-0 flex-1">
               <DiagnosticsWorkspace />
             </div>
           </div>

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -82,8 +82,9 @@ Messages are formatted as `[tag] message` with optional JSON data. Calls are fir
 The workspace is rendered inside the main window under **Settings →
 Performance**. **⌘L**, the command-palette diagnostics action, and General's
 **View Performance** button all navigate to the same page. The diagnostics
-shell owns its inner scroll regions so live Events and charts remain usable
-without opening or managing a second native window.
+tabs begin at the top of the settings content area without a duplicate page
+title. The diagnostics shell owns its inner scroll regions so live Events and
+charts remain usable without opening or managing a second native window.
 
 ### Events Tab
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -13,7 +13,9 @@ Dictation settings are stored in `localStorage` under the key
 versioned document under `murmur-appearance`; it is never merged into this
 interface or emitted through `dictation-settings`.
 
-The native Settings window has nine pages in this order (`SETTINGS_CATEGORIES` in `SettingsPanel.tsx`):
+The native Settings window has nine pages in this order (`SETTINGS_CATEGORIES`
+in `SettingsPanel.tsx`). While Settings is open, the dashboard usage cards are
+hidden so the workspace receives the available vertical space:
 
 1. **Recording** — microphone, voice detection, recording trigger, and shortcut feedback
 2. **Transcription** — one model selector, language, model lifecycle/download state, and idle release


### PR DESCRIPTION
## Summary
- hide the four dashboard usage cards while Settings is open and restore them on close
- remove the redundant Performance title block so diagnostics begin at the tabs
- cover both layout contracts with focused frontend tests and update the docs

## Validation
- `npx tsc --noEmit`
- `npm test -- --run` (623 passed)
- `cargo check`
- `cargo test -- --test-threads=1`
- native Mac mini smoke at default and zoomed window sizes

Closes #441