### PR TITLE
feat(diagnostics): server-triggered on-demand probe collection + process/assertion probes

### DIFF
--- a/app/src-tauri/src/hang_diagnostics.rs
+++ b/app/src-tauri/src/hang_diagnostics.rs
@@ -12,7 +12,7 @@
 //! needed) and takes effect on the next shipper tick.
 
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -20,6 +20,12 @@ use crate::MutexExt;
 
 static ARMED: AtomicBool = AtomicBool::new(false);
 static CONFIG: OnceLock<Mutex<Option<(String, String)>>> = OnceLock::new();
+// Highest on-demand collection epoch already honored this process lifetime.
+// The receiver's reply carries an integer epoch per armed install; a value
+// greater than this triggers exactly one probe-bundle collection. The epoch
+// selects only WHEN a collection runs — WHAT runs is this compiled-in probe
+// list, never server-supplied text.
+static LAST_COLLECT_EPOCH: AtomicU64 = AtomicU64::new(0);
 
 const SECTION_CAP_BYTES: usize = 1_500_000;
 const SAMPLE_SECONDS: &str = "1";
@@ -29,8 +35,14 @@ fn config_cell() -> &'static Mutex<Option<(String, String)>> {
 }
 
 /// Called by the log shipper once per successful ingest: records where a
