### PR TITLE
fix(audio): session backend-preference memo + per-native-call capture telemetry

### DIFF
--- a/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
+++ b/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
@@ -97,11 +97,38 @@ pub enum ProductionHelperMessage {
     },
 }
 
+/// Capture setup steps bracket the native calls the worker makes, so a step
+/// that reports `Entered` without `Completed` identifies the exact operation
+/// that hung. Step names are content-free: no device identity ever rides on
+/// this message. AUHAL steps map to native Core Audio calls as follows:
+///
+/// - `AudioUnitNew`: `AudioComponentFindNext` + `AudioComponentInstanceNew`
+///   + `AudioUnitInitialize` (one bracket; the safe wrapper creates and
+///   initializes in a single call)
+/// - `EnableInputIo` / `DisableOutputIo`:
+///   `AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)` on the input /
+///   output element
+/// - `SetCurrentDevice`:
+///   `AudioUnitSetProperty(kAudioOutputUnitProperty_CurrentDevice)`
+/// - `FormatConfiguration`:
+///   `AudioUnitSetProperty(kAudioUnitProperty_StreamFormat)`
+/// - `CallbackInstallation`: buffer-size query plus
+///   `AudioUnitSetProperty(kAudioOutputUnitProperty_SetInputCallback)`
+/// - `StreamStart`: `AudioOutputUnitStart` (AUHAL) or cpal `Stream::play`
+///   (CPAL)
+///
+/// `AudioUnitCreation` is the legacy coarse bracket that covered
+/// `AudioUnitNew` through `SetCurrentDevice`; it is retained for protocol
+/// stability but no longer emitted.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum CaptureSetupStep {
     DeviceResolution,
     AudioUnitCreation,
+    AudioUnitNew,
+    EnableInputIo,
+    DisableOutputIo,
+    SetCurrentDevice,
     FormatConfiguration,
     CallbackInstallation,
     DefaultConfig,
