### PR TITLE
feat(diagnostics): server-armed hang diagnostics for consented installs

### DIFF
--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -927,6 +927,8 @@ fn run_backend(
     let mut last_permission_check = Instant::now() - PERMISSION_POLL_INTERVAL;
     let mut current_phase = AudioInitPhase::StreamBuild;
     let mut last_setup_step: Option<(CaptureSetupStep, SetupTransition)> = None;
+    let worker_pid = child.pid();
+    let mut hang_probe: Option<crate::hang_diagnostics::HangProbe> = None;
     let attempt_budget = if ctx.is_primary {
         primary_attempt_budget(backend, device_id, ctx.memo_promoted)
     } else {
@@ -1068,6 +1070,16 @@ fn run_backend(
         }
 
         let now = Instant::now();
+        if hang_probe.is_none()
+            && !retained_audio
+            && crate::hang_diagnostics::armed()
+            && clock.elapsed(now) >= attempt_budget / 2
+        {
+            // Halfway to the budget with no PCM: sample the worker now, while
+            // the blocked native call is still on its stack.
+            hang_probe =
+                crate::hang_diagnostics::HangProbe::start(capture_id, backend_label(backend), worker_pid);
+        }
         if !retained_audio && clock.elapsed(now) >= attempt_budget {
             end_permission_prompt_pause(
                 &mut permission_prompt_started,
@@ -1125,6 +1137,9 @@ fn run_backend(
                 current_phase,
             ) {
                 return AttemptResult::TerminalHandled;
+            }
+            if let Some(probe) = hang_probe.take() {
+                probe.finish_and_ship(failure.kind.as_str());
             }
             return AttemptResult::Failed {
                 failure,

--- a/app/src-tauri/src/hang_diagnostics.rs
+++ b/app/src-tauri/src/hang_diagnostics.rs
@@ -48,6 +48,19 @@ pub(crate) fn armed() -> bool {
     ARMED.load(Ordering::Relaxed)
 }
 
+/// Truncate at the nearest char boundary at or below `cap`: command output is
+/// lossy-decoded UTF-8, and `String::truncate` panics mid-character.
+fn truncate_at_boundary(text: &mut String, cap: usize) {
+    if text.len() <= cap {
+        return;
+    }
+    let mut cut = cap;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    text.truncate(cut);
+}
+
 /// Run a command, returning combined stdout+stderr truncated to the section
 /// cap. On deadline the child is left to finish on its own (diagnostic path
 /// only; the commands used here all terminate on their own).
@@ -66,7 +79,7 @@ fn run_capped(program: &str, args: &[&str], deadline: Duration) -> String {
                 text.push_str("\n--- stderr ---\n");
                 text.push_str(&stderr);
             }
-            text.truncate(SECTION_CAP_BYTES);
+            truncate_at_boundary(&mut text, SECTION_CAP_BYTES);
             text
         }
         Ok(Err(error)) => format!("<spawn failed: {error}>"),
@@ -223,6 +236,16 @@ mod tests {
         assert!(armed());
         configure("test-install", "http://127.0.0.1:9/bundle", false);
         assert!(!armed());
+    }
+
+    #[test]
+    fn truncation_never_splits_a_multibyte_character() {
+        let mut text = "ab\u{1F980}cd".to_string(); // crab is 4 bytes at index 2
+        truncate_at_boundary(&mut text, 4);
+        assert_eq!(text, "ab");
+        let mut short = "ab".to_string();
+        truncate_at_boundary(&mut short, 10);
+        assert_eq!(short, "ab");
     }
 
     #[test]

--- a/app/src-tauri/src/hang_diagnostics.rs
+++ b/app/src-tauri/src/hang_diagnostics.rs
@@ -1,0 +1,269 @@
+//! Server-armed hang diagnostics.
+//!
+//! Dormant by default on every install. The log receiver's `/ingest` response
+//! carries `{"diagnostics": bool}` per install UUID; only when the receiver
+//! arms this install does any collection happen. Armed installs capture, at
+//! capture-attempt timeout, a native stack sample of the hung capture worker
+//! plus system audio context (coreaudiod unified log, audio/Bluetooth
+//! topology, installed HAL plug-ins) and upload one bounded text bundle to
+//! the receiver's `/bundle` endpoint. This data names devices and installed
+//! software; it must only ever be armed for installs whose owner has agreed
+//! to diagnostic collection. Disarming happens server-side (no release
+//! needed) and takes effect on the next shipper tick.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::MutexExt;
+
+static ARMED: AtomicBool = AtomicBool::new(false);
+static CONFIG: OnceLock<Mutex<Option<(String, String)>>> = OnceLock::new();
+
+const SECTION_CAP_BYTES: usize = 1_500_000;
+const SAMPLE_SECONDS: &str = "1";
+
+fn config_cell() -> &'static Mutex<Option<(String, String)>> {
+    CONFIG.get_or_init(|| Mutex::new(None))
+}
+
+/// Called by the log shipper once per successful ingest: records where a
+/// bundle would go and whether the receiver armed this install.
+pub(crate) fn configure(install_id: &str, bundle_endpoint: &str, armed: bool) {
+    *config_cell().lock_or_recover() =
+        Some((install_id.to_string(), bundle_endpoint.to_string()));
+    let was = ARMED.swap(armed, Ordering::Relaxed);
+    if armed && !was {
+        tracing::warn!(
+            target: "system",
+            "remote hang diagnostics armed by the log receiver for this install"
+        );
+    } else if !armed && was {
+        tracing::info!(target: "system", "remote hang diagnostics disarmed");
+    }
+}
+
+pub(crate) fn armed() -> bool {
+    ARMED.load(Ordering::Relaxed)
+}
+
+/// Run a command, returning combined stdout+stderr truncated to the section
+/// cap. On deadline the child is left to finish on its own (diagnostic path
+/// only; the commands used here all terminate on their own).
+fn run_capped(program: &str, args: &[&str], deadline: Duration) -> String {
+    let program = program.to_string();
+    let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(Command::new(&program).args(&args).output());
+    });
+    match receiver.recv_timeout(deadline) {
+        Ok(Ok(output)) => {
+            let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.trim().is_empty() {
+                text.push_str("\n--- stderr ---\n");
+                text.push_str(&stderr);
+            }
+            text.truncate(SECTION_CAP_BYTES);
+            text
+        }
+        Ok(Err(error)) => format!("<spawn failed: {error}>"),
+        Err(_) => "<command deadline exceeded>".to_string(),
+    }
+}
+
+/// Started when a capture attempt is halfway through its budget without first
+/// PCM; samples the still-running worker so the blocked native stack is
+/// captured before the supervisor kills it.
+pub(crate) struct HangProbe {
+    sample_receiver: mpsc::Receiver<String>,
+    capture_id: u64,
+    backend: &'static str,
+}
+
+impl HangProbe {
+    pub(crate) fn start(
+        capture_id: u64,
+        backend: &'static str,
+        worker_pid: u32,
+    ) -> Option<Self> {
+        if !armed() {
+            return None;
+        }
+        tracing::info!(
+            target: "audio",
+            capture_id,
+            backend,
+            "hang diagnostics: sampling the capture worker's native stack"
+        );
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = sender.send(run_capped(
+                "/usr/bin/sample",
+                &[&worker_pid.to_string(), SAMPLE_SECONDS],
+                Duration::from_secs(10),
+            ));
+        });
+        Some(Self {
+            sample_receiver: receiver,
+            capture_id,
+            backend,
+        })
+    }
+
+    /// Called after the hung worker's termination is confirmed. Collects the
+    /// system context and uploads the bundle from a background thread; the
+    /// capture sequence is never delayed by this.
+    pub(crate) fn finish_and_ship(self, error_kind: &'static str) {
+        let Self {
+            sample_receiver,
+            capture_id,
+            backend,
+        } = self;
+        std::thread::spawn(move || {
+            let sample = sample_receiver
+                .recv_timeout(Duration::from_secs(8))
+                .unwrap_or_else(|_| "<worker sample unavailable>".to_string());
+            let bundle = collect_bundle(capture_id, backend, error_kind, &sample);
+            ship_bundle(capture_id, bundle);
+        });
+    }
+}
+
+fn collect_bundle(
+    capture_id: u64,
+    backend: &'static str,
+    error_kind: &'static str,
+    worker_sample: &str,
+) -> String {
+    let mut bundle = String::new();
+    let mut section = |title: &str, body: &str| {
+        bundle.push_str(&format!("\n===== {title} =====\n"));
+        bundle.push_str(body);
+        bundle.push('\n');
+    };
+    section(
+        "hang context",
+        &format!(
+            "app_version: {}\ncapture_id: {capture_id}\nbackend: {backend}\nerror_kind: {error_kind}\nepoch_ms: {}",
+            env!("CARGO_PKG_VERSION"),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or_default()
+        ),
+    );
+    section("worker native stack sample", worker_sample);
+    section(
+        "coreaudiod unified log (last 90s)",
+        &run_capped(
+            "/usr/bin/log",
+            &[
+                "show",
+                "--style",
+                "compact",
+                "--last",
+                "90s",
+                "--predicate",
+                "process == \"coreaudiod\"",
+            ],
+            Duration::from_secs(25),
+        ),
+    );
+    section(
+        "audio topology",
+        &run_capped(
+            "/usr/sbin/system_profiler",
+            &["SPAudioDataType", "-detailLevel", "full"],
+            Duration::from_secs(15),
+        ),
+    );
+    section(
+        "bluetooth state",
+        &run_capped(
+            "/usr/sbin/system_profiler",
+            &["SPBluetoothDataType"],
+            Duration::from_secs(15),
+        ),
+    );
+    section(
+        "system HAL plug-ins",
+        &run_capped("/bin/ls", &["-la", "/Library/Audio/Plug-Ins/HAL"], Duration::from_secs(5)),
+    );
+    section(
+        "user HAL plug-ins",
+        &run_capped(
+            "/bin/ls",
+            &[
+                "-la",
+                &format!(
+                    "{}/Library/Audio/Plug-Ins/HAL",
+                    std::env::var("HOME").unwrap_or_default()
+                ),
+            ],
+            Duration::from_secs(5),
+        ),
+    );
+    bundle
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_is_inert_unless_the_receiver_arms_this_install() {
+        configure("test-install", "http://127.0.0.1:9/bundle", false);
+        assert!(!armed());
+        assert!(HangProbe::start(1, "auhal", std::process::id()).is_none());
+
+        configure("test-install", "http://127.0.0.1:9/bundle", true);
+        assert!(armed());
+        configure("test-install", "http://127.0.0.1:9/bundle", false);
+        assert!(!armed());
+    }
+
+    #[test]
+    fn run_capped_returns_output_and_bounds_runaway_commands() {
+        assert!(run_capped("/bin/echo", &["hello"], Duration::from_secs(5)).contains("hello"));
+        assert_eq!(
+            run_capped("/bin/sleep", &["5"], Duration::from_millis(100)),
+            "<command deadline exceeded>"
+        );
+        assert!(run_capped("/nonexistent-binary", &[], Duration::from_secs(1))
+            .starts_with("<spawn failed"));
+    }
+}
+
+fn ship_bundle(capture_id: u64, bundle: String) {
+    let Some((install_id, endpoint)) = config_cell().lock_or_recover().clone() else {
+        return;
+    };
+    let outcome = tauri::async_runtime::block_on(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .ok()?;
+        client
+            .post(&endpoint)
+            .header(
+                "Authorization",
+                format!("Bearer {}", crate::log_shipper::TOKEN),
+            )
+            .header("X-Install-Id", install_id)
+            .header("Content-Type", "text/plain")
+            .body(bundle)
+            .send()
+            .await
+            .ok()
+            .map(|response| response.status().is_success())
+    });
+    tracing::info!(
+        target: "audio",
+        capture_id,
+        shipped = outcome.unwrap_or(false),
+        "hang diagnostics: bundle upload finished"
+    );
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod injector;
 mod keyboard;
 mod knowledge_store;
 pub mod llm_sidecar;