-/// bundle would go and whether the receiver armed this install.
-pub(crate) fn configure(install_id: &str, bundle_endpoint: &str, armed: bool) {
+/// bundle would go, whether the receiver armed this install, and whether an
+/// on-demand probe collection was requested.
+pub(crate) fn configure(
+    install_id: &str,
+    bundle_endpoint: &str,
+    armed: bool,
+    collect_now_epoch: u64,
+) {
     *config_cell().lock_or_recover() =
         Some((install_id.to_string(), bundle_endpoint.to_string()));
     let was = ARMED.swap(armed, Ordering::Relaxed);
@@ -42,6 +54,30 @@ pub(crate) fn configure(install_id: &str, bundle_endpoint: &str, armed: bool) {
     } else if !armed && was {
         tracing::info!(target: "system", "remote hang diagnostics disarmed");
     }
+    if take_collect_now(armed, collect_now_epoch) {
+        tracing::warn!(
+            target: "system",
+            collect_epoch = collect_now_epoch,
+            "on-demand diagnostic probe collection requested by the log receiver"
+        );
+        std::thread::spawn(move || {
+            let bundle = collect_bundle(
+                0,
+                "none",
+                "on_demand",
+                "<on-demand collection - no hung worker to sample>",
+            );
+            ship_bundle(0, bundle);
+        });
+    }
+}
+
+/// True exactly once per new nonzero epoch while armed.
+fn take_collect_now(armed: bool, epoch: u64) -> bool {
+    if !armed || epoch == 0 {
+        return false;
+    }
+    LAST_COLLECT_EPOCH.fetch_max(epoch, Ordering::Relaxed) < epoch
 }
 
 pub(crate) fn armed() -> bool {
@@ -202,6 +238,18 @@ fn collect_bundle(
         ),
     );
     section(
+        "process list",
+        &run_capped(
+            "/bin/ps",
+            &["axo", "pid,ppid,user,lstart,comm"],
+            Duration::from_secs(10),
+        ),
+    );
+    section(
+        "power assertions",
+        &run_capped("/usr/bin/pmset", &["-g", "assertions"], Duration::from_secs(10)),
+    );
+    section(
         "system HAL plug-ins",
         &run_capped("/bin/ls", &["-la", "/Library/Audio/Plug-Ins/HAL"], Duration::from_secs(5)),
     );
@@ -228,14 +276,25 @@ mod tests {
 
     #[test]
     fn probe_is_inert_unless_the_receiver_arms_this_install() {
-        configure("test-install", "http://127.0.0.1:9/bundle", false);
+        configure("test-install", "http://127.0.0.1:9/bundle", false, 0);
         assert!(!armed());
         assert!(HangProbe::start(1, "auhal", std::process::id()).is_none());
 
-        configure("test-install", "http://127.0.0.1:9/bundle", true);
+        configure("test-install", "http://127.0.0.1:9/bundle", true, 0);
         assert!(armed());
-        configure("test-install", "http://127.0.0.1:9/bundle", false);
+        configure("test-install", "http://127.0.0.1:9/bundle", false, 0);
         assert!(!armed());
+    }
+
+    #[test]
+    fn collect_now_fires_once_per_new_epoch_and_never_unarmed() {
+        assert!(!take_collect_now(false, 7)); // unarmed: never
+        assert!(!take_collect_now(true, 0)); // zero epoch: never
+        assert!(take_collect_now(true, 7)); // new epoch: once
+        assert!(!take_collect_now(true, 7)); // same epoch: consumed
+        assert!(!take_collect_now(true, 3)); // older epoch: never
+        assert!(take_collect_now(true, 9)); // newer epoch: once again
+        assert!(!take_collect_now(true, 9));
     }
 
     #[test]

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -234,17 +234,24 @@ async fn ship(
             // The receiver's success body carries the per-install diagnostics
             // flag; older receivers reply 204 with no body, which reads as
             // disarmed. The flag can only arm what the server names.
-            let armed = resp
+            let reply = resp
                 .text()
                 .await
                 .ok()
-                .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
+                .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok());
+            let armed = reply
+                .as_ref()
                 .and_then(|value| value.get("diagnostics").and_then(|flag| flag.as_bool()))
                 .unwrap_or(false);
+            let collect_now = reply
+                .as_ref()
+                .and_then(|value| value.get("collect_now").and_then(|epoch| epoch.as_u64()))
+                .unwrap_or(0);
             crate::hang_diagnostics::configure(
                 install_id,
                 &endpoint.replace("/ingest", "/bundle"),
                 armed,
+                collect_now,
             );
             true
         }

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -34,6 +34,16 @@ install must only be armed with its owner's agreement; disarming is
 server-side and takes effect within one shipper tick. Arming is logged
 loudly in the armed install's own event stream.
 
+An armed install's ingest reply may also carry `collect_now: <epoch>`
+(receiver `collect-now.txt`, lines of `uuid epoch`): an epoch greater than
+any already honored triggers exactly one immediate probe-bundle collection
+(no hang required). The epoch chooses only *when* a collection runs — *what*
+runs is the compiled-in, read-only probe list (process table, power
+assertions, and the standard bundle sections); the client never executes
+server-supplied text. The last honored epoch is process-lifetime state, so
+clear the install's `collect-now.txt` line once its bundle arrives to avoid
+a re-collection on the next app launch.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## What

Extends the server-armed diagnostics (#451) so an armed install can be asked to collect its probe bundle **on demand** — no hang required — and adds two probes that name the audio-tap-holding client we've been chasing.

- Ingest reply gains `collect_now: <epoch>` (receiver reads `collect-now.txt`, lines of `uuid epoch` — already deployed to whoop-vm). An epoch greater than any already honored triggers exactly one collection + upload.
- The epoch chooses only **when** a collection runs. **What** runs is the compiled-in, read-only probe list — the client never executes server-supplied text, so this is telemetry with a trigger, not a command channel.
- New probes in every bundle: process table (`ps axo pid,ppid,user,lstart,comm`) and power assertions (`pmset -g assertions`) — the missing pieces that turn "pid 72225 holds a SpeakerTap" into an actual process name.
- Unarmed installs (everyone but the one consented machine) ignore the field entirely; same loud arming log, same server-side kill switch, same planned removal once the investigation closes.

## Verification

`cargo test --lib -- --test-threads=1`: **707 passed** — new test covers the epoch semantics (never unarmed, never zero, once per new epoch, older epochs ignored). Receiver change deployed and compile-checked on whoop-vm; old clients are unaffected (they don't read the field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-directed, on-demand diagnostic collection for configured installations.
  * New collection requests trigger one diagnostic bundle for each newer request.
  * Diagnostic bundles now include process-list and power-assertion data.

* **Documentation**
  * Documented immediate diagnostic collection behavior and safety restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->