### PR TITLE
Improve vocabulary editor usability

### DIFF
--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -91,7 +91,7 @@ describe('SettingsPanel information architecture', () => {
 
   it('moves vocabulary, app overrides, Benchmark, Performance, and startup into their intended pages', async () => {
     for (const [page, expected] of [
-      ['Text & Vocabulary', 'Names & Terms'],
+      ['Text & Vocabulary', 'Names & special words'],
       ['Delivery', 'Always copied to clipboard'],
       ['Benchmark', 'Performance lab'],
       ['Performance', 'Diagnostics workspace'],

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -713,8 +713,10 @@ export function SettingsPanel({
               </div>
             )}
             <div className="border-t border-outline-variant/20 pt-4">
-              <h2 className="text-sm font-medium text-on-surface">Names & Terms</h2>
-              <p className="mt-1 mb-3 text-xs text-on-surface-variant">Teach Murmur preferred spellings and exact spoken variants.</p>
+              <h2 className="text-sm font-medium text-on-surface">Names & special words</h2>
+              <p className="mt-1 mb-3 text-xs text-on-surface-variant">
+                Fix a word once and Murmur will type it your way. For example, if Murmur hears “Tori,” tell it to type “Tauri.”
+              </p>
               <VocabularyAliasesEditor entries={settings.vocabularyEntries} voiceCommands={settings.voiceCommands} onChange={(vocabularyEntries) => onUpdateSettings({ vocabularyEntries, customVocabulary: vocabularyPrompt(vocabularyEntries) })} />
             </div>
             <SettingToggle title="Developer Terms" description="Make built-in development terms and an optional project scan available only to apps configured as Code / technical or with Local IDE project context." checked={settings.codeVocabEnabled} onChange={() => onUpdateSettings({ codeVocabEnabled: !settings.codeVocabEnabled })} />

--- a/app/src/components/settings/VocabularyAliasesEditor.test.tsx
+++ b/app/src/components/settings/VocabularyAliasesEditor.test.tsx
@@ -46,16 +46,31 @@ describe('VocabularyAliasesEditor', () => {
     expect(onChange).toHaveBeenLastCalledWith([]);
 
     const addButton = Array.from(container.querySelectorAll('button'))
-      .find((button) => button.textContent === 'Add term') as HTMLButtonElement;
+      .find((button) => button.textContent?.includes('Add spelling')) as HTMLButtonElement;
     await act(async () => addButton.click());
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain('written form');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelectorAll('[aria-label^="Written form"]')).toHaveLength(1);
   });
 
-  it('shows the canonical term, aliases, global scope, and local preview affordance', () => {
+  it('shows a compact hears-to-types mapping and a collapsed local preview', async () => {
     expect((container.querySelector('[aria-label="Written form 1"]') as HTMLInputElement).value).toBe('Tauri');
     expect((container.querySelector('[aria-label="Spoken aliases for Tauri"]') as HTMLInputElement).value).toBe('Tori, Tory');
-    expect(container.textContent).toContain('Global');
-    expect(container.textContent).toContain('Try your aliases');
-    expect(container.textContent).toContain('Nothing is recorded, copied, or logged.');
+    expect(container.textContent).toContain('Murmur hears');
+    expect(container.textContent).toContain('Murmur types');
+    expect(container.textContent).not.toContain('Spoken aliases');
+    expect(container.textContent).not.toContain('Global');
+
+    const previewButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Test a phrase')) as HTMLButtonElement;
+    expect(previewButton.getAttribute('aria-expanded')).toBe('false');
+    await act(async () => previewButton.click());
+    expect(container.textContent).toContain('Nothing is copied or logged.');
+    expect(container.querySelector('[aria-label="Alias preview input"]')).not.toBeNull();
+  });
+
+  it('caps the visible list height so saved spellings do not grow the settings page forever', () => {
+    const list = container.querySelector('[aria-label="Saved spellings"]') as HTMLDivElement;
+    expect(list.className).toContain('max-h-[286px]');
+    expect(list.className).toContain('overflow-y-auto');
   });
 });

--- a/app/src/components/settings/VocabularyAliasesEditor.tsx
+++ b/app/src/components/settings/VocabularyAliasesEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { VocabularyEntry, VoiceCommand } from '../../lib/settings';
 import { vocabularyPrompt } from '../../lib/settings';
 import { previewVocabularyAliases } from '../../lib/dictation';
@@ -23,6 +23,8 @@ export function VocabularyAliasesEditor({
   const [previewOutput, setPreviewOutput] = useState('');
   const [previewing, setPreviewing] = useState(false);
   const [includeCli, setIncludeCli] = useState(true);
+  const [previewExpanded, setPreviewExpanded] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { setDraft(entries); }, [entries]);
 
@@ -38,6 +40,22 @@ export function VocabularyAliasesEditor({
 
   const patchEntry = (index: number, patch: Partial<VocabularyEntry>) => {
     update(draft.map((entry, entryIndex) => entryIndex === index ? { ...entry, ...patch } : entry));
+  };
+
+  const addEntry = () => {
+    setError(null);
+    setPreviewOutput('');
+    setDraft((current) => [...current, {
+      id: newEntryId(),
+      written: '',
+      aliases: [],
+      enabled: true,
+      scope: { kind: 'global' },
+    }]);
+    requestAnimationFrame(() => {
+      const list = listRef.current;
+      list?.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
+    });
   };
 
   const runPreview = async () => {
@@ -56,87 +74,112 @@ export function VocabularyAliasesEditor({
 
   return (
     <div>
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex items-center justify-between gap-4">
         <div>
-          <label className="block text-sm font-medium text-on-surface">Custom Vocabulary</label>
-          <p className="mt-1 text-xs text-on-surface-variant">
-            Add the written term you want, then exact variants Murmur may hear. Aliases run locally on every model.
+          <p className="text-xs font-medium text-on-surface">
+            {draft.length === 0 ? 'No saved spellings' : `${draft.length} saved ${draft.length === 1 ? 'spelling' : 'spellings'}`}
+          </p>
+          <p className="mt-0.5 text-[11px] text-on-surface-variant">
+            If Murmur hears it more than one way, separate them with commas.
           </p>
         </div>
         <button
           type="button"
-          onClick={() => update([...draft, {
-            id: newEntryId(),
-            written: '',
-            aliases: [],
-            enabled: true,
-            scope: { kind: 'global' },
-          }])}
-          className="shrink-0 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-1.5 text-xs font-medium text-on-surface hover:border-primary/50"
+          onClick={addEntry}
+          className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-on-primary hover:brightness-110"
         >
-          Add term
+          + Add spelling
         </button>
       </div>
 
-      <div className="mt-3 space-y-3">
-        {draft.length === 0 && (
-          <div className="rounded-lg border border-dashed border-outline-variant/30 px-3 py-4 text-center text-xs text-on-surface-variant">
-            No custom terms yet. Add one to teach Murmur a canonical spelling and spoken aliases.
+      {draft.length === 0 ? (
+        <div className="mt-3 rounded-xl border border-dashed border-outline-variant/40 bg-surface-container-lowest px-4 py-5 text-center">
+          <p className="text-xs font-medium text-on-surface">Everything spelled correctly?</p>
+          <p className="mt-1 text-[11px] text-on-surface-variant">
+            Add a name or unusual word when Murmur gets it wrong.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-3 overflow-hidden rounded-xl border border-outline-variant/30 bg-surface-container-lowest">
+          <div className="grid grid-cols-[minmax(0,1fr)_20px_minmax(0,1fr)_76px] items-center gap-2 border-b border-outline-variant/30 bg-surface-container-low px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-on-surface-variant">
+            <span>Murmur hears <span className="font-normal normal-case tracking-normal">(optional)</span></span>
+            <span aria-hidden="true" />
+            <span>Murmur types</span>
+            <span className="sr-only">Actions</span>
           </div>
-        )}
-        {draft.map((entry, index) => (
-          <div key={entry.id} className={`rounded-xl border p-3 ${entry.enabled ? 'border-outline-variant/30 bg-surface-container-lowest' : 'border-outline-variant/20 bg-surface-container-low opacity-70'}`}>
-            <div className="flex items-center gap-2">
-              <input
-                aria-label={`Written form ${index + 1}`}
-                value={entry.written}
-                onChange={(event) => patchEntry(index, { written: event.target.value })}
-                placeholder="Written form, e.g. Tauri"
-                autoComplete="off"
-                autoCorrect="off"
-                spellCheck={false}
-                className="min-w-0 flex-1 rounded-lg border border-on-surface-variant bg-surface-container px-3 py-2 text-xs text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-              <span className="rounded-full bg-primary/10 px-2 py-1 text-[10px] font-medium text-on-surface">Global</span>
-              <button
-                type="button"
-                role="switch"
-                aria-label={`${entry.enabled ? 'Disable' : 'Enable'} ${entry.written || `term ${index + 1}`}`}
-                aria-checked={entry.enabled}
-                onClick={() => patchEntry(index, { enabled: !entry.enabled })}
-                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ${entry.enabled ? 'bg-primary' : 'bg-surface-container-highest'}`}
+          <div
+            ref={listRef}
+            aria-label="Saved spellings"
+            className="max-h-[286px] divide-y divide-outline-variant/20 overflow-y-auto overscroll-contain"
+          >
+            {draft.map((entry, index) => (
+              <div
+                key={entry.id}
+                className={`grid grid-cols-[minmax(0,1fr)_20px_minmax(0,1fr)_76px] items-center gap-2 px-3 py-2 ${entry.enabled ? '' : 'bg-surface-container-low opacity-60'}`}
               >
-                <span className={`inline-block h-3.5 w-3.5 rounded-full shadow transition-transform ${entry.enabled ? 'translate-x-4 bg-on-primary' : 'translate-x-1 bg-on-surface-variant'}`} />
-              </button>
-              <button
-                type="button"
-                aria-label={`Delete ${entry.written || `term ${index + 1}`}`}
-                onClick={() => update(draft.filter((_, entryIndex) => entryIndex !== index))}
-                className="text-xs text-on-surface-variant underline hover:text-error"
-              >
-                Delete
-              </button>
-            </div>
-            <label className="mt-2 block text-[11px] font-medium text-on-surface-variant">
-              Spoken aliases
-            </label>
-            <input
-              aria-label={`Spoken aliases for ${entry.written || `term ${index + 1}`}`}
-              value={entry.aliases.join(', ')}
-              onChange={(event) => patchEntry(index, {
-                aliases: event.target.value.trim()
-                  ? event.target.value.split(',').map((alias) => alias.trim())
-                  : [],
-              })}
-              placeholder="Tori, Tory"
-              autoComplete="off"
-              autoCorrect="off"
-              spellCheck={false}
-              className="mt-1 w-full rounded-lg border border-on-surface-variant bg-surface-container px-3 py-2 text-xs text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+                <input
+                  aria-label={`Spoken aliases for ${entry.written || `term ${index + 1}`}`}
+                  value={entry.aliases.join(', ')}
+                  onChange={(event) => patchEntry(index, {
+                    aliases: event.target.value.trim()
+                      ? event.target.value.split(',').map((alias) => alias.trim())
+                      : [],
+                  })}
+                  placeholder="e.g. Tori, Tory"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="min-w-0 rounded-lg border border-on-surface-variant bg-surface-container px-2.5 py-1.5 text-xs text-on-surface placeholder:text-on-surface-variant/70 focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 20 20"
+                  className="h-4 w-4 justify-self-center text-on-surface-variant"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path d="M3 10h13m-4-4 4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <input
+                  aria-label={`Written form ${index + 1}`}
+                  value={entry.written}
+                  onChange={(event) => patchEntry(index, { written: event.target.value })}
+                  placeholder="e.g. Tauri"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="min-w-0 rounded-lg border border-on-surface-variant bg-surface-container px-2.5 py-1.5 text-xs font-medium text-on-surface placeholder:font-normal placeholder:text-on-surface-variant/70 focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-label={`${entry.enabled ? 'Disable' : 'Enable'} ${entry.written || `term ${index + 1}`}`}
+                    aria-checked={entry.enabled}
+                    title={entry.enabled ? 'Turn off' : 'Turn on'}
+                    onClick={() => patchEntry(index, { enabled: !entry.enabled })}
+                    className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ${entry.enabled ? 'bg-primary' : 'bg-surface-container-highest'}`}
+                  >
+                    <span className={`inline-block h-3.5 w-3.5 rounded-full shadow transition-transform ${entry.enabled ? 'translate-x-4 bg-on-primary' : 'translate-x-1 bg-on-surface-variant'}`} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${entry.written || `term ${index + 1}`}`}
+                    title="Delete"
+                    onClick={() => update(draft.filter((_, entryIndex) => entryIndex !== index))}
+                    className="rounded p-1 text-on-surface-variant hover:bg-error/10 hover:text-error"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path d="M4.5 6h11M8 3.5h4M6.5 6l.6 10h5.8l.6-10M8.5 8.5v5M11.5 8.5v5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      )}
 
       {error && (
         <p role="alert" className="mt-2 rounded-lg bg-error/10 px-3 py-2 text-xs text-error">
@@ -144,43 +187,58 @@ export function VocabularyAliasesEditor({
         </p>
       )}
 
-      <div className="mt-3 rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-3">
-        <div className="flex items-center justify-between gap-3">
+      <div className="mt-3 rounded-xl border border-outline-variant/30 bg-surface-container-lowest">
+        <button
+          type="button"
+          aria-expanded={previewExpanded}
+          onClick={() => setPreviewExpanded((expanded) => !expanded)}
+          className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+        >
           <div>
-            <p className="text-xs font-medium text-on-surface">Try your aliases</p>
-            <p className="mt-0.5 text-[11px] text-on-surface-variant">Runs locally in memory. Nothing is recorded, copied, or logged.</p>
+            <p className="text-xs font-medium text-on-surface">Test a phrase</p>
+            <p className="mt-0.5 text-[11px] text-on-surface-variant">See the result without recording anything.</p>
           </div>
-          <label className="flex items-center gap-2 text-[11px] text-on-surface-variant">
-            <input type="checkbox" checked={includeCli} onChange={(event) => setIncludeCli(event.target.checked)} />
-            Include CLI formatting
-          </label>
-        </div>
-        <div className="mt-2 flex gap-2">
-          <input
-            aria-label="Alias preview input"
-            value={previewInput}
-            onChange={(event) => { setPreviewInput(event.target.value); setPreviewOutput(''); }}
-            className="min-w-0 flex-1 rounded-lg border border-on-surface-variant bg-surface-container px-3 py-2 text-xs text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
-          />
-          <button
-            type="button"
-            disabled={previewing || !previewInput.trim()}
-            onClick={() => void runPreview()}
-            className="rounded-lg bg-primary px-3 py-2 text-xs font-medium text-on-primary disabled:opacity-50"
-          >
-            {previewing ? 'Testing…' : 'Test'}
-          </button>
-        </div>
-        {previewOutput && (
-          <output aria-label="Alias preview output" className="mt-2 block rounded-lg bg-surface-container px-3 py-2 font-mono text-xs text-on-surface">
-            {previewOutput}
-          </output>
+          <svg aria-hidden="true" viewBox="0 0 20 20" className={`h-4 w-4 shrink-0 text-on-surface-variant transition-transform ${previewExpanded ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="m5 7.5 5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        {previewExpanded && (
+          <div className="border-t border-outline-variant/20 px-3 pb-3 pt-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[11px] text-on-surface-variant">Runs locally in memory. Nothing is copied or logged.</p>
+              <label className="flex shrink-0 items-center gap-2 text-[11px] text-on-surface-variant">
+                <input type="checkbox" checked={includeCli} onChange={(event) => setIncludeCli(event.target.checked)} />
+                Include CLI formatting
+              </label>
+            </div>
+            <div className="mt-2 flex gap-2">
+              <input
+                aria-label="Alias preview input"
+                value={previewInput}
+                onChange={(event) => { setPreviewInput(event.target.value); setPreviewOutput(''); }}
+                className="min-w-0 flex-1 rounded-lg border border-on-surface-variant bg-surface-container px-3 py-2 text-xs text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <button
+                type="button"
+                disabled={previewing || !previewInput.trim()}
+                onClick={() => void runPreview()}
+                className="rounded-lg bg-primary px-3 py-2 text-xs font-medium text-on-primary disabled:opacity-50"
+              >
+                {previewing ? 'Testing…' : 'Test'}
+              </button>
+            </div>
+            {previewOutput && (
+              <output aria-label="Alias preview output" className="mt-2 block rounded-lg bg-surface-container px-3 py-2 font-mono text-xs text-on-surface">
+                {previewOutput}
+              </output>
+            )}
+          </div>
         )}
       </div>
 
       {enabledPrompt && (
         <p className="mt-2 text-[11px] text-on-surface-variant">
-          Enabled written terms also bias Whisper; spoken aliases are post-model only.
+          Your saved spellings work locally with every transcription model.
         </p>
       )}
     </div>


### PR DESCRIPTION
## What changed

- replace stacked vocabulary cards with compact “Murmur hears → Murmur types” rows
- bound long vocabulary lists to an internal scroll area
- remove technical “spoken aliases” and redundant “Global” language from the visible UI
- keep the phrase preview collapsed until requested
- let users add a blank spelling without showing an error before they type

## Why

The old editor consumed two full lines per term and grew the entire settings page indefinitely. Its labels exposed implementation terminology that was difficult for non-technical users to understand.

## Behavior

The persisted `VocabularyEntry` schema, validation, enable/disable behavior, alias matching, model prompting, and local preview command are unchanged.

## Validation

- `npm test` — 624 tests passed
- `npx tsc --noEmit` — passed
- native macOS smoke with seven entries — compact list, internal scrolling, add/edit/delete, and phrase preview verified
