### PR TITLE
fix(audio): self-disproving backend promotion + fast-fail primary budget for first-attempt-bound hangs

### DIFF
--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -647,41 +647,121 @@ fn preferred_backends() -> [CaptureBackend; 2] {
     }
 }
 
-// Session memo of the backend that most recently delivered first PCM, keyed
-// by the requested device (None = system default input). On machines where
-// the platform-primary backend hangs until its attempt budget on every
-// recording, this puts the known-good backend first so only the first
-// recording of a session pays the timeout. It only reorders the two attempts:
-// both backends stay in the sequence, per-attempt budgets, termination
-// confirmation, and fallback eligibility are unchanged, and the memo is
-// process-local (never persisted, never logged with device identity).
-static LAST_READY_BACKEND: Mutex<Vec<(Option<String>, CaptureBackend)>> = Mutex::new(Vec::new());
+// Session memo, keyed by the requested device (None = system default input).
+// It adapts the attempt sequence to two observed hang pathologies without
+// touching the safety contract (both backends always stay in the sequence,
+// per-attempt budgets only ever shrink, termination confirmation and
+// fallback-eligibility rules are unchanged, nothing is persisted, and device
+// keys never reach telemetry):
+//
+// - Backend-bound hang (one backend hangs, the other works): the backend
+//   that most recently delivered first PCM is ordered first.
+// - First-attempt-bound hang (whichever backend goes first hangs in
+//   AudioOutputUnitStart and the second attempt succeeds in ~160ms —
+//   observed in the field on macOS 26.6/M5): promotion is proven wrong when
+//   the promoted backend itself times out before first PCM, so promotion is
+//   disabled for the key (sticky for the session, otherwise the order
+//   oscillates and doubles the latency on CPAL-first recordings). After
+//   FAST_FAIL_ARM_COUNT consecutive recordings of "primary failed before
+//   first PCM, fallback delivered it within FAST_RESCUE_THRESHOLD", the
+//   primary attempt budget shrinks to FAST_FAIL_PRIMARY_BUDGET so the
+//   reliable rescue starts sooner. A primary success resets the counter and
+//   restores full budgets.
+const PROMOTED_PRIMARY_BUDGET_CAP: Duration = AUHAL_ATTEMPT_BUDGET;
+const FAST_FAIL_PRIMARY_BUDGET: Duration = Duration::from_secs(2);
+const FAST_RESCUE_THRESHOLD: Duration = Duration::from_secs(1);
+const FAST_FAIL_ARM_COUNT: u32 = 2;
 