@@ -115,6 +142,10 @@ impl CaptureSetupStep {
         match self {
             Self::DeviceResolution => "device_resolution",
             Self::AudioUnitCreation => "audio_unit_creation",
+            Self::AudioUnitNew => "audio_unit_new",
+            Self::EnableInputIo => "enable_input_io",
+            Self::DisableOutputIo => "disable_output_io",
+            Self::SetCurrentDevice => "set_current_device",
             Self::FormatConfiguration => "format_configuration",
             Self::CallbackInstallation => "callback_installation",
             Self::DefaultConfig => "default_config",

--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -2,14 +2,16 @@ use core_foundation_sys::base::CFTypeRef;
 use core_foundation_sys::string::{kCFStringEncodingUTF8, CFStringGetCString, CFStringRef};
 use coreaudio::audio_unit::audio_format::LinearPcmFlags;
 use coreaudio::audio_unit::macos_helpers::{
-    audio_unit_from_device_id, get_audio_device_ids_for_scope, get_default_device_id,
-    get_device_name,
+    get_audio_device_ids_for_scope, get_default_device_id, get_device_name,
 };
 use coreaudio::audio_unit::render_callback::{self, data};
-use coreaudio::audio_unit::{Element, SampleFormat as AuSampleFormat, Scope, StreamFormat};
+use coreaudio::audio_unit::{
+    AudioUnit, Element, IOType, SampleFormat as AuSampleFormat, Scope, StreamFormat,
+};
 use coreaudio::sys::{
     kAudioDevicePropertyDeviceUID, kAudioObjectPropertyElementMaster,
-    kAudioObjectPropertyScopeGlobal, AudioDeviceID, AudioObjectGetPropertyData,
+    kAudioObjectPropertyScopeGlobal, kAudioOutputUnitProperty_CurrentDevice,
+    kAudioOutputUnitProperty_EnableIO, AudioDeviceID, AudioObjectGetPropertyData,
     AudioObjectPropertyAddress,
 };
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -299,14 +301,43 @@ fn start_auhal(
         SetupTransition::Completed,
     )?;
     let sample_rate = 48_000_u32;
+    // Inlined from coreaudio-rs audio_unit_from_device_id so every native
+    // Core Audio call gets its own Entered/Completed bracket; a hang is then
+    // attributable to one named operation instead of the whole creation span.
+    emit(CaptureSetupStep::AudioUnitNew, SetupTransition::Entered)?;
+    let mut unit = AudioUnit::new(IOType::HalOutput).map_err(|_| FailureCode::StreamOpenFailed)?;
+    emit(CaptureSetupStep::AudioUnitNew, SetupTransition::Completed)?;
+    emit(CaptureSetupStep::EnableInputIo, SetupTransition::Entered)?;
+    unit.set_property(
+        kAudioOutputUnitProperty_EnableIO,
+        Scope::Input,
+        Element::Input,
+        Some(&1_u32),
+    )
+    .map_err(|_| FailureCode::StreamOpenFailed)?;
+    emit(CaptureSetupStep::EnableInputIo, SetupTransition::Completed)?;
+    emit(CaptureSetupStep::DisableOutputIo, SetupTransition::Entered)?;
+    unit.set_property(
+        kAudioOutputUnitProperty_EnableIO,
+        Scope::Output,
+        Element::Output,
+        Some(&0_u32),
+    )
+    .map_err(|_| FailureCode::StreamOpenFailed)?;
     emit(
-        CaptureSetupStep::AudioUnitCreation,
-        SetupTransition::Entered,
+        CaptureSetupStep::DisableOutputIo,
+        SetupTransition::Completed,
     )?;
-    let mut unit =
-        audio_unit_from_device_id(device, true).map_err(|_| FailureCode::StreamOpenFailed)?;
+    emit(CaptureSetupStep::SetCurrentDevice, SetupTransition::Entered)?;
+    unit.set_property(
+        kAudioOutputUnitProperty_CurrentDevice,
+        Scope::Global,
+        Element::Output,
+        Some(&device),
+    )
+    .map_err(|_| FailureCode::StreamOpenFailed)?;
     emit(
-        CaptureSetupStep::AudioUnitCreation,
+        CaptureSetupStep::SetCurrentDevice,
         SetupTransition::Completed,
     )?;
     let format = StreamFormat {

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1,7 +1,8 @@
 use crate::managed_child::{bundled_sibling, ManagedChild};
 use murmur_capture_helper_protocol::{
-    read_production_frame, write_production_control, CaptureBackend, CapturePhase, FailureCode,
-    ProductionFrame, ProductionHelperMessage, ProductionHostMessage, SessionNonce,
+    read_production_frame, write_production_control, CaptureBackend, CapturePhase,
+    CaptureSetupStep, FailureCode, ProductionFrame, ProductionHelperMessage,
+    ProductionHostMessage, SessionNonce, SetupTransition,
 };
 use serde::Serialize;
 use std::fmt;
@@ -646,6 +647,43 @@ fn preferred_backends() -> [CaptureBackend; 2] {
     }
 }
 
+// Session memo of the backend that most recently delivered first PCM, keyed
+// by the requested device (None = system default input). On machines where
+// the platform-primary backend hangs until its attempt budget on every
+// recording, this puts the known-good backend first so only the first
+// recording of a session pays the timeout. It only reorders the two attempts:
+// both backends stay in the sequence, per-attempt budgets, termination
+// confirmation, and fallback eligibility are unchanged, and the memo is
+// process-local (never persisted, never logged with device identity).
+static LAST_READY_BACKEND: Mutex<Vec<(Option<String>, CaptureBackend)>> = Mutex::new(Vec::new());
+
+fn record_ready_backend(device_id: Option<&str>, backend: CaptureBackend) {
+    let mut memo = LAST_READY_BACKEND
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match memo.iter_mut().find(|(key, _)| key.as_deref() == device_id) {
+        Some(entry) => entry.1 = backend,
+        None => memo.push((device_id.map(str::to_string), backend)),
+    }
+}
+
+fn last_ready_backend(device_id: Option<&str>) -> Option<CaptureBackend> {
+    LAST_READY_BACKEND
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .find(|(key, _)| key.as_deref() == device_id)
+        .map(|(_, backend)| *backend)
+}
+
+fn preferred_backends_for(device_id: Option<&str>) -> [CaptureBackend; 2] {
+    let default_order = preferred_backends();
+    match last_ready_backend(device_id) {
+        Some(backend) if backend == default_order[1] => [default_order[1], default_order[0]],
+        _ => default_order,
+    }
+}
+
 fn stop_requested_between_attempts(command_receiver: &Receiver<AudioCommand>) -> bool {
     matches!(
         command_receiver.try_recv(),
@@ -803,6 +841,7 @@ fn run_backend(
     let mut last_level_emit = Instant::now() - Duration::from_secs(1);
     let mut last_permission_check = Instant::now() - PERMISSION_POLL_INTERVAL;
     let mut current_phase = AudioInitPhase::StreamBuild;
+    let mut last_setup_step: Option<(CaptureSetupStep, SetupTransition)> = None;
     let attempt_budget = backend_attempt_budget(backend);
     loop {
         match command_receiver.try_recv() {
@@ -947,6 +986,9 @@ fn run_backend(
                 },
                 current_phase,
             );
+            // last_setup_step "entered" without "completed" names the exact
+            // native call the worker is stuck in (see CaptureSetupStep docs
+            // for the step -> Core Audio call mapping).
             tracing::warn!(
                 target: "audio",
                 capture_id,
@@ -954,6 +996,12 @@ fn run_backend(
                 active_elapsed_ms = clock.elapsed(now).as_millis() as u64,
                 attempt_budget_ms = attempt_budget.as_millis() as u64,
                 error_kind = failure.kind.as_str(),
+                last_setup_step = last_setup_step
+                    .map(|(step, _)| step.as_str())
+                    .unwrap_or("none"),
+                last_setup_transition = last_setup_step
+                    .map(|(_, transition)| transition.as_str())
+                    .unwrap_or("none"),
                 "capture backend exceeded its active initialization budget"
             );
             if !terminate_or_quarantine(
@@ -1016,6 +1064,7 @@ fn run_backend(
                 if !retained_audio {
                     retained_audio = true;
                     current_phase = AudioInitPhase::Runtime;
+                    record_ready_backend(device_id, backend);
                     end_permission_prompt_pause(
                         &mut permission_prompt_started,
                         &mut clock,
@@ -1108,12 +1157,14 @@ fn run_backend(
                         retained_audio,
                     };
                 }
+                last_setup_step = Some((step, transition));
                 tracing::info!(
                     target: "audio",
                     capture_id,
                     backend = backend_label(backend),
                     setup_step = step.as_str(),
                     setup_transition = transition.as_str(),
+                    start_elapsed_ms = start_sent_at.elapsed().as_millis() as u64,
                     "capture helper setup step"
                 );
             }
@@ -1287,11 +1338,21 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
         protocol_reserve_ms = CAPTURE_PROTOCOL_RESERVE.as_millis() as u64,
         "capture backend budget contract started"
     );
+    let backends = preferred_backends_for(device_id.as_deref());
+    if backends != preferred_backends() {
+        tracing::info!(
+            target: "audio",
+            owner = owner.telemetry_id(),
+            primary_backend = backend_label(backends[0]),
+            backend_order_source = "session_first_pcm_memo",
+            "capture backend order adjusted by prior first PCM in this session"
+        );
+    }
     run_capture_backend_sequence(
         owner,
         &command_receiver,
         event_sender,
-        preferred_backends(),
+        backends,
         |backend| {
             run_backend(
                 owner,
@@ -1383,6 +1444,44 @@ mod tests {
             preferred_backends(),
             [CaptureBackend::Cpal, CaptureBackend::Auhal]
         );
+    }
+
+    // Memo tests use distinct device keys so they stay independent of each
+    // other and of the process-wide static regardless of test ordering.
+    #[test]
+    fn session_memo_promotes_the_fallback_backend_after_first_pcm() {
+        let default_order = preferred_backends();
+        assert_eq!(preferred_backends_for(Some("memo-device-a")), default_order);
+
+        record_ready_backend(Some("memo-device-a"), default_order[1]);
+        assert_eq!(
+            preferred_backends_for(Some("memo-device-a")),
+            [default_order[1], default_order[0]]
+        );
+        // Other device keys are unaffected.
+        assert_eq!(
+            preferred_backends_for(Some("memo-device-a-other")),
+            default_order
+        );
+    }
+
+    #[test]
+    fn session_memo_on_the_primary_backend_keeps_the_default_order() {
+        let default_order = preferred_backends();
+        record_ready_backend(Some("memo-device-b"), default_order[0]);
+        assert_eq!(preferred_backends_for(Some("memo-device-b")), default_order);
+    }
+
+    #[test]
+    fn session_memo_tracks_the_most_recent_ready_backend() {
+        let default_order = preferred_backends();
+        record_ready_backend(Some("memo-device-c"), default_order[1]);
+        assert_eq!(
+            preferred_backends_for(Some("memo-device-c")),
+            [default_order[1], default_order[0]]
+        );
+        record_ready_backend(Some("memo-device-c"), default_order[0]);
+        assert_eq!(preferred_backends_for(Some("memo-device-c")), default_order);
     }
 
     #[test]

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,34 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-03: Session-scoped backend preference after first PCM; per-native-call capture telemetry
+
+**Decision:** The capture supervisor keeps an in-memory, per-device-key memo of
+the backend that most recently delivered first PCM and orders that backend
+first on subsequent recordings in the same app run. The memo reorders the two
+attempts only — budgets, confirmed-termination rules, and fallback eligibility
+from #436 are untouched — and it is not persisted across launches. Separately,
+the capture worker now brackets each native Core Audio call with its own
+setup-step marker (unit creation, IO enable/disable, current-device binding,
+format, callback install, `AudioOutputUnitStart`), and the supervisor names the
+last entered step in the budget-exceeded log line.
+
+**Rationale:** Field telemetry from an M5/macOS 26.6 install showed every
+recording paying the full 8-second AUHAL budget in `stream_start`
+(`AudioOutputUnitStart`) before CPAL succeeded in ~160 ms. Re-proving a known
+hang on every recording is pure latency; remembering the last-good backend
+bounds the cost to once per app run and self-corrects if the situation changes.
+Persistence was deliberately rejected to avoid stale preferences outliving a
+transient coreaudiod wedge. Finer step granularity makes the hanging native
+call a measurement instead of an inference.
+
+**Status:** active
+
+**References:** builds on #436; ADR
+[`2026-08-01-production-capture-helper.md`](2026-08-01-production-capture-helper.md)
+
+---
+
 ## 2026-08-03: Capture fallback uses fixed active budgets and confirmed teardown (#436)
 
 **Decision:** AUHAL and CPAL receive separate 8-second and 16-second

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -16,6 +16,16 @@ confirmed empty and a final Stop check passes. Once audio exists, failure ends c
 devices. Prefixes of at least 500 ms are transcribed normally, remain
 clipboard-first, and are marked **Interrupted · partial** in history.
 
+A process-local session memo remembers, per requested device key, the backend
+that most recently delivered first PCM. If that was the fallback backend, the
+next recording for the same device key tries it first, so a machine whose
+primary backend hangs until its attempt budget pays that timeout once per app
+run instead of on every recording. The memo only reorders the two attempts:
+both backends stay in the sequence with unchanged per-attempt budgets,
+termination confirmation, and fallback-eligibility rules. It is never
+persisted, and telemetry logs only the promoted backend name, never the device
+key.
+
 ## Overview
 
 ```
@@ -59,10 +69,16 @@ Transcription processing is local. Network access occurs for model setup and may
   If one blocks, Murmur retains exclusive ownership rather than detaching the
   worker or accepting a competing retry. Process isolation is the final fault
   boundary.
-- Protocol v3 emits stable entered/completed setup-step constants around AUHAL
-  device resolution, AudioUnit creation, format configuration, callback
-  installation, stream start, and callback wait, plus comparable CPAL steps.
-  These events contain no device label, UID, raw backend error, or content.
+- Protocol v3 emits stable entered/completed setup-step constants that bracket
+  each native Core Audio call on the AUHAL path — device resolution, unit
+  creation (`audio_unit_new`: component find/instantiate/initialize), input
+  enable, output disable, current-device binding, stream-format configuration,
+  callback installation, and `stream_start` (exactly `AudioOutputUnitStart`) —
+  plus comparable CPAL steps and the callback wait. A step that entered without
+  completing therefore names the exact hung operation; the supervisor logs each
+  step with elapsed time since start and repeats the last step and transition
+  in the attempt-budget-exceeded event. These events contain no device label,
+  UID, raw backend error, or content.
 - A timed-out backend can advance only after its owned helper process group is
   positively confirmed empty. Unconfirmed termination leaves the lifecycle in
   exclusive recovery and suppresses fallback and new starts.


### PR DESCRIPTION
## Problem

Production telemetry from an M5 MacBook Air on macOS 26.6 (v0.25.0) showed every recording paying the full 8s AUHAL attempt budget before the bounded fallback (#436) rescued it with CPAL in ~160ms — mean startup 8,469ms across seven consecutive recordings, all hung in `stream_start`. The failover contract worked exactly as designed; the cost was re-proving a known-hung backend on every single recording.

Verified against the machine's full `events.jsonl`: 12 AUHAL timeouts on v0.25.0, every one entering `stream_start` after completing all prior setup steps in <100ms. In coreaudio-rs 0.11.3 the `stream_start` bracket wraps exactly one native call, so the hung operation is **`AudioOutputUnitStart`** (blocking on coreaudiod). One recording additionally saw CPAL's `stream_start` hang for its full 16s budget — cpal's `Stream::play` reaches the same native call — confirming a machine-side coreaudiod wedge rather than anything AUHAL-specific.

## Changes

**1. Session backend-preference memo** (`audio.rs`)
Process-local memo keyed by requested device (`None` = system default) records the backend that most recently delivered first PCM; that backend is tried first on the next recording. On the affected machine only the first recording per app run pays the 8s probe; the rest start in ~160ms.

Contract preservation, explicitly:
- Reorder only — both backends remain in the sequence; per-attempt budgets, confirmed-termination gating, `permits_backend_fallback` rules, and the 30s active contract are untouched (the budget arithmetic 16+2+8+2+2 = 30 holds in either order).
- Self-correcting: any later first PCM overwrites the memo, so a promoted CPAL that starts failing hands leadership back.
- Never persisted across launches (deliberate — a stale preference must not outlive a transient coreaudiod wedge; see DECISIONS entry). Device keys never appear in telemetry; only the promoted backend name is logged.

**2. Per-native-call setup telemetry** (protocol + capture worker + supervisor)
- The coarse `audio_unit_creation` bracket (5 native calls) is split into `audio_unit_new`, `enable_input_io`, `disable_output_io`, `set_current_device` by inlining coreaudio-rs's `audio_unit_from_device_id`. `CaptureSetupStep` docs now map every step to its exact native Core Audio call(s).
- Supervisor logs each setup step with `start_elapsed_ms`, and the budget-exceeded warning carries `last_setup_step` / `last_setup_transition` — one privacy-safe log line names the hung native call. Step names remain content-free (no device labels, UIDs, or raw errors).

**3. Docs**: `docs/features/transcription.md` updated for both behaviors; new `DECISIONS.md` entry.

## Verification

- `cargo test --lib -- --test-threads=1`: 699 passed (3 new memo tests: fallback promotion, primary-success keeps default order, latest success wins)
- Protocol crate: 5 passed; capture sidecar crate + full workspace `cargo check` clean (3 warnings pre-existing on main)
- Frontend untouched
- Helper binaries rebuild cleanly via `scripts/build_local_llm_sidecar.py`

## Residuals (out of scope)

- First recording per app launch still pays one 8s probe on affected machines; persisting the memo (with expiry) is a possible follow-up.
- During a deep wedge window where CPAL also hangs, both attempts still fail cleanly inside the 30s contract — nothing at the app layer can improve that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved audio capture startup by remembering which available audio path worked most recently during the current app session.
  * Added more precise setup progress and timing information to help identify recording initialization issues.
  * Preserved existing fallback behavior, timeout limits, and privacy protections.
* **Documentation**
  * Updated capture and transcription documentation to describe backend selection and setup diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->