### PR TITLE
Harden updater state ownership and release manifest policy

### DIFF
--- a/.github/updater-policy.json
+++ b/.github/updater-policy.json
@@ -1,0 +1,3 @@
+{
+  "min_version": null
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,6 +422,19 @@ jobs:
             echo "ERROR: $TAG has no generated release notes"
             exit 1
           fi
+          jq -e '
+            type == "object"
+            and (keys == ["min_version"])
+            and (.min_version == null or (.min_version | type == "string"))
+          ' .github/updater-policy.json >/dev/null || {
+            echo "ERROR: updater policy must contain exactly one null or string min_version"
+            exit 1
+          }
+          MIN_VERSION_ARGS=()
+          if jq -e '.min_version != null' .github/updater-policy.json >/dev/null; then
+            MIN_VERSION=$(jq -r '.min_version' .github/updater-policy.json)
+            MIN_VERSION_ARGS=(--min-version "$MIN_VERSION")
+          fi
           python3 scripts/release_artifacts.py manifests \
             --validated validated-release.json \
             --tag "$TAG" \
@@ -429,6 +442,7 @@ jobs:
             --bridge-url "$BRIDGE_URL" \
             --bridge-signature "$BRIDGE_SIG" \
             --release-notes release-notes.md \
+            "${MIN_VERSION_ARGS[@]}" \
             --output-dir manifests
 
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -458,6 +472,27 @@ jobs:
             and ([.platforms[] | .signature] | index($linux)) != null
           ' remote-manifests/latest-v2.json >/dev/null || {
             echo "ERROR: published modern manifest signatures do not match uploaded .sig assets"
+            exit 1
+          }
+
+          EXPECTED_MIN_VERSION=$(jq -r '.min_version // empty' .github/updater-policy.json)
+          ACTUAL_MIN_VERSION=$(jq -r '.min_version // empty' remote-manifests/latest-v2.json)
+          if [ "$ACTUAL_MIN_VERSION" != "$EXPECTED_MIN_VERSION" ]; then
+            echo "ERROR: published updater policy differs from the trusted source policy"
+            exit 1
+          fi
+
+      - name: Verify release metadata matches updater manifest
+        if: needs.resolve.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          RELEASE_NOTES=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body)
+          jq -e --arg notes "$RELEASE_NOTES" '.notes == $notes' \
+            remote-manifests/latest-v2.json >/dev/null || {
+            echo "ERROR: draft release notes differ from the updater manifest"
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Update checks and installs now have a single owner, preventing duplicate
+  downloads and state replacement during install preparation. Release
+  promotion can publish a validated source-controlled minimum-version policy
+  and fails if release notes drift from the updater manifest (#439).
+
 ## [0.28.1] - 2026-08-07
 
 ### Fixed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -188,6 +188,7 @@ function App() {
     },
     { phase: 'available', version: '0.7.0', notes: '## What\'s New\n- OTA auto-updater\n- Bug fixes\n- Performance improvements', isForced: false },
     { phase: 'available', version: '0.7.0', notes: 'Critical security fix.', isForced: true },
+    { phase: 'preparing', version: '0.7.0' },
     { phase: 'downloading', version: '0.7.0', progress: 65 },
   ] : [];
   const [devUpdateStatus, setDevUpdateStatus] = useState<UpdateStatus | null>(null);