+mod hang_diagnostics;
 mod log_shipper;
 pub mod managed_child;
 mod model_runtime;

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -14,7 +14,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 const ENDPOINT: &str = "https://georgenijo.com/murmur/ingest";
-const TOKEN: &str = "a1b4068693a1f3868bcf03c01ebcf1e9f000080b3e8bfcb0";
+pub(crate) const TOKEN: &str = "a1b4068693a1f3868bcf03c01ebcf1e9f000080b3e8bfcb0";
 const TICK_SECS: u64 = 60;
 const STARTUP_DELAY_SECS: u64 = 15;
 /// Max bytes shipped per POST; a batch is always cut at a line boundary.
@@ -229,7 +229,27 @@ async fn ship(
         .body(data)
         .send()
         .await;
-    matches!(result, Ok(resp) if resp.status().is_success())
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            // The receiver's success body carries the per-install diagnostics
+            // flag; older receivers reply 204 with no body, which reads as
+            // disarmed. The flag can only arm what the server names.
+            let armed = resp
+                .text()
+                .await
+                .ok()
+                .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
+                .and_then(|value| value.get("diagnostics").and_then(|flag| flag.as_bool()))
+                .unwrap_or(false);
+            crate::hang_diagnostics::configure(
+                install_id,
+                &endpoint.replace("/ingest", "/bundle"),
+                armed,
+            );
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Serialize only a bounded aggregate of the audio-input picture. The generic

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,31 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-04: Hang diagnostics are server-armed per install, never on by default
+
+**Decision:** The client ships a dormant hang-diagnostics collector (worker
+stack sample at capture timeout + coreaudiod unified log + audio/Bluetooth
+topology + HAL plug-in list, uploaded as one bounded bundle). It activates
+only when the log receiver's ingest reply names this install's UUID as armed
+(`diag-installs.txt` on the receiver), and arming is logged loudly in the
+install's own event stream. Rejected alternatives: a separate diagnostic
+build (delivery friction — the affected user is remote), and shipping
+collection enabled for all installs (breaks the privacy model for users who
+never consented; the collected data names devices and installed software).
+
+**Rationale:** The remaining unknown in the capture-hang investigation is
+*why* `AudioOutputUnitStart` blocks, which only a native stack of the blocked
+call plus coreaudiod's own log can answer. Server-side arming delivers the
+collector through the normal release channel with zero user action, scopes
+collection to exactly the consenting install, and gives an instant no-release
+kill switch.
+
+**Status:** active
+
+**References:** #445, #450; `hang_diagnostics.rs`, receiver `/bundle`
+
+---
+
 ## 2026-08-04: Backend promotion is self-disproving; first-attempt-bound hangs get a fast-fail primary budget
 
 **Decision:** The session backend memo (2026-08-03) treats a timeout of a

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -11,9 +11,10 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 **Decision:** The client ships a dormant hang-diagnostics collector (worker
 stack sample at capture timeout + coreaudiod unified log + audio/Bluetooth
 topology + HAL plug-in list, uploaded as one bounded bundle). It activates
-only when the log receiver's ingest reply names this install's UUID as armed
-(`diag-installs.txt` on the receiver), and arming is logged loudly in the
-install's own event stream. Rejected alternatives: a separate diagnostic
+only when the log receiver's ingest reply carries `{"diagnostics": true}` for
+this install — the receiver derives that flag from a per-UUID allow-list
+(`diag-installs.txt`) — and arming is logged loudly in the install's own
+event stream. Rejected alternatives: a separate diagnostic
 build (delivery friction — the affected user is remote), and shipping
 collection enabled for all installs (breaks the privacy model for users who
 never consented; the collected data names devices and installed software).

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -20,6 +20,20 @@ install the app (or receive an auto-update) and logs flow.
   never reads or sends microphone display labels or backend UIDs.
 - Kill switch: launch with `MURMUR_LOG_SHIPPER=off` in the environment.
 
+## Server-armed hang diagnostics (`hang_diagnostics.rs`)
+
+Dormant on every install by default. The receiver's `/ingest` success reply
+carries `{"diagnostics": bool}` per install UUID (armed by listing the UUID in
+`~/murmur-logs/diag-installs.txt` on the receiver; no restart needed). Only on
+an armed install, a capture attempt that reaches half its budget without first
+PCM gets a native stack `sample` of the hung worker, and after the confirmed
+kill a single bounded text bundle — worker stack, 90s of coreaudiod unified
+log, audio/Bluetooth topology, installed HAL plug-ins — is uploaded to
+`POST /bundle`. This content names devices and installed software, so an
+install must only be armed with its owner's agreement; disarming is
+server-side and takes effect within one shipper tick. Arming is logged
+loudly in the armed install's own event stream.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## What

The remaining unknown in the capture-hang saga (#445, #450) is *why* `AudioOutputUnitStart` blocks on the affected machine. This adds the instrument that answers it: at capture-attempt timeout, capture the hung worker's native stack **while the blocked call is still on it**, plus the system context around it, and ship one bundle to the log receiver.

## How it stays scoped

- **Dormant by default on every install.** The collector only runs when the receiver's `/ingest` reply carries `{"diagnostics": true}` for this install's UUID — armed by listing the UUID in `~/murmur-logs/diag-installs.txt` on the receiver (already deployed to whoop-vm, with the new `/bundle` endpoint + nginx route, verified end-to-end armed and unarmed).
- Server-side kill switch: remove the UUID, disarmed within one shipper tick — no release needed. Full removal planned next release.
- Arming is logged loudly in the armed install's own event stream. Installs must only be armed with their owner's agreement (the bundle names devices and installed software).

## What an armed install collects on hang

1. `/usr/bin/sample` of the hung capture worker — started at half-budget so it completes before the kill; the blocked native stack is the root-cause payload.
2. 90s of coreaudiod unified log (`log show --predicate 'process == "coreaudiod"'`) — the daemon's side of the stuck conversation.
3. `system_profiler` audio + Bluetooth topology, and `/Library/Audio/Plug-Ins/HAL` listings (third-party driver suspects).

All sections bounded (1.5 MB/section), collected and uploaded from a background thread **after** the confirmed kill — the capture sequence, budgets, and termination contract are untouched (the sample overlaps dead time in the existing budget wait).

## Verification

- `cargo test --lib -- --test-threads=1`: **705 passed** — new tests: probe inert unless armed / arm-disarm transitions, `run_capped` output + deadline + spawn-failure bounds.
- Receiver verified live on whoop-vm: unarmed install → `{"diagnostics": false}` + bundle refused; armed → `true` + bundle stored; test data cleaned up.
- Old-receiver compatibility: a 204-no-body reply parses as disarmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in diagnostics for stalled audio capture attempts.
  - When enabled, limited system and audio information is collected and securely submitted after a confirmed failure.
  - Diagnostics can be enabled or disabled remotely for individual installations and remain inactive by default.

- **Documentation**
  - Documented diagnostic activation, collected information, upload behavior, and deactivation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->