-fn record_ready_backend(device_id: Option<&str>, backend: CaptureBackend) {
-    let mut memo = LAST_READY_BACKEND
+#[derive(Default)]
+struct BackendMemo {
+    last_ready: Option<CaptureBackend>,
+    promotion_disabled: bool,
+    consecutive_fast_rescues: u32,
+}
+
+static CAPTURE_MEMO: Mutex<Vec<(Option<String>, BackendMemo)>> = Mutex::new(Vec::new());
+
+fn with_memo<R>(device_id: Option<&str>, apply: impl FnOnce(&mut BackendMemo) -> R) -> R {
+    let mut memo = CAPTURE_MEMO
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match memo.iter_mut().find(|(key, _)| key.as_deref() == device_id) {
-        Some(entry) => entry.1 = backend,
-        None => memo.push((device_id.map(str::to_string), backend)),
+    if let Some(position) = memo.iter().position(|(key, _)| key.as_deref() == device_id) {
+        apply(&mut memo[position].1)
+    } else {
+        memo.push((device_id.map(str::to_string), BackendMemo::default()));
+        apply(&mut memo.last_mut().expect("entry just pushed").1)
     }
 }
 
-fn last_ready_backend(device_id: Option<&str>) -> Option<CaptureBackend> {
-    LAST_READY_BACKEND
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .iter()
-        .find(|(key, _)| key.as_deref() == device_id)
-        .map(|(_, backend)| *backend)
+fn note_first_pcm(
+    device_id: Option<&str>,
+    backend: CaptureBackend,
+    was_primary: bool,
+    start_to_first_pcm: Duration,
+) {
+    with_memo(device_id, |memo| {
+        if was_primary {
+            memo.consecutive_fast_rescues = 0;
+            memo.last_ready = Some(backend);
+        } else {
+            memo.consecutive_fast_rescues = if start_to_first_pcm <= FAST_RESCUE_THRESHOLD {
+                memo.consecutive_fast_rescues.saturating_add(1)
+            } else {
+                0
+            };
+            if !memo.promotion_disabled {
+                memo.last_ready = Some(backend);
+            }
+        }
+    });
+}
+
+fn note_promoted_primary_timeout(device_id: Option<&str>) {
+    with_memo(device_id, |memo| {
+        memo.promotion_disabled = true;
+        memo.last_ready = None;
+    });
 }
 
 fn preferred_backends_for(device_id: Option<&str>) -> [CaptureBackend; 2] {
     let default_order = preferred_backends();
-    match last_ready_backend(device_id) {
+    let last_ready = with_memo(device_id, |memo| {
+        if memo.promotion_disabled {
+            None
+        } else {
+            memo.last_ready
+        }
+    });
+    match last_ready {
         Some(backend) if backend == default_order[1] => [default_order[1], default_order[0]],
         _ => default_order,
     }
+}
+
+fn primary_attempt_budget(
+    backend: CaptureBackend,
+    device_id: Option<&str>,
+    memo_promoted: bool,
+) -> Duration {
+    let mut budget = backend_attempt_budget(backend);
+    if memo_promoted {
+        // A promoted backend must never cost more than the default primary
+        // would have: cap it so a wrong promotion cannot worsen the worst
+        // case beyond the default order's.
+        budget = budget.min(PROMOTED_PRIMARY_BUDGET_CAP);
+    }
+    if with_memo(device_id, |memo| {
+        memo.consecutive_fast_rescues >= FAST_FAIL_ARM_COUNT
+    }) {
+        budget = budget.min(FAST_FAIL_PRIMARY_BUDGET);
+    }
+    budget
+}
+
+#[derive(Clone, Copy)]
+struct AttemptContext {
+    is_primary: bool,
+    memo_promoted: bool,
 }
 
 fn stop_requested_between_attempts(command_receiver: &Receiver<AudioCommand>) -> bool {
@@ -695,6 +775,7 @@ fn run_backend(
     owner: crate::audio_lifecycle::AudioOwner,
     backend: CaptureBackend,
     device_id: Option<&str>,
+    ctx: AttemptContext,
     command_receiver: &Receiver<AudioCommand>,
     shared: &Arc<Mutex<Vec<f32>>>,
     active: &Arc<AtomicBool>,
@@ -842,7 +923,20 @@ fn run_backend(
     let mut last_permission_check = Instant::now() - PERMISSION_POLL_INTERVAL;
     let mut current_phase = AudioInitPhase::StreamBuild;
     let mut last_setup_step: Option<(CaptureSetupStep, SetupTransition)> = None;
-    let attempt_budget = backend_attempt_budget(backend);
+    let attempt_budget = if ctx.is_primary {
+        primary_attempt_budget(backend, device_id, ctx.memo_promoted)
+    } else {
+        backend_attempt_budget(backend)
+    };
+    if attempt_budget != backend_attempt_budget(backend) {
+        tracing::info!(
+            target: "audio",
+            capture_id,
+            backend = backend_label(backend),
+            attempt_budget_ms = attempt_budget.as_millis() as u64,
+            "capture primary attempt budget shortened by session adaptation"
+        );
+    }
     loop {
         match command_receiver.try_recv() {
             Ok(AudioCommand::Stop) | Err(mpsc::TryRecvError::Disconnected) => {
@@ -986,6 +1080,18 @@ fn run_backend(
                 },
                 current_phase,
             );
+            if ctx.is_primary && ctx.memo_promoted {
+                // The promoted backend hung too, so the hang on this device
+                // is first-attempt-bound rather than backend-bound; keeping
+                // the promotion would oscillate the order every recording.
+                note_promoted_primary_timeout(device_id);
+                tracing::info!(
+                    target: "audio",
+                    capture_id,
+                    backend = backend_label(backend),
+                    "capture memo promotion disabled after the promoted backend timed out before first PCM"
+                );
+            }
             // last_setup_step "entered" without "completed" names the exact
             // native call the worker is stuck in (see CaptureSetupStep docs
             // for the step -> Core Audio call mapping).
@@ -1064,7 +1170,7 @@ fn run_backend(
                 if !retained_audio {
                     retained_audio = true;
                     current_phase = AudioInitPhase::Runtime;
-                    record_ready_backend(device_id, backend);
+                    note_first_pcm(device_id, backend, ctx.is_primary, start_sent_at.elapsed());
                     end_permission_prompt_pause(
                         &mut permission_prompt_started,
                         &mut clock,
@@ -1339,7 +1445,8 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
         "capture backend budget contract started"
     );
     let backends = preferred_backends_for(device_id.as_deref());
-    if backends != preferred_backends() {
+    let memo_promoted = backends != preferred_backends();
+    if memo_promoted {
         tracing::info!(
             target: "audio",
             owner = owner.telemetry_id(),
@@ -1358,6 +1465,10 @@ fn run_audio_capture(spec: AudioWorkerSpec, event_sender: &AudioWorkerEventSende
                 owner,
                 backend,
                 device_id.as_deref(),
+                AttemptContext {
+                    is_primary: backend == backends[0],
+                    memo_promoted,
+                },
                 &command_receiver,
                 &shared,
                 &active,
@@ -1448,12 +1559,15 @@ mod tests {
 
     // Memo tests use distinct device keys so they stay independent of each
     // other and of the process-wide static regardless of test ordering.
+    const FAST: Duration = Duration::from_millis(200);
+    const SLOW: Duration = Duration::from_millis(1500);
+
     #[test]
     fn session_memo_promotes_the_fallback_backend_after_first_pcm() {
         let default_order = preferred_backends();
         assert_eq!(preferred_backends_for(Some("memo-device-a")), default_order);
 
-        record_ready_backend(Some("memo-device-a"), default_order[1]);
+        note_first_pcm(Some("memo-device-a"), default_order[1], false, FAST);
         assert_eq!(
             preferred_backends_for(Some("memo-device-a")),
             [default_order[1], default_order[0]]
@@ -1468,20 +1582,82 @@ mod tests {
     #[test]
     fn session_memo_on_the_primary_backend_keeps_the_default_order() {
         let default_order = preferred_backends();
-        record_ready_backend(Some("memo-device-b"), default_order[0]);
+        note_first_pcm(Some("memo-device-b"), default_order[0], true, FAST);
         assert_eq!(preferred_backends_for(Some("memo-device-b")), default_order);
     }
 
     #[test]
     fn session_memo_tracks_the_most_recent_ready_backend() {
         let default_order = preferred_backends();
-        record_ready_backend(Some("memo-device-c"), default_order[1]);
+        note_first_pcm(Some("memo-device-c"), default_order[1], false, FAST);
         assert_eq!(
             preferred_backends_for(Some("memo-device-c")),
             [default_order[1], default_order[0]]
         );
-        record_ready_backend(Some("memo-device-c"), default_order[0]);
+        note_first_pcm(Some("memo-device-c"), default_order[0], true, FAST);
         assert_eq!(preferred_backends_for(Some("memo-device-c")), default_order);
+    }
+
+    #[test]
+    fn promoted_backend_timeout_disables_promotion_for_the_session() {
+        let key = Some("memo-device-guard");
+        let default_order = preferred_backends();
+        note_first_pcm(key, default_order[1], false, FAST);
+        assert_ne!(preferred_backends_for(key), default_order);
+
+        // The promoted backend hung too: the hang is first-attempt-bound.
+        note_promoted_primary_timeout(key);
+        assert_eq!(preferred_backends_for(key), default_order);
+
+        // Sticky: a later fallback success must not re-promote and restart
+        // the oscillation.
+        note_first_pcm(key, default_order[1], false, FAST);
+        assert_eq!(preferred_backends_for(key), default_order);
+    }
+
+    #[test]
+    fn repeated_fast_rescues_arm_the_short_primary_budget_and_success_resets_it() {
+        let key = Some("memo-device-fastfail");
+        let default_order = preferred_backends();
+        let full = backend_attempt_budget(default_order[0]);
+
+        note_first_pcm(key, default_order[1], false, FAST);
+        assert_eq!(primary_attempt_budget(default_order[0], key, false), full);
+        note_first_pcm(key, default_order[1], false, FAST);
+        assert_eq!(
+            primary_attempt_budget(default_order[0], key, false),
+            FAST_FAIL_PRIMARY_BUDGET
+        );
+
+        // A primary success means the machine healed: full budgets return.
+        note_first_pcm(key, default_order[0], true, FAST);
+        assert_eq!(primary_attempt_budget(default_order[0], key, false), full);
+    }
+
+    #[test]
+    fn slow_rescues_reset_the_fast_fail_counter() {
+        let key = Some("memo-device-slowrescue");
+        let default_order = preferred_backends();
+        let full = backend_attempt_budget(default_order[0]);
+
+        note_first_pcm(key, default_order[1], false, FAST);
+        note_first_pcm(key, default_order[1], false, SLOW);
+        note_first_pcm(key, default_order[1], false, FAST);
+        // fast, slow, fast -> counter is 1, not 2: still the full budget.
+        assert_eq!(primary_attempt_budget(default_order[0], key, false), full);
+    }
+
+    #[test]
+    fn a_promoted_backend_never_gets_more_budget_than_the_default_primary() {
+        assert_eq!(
+            primary_attempt_budget(CaptureBackend::Cpal, Some("memo-device-cap"), true),
+            PROMOTED_PRIMARY_BUDGET_CAP
+        );
+        // Unpromoted, CPAL keeps its own budget.
+        assert_eq!(
+            primary_attempt_budget(CaptureBackend::Cpal, Some("memo-device-cap"), false),
+            CPAL_ATTEMPT_BUDGET
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1,4 +1,5 @@
 use crate::managed_child::{bundled_sibling, ManagedChild};
+use crate::MutexExt;
 use murmur_capture_helper_protocol::{
     read_production_frame, write_production_control, CaptureBackend, CapturePhase,
     CaptureSetupStep, FailureCode, ProductionFrame, ProductionHelperMessage,
@@ -681,10 +682,13 @@ struct BackendMemo {
 
 static CAPTURE_MEMO: Mutex<Vec<(Option<String>, BackendMemo)>> = Mutex::new(Vec::new());
 
+// Memo writes are deliberately not gated on capture ownership: they record
+// observations about device behavior (a backend delivered PCM, a promoted
+// backend hung), and an observation made by an attempt that was cancelled a
+// moment later is exactly as true about the hardware. Ownership generations
+// guard recording state and publication, not this ordering heuristic.
 fn with_memo<R>(device_id: Option<&str>, apply: impl FnOnce(&mut BackendMemo) -> R) -> R {
-    let mut memo = CAPTURE_MEMO
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut memo = CAPTURE_MEMO.lock_or_recover();
     if let Some(position) = memo.iter().position(|(key, _)| key.as_deref() == device_id) {
         apply(&mut memo[position].1)
     } else {

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -14,9 +14,10 @@ backend-bound: promotion is disabled for that device key for the rest of the
 session, a promoted backend's attempt budget is capped at the default
 primary's 8 seconds, and after two consecutive recordings of "primary failed
 before first PCM, fallback delivered it within 1 second" the primary attempt
-budget shrinks to 2 seconds until a primary attempt succeeds again. Budgets
-only ever shrink; sequence membership, termination confirmation, and
-fallback-eligibility rules are unchanged.
+budget shrinks to 2 seconds until a primary attempt succeeds again (a slow
+rescue also resets the counter). Budgets only ever shrink; sequence
+membership, termination confirmation, and fallback-eligibility rules are
+unchanged.
 
 **Rationale:** v0.25.1 field telemetry (M5/macOS 26.6) falsified the
 backend-bound model the memo assumed: with CPAL promoted, CPAL hung in

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,36 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-04: Backend promotion is self-disproving; first-attempt-bound hangs get a fast-fail primary budget
+
+**Decision:** The session backend memo (2026-08-03) treats a timeout of a
+*promoted* backend as proof that the hang is first-attempt-bound rather than
+backend-bound: promotion is disabled for that device key for the rest of the
+session, a promoted backend's attempt budget is capped at the default
+primary's 8 seconds, and after two consecutive recordings of "primary failed
+before first PCM, fallback delivered it within 1 second" the primary attempt
+budget shrinks to 2 seconds until a primary attempt succeeds again. Budgets
+only ever shrink; sequence membership, termination confirmation, and
+fallback-eligibility rules are unchanged.
+
+**Rationale:** v0.25.1 field telemetry (M5/macOS 26.6) falsified the
+backend-bound model the memo assumed: with CPAL promoted, CPAL hung in
+`stream_start` for its full 16-second budget and AUHAL then delivered first
+PCM in 164ms — the memo oscillated and doubled the user-visible latency on
+alternate recordings. On such machines the second attempt reliably succeeds
+in ~160ms, so the dominant latency cost is the first attempt's budget; the
+fast-fail budget cuts steady-state startup from ~8.5s to ~2.6s while the
+detector (fallback must succeed fast) keeps genuinely slow-but-healthy
+machines, like the July coreaudiod slowdown where both backends were slow, on
+full budgets.
+
+**Status:** active
+
+**References:** supersedes the promotion behavior of the 2026-08-03 memo
+entry below; #445
+
+---
+
 ## 2026-08-03: Session-scoped backend preference after first PCM; per-native-call capture telemetry
 
 **Decision:** The capture supervisor keeps an in-memory, per-device-key memo of

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -16,15 +16,23 @@ confirmed empty and a final Stop check passes. Once audio exists, failure ends c
 devices. Prefixes of at least 500 ms are transcribed normally, remain
 clipboard-first, and are marked **Interrupted · partial** in history.
 
-A process-local session memo remembers, per requested device key, the backend
-that most recently delivered first PCM. If that was the fallback backend, the
-next recording for the same device key tries it first, so a machine whose
-primary backend hangs until its attempt budget pays that timeout once per app
-run instead of on every recording. The memo only reorders the two attempts:
-both backends stay in the sequence with unchanged per-attempt budgets,
-termination confirmation, and fallback-eligibility rules. It is never
-persisted, and telemetry logs only the promoted backend name, never the device
-key.
+A process-local session memo, keyed per requested device, adapts the attempt
+sequence to two observed hang pathologies. For a backend-bound hang (one
+backend hangs, the other works), the backend that most recently delivered
+first PCM is ordered first, so the timeout is paid once per app run instead of
+per recording. For a first-attempt-bound hang (whichever backend goes first
+hangs in `AudioOutputUnitStart` while the second attempt succeeds within
+~160ms), promotion is disproven the moment a promoted backend itself times out
+before first PCM: promotion is then disabled for that key for the session
+(otherwise the order oscillates), a promoted backend's budget is always capped
+at the default primary's 8s so a wrong promotion can never worsen the worst
+case, and after two consecutive recordings of "primary failed before first
+PCM, fallback delivered it within 1s" the primary attempt budget shrinks to
+2s so the reliable rescue starts sooner (a primary success resets this and
+restores full budgets). The memo only reorders and shrinks: both backends
+always stay in the sequence, budgets never grow, and termination confirmation
+and fallback-eligibility rules are unchanged. It is never persisted, and
+telemetry logs only backend names, never the device key.
 
 ## Overview
 

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -28,8 +28,9 @@ before first PCM: promotion is then disabled for that key for the session
 at the default primary's 8s so a wrong promotion can never worsen the worst
 case, and after two consecutive recordings of "primary failed before first
 PCM, fallback delivered it within 1s" the primary attempt budget shrinks to
-2s so the reliable rescue starts sooner (a primary success resets this and
-restores full budgets). The memo only reorders and shrinks: both backends
+2s so the reliable rescue starts sooner. A primary success or a slow rescue
+resets that counter and restores full budgets — a machine where both backends
+are slow never arms the short budget. The memo only reorders and shrinks: both backends
 always stay in the sequence, budgets never grow, and termination confirmation
 and fallback-eligibility rules are unchanged. It is never persisted, and
 telemetry logs only backend names, never the device key.


### PR DESCRIPTION
## Problem

v0.25.1 telemetry from the affected M5/macOS 26.6 install falsified the model behind the #445 session memo. The hang there is **first-attempt-bound, not backend-bound**: whichever backend starts first hangs in `AudioOutputUnitStart`; the second attempt succeeds in ~160ms, every time. Concretely (2026-08-04 16:13Z): memo promoted CPAL → CPAL hung in `stream_start` for its full **16s** budget → AUHAL (the supposedly broken backend) delivered first PCM in **164ms** → 16.5s user-visible "Connecting microphone". The memo oscillates on such machines and doubles latency on alternate recordings — a regression of #445 for this pathology.

## Changes (all in `audio.rs`, memo layer only)

1. **Self-disproving promotion:** a *promoted* backend timing out before first PCM proves the hang follows attempt order, not backend — promotion is disabled for that device key for the session, stickily (later fallback successes do not re-promote, which is what caused the oscillation).
2. **Promotion budget cap:** a promoted backend's attempt budget is capped at the default primary's 8s, so even the discovery recording can never exceed the default order's worst case (no more 16s CPAL-first hangs).
3. **Fast-fail primary budget:** after 2 consecutive recordings of "primary failed pre-PCM → fallback delivered first PCM within 1s", the primary attempt budget shrinks to 2s. Steady-state startup on the affected machine: **~8.5s → ~2.6s**. A primary success resets the counter and restores full budgets; a *slow* rescue also resets it, so machine-wide slowdowns (like the July incident where both backends took 10–12s) keep full budgets and the fast-fail never fires there.

## Contract preservation

- Both backends always remain in the sequence; fallback-eligibility, confirmed-termination gating, and the 30s active contract are untouched.
- Budgets only ever **shrink** — every prior worst-case bound still holds.
- Memo remains process-local, never persisted; telemetry carries backend names only, never device keys.

## Expected timeline on the affected install (fresh session)

R1: AUHAL 8s hang → CPAL rescue (8.5s). R2: CPAL promoted but capped at 8s → hangs → promotion disabled, counter=2 (8.5s). R3+: default order, primary budget 2s → **~2.6s startups**, stable, no oscillation.

## Verification

`cargo test --lib -- --test-threads=1`: **703 passed** — 4 new tests (sticky disable on promoted timeout, fast-fail arming + reset on primary success, slow-rescue counter reset, promoted budget cap) plus the 3 rewritten memo tests. Docs + DECISIONS updated (new entry supersedes the 2026-08-03 promotion behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved transcription reliability by adapting audio backend selection for each device during a session.
  * Faster fallback is now available when the preferred audio path hangs or fails to provide audio promptly.
  * Repeated quick recoveries can shorten retry times, while successful primary connections restore normal timing.
  * Backend preferences reset for new sessions, and existing fallback and termination behavior remains unchanged.

* **Documentation**
  * Added documentation describing adaptive audio recovery behavior and timing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->