--- a/app/src/components/UpdateModal.test.tsx
+++ b/app/src/components/UpdateModal.test.tsx
@@ -1,0 +1,44 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateModal } from './UpdateModal';
+
+describe('UpdateModal', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('makes environment verification visibly busy and non-actionable', async () => {
+    const onDownload = vi.fn();
+    const onDismiss = vi.fn();
+    await act(async () => {
+      root.render(
+        <UpdateModal
+          status={{ phase: 'preparing', version: '0.24.3' }}
+          onDownload={onDownload}
+          onSkip={vi.fn()}
+          onDismiss={onDismiss}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Preparing update...');
+    expect(container.querySelector('button')).toBeNull();
+
+    await act(async () => {
+      (container.firstElementChild as HTMLElement).click();
+    });
+    expect(onDownload).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/UpdateModal.tsx
+++ b/app/src/components/UpdateModal.tsx
@@ -13,6 +13,7 @@ interface UpdateModalProps {
 export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateModalProps) {
   if (
     status.phase !== 'available' &&
+    status.phase !== 'preparing' &&
     status.phase !== 'downloading' &&
     status.phase !== 'ready' &&
     status.phase !== 'error'
@@ -21,14 +22,16 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
   }
 
   const isForced = (status.phase === 'available' || status.phase === 'error') && status.isForced;
+  const isPreparing = status.phase === 'preparing';
   const isDownloading = status.phase === 'downloading';
   const isReady = status.phase === 'ready';
   const isError = status.phase === 'error';
   const requiresReinstall = isError && status.recovery === 'reinstall';
-  const isBusy = isDownloading || isReady;
+  const isBusy = isPreparing || isDownloading || isReady;
 
   const version =
     status.phase === 'available' ? status.version :
+    status.phase === 'preparing' ? status.version :
     status.phase === 'downloading' ? status.version :
     status.phase === 'ready' ? status.version : '';
 
@@ -91,6 +94,12 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
           )}
 
           {/* Download progress */}
+          {isPreparing && (
+            <p className="text-sm text-on-surface text-center mb-4">
+              Preparing update...
+            </p>
+          )}
+
           {isDownloading && (
             <div className="mb-4">
               <div className="flex justify-between text-xs text-on-surface-variant mb-1">

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -965,7 +965,7 @@ export function SettingsPanel({
               </div>
             </details>
             <div>
-              <button type="button" onClick={() => void onCheckForUpdate()} disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'downloading'} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary disabled:cursor-not-allowed disabled:opacity-50">{updateStatus.phase === 'checking' ? 'Checking…' : 'Check for Updates'}</button>
+              <button type="button" onClick={() => void onCheckForUpdate()} disabled={updateStatus.phase === 'checking' || updateStatus.phase === 'preparing' || updateStatus.phase === 'downloading' || updateStatus.phase === 'ready'} className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:text-primary disabled:cursor-not-allowed disabled:opacity-50">{updateStatus.phase === 'checking' ? 'Checking…' : 'Check for Updates'}</button>
               {updateStatus.phase === 'up-to-date' && <p className="mt-1.5 text-xs text-success">You’re up to date.</p>}
               {updateStatus.phase === 'available' && <p className="mt-1.5 text-xs text-primary">v{updateStatus.version} available</p>}
               {updateStatus.phase === 'error' && (

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -42,15 +42,17 @@ describe('useAutoUpdater presentation state', () => {
   let container: HTMLDivElement;
   let root: Root;
   let current: UseAutoUpdaterReturn;
+  let automaticChecksEnabled: boolean;
 
   function Harness() {
-    current = useAutoUpdater();
+    current = useAutoUpdater({ automaticChecksEnabled });
     return null;
   }
 
   beforeEach(async () => {
     localStorage.clear();
     vi.clearAllMocks();
+    automaticChecksEnabled = false;
     mocks.getVersion.mockResolvedValue('0.22.1');
     mocks.listen.mockResolvedValue(vi.fn());
     mocks.isPermissionGranted.mockResolvedValue(true);
@@ -145,6 +147,47 @@ describe('useAutoUpdater presentation state', () => {
     );
   });
 
+  it('fails closed when update availability is known but policy cannot be verified', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall: vi.fn(),
+    });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    await act(async () => current.checkForUpdate());
+
+    expect(current.updateStatus).toMatchObject({
+      phase: 'error',
+      stage: 'check',
+      message: expect.stringContaining('verify the update policy'),
+    });
+    expect(localStorage.getItem('updater-last-check')).toBeNull();
+  });
+
+  it('opens a required update when the verified policy is above the installed version', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Required reliability update',
+      downloadAndInstall: vi.fn(),
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ min_version: '0.24.0' }),
+    }));
+
+    await act(async () => current.checkForUpdate());
+
+    expect(current.updateStatus).toMatchObject({
+      phase: 'available',
+      version: '0.24.2',
+      isForced: true,
+    });
+    expect(current.isUpdateDialogOpen).toBe(true);
+  });
+
   it('blocks installation before download when Gatekeeper translocated the app', async () => {
     const downloadAndInstall = vi.fn();
     mocks.check.mockResolvedValue({
@@ -219,5 +262,112 @@ describe('useAutoUpdater presentation state', () => {
         error: 'Error: disk full',
       },
     );
+  });
+
+  it('allows only one install owner while environment verification is pending', async () => {
+    let resolveEnvironment!: (value: { appTranslocated: boolean }) => void;
+    const environment = new Promise<{ appTranslocated: boolean }>((resolve) => {
+      resolveEnvironment = resolve;
+    });
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall,
+    });
+    mocks.getUpdateInstallEnvironment.mockReturnValue(environment);
+
+    await act(async () => current.checkForUpdate());
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    await act(async () => {
+      first = current.startDownload();
+      second = current.startDownload();
+      await Promise.resolve();
+    });
+
+    expect(current.updateStatus).toEqual({ phase: 'preparing', version: '0.24.2' });
+    expect(mocks.getUpdateInstallEnvironment).toHaveBeenCalledOnce();
+
+    resolveEnvironment({ appTranslocated: false });
+    await act(async () => Promise.all([first, second]));
+    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a manual check while install owns the updater', async () => {
+    let resolveEnvironment!: (value: { appTranslocated: boolean }) => void;
+    const environment = new Promise<{ appTranslocated: boolean }>((resolve) => {
+      resolveEnvironment = resolve;
+    });
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: '',
+      downloadAndInstall,
+    });
+    mocks.getUpdateInstallEnvironment.mockReturnValue(environment);
+
+    await act(async () => current.checkForUpdate());
+    let install!: Promise<void>;
+    await act(async () => {
+      install = current.startDownload();
+      await Promise.resolve();
+    });
+    await act(async () => current.checkForUpdate());
+
+    expect(mocks.check).toHaveBeenCalledOnce();
+    expect(current.updateStatus).toEqual({ phase: 'preparing', version: '0.24.2' });
+
+    resolveEnvironment({ appTranslocated: false });
+    await act(async () => install);
+  });
+
+  it('ignores a due native wake check while install owns the updater', async () => {
+    let wakeCheck: (() => void) | undefined;
+    mocks.listen.mockImplementation(async (event: string, callback: () => void) => {
+      if (event === 'updater-background-check-requested') wakeCheck = callback;
+      return vi.fn();
+    });
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: '',
+      downloadAndInstall,
+    });
+
+    await act(async () => root.unmount());
+    automaticChecksEnabled = true;
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<Harness />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(current.updateStatus.phase).toBe('available');
+    expect(mocks.check).toHaveBeenCalledOnce();
+    expect(wakeCheck).toBeDefined();
+
+    let resolveEnvironment!: (value: { appTranslocated: boolean }) => void;
+    mocks.getUpdateInstallEnvironment.mockReturnValue(
+      new Promise<{ appTranslocated: boolean }>((resolve) => {
+        resolveEnvironment = resolve;
+      }),
+    );
+    let install!: Promise<void>;
+    await act(async () => {
+      install = current.startDownload();
+      await Promise.resolve();
+    });
+    localStorage.setItem('updater-last-check', '0');
+    await act(async () => wakeCheck?.());
+
+    expect(mocks.check).toHaveBeenCalledOnce();
+    expect(current.updateStatus).toEqual({ phase: 'preparing', version: '0.24.2' });
+
+    resolveEnvironment({ appTranslocated: false });
+    await act(async () => install);
   });
 });

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -21,13 +21,21 @@ import {
   getPendingUpdateForVersion,
   isDueForCheck,
   setLastCheckTimestamp,
-  fetchMinVersion,
+  fetchMinVersionPolicy,
   CHECK_TIMER_TICK_MS,
 } from '../updater';
 import { getUpdateInstallEnvironment } from '../updaterEnvironment';
 
 const APP_TRANSLOCATION_MESSAGE =
   'macOS opened Murmur from a read-only security location. Quit Murmur, then use Finder to move or reinstall it in Applications before reopening it and trying the update again.';
+const UPDATE_POLICY_UNAVAILABLE_MESSAGE =
+  'Could not verify the update policy. Check your connection and try again.';
+
+type UpdaterOperation = 'idle' | 'checking' | 'installing';
+
+interface UseAutoUpdaterOptions {
+  automaticChecksEnabled?: boolean;
+}
 
 export interface UseAutoUpdaterReturn {
   updateStatus: UpdateStatus;
@@ -41,12 +49,15 @@ export interface UseAutoUpdaterReturn {
   dismissCompletedUpdate: () => void;
 }
 
-export function useAutoUpdater(): UseAutoUpdaterReturn {
+export function useAutoUpdater(
+  options: UseAutoUpdaterOptions = {},
+): UseAutoUpdaterReturn {
+  const automaticChecksEnabled = options.automaticChecksEnabled ?? !import.meta.env.DEV;
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ phase: 'idle' });
   const [completedUpdate, setCompletedUpdate] = useState<CompletedUpdate | null>(null);
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
   const updateRef = useRef<Update | null>(null);
-  const isCheckingRef = useRef(false);
+  const operationRef = useRef<UpdaterOperation>('idle');
   const isForcedRef = useRef(false);
   const manualPresentationRequestedRef = useRef(false);
 
@@ -77,13 +88,17 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, []);
 
   const performCheck = useCallback(async (opts: { isBackground: boolean }) => {
+    if (operationRef.current === 'installing') {
+      flog.info('updater', 'check ignored while install owns updater');
+      return;
+    }
     if (!opts.isBackground) {
       clearSkippedVersion();
       manualPresentationRequestedRef.current = true;
       setUpdateStatus({ phase: 'checking' });
     }
-    if (isCheckingRef.current) return;
-    isCheckingRef.current = true;
+    if (operationRef.current === 'checking') return;
+    operationRef.current = 'checking';
     isForcedRef.current = false;
 
     const shouldPresentManualResult = () =>
@@ -91,9 +106,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
 
     try {
       const update = await check();
-      setLastCheckTimestamp(Date.now());
 
       if (!update?.available || !update.version) {
+        setLastCheckTimestamp(Date.now());
         flog.info('updater', 'no update available', {
           event_code: 'updater.check_current',
         });
@@ -110,8 +125,26 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
 
       // Check min_version (custom field not exposed by Tauri updater)
       const currentVersion = await getVersion();
-      const minVersion = await fetchMinVersion();
-      const isForced = minVersion !== null && isBelowMinVersion(currentVersion, minVersion);
+      const policy = await fetchMinVersionPolicy();
+      if (policy.status === 'unavailable') {
+        flog.warn('updater', 'could not verify update policy', {
+          error: policy.message,
+        });
+        if (shouldPresentManualResult()) {
+          setIsUpdateDialogOpen(false);
+          setUpdateStatus({
+            phase: 'error',
+            stage: 'check',
+            message: UPDATE_POLICY_UNAVAILABLE_MESSAGE,
+            isForced: false,
+          });
+        }
+        return;
+      }
+      setLastCheckTimestamp(Date.now());
+      const isForced =
+        policy.status === 'present' &&
+        isBelowMinVersion(currentVersion, policy.minVersion);
 
       // If not forced and user previously skipped this version, suppress
       if (!isForced && getSkippedVersion() === update.version) {
@@ -167,7 +200,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       }
       // Background errors are silent
     } finally {
-      isCheckingRef.current = false;
+      if (operationRef.current === 'checking') {
+        operationRef.current = 'idle';
+      }
       manualPresentationRequestedRef.current = false;
     }
   }, []);
@@ -179,7 +214,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   // Skip entirely in dev — a dev build auto-updating to a prod release would
   // download+relaunch into /Applications, making `tauri dev` impossible.
   useEffect(() => {
-    if (import.meta.env.DEV) {
+    if (!automaticChecksEnabled) {
       flog.info('updater', 'dev build — skipping automatic update check');
       return;
     }
@@ -219,7 +254,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       document.removeEventListener('visibilitychange', onVisibilityChange);
       unlistenWake?.();
     };
-  }, [performCheck]);
+  }, [automaticChecksEnabled, performCheck]);
 
   const checkForUpdate = useCallback(async () => {
     await performCheck({ isBackground: false });
@@ -235,12 +270,20 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
   }, [updateStatus]);
 
   const startDownload = useCallback(async () => {
+    if (operationRef.current !== 'idle') {
+      flog.info('updater', 'install ignored because updater is already busy', {
+        operation: operationRef.current,
+      });
+      return;
+    }
     const update = updateRef.current;
     if (!update) return;
 
     const version =
       updateStatus.phase === 'available' ? updateStatus.version
       : updateRef.current?.version ?? 'unknown';
+    operationRef.current = 'installing';
+    setUpdateStatus({ phase: 'preparing', version });
 
     try {
       const environment = await getUpdateInstallEnvironment();
@@ -255,6 +298,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
           isForced: isForcedRef.current,
           recovery: 'reinstall',
         });
+        operationRef.current = 'idle';
         return;
       }
 
@@ -294,6 +338,7 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       clearSkippedVersion();
       await relaunch();
     } catch (err) {
+      operationRef.current = 'idle';
       flog.error('updater', 'download/install failed', {
         event_code: 'updater.install_failed',
         error: String(err),

--- a/app/src/lib/updater.test.ts
+++ b/app/src/lib/updater.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   parseSemver,
   compareSemver,
@@ -12,6 +12,7 @@ import {
   setPendingUpdate,
   clearPendingUpdate,
   getPendingUpdateForVersion,
+  fetchMinVersionPolicy,
   CHECK_INTERVAL_MS,
 } from './updater';
 
@@ -181,5 +182,51 @@ describe('post-update release notes', () => {
     clearPendingUpdate();
 
     expect(getPendingUpdateForVersion('0.22.0')).toBeNull();
+  });
+});
+
+describe('minimum-version policy fetch', () => {
+  it('distinguishes an intentionally absent policy', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '0.24.2' }),
+    }));
+
+    await expect(fetchMinVersionPolicy()).resolves.toEqual({ status: 'absent' });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a present policy', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ min_version: '0.23.0' }),
+    }));
+
+    await expect(fetchMinVersionPolicy()).resolves.toEqual({
+      status: 'present',
+      minVersion: '0.23.0',
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('does not collapse transport and schema failures into absence', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    }));
+    await expect(fetchMinVersionPolicy()).resolves.toMatchObject({
+      status: 'unavailable',
+      message: expect.stringContaining('503'),
+    });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ min_version: 23 }),
+    }));
+    await expect(fetchMinVersionPolicy()).resolves.toMatchObject({
+      status: 'unavailable',
+      message: expect.stringContaining('not a string'),
+    });
+    vi.unstubAllGlobals();
   });
 });

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -155,19 +155,36 @@ function normalizedVersionIdentity(version: string): string | null {
 
 // --- min_version fetch ---
 
+export type MinVersionPolicy =
+  | { status: 'present'; minVersion: string }
+  | { status: 'absent' }
+  | { status: 'unavailable'; message: string };
+
 /**
  * Fetch the custom min_version field from the current update channel.
- * Returns null if absent, fetch fails, or JSON is invalid.
+ * Absence is an intentional optional-update policy; transport and schema
+ * failures stay distinct so callers cannot silently downgrade enforcement.
  */
-export async function fetchMinVersion(): Promise<string | null> {
+export async function fetchMinVersionPolicy(): Promise<MinVersionPolicy> {
   try {
     const response = await fetch(LATEST_JSON_URL, { cache: 'no-store' });
-    if (!response.ok) return null;
-    const data = await response.json();
-    if (typeof data.min_version === 'string') return data.min_version;
-    return null;
-  } catch {
-    return null;
+    if (!response.ok) {
+      return {
+        status: 'unavailable',
+        message: `Update policy request failed with status ${response.status}.`,
+      };
+    }
+    const data: unknown = await response.json();
+    if (typeof data !== 'object' || data === null) {
+      return { status: 'unavailable', message: 'Update policy response was not an object.' };
+    }
+    if (!('min_version' in data)) return { status: 'absent' };
+    if (typeof data.min_version !== 'string') {
+      return { status: 'unavailable', message: 'Update policy min_version was not a string.' };
+    }
+    return { status: 'present', minVersion: data.min_version };
+  } catch (error) {
+    return { status: 'unavailable', message: String(error) };
   }
 }
 
@@ -177,6 +194,7 @@ export type UpdateStatus =
   | { phase: 'idle' }
   | { phase: 'checking' }
   | { phase: 'available'; version: string; notes: string; isForced: boolean }
+  | { phase: 'preparing'; version: string }
   | { phase: 'downloading'; version: string; progress: number }
   | { phase: 'ready'; version: string }
   | {

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -39,6 +39,10 @@ The Core ML release raises Murmur's minimum macOS version from 13 to 14. Existin
 An old Mac installs the bridge from `latest.json`, relaunches on the new endpoint, and then receives the current Core ML build from `latest-v2.json`. The modern release job fails if it cannot resolve the signed v0.14.1 bridge asset, preventing a release that would strand older clients. Keep the bridge release published while pre-v0.14.1 clients may still exist.
 
 The manifest contains version information, download URLs, signatures, and an optional `min_version` field for forced updates.
+The modern channel's policy is version-controlled in
+`.github/updater-policy.json`. A `null` value omits `min_version`; a stable
+`major.minor.patch` value publishes it after verifying that it is not newer
+than the release. The legacy bridge manifest intentionally omits this policy.
 
 ## Update Flow
 
@@ -54,10 +58,13 @@ When a new version is available and the current version is above `min_version`:
    - "Update Now" — begins download
    - "Skip This Version" — stores the version in localStorage (`skipped-update-version`), suppresses future background checks for that version
    - "Later" — dismisses the modal without skipping; the update pill remains
-2. **Downloading** — Progress bar with percentage. Progress reported via Tauri's `downloadAndInstall` callback.
-3. **Ready** — "Installing and relaunching..." text displayed.
-4. **Relaunch** — App restarts automatically via `@tauri-apps/plugin-process`.
-5. **What's New** — After the relaunched binary confirms that it is the
+2. **Preparing** — A single updater owner verifies that the app is installed
+   in a writable location. Repeated actions and manual, timer, focus,
+   visibility, or wake checks cannot enter while this owner is active.
+3. **Downloading** — Progress bar with percentage. Progress reported via Tauri's `downloadAndInstall` callback.
+4. **Ready** — "Installing and relaunching..." text displayed.
+5. **Relaunch** — App restarts automatically via `@tauri-apps/plugin-process`.
+6. **What's New** — After the relaunched binary confirms that it is the
    downloaded version, a one-time modal shows that release's features, fixes,
    and other changes.
 
@@ -94,6 +101,12 @@ Check failures and installation failures remain distinct in `UpdateStatus`, so
 the Settings page and homepage indicator do not describe a completed download
 or failed installation as an update-check failure.
 
+The updater manifest policy fetch also distinguishes an intentionally absent
+`min_version` from an unavailable or malformed response. Once update
+availability is known, Murmur refuses to present it as optional unless the
+policy was verified. A policy failure is retryable as an update-check error and
+does not advance the successful-check timestamp.
+
 ### Background Notifications
 
 When an update is detected during a background check (not user-initiated), a native macOS notification is sent: "Murmur vX.Y.Z is ready to install." This requires notification permission to be granted.
@@ -119,6 +132,12 @@ fails if the body is missing or empty. `.github/release.yml` groups merged pull
 requests into **New Features** (`enhancement`), **Bug Fixes** (`bug`), and
 **Other Changes** categories.
 
+Immediately before publication, promotion compares the draft release body with
+the remotely downloaded updater manifest and fails if they differ. Published
+updater assets are immutable: do not edit a published release body
+independently. A correction that must reach both the public release and the
+in-app dialogs requires a patch release.
+
 The same sanitized notes appear in two places:
 
 - the update-available dialog, before download
@@ -142,6 +161,7 @@ type UpdateStatus =
   | { phase: 'checking' }
   | { phase: 'up-to-date' }
   | { phase: 'available'; version: string; notes: string; isForced: boolean }
+  | { phase: 'preparing'; version: string }
   | { phase: 'downloading'; version: string; progress: number }
   | { phase: 'ready'; version: string }
   | {
@@ -153,7 +173,9 @@ type UpdateStatus =
     };
 ```
 
-The update modal renders for `available`, `downloading`, `ready`, and `error` phases. The `idle`, `checking`, and `up-to-date` phases return null (no modal).
+The update modal renders for `available`, `preparing`, `downloading`, `ready`,
+and `error` phases. The `idle`, `checking`, and `up-to-date` phases return null
+(no modal).
 
 Post-update notes use separate `CompletedUpdate` state rather than adding a
 phase to `UpdateStatus`; this prevents the Settings update checker from treating
@@ -161,7 +183,7 @@ an already-installed release as an available update.
 
 ## Settings Integration
 
-- The "Check for Updates" button in the About section of settings triggers a manual check. It is disabled during `checking` or `downloading` phases.
+- The "Check for Updates" button in the About section of settings triggers a manual check. It is disabled during `checking`, `preparing`, `downloading`, and `ready` phases.
 - Status text shows: "Checking...", "You're up to date", "vX.Y.Z available", or "Update check failed".
 - The macOS menu-bar menu exposes the same manual check. It brings the main
   window forward, reports checking/up-to-date/error status beside the Record

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -58,8 +58,12 @@ native notification fires only on the first background discovery of a version
 during the process lifetime.
 
 Returns `{updateStatus, isUpdateDialogOpen, checkForUpdate, showAvailableUpdate,
-startDownload, skipVersion, dismissUpdate}`. Reads `min_version` from the
-`latest-v2.json` channel; persists `skipped-update-version` and
+startDownload, skipVersion, dismissUpdate}`. Uses a single-owner
+check/install operation guard, exposes a non-actionable `preparing` phase while
+verifying the install location, and reads a typed `min_version` policy result
+from the `latest-v2.json` channel. Policy absence permits an optional update;
+an unavailable or malformed policy fails the check without silently
+downgrading enforcement. Persists `skipped-update-version` and
 `updater-last-check` to localStorage.
 
 ### `useOpenSettingsListener`

--- a/docs/release.md
+++ b/docs/release.md
@@ -57,6 +57,25 @@ The modern updater manifest is generated from the downloaded `.sig` files.
 After release-asset upload, the workflow downloads the remote `.sig` assets and
 compares them byte-for-byte, uploads the manifests, downloads them again, and
 checks that `latest-v2.json` contains those exact signatures before publishing.
+It also reads the source-controlled `.github/updater-policy.json`: `null` keeps
+the release optional, while a stable minimum version at or below the target
+release is emitted as `min_version` on the modern channel. Invalid or future
+minimum versions fail promotion.
+
+Set that file before the version-bump commit:
+
+```json
+{ "min_version": null }
+```
+
+Use a quoted stable version such as `"0.24.0"` only when every installed
+version below that threshold must update or quit. Policy changes receive the
+same code review and trusted-main provenance as the release itself.
+
+Immediately before publication, the workflow requires the draft release body
+to match the remotely downloaded updater manifest notes. Once published,
+updater assets are immutable; do not edit the release body independently. Ship
+a patch release when corrected notes must appear both on GitHub and in Murmur.
 
 ## Non-publishing rehearsal
 

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -31,16 +31,22 @@ Analyse the commits using these rules (in priority order):
 
 Determine the new version by applying the bump to the current version in `tauri.conf.json`.
 
-## 3b. Assess min_version
+## 3b. Set the Updater Policy
 
 Check if any commits since the last tag contain:
 - Security fixes
 - Breaking changes to the update mechanism itself
 - Data format changes that make old versions incompatible
 
-If any of the above apply, ask: **"Is this a critical update? Should min_version be set to this release?"**
-- Default: No (optional update — users can skip or defer)
-- If yes: after the release publishes, download `latest.json` from the GitHub release assets, add `"min_version": "{new_version}"` to the JSON, then re-upload with `gh release upload v{new_version} latest.json --clobber` to replace the asset. Users running versions older than min_version will see a non-dismissable forced update modal.
+Set `.github/updater-policy.json` before preparing the version bump:
+- Default/optional update: `"min_version": null` (users can skip or defer).
+- Critical update: `"min_version": "{new_version}"` (older versions receive a
+  non-dismissable forced-update modal).
+
+If the criticality is unclear, ask: **"Is this a critical update? Should
+min_version be set to this release?"** Never edit or replace the published
+`latest.json` afterward. Trusted promotion validates the source-controlled
+policy and emits the immutable updater manifest.
 
 Include the min_version decision in the release summary.
 
@@ -61,16 +67,18 @@ the version bump, main push, and automatic tag/publish after all gates pass.
 
 Run these steps in order:
 
-1. Run `python3 scripts/release_version.py prepare {new_version}`. This updates
+1. Set and review `.github/updater-policy.json` using the decision from Step 3b.
+2. Run `python3 scripts/release_version.py prepare {new_version}`. This updates
    `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `package.json`, and
    `package-lock.json`, cuts the current `[Unreleased]` notes into a dated
    `{new_version}` section, and opens a fresh empty `[Unreleased]` section.
-2. Review the version-file and CHANGELOG diff, then run
+3. Review the version-file, CHANGELOG, and updater-policy diff, then run
    `python3 scripts/release_version.py check {new_version}`.
-3. Commit all six release files with: `chore: bump version to {new_version}`
-4. Push: `git push origin main`
-5. Wait for the `Release Build` workflow on that exact commit to succeed.
-6. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
+4. Commit the synchronized version files, CHANGELOG, and updater policy with:
+   `chore: bump version to {new_version}`.
+5. Push: `git push origin main`
+6. Wait for the `Release Build` workflow on that exact commit to succeed.
+7. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
    artifacts named with the exact 40-character commit SHA, package smoke tests,
    and cache summaries. Do not continue if any job or artifact is missing.
 

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -417,6 +417,7 @@ def write_updater_manifests(
     bridge_signature: str,
     release_notes_path: Path,
     output_dir: Path,
+    min_version: str | None = None,
 ) -> tuple[Path, Path]:
     if not re.fullmatch(r"v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", tag):
         raise ArtifactError(f"invalid release tag: {tag}")
@@ -435,6 +436,20 @@ def write_updater_manifests(
     macos = validated["platforms"]["macos"]
     linux = validated["platforms"]["linux"]
     version = tag[1:]
+    if min_version is not None:
+        min_version = min_version.strip()
+        if not re.fullmatch(r"\d+\.\d+\.\d+", min_version):
+            raise ArtifactError(
+                "min_version must be a stable major.minor.patch version"
+            )
+        release_core = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+        assert release_core is not None
+        release_parts = tuple(int(part) for part in release_core.groups())
+        min_parts = tuple(int(part) for part in min_version.split("."))
+        if min_parts > release_parts:
+            raise ArtifactError(
+                f"min_version {min_version} is newer than release {version}"
+            )
     base_url = f"https://github.com/{repository}/releases/download/{tag}"
     pub_date = "${PUB_DATE}"
 
@@ -453,6 +468,8 @@ def write_updater_manifests(
         },
         "notes": release_notes,
     }
+    if min_version is not None:
+        modern["min_version"] = min_version
     legacy = {
         "version": version,
         "pub_date": pub_date,
@@ -544,6 +561,7 @@ def _parser() -> argparse.ArgumentParser:
     manifests.add_argument("--bridge-url", required=True)
     manifests.add_argument("--bridge-signature", required=True)
     manifests.add_argument("--release-notes", type=Path, required=True)
+    manifests.add_argument("--min-version")
     manifests.add_argument("--output-dir", type=Path, required=True)
     return parser
 
@@ -669,6 +687,7 @@ def main() -> None:
                 args.bridge_signature,
                 args.release_notes,
                 args.output_dir,
+                args.min_version,
             )
             print(f"wrote updater manifests: {modern}, {legacy}")
     except ArtifactError as exc:

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -506,6 +506,11 @@ def validate_promotion_policy(workflow: str) -> int:
     assert 'gh release view "$TAG"' in workflow
     assert "--json body --jq .body > release-notes.md" in workflow
     assert "--release-notes release-notes.md" in workflow
+    assert ".github/updater-policy.json" in workflow
+    assert "updater policy must contain exactly one null or string min_version" in workflow
+    assert '--min-version "$MIN_VERSION"' in workflow
+    assert "published updater policy differs from the trusted source policy" in workflow
+    assert "draft release notes differ from the updater manifest" in workflow
     assert workflow.index("scripts/release_artifacts.py validate") < workflow.index(
         "Create automatic release tag"
     )
@@ -517,11 +522,15 @@ def validate_promotion_policy(workflow: str) -> int:
         "Verify uploaded updater signatures",
         "Generate updater channel manifests from verified signatures",
         "Upload and verify updater manifests",
+        "Verify release metadata matches updater manifest",
         "Publish release",
     )
     for name in publish_steps:
         block = named_step_block(workflow, name, 6)
         assert "if: needs.resolve.outputs.publish == 'true'" in block
+    assert workflow.index("Verify release metadata matches updater manifest") < workflow.index(
+        "Publish release"
+    )
     rehearsal = named_step_block(
         workflow, "Report non-publishing promotion rehearsal", 6
     )

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -112,6 +112,67 @@ class ReleaseArtifactTests(unittest.TestCase):
                 self.root / "manifests",
             )
 
+    def test_manifest_generation_includes_valid_minimum_version_on_modern_channel(self) -> None:
+        validated_path = self.root / "validated.json"
+        validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        release_notes_path = self.root / "release-notes.md"
+        release_notes_path.write_text("Required reliability update.\n")
+
+        modern_path, legacy_path = write_updater_manifests(
+            validated_path,
+            "v1.2.3",
+            "owner/repo",
+            "https://example.invalid/bridge.app.tar.gz",
+            "bridge-signature",
+            release_notes_path,
+            self.root / "manifests",
+            min_version="1.1.0",
+        )
+
+        self.assertEqual(json.loads(modern_path.read_text())["min_version"], "1.1.0")
+        self.assertNotIn("min_version", json.loads(legacy_path.read_text()))
+
+    def test_manifest_generation_omits_absent_minimum_version(self) -> None:
+        validated_path = self.root / "validated.json"
+        validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        release_notes_path = self.root / "release-notes.md"
+        release_notes_path.write_text("Optional update.\n")
+
+        modern_path, _ = write_updater_manifests(
+            validated_path,
+            "v1.2.3",
+            "owner/repo",
+            "https://example.invalid/bridge.app.tar.gz",
+            "bridge-signature",
+            release_notes_path,
+            self.root / "manifests",
+        )
+
+        self.assertNotIn("min_version", json.loads(modern_path.read_text()))
+
+    def test_manifest_generation_rejects_invalid_or_future_minimum_version(self) -> None:
+        validated_path = self.root / "validated.json"
+        validate_release(self.artifacts, SHA, RUN_ID, validated_path)
+        release_notes_path = self.root / "release-notes.md"
+        release_notes_path.write_text("Policy validation.\n")
+        common = (
+            validated_path,
+            "v1.2.3",
+            "owner/repo",
+            "https://example.invalid/bridge.app.tar.gz",
+            "bridge-signature",
+            release_notes_path,
+            self.root / "manifests",
+        )
+
+        for invalid in ("", "v1.0.0", "1.2", "1.2.3-beta"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ArtifactError, "stable major.minor.patch"):
+                    write_updater_manifests(*common, min_version=invalid)
+
+        with self.assertRaisesRegex(ArtifactError, "newer than release"):
+            write_updater_manifests(*common, min_version="1.2.4")
+
     def test_commit_sha_mismatch_fails_closed(self) -> None:
         with self.assertRaisesRegex(ArtifactError, "commit_sha mismatch"):
             validate_release(self.artifacts, OTHER_SHA, RUN_ID)


### PR DESCRIPTION
## Summary

- serialize updater checks and installs behind one owner and expose a non-actionable preparing phase before download
- fail closed when update availability is known but the minimum-version policy cannot be verified
- publish a validated source-controlled `min_version` policy through immutable updater assets
- block promotion when release notes drift from the updater manifest
- align the current release prompt with synchronized version surfaces and forbid post-publication `latest.json` replacement

## Stack

Rebased onto `codex/health-sweep-integration` after health-sweep issues #476, #477, #478, #479, #480, #482, #484, and #485. This PR lands into the integration branch only; it does not merge to `main`.

## Validation

- `npx tsc --noEmit`
- `npm test -- --run` — 71 files, 661 tests passed
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest discover -s tests -p test_*.py` — 114 tests passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --all-targets`
- `cargo test -- --test-threads=1` — 750 passed, 5 ignored, plus all integration suites
- capture helper — 6 passed
- `git diff --check`

Canonical Rust formatting remains deliberately deferred to load-bearing final issue #483.

Relates #439 and #481.