### PR TITLE
Fleet dashboard: add a plain-English health view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,12 @@ jobs:
               - 'scripts/capture_agent_matrix.py'
               - 'scripts/smoke_test_capture_worker.py'
               - 'scripts/validate_capture_boundary.py'
+              - 'infra/log-receiver/**'
               - 'tests/test_release_artifacts.py'
               - 'tests/test_workflow_policy.py'
               - 'tests/test_capture_agent_matrix.py'
               - 'tests/test_capture_worker_smoke.py'
+              - 'tests/test_log_receiver.py'
 
       - name: Validate workflow policy
         run: |
@@ -62,7 +64,8 @@ jobs:
             tests/test_release_artifacts.py \
             tests/test_workflow_policy.py \
             tests/test_capture_agent_matrix.py \
-            tests/test_capture_worker_smoke.py
+            tests/test_capture_worker_smoke.py \
+            tests/test_log_receiver.py
 
   typecheck:
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- The fleet diagnostics dashboard now leads with privacy-safe plain-English
+  health for microphone capture, shortcuts, dictation, updates, and transforms;
+  repeated warnings collapse into counted incidents, recovered fallback is
+  distinguished from failure, and raw technical evidence remains expandable
+  (#454).
 - Production microphone capture now runs behind a signed, killable helper with
   capture-scoped binary PCM framing, an allocation-free SPSC callback boundary,
   CPAL and direct AUHAL backends, exact-device pre-buffer failover, deterministic

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1115,6 +1115,7 @@ fn run_backend(
                 target: "audio",
                 event_code = "audio.capture_backend_timeout",
                 capture_id,
+                owner = owner.telemetry_id(),
                 backend = backend_label(backend),
                 active_elapsed_ms = clock.elapsed(now).as_millis() as u64,
                 attempt_budget_ms = attempt_budget.as_millis() as u64,

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -1113,6 +1113,7 @@ fn run_backend(
             // for the step -> Core Audio call mapping).
             tracing::warn!(
                 target: "audio",
+                event_code = "audio.capture_backend_timeout",
                 capture_id,
                 backend = backend_label(backend),
                 active_elapsed_ms = clock.elapsed(now).as_millis() as u64,
@@ -1413,6 +1414,7 @@ fn run_capture_backend_sequence(
                 }
                 tracing::warn!(
                     target: "audio",
+                    event_code = "audio.fallback_started",
                     owner = owner.telemetry_id(),
                     from_backend = backend_label(backend),
                     to_backend = backend_label(backends[1]),
@@ -1427,6 +1429,7 @@ fn run_capture_backend_sequence(
                 if !retained_audio && attempt_index == 1 {
                     tracing::error!(
                         target: "audio",
+                        event_code = "audio.capture_failed",
                         owner = owner.telemetry_id(),
                         primary_backend = backend_label(backends[0]),
                         fallback_backend = backend_label(backend),

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -782,6 +782,7 @@ fn handle_worker_event(
                 public.set_phase(PublicPhase::Recording);
                 tracing::info!(
                     target: "audio",
+                    event_code = "audio.capture_ready",
                     owner = owner.telemetry_id(),
                     owner_kind = owner.kind(),
                     startup_ms = current.accepted_at.elapsed().as_millis() as u64,
@@ -1051,6 +1052,7 @@ fn report_failure_once(attempt: &mut Attempt, sink: &dyn LifecycleSink, failure:
     attempt.failure_reported = true;
     tracing::error!(
         target: "audio",
+        event_code = "audio.lifecycle_failed",
         owner = attempt.owner.telemetry_id(),
         owner_kind = attempt.owner.kind(),
         error_kind = failure.kind.as_str(),

--- a/app/src-tauri/src/commands/logging.rs
+++ b/app/src-tauri/src/commands/logging.rs
@@ -11,19 +11,53 @@ pub fn clear_logs() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn log_frontend(level: String, message: String, transform_pass_id: Option<u64>) {
-    match (level.to_uppercase().as_str(), transform_pass_id) {
-        ("WARN", Some(transform_pass_id)) => {
+pub fn log_frontend(
+    level: String,
+    message: String,
+    transform_pass_id: Option<u64>,
+    event_code: Option<String>,
+) {
+    let event_code = event_code
+        .as_deref()
+        .and_then(crate::telemetry::canonical_event_code);
+    match (
+        level.to_uppercase().as_str(),
+        transform_pass_id,
+        event_code,
+    ) {
+        ("WARN", Some(transform_pass_id), Some(event_code)) => {
+            tracing::warn!(target: "system", source = "frontend", transform_pass_id, event_code, "{}", message)
+        }
+        ("ERROR", Some(transform_pass_id), Some(event_code)) => {
+            tracing::error!(target: "system", source = "frontend", transform_pass_id, event_code, "{}", message)
+        }
+        (_, Some(transform_pass_id), Some(event_code)) => {
+            tracing::info!(target: "system", source = "frontend", transform_pass_id, event_code, "{}", message)
+        }
+        ("WARN", Some(transform_pass_id), None) => {
             tracing::warn!(target: "system", source = "frontend", transform_pass_id, "{}", message)
         }
-        ("ERROR", Some(transform_pass_id)) => {
+        ("ERROR", Some(transform_pass_id), None) => {
             tracing::error!(target: "system", source = "frontend", transform_pass_id, "{}", message)
         }
-        (_, Some(transform_pass_id)) => {
+        (_, Some(transform_pass_id), None) => {
             tracing::info!(target: "system", source = "frontend", transform_pass_id, "{}", message)
         }
-        ("WARN", None) => tracing::warn!(target: "system", source = "frontend", "{}", message),
-        ("ERROR", None) => tracing::error!(target: "system", source = "frontend", "{}", message),
-        (_, None) => tracing::info!(target: "system", source = "frontend", "{}", message),
+        ("WARN", None, Some(event_code)) => {
+            tracing::warn!(target: "system", source = "frontend", event_code, "{}", message)
+        }
+        ("ERROR", None, Some(event_code)) => {
+            tracing::error!(target: "system", source = "frontend", event_code, "{}", message)
+        }
+        (_, None, Some(event_code)) => {
+            tracing::info!(target: "system", source = "frontend", event_code, "{}", message)
+        }
+        ("WARN", None, None) => {
+            tracing::warn!(target: "system", source = "frontend", "{}", message)
+        }
+        ("ERROR", None, None) => {
+            tracing::error!(target: "system", source = "frontend", "{}", message)
+        }
+        (_, None, None) => tracing::info!(target: "system", source = "frontend", "{}", message),
     }
 }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -2782,7 +2782,12 @@ pub async fn stop_native_recording(
     let pipeline = match pipeline_result {
         Ok(result) => result,
         Err(error) => {
-            tracing::error!(target: "pipeline", "stop_native_recording: pipeline failed: {}", error);
+            tracing::error!(
+                target: "pipeline",
+                event_code = "pipeline.dictation_failed",
+                "stop_native_recording: pipeline failed: {}",
+                error
+            );
             return Err(error);
         }
     };
@@ -2805,6 +2810,7 @@ pub async fn stop_native_recording(
 
     tracing::info!(
         target: "pipeline",
+        event_code = "pipeline.dictation_completed",
         recording_id = rid,
         vad_ms = timings.vad_ms,
         model_load_ms = timings.model_load_ms,

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -852,7 +852,11 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
             // them directly from this background thread.
             #[cfg(target_os = "macos")]
             set_is_main_thread(false);
-            tracing::info!(target: "keyboard", "rdev listener thread started");
+            tracing::info!(
+                target: "keyboard",
+                event_code = "keyboard.listener_started",
+                "rdev listener thread started"
+            );
 
             let callback = move |event: Event| {
                 // The dictation listener (LISTENER_ACTIVE) and the transform
@@ -1276,7 +1280,12 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
             };
 
             if let Err(e) = listen(callback) {
-                tracing::error!(target: "keyboard", "rdev listener error: {:?}", e);
+                tracing::error!(
+                    target: "keyboard",
+                    event_code = "keyboard.listener_failed",
+                    "rdev listener error: {:?}",
+                    e
+                );
                 LISTENER_THREAD_SPAWNED.store(false, Ordering::SeqCst);
                 LISTENER_ACTIVE.store(false, Ordering::SeqCst);
                 let _ = error_handle.emit("keyboard-listener-error", format!("{:?}", e));
@@ -1298,6 +1307,7 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                     LAST_TAP_SILENCE_WARNING_AT_MS.store(now, Ordering::SeqCst);
                     tracing::warn!(
                         target: "keyboard",
+                        event_code = "keyboard.listener_silent",
                         silent_for_ms = silent_for_ms,
                         threshold_ms = TAP_SILENCE_WARNING_MS,
                         "listener heartbeat — no rdev callbacks observed"

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -170,8 +170,31 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for TauriEmitterLayer 
 /// discipline. Transform traces may retain only stable enum/bucket fields;
 /// arbitrary strings (and therefore transform content, paths, app/device
 /// identifiers, or raw errors) are discarded in both debug and release builds.
+pub(crate) fn canonical_event_code(value: &str) -> Option<&'static str> {
+    match value {
+        "keyboard.listener_started" => Some("keyboard.listener_started"),
+        "keyboard.listener_silent" => Some("keyboard.listener_silent"),
+        "keyboard.listener_failed" => Some("keyboard.listener_failed"),
+        "audio.capture_backend_timeout" => Some("audio.capture_backend_timeout"),
+        "audio.fallback_started" => Some("audio.fallback_started"),
+        "audio.capture_ready" => Some("audio.capture_ready"),
+        "audio.capture_failed" => Some("audio.capture_failed"),
+        "audio.lifecycle_failed" => Some("audio.lifecycle_failed"),
+        "pipeline.dictation_completed" => Some("pipeline.dictation_completed"),
+        "pipeline.dictation_failed" => Some("pipeline.dictation_failed"),
+        "transform.pass_outcome" => Some("transform.pass_outcome"),
+        "updater.check_current" => Some("updater.check_current"),
+        "updater.check_failed" => Some("updater.check_failed"),
+        "updater.install_blocked" => Some("updater.install_blocked"),
+        "updater.install_ready" => Some("updater.install_ready"),
+        "updater.install_failed" => Some("updater.install_failed"),
+        _ => None,
+    }
+}
+
 fn is_safe_transform_string(key: &str, value: &str) -> bool {
     match key {
+        "event_code" => canonical_event_code(value).is_some(),
         "event" => matches!(value, "hold_start" | "hold_stop" | "armed" | "stopped"),
         "reason" => matches!(
             value,
@@ -321,7 +344,13 @@ fn sanitize_event_data(stream: &str, data: &mut serde_json::Value, debug_build: 
         return;
     };
     if !debug_build && stream == "pipeline" {
-        obj.retain(|_, value| !value.is_string());
+        obj.retain(|key, value| {
+            !value.is_string()
+                || (key == "event_code"
+                    && value
+                        .as_str()
+                        .is_some_and(|code| canonical_event_code(code).is_some()))
+        });
         return;
     }
     if stream == "transform" {
@@ -559,6 +588,7 @@ mod tests {
     #[test]
     fn transform_event_sanitizer_keeps_documented_stable_values() {
         let mut data = serde_json::json!({
+            "event_code": "transform.pass_outcome",
             "event": "hold_stop",
             "reason": "released",
             "from": "listening",
@@ -574,6 +604,7 @@ mod tests {
 
         sanitize_event_data("transform", &mut data, true);
 
+        assert_eq!(data["event_code"], "transform.pass_outcome");
         assert_eq!(data["event"], "hold_stop");
         assert_eq!(data["reason"], "released");
         assert_eq!(data["from"], "listening");
@@ -594,6 +625,7 @@ mod tests {
             "transform_pass_id": 23,
             "duration_ms": 9,
             "won": true,
+            "event_code": sentinel,
             "event": sentinel,
             "reason": sentinel,
             "from": sentinel,
@@ -616,5 +648,28 @@ mod tests {
         assert!(!encoded.contains("SENTINEL"));
         assert!(!encoded.contains("/Users/private"));
         assert_eq!(data.as_object().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn release_pipeline_keeps_only_allowlisted_event_codes_from_string_fields() {
+        let mut data = serde_json::json!({
+            "recording_id": 9,
+            "total_ms": 420,
+            "event_code": "pipeline.dictation_completed",
+            "model": "PRIVATE_MODEL",
+            "error": "/Users/private/project"
+        });
+
+        sanitize_event_data("pipeline", &mut data, false);
+
+        assert_eq!(data["recording_id"], 9);
+        assert_eq!(data["total_ms"], 420);
+        assert_eq!(data["event_code"], "pipeline.dictation_completed");
+        assert!(data.get("model").is_none());
+        assert!(data.get("error").is_none());
+
+        data["event_code"] = serde_json::Value::String("private.content".to_string());
+        sanitize_event_data("pipeline", &mut data, false);
+        assert!(data.get("event_code").is_none());
     }
 }

--- a/app/src-tauri/src/transform_trace.rs
+++ b/app/src-tauri/src/transform_trace.rs
@@ -45,6 +45,7 @@ pub fn resolution(
     if let Some(error_code) = error_code {
         tracing::info!(
             target: "transform",
+            event_code = "transform.pass_outcome",
             transform_pass_id,
             outcome,
             stage,
@@ -54,6 +55,7 @@ pub fn resolution(
     } else {
         tracing::info!(
             target: "transform",
+            event_code = "transform.pass_outcome",
             transform_pass_id,
             outcome,
             stage,

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   sendNotification: vi.fn(),
   listen: vi.fn(),
   getUpdateInstallEnvironment: vi.fn(),
+  flogInfo: vi.fn(),
+  flogWarn: vi.fn(),
+  flogError: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/plugin-updater', () => ({ check: mocks.check }));
@@ -27,9 +30,9 @@ vi.mock('../updaterEnvironment', () => ({
 }));
 vi.mock('../log', () => ({
   flog: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
+    info: mocks.flogInfo,
+    warn: mocks.flogWarn,
+    error: mocks.flogError,
   },
 }));
 
@@ -109,6 +112,18 @@ describe('useAutoUpdater presentation state', () => {
     expect(localStorage.getItem('skipped-update-version')).toBe('0.23.0');
   });
 
+  it('logs the stable current-version event code when no update is available', async () => {
+    mocks.check.mockResolvedValue({ available: false });
+
+    await act(async () => current.checkForUpdate());
+
+    expect(mocks.flogInfo).toHaveBeenCalledWith(
+      'updater',
+      'no update available',
+      { event_code: 'updater.check_current' },
+    );
+  });
+
   it('keeps a failed manual check inline instead of opening a broken retry modal', async () => {
     mocks.check.mockRejectedValue(new Error('offline'));
 
@@ -120,6 +135,14 @@ describe('useAutoUpdater presentation state', () => {
       message: 'Error: offline',
     });
     expect(current.isUpdateDialogOpen).toBe(false);
+    expect(mocks.flogError).toHaveBeenCalledWith(
+      'updater',
+      'check failed',
+      {
+        event_code: 'updater.check_failed',
+        error: 'Error: offline',
+      },
+    );
   });
 
   it('blocks installation before download when Gatekeeper translocated the app', async () => {
@@ -146,6 +169,11 @@ describe('useAutoUpdater presentation state', () => {
       .toContain('read-only security location');
     expect(localStorage.getItem('pending-update-release-notes')).toBeNull();
     expect(current.isUpdateDialogOpen).toBe(true);
+    expect(mocks.flogWarn).toHaveBeenCalledWith(
+      'updater',
+      'install blocked by macOS App Translocation',
+      { event_code: 'updater.install_blocked' },
+    );
   });
 
   it('keeps the normal writable installation path unchanged', async () => {
@@ -163,5 +191,33 @@ describe('useAutoUpdater presentation state', () => {
     expect(downloadAndInstall).toHaveBeenCalledOnce();
     expect(mocks.relaunch).toHaveBeenCalledOnce();
     expect(current.updateStatus).toEqual({ phase: 'ready', version: '0.24.2' });
+    expect(mocks.flogInfo).toHaveBeenCalledWith(
+      'updater',
+      'installed, relaunching',
+      { event_code: 'updater.install_ready' },
+    );
+  });
+
+  it('logs the stable install-failure event code when download fails', async () => {
+    const downloadAndInstall = vi.fn().mockRejectedValue(new Error('disk full'));
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall,
+    });
+
+    await act(async () => current.checkForUpdate());
+    await act(async () => current.startDownload());
+
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    expect(mocks.flogError).toHaveBeenCalledWith(
+      'updater',
+      'download/install failed',
+      {
+        event_code: 'updater.install_failed',
+        error: 'Error: disk full',
+      },
+    );
   });
 });

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -94,7 +94,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       setLastCheckTimestamp(Date.now());
 
       if (!update?.available || !update.version) {
-        flog.info('updater', 'no update available');
+        flog.info('updater', 'no update available', {
+          event_code: 'updater.check_current',
+        });
         if (shouldPresentManualResult()) {
           setIsUpdateDialogOpen(false);
           setUpdateStatus({ phase: 'up-to-date' });
@@ -150,7 +152,10 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
         }
       }
     } catch (err) {
-      flog.error('updater', 'check failed', { error: String(err) });
+      flog.error('updater', 'check failed', {
+        event_code: 'updater.check_failed',
+        error: String(err),
+      });
       if (shouldPresentManualResult()) {
         setIsUpdateDialogOpen(false);
         setUpdateStatus({
@@ -240,7 +245,9 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
     try {
       const environment = await getUpdateInstallEnvironment();
       if (environment.appTranslocated) {
-        flog.warn('updater', 'install blocked by macOS App Translocation');
+        flog.warn('updater', 'install blocked by macOS App Translocation', {
+          event_code: 'updater.install_blocked',
+        });
         setUpdateStatus({
           phase: 'error',
           stage: 'install',
@@ -281,11 +288,16 @@ export function useAutoUpdater(): UseAutoUpdaterReturn {
       });
 
       setUpdateStatus({ phase: 'ready', version });
-      flog.info('updater', 'installed, relaunching');
+      flog.info('updater', 'installed, relaunching', {
+        event_code: 'updater.install_ready',
+      });
       clearSkippedVersion();
       await relaunch();
     } catch (err) {
-      flog.error('updater', 'download/install failed', { error: String(err) });
+      flog.error('updater', 'download/install failed', {
+        event_code: 'updater.install_failed',
+        error: String(err),
+      });
       setUpdateStatus({
         phase: 'error',
         stage: 'install',

--- a/app/src/lib/log.test.ts
+++ b/app/src/lib/log.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+
+import { flog } from './log';
+
+describe('flog event codes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards a string event code to the Rust logging command', () => {
+    flog.info('updater', 'no update available', {
+      event_code: 'updater.check_current',
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith('log_frontend', {
+      level: 'INFO',
+      message:
+        '[updater] no update available {"event_code":"updater.check_current"}',
+      transformPassId: null,
+      eventCode: 'updater.check_current',
+    });
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['non-string', { event_code: 42 }],
+  ])('sends a null event code when the field is %s', (_label, data) => {
+    flog.warn('updater', 'check failed', data);
+
+    expect(mocks.invoke).toHaveBeenCalledWith('log_frontend', {
+      level: 'WARN',
+      message: data
+        ? '[updater] check failed {"event_code":42}'
+        : '[updater] check failed',
+      transformPassId: null,
+      eventCode: null,
+    });
+  });
+});

--- a/app/src/lib/log.ts
+++ b/app/src/lib/log.ts
@@ -12,8 +12,18 @@ function write(level: string, tag: string, message: string, data?: Record<string
       && candidatePassId > 0
       ? candidatePassId
       : null;
+  const candidateEventCode = data?.event_code;
+  const eventCode =
+    typeof candidateEventCode === 'string'
+      ? candidateEventCode
+      : null;
   // Fire-and-forget — don't await, don't block the caller
-  invoke('log_frontend', { level, message: line, transformPassId }).catch(() => {});
+  invoke('log_frontend', {
+    level,
+    message: line,
+    transformPassId,
+    eventCode,
+  }).catch(() => {});
 }
 
 export const flog = {

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -68,8 +68,9 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
 - Batches are cut at line boundaries, max 1 MB per POST, max 8 POSTs per tick.
 - Auth is a static bearer token baked into the binary — spam control for the
   public URL, not a security boundary.
-- Dev builds ship `events.dev.jsonl` with `X-Dev: 1`; the receiver stores them
-  as `events.dev.jsonl` so dev noise is separable.
+- Normal dev builds do not ship. The receiver acknowledges and discards
+  `X-Dev: 1` batches from older builds so their local retry offsets can advance
+  without adding development noise to the fleet.
 - `MURMUR_LOG_ENDPOINT=<url>` overrides the endpoint for testing.
 
 ### Receiver (whoop-vm)
@@ -86,8 +87,33 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
 
 `https://murmur.georgenijo.com` (Cloudflare Access, george.nijo8@gmail.com
 only) — one row per install stream with device name, OS, version, event count,
-and freshness; click a row for the per-device page (recent warnings/errors on
-top, last 200 events below). Served by the same receiver process.
+and freshness. Each installation page leads with a **Plain-English health**
+summary for microphone capture, shortcuts, dictation, updates, and transforms.
+Repeated equivalent problems are grouped with occurrence counts, and ordered
+evidence distinguishes automatic recovery from an unresolved failure. Raw
+events remain available in an expandable technical timeline and as a complete
+JSONL download. Served by the same receiver process.
+
+### Operator event semantics
+
+High-value producers attach an allowlisted, privacy-safe `event_code` inside
+the structured `data` object. Examples include
+`audio.capture_backend_timeout`, `audio.fallback_started`,
+`audio.capture_ready`, `audio.capture_failed`,
+`keyboard.listener_silent`, `pipeline.dictation_completed`,
+`transform.pass_outcome`, and `updater.install_failed`.
+
+The dashboard maps those stable codes plus bounded fields to operator-facing
+language. A bounded compatibility table recognizes the corresponding constant
+summary strings in historical JSONL. Unknown events are never guessed: warnings
+and errors remain visible as technical events with their original escaped
+summary and data.
+
+Health conclusions are limited to the loaded event window. A fallback is shown
+as recovered only when later readiness for the same audio owner proves it;
+otherwise the outcome remains degraded or unknown. Listener silence is
+diagnostic rather than proof of failure because an idle or sleeping Mac also
+produces no global keyboard callbacks.
 
 ## Reading the logs
 

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -25,7 +25,7 @@ type AppEvent = {
   stream: StreamName;   // "pipeline" | "audio" | "keyboard" | "transform" | "system"
   level: LevelName;     // "trace" | "debug" | "info" | "warn" | "error"
   summary: string;      // the tracing message
-  data: Record<string, unknown>; // structured fields
+  data: Record<string, unknown>; // structured fields; may include a stable event_code
 };
 ```
 
@@ -48,6 +48,14 @@ When the JSONL file exceeds 5MB, it is rotated — renamed to `.jsonl.1` — and
 ### Privacy Stripping
 
 In release builds, all string-valued fields from `pipeline` target events are stripped from the `data` object. Only numeric fields survive. For the `transform` stream in both debug and release builds, each string must match an explicit key-specific enum/bucket vocabulary; unknown keys or values are dropped. Numeric and boolean diagnostic fields are retained. The `summary` (message) field is not stripped and transform summaries are constant. This prevents transcription or transform content from being persisted in structured log data.
+
+The one exception to pipeline string removal is an exact allowlisted
+`event_code`. Event codes are fixed identifiers such as
+`pipeline.dictation_completed`; arbitrary values are removed. Transform event
+codes pass through the same exact-value allowlist. Frontend-originated codes
+are validated by Rust before entering the structured event. This gives local
+and fleet presentation layers a stable semantic key without permitting user
+content or arbitrary labels.
 
 ### Pretty-Printed Log File
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -112,7 +112,8 @@ interface AppEvent {
   stream: StreamName;             // tracing target
   level: LevelName;
   summary: string;                // the tracing message
-  data: Record<string, unknown>;  // structured fields, after privacy stripping
+  data: Record<string, unknown>;  // structured fields after privacy stripping;
+                                  // high-value outcomes may include allowlisted event_code
 }
 
 type StreamName = 'pipeline' | 'audio' | 'keyboard' | 'transform' | 'system';

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -37,3 +37,12 @@ curl -s https://georgenijo.com/murmur/healthz   # expect: ok
 `meta.json` (device identity), `state.json` (latest mic/device snapshot).
 Caps: 8 MB/request, 200 MB/install, 10 GB global, 150 installs.
 Dev-tagged batches are acked and discarded.
+
+## Tests
+
+The receiver stays stdlib-only. Its plain-English classification, recovery
+correlation, grouping, unknown-event fallback, and HTML escaping are covered by:
+
+```bash
+python3 -m unittest tests/test_log_receiver.py
+```

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -159,6 +159,651 @@ def ago(ts):
     return "%dd ago" % (s // 86400)
 
 
+HEALTH_AREAS = (
+    ("microphone", "Microphone"),
+    ("shortcuts", "Shortcuts"),
+    ("dictation", "Dictation"),
+    ("updates", "Updates"),
+    ("transforms", "Transforms"),
+)
+
+EVENT_CODE_COMPATIBILITY = (
+    ("rdev listener thread started", "keyboard.listener_started"),
+    ("listener heartbeat — no rdev callbacks observed", "keyboard.listener_silent"),
+    ("rdev listener error:", "keyboard.listener_failed"),
+    (
+        "capture backend exceeded its active initialization budget",
+        "audio.capture_backend_timeout",
+    ),
+    (
+        "capture backend failed before retained audio; trying bounded fallback",
+        "audio.fallback_started",
+    ),
+    ("audio readiness accepted", "audio.capture_ready"),
+    (
+        "both capture backend attempts failed before first PCM",
+        "audio.capture_failed",
+    ),
+    ("audio lifecycle failed", "audio.lifecycle_failed"),
+    ("transcription complete", "pipeline.dictation_completed"),
+    ("stop_native_recording: pipeline failed:", "pipeline.dictation_failed"),
+    ("transform_pass_outcome", "transform.pass_outcome"),
+    ("[updater] no update available", "updater.check_current"),
+    ("[updater] check failed", "updater.check_failed"),
+    (
+        "[updater] install blocked by macOS App Translocation",
+        "updater.install_blocked",
+    ),
+    ("[updater] installed, relaunching", "updater.install_ready"),
+    ("[updater] download/install failed", "updater.install_failed"),
+)
+
+STATUS_PRIORITY = {
+    "healthy": 0,
+    "diagnostic": 1,
+    "recovered": 2,
+    "degraded": 3,
+    "action": 4,
+}
+
+STATUS_LABELS = {
+    "healthy": "OK",
+    "diagnostic": "FYI",
+    "recovered": "Recovered",
+    "degraded": "Watch",
+    "action": "Action",
+}
+
+
+def event_code(event):
+    """Return a stable event code, with a bounded fallback for old JSONL."""
+    data = event.get("data")
+    if isinstance(data, dict):
+        code = data.get("event_code")
+        if isinstance(code, str) and re.match(r"^[a-z][a-z0-9_.-]{2,80}$", code):
+            return code
+    summary = str(event.get("summary", ""))
+    for prefix, code in EVENT_CODE_COMPATIBILITY:
+        if summary.startswith(prefix):
+            return code
+    return None
+
+
+def event_epoch(event):
+    try:
+        return datetime.fromisoformat(
+            str(event.get("timestamp", "")).replace("Z", "+00:00")
+        ).timestamp()
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def display_event_time(event):
+    try:
+        dt = datetime.fromisoformat(
+            str(event.get("timestamp", "")).replace("Z", "+00:00")
+        )
+        return dt.astimezone(EASTERN).strftime("%b %-d, %H:%M:%S")
+    except (ValueError, TypeError):
+        return str(event.get("timestamp", ""))[:24] or "unknown"
+
+
+def event_value(event, key, default=None):
+    data = event.get("data")
+    return data.get(key, default) if isinstance(data, dict) else default
+
+
+def format_duration_ms(value):
+    try:
+        milliseconds = max(0, int(value))
+    except (TypeError, ValueError):
+        return None
+    if milliseconds < 1_000:
+        return "%d ms" % milliseconds
+    if milliseconds < 60_000:
+        return "%.1f seconds" % (milliseconds / 1_000)
+    if milliseconds < 3_600_000:
+        return "%d minutes" % (milliseconds // 60_000)
+    hours = milliseconds / 3_600_000
+    return "%.1f hours" % hours
+
+
+def signal(
+    area,
+    status,
+    code,
+    title,
+    explanation,
+    action,
+    events,
+    group=None,
+):
+    source_events = list(events)
+    return {
+        "area": area,
+        "status": status,
+        "code": code,
+        "group": group or code,
+        "title": title,
+        "explanation": explanation,
+        "action": action,
+        "events": source_events,
+        "first_epoch": min((event_epoch(e) for e in source_events), default=0),
+        "last_epoch": max((event_epoch(e) for e in source_events), default=0),
+        "count": 1,
+    }
+
+
+def classify_event(event):
+    """Translate one event without guessing beyond its stable evidence."""
+    code = event_code(event)
+    if code == "keyboard.listener_started":
+        return signal(
+            "shortcuts",
+            "healthy",
+            code,
+            "Shortcut listener started",
+            "Murmur is listening for the configured global shortcut.",
+            "No action required.",
+            [event],
+        )
+    if code == "keyboard.listener_silent":
+        elapsed = format_duration_ms(event_value(event, "silent_for_ms"))
+        detail = (
+            "No global keyboard callback was observed for %s." % elapsed
+            if elapsed
+            else "No global keyboard callback was observed for a while."
+        )
+        return signal(
+            "shortcuts",
+            "diagnostic",
+            code,
+            "No recent shortcut activity",
+            detail + " This is usually normal while the Mac is idle or asleep.",
+            "Check only if Murmur's shortcut has stopped responding.",
+            [event],
+        )
+    if code == "keyboard.listener_failed":
+        return signal(
+            "shortcuts",
+            "action",
+            code,
+            "Shortcut listener failed",
+            "Murmur's global keyboard listener exited with an error.",
+            "Restart Murmur, then verify Accessibility permission if shortcuts still fail.",
+            [event],
+        )
+    if code == "audio.capture_backend_timeout":
+        backend = event_value(event, "backend", "primary")
+        setup_step = event_value(event, "last_setup_step")
+        where = (
+            " while opening %s" % str(setup_step).replace("_", " ")
+            if setup_step and setup_step != "none"
+            else ""
+        )
+        return signal(
+            "microphone",
+            "degraded",
+            code,
+            "A microphone backend timed out",
+            "The %s capture backend took too long%s." % (backend, where),
+            "Murmur may recover by switching backends; check the later outcome.",
+            [event],
+        )
+    if code == "audio.fallback_started":
+        source = event_value(event, "from_backend", "primary")
+        target = event_value(event, "to_backend", "backup")
+        return signal(
+            "microphone",
+            "degraded",
+            code,
+            "Murmur switched microphone backends",
+            "The %s backend failed before audio arrived, so Murmur tried %s."
+            % (source, target),
+            "The loaded events do not yet prove whether fallback succeeded.",
+            [event],
+        )
+    if code == "audio.capture_ready":
+        startup = format_duration_ms(event_value(event, "startup_ms"))
+        detail = "Microphone audio became ready"
+        if startup:
+            detail += " in %s" % startup
+        return signal(
+            "microphone",
+            "healthy",
+            code,
+            "Microphone started",
+            detail + ".",
+            "No action required.",
+            [event],
+        )
+    if code in ("audio.capture_failed", "audio.lifecycle_failed"):
+        kind = event_value(event, "error_kind")
+        detail = "Murmur could not start or retain microphone audio."
+        if kind:
+            detail += " The reported failure was %s." % str(kind).replace("_", " ")
+        return signal(
+            "microphone",
+            "action",
+            code,
+            "Microphone failed",
+            detail,
+            "Try recording again; inspect Technical details if the failure repeats.",
+            [event],
+            group="audio.capture_failed",
+        )
+    if code == "pipeline.dictation_completed":
+        duration = format_duration_ms(event_value(event, "total_ms"))
+        detail = "The most recent recognized dictation completed successfully"
+        if duration:
+            detail += " in %s" % duration
+        return signal(
+            "dictation",
+            "healthy",
+            code,
+            "Dictation completed",
+            detail + ".",
+            "No action required.",
+            [event],
+        )
+    if code == "pipeline.dictation_failed":
+        return signal(
+            "dictation",
+            "action",
+            code,
+            "Dictation processing failed",
+            "Microphone audio reached the processing pipeline, but dictation did not complete.",
+            "Retry once; inspect Technical details if it happens again.",
+            [event],
+        )
+    if code == "updater.check_current":
+        return signal(
+            "updates",
+            "healthy",
+            code,
+            "Murmur is up to date",
+            "The latest update check completed and found no newer release.",
+            "No action required.",
+            [event],
+        )
+    if code == "updater.check_failed":
+        return signal(
+            "updates",
+            "degraded",
+            code,
+            "Update check failed",
+            "Murmur could not check for a new version.",
+            "Murmur will try again later; check the network if this persists.",
+            [event],
+        )
+    if code == "updater.install_blocked":
+        return signal(
+            "updates",
+            "action",
+            code,
+            "Update installation is blocked",
+            "macOS App Translocation prevents Murmur from safely installing the update.",
+            "Move Murmur to Applications from Finder, reopen it, and retry.",
+            [event],
+        )
+    if code == "updater.install_ready":
+        return signal(
+            "updates",
+            "healthy",
+            code,
+            "Update installed",
+            "The update finished installing and Murmur began relaunching.",
+            "No action required.",
+            [event],
+        )
+    if code == "updater.install_failed":
+        return signal(
+            "updates",
+            "action",
+            code,
+            "Update installation failed",
+            "Murmur could not finish downloading or installing the update.",
+            "Retry the update; inspect Technical details if it fails again.",
+            [event],
+        )
+    if code == "transform.pass_outcome":
+        outcome = str(event_value(event, "outcome", "unknown"))
+        if outcome in ("ok", "ready", "applied", "undone"):
+            status = "healthy"
+            title = "Transform completed"
+            explanation = "The selected-text transform reached %s." % outcome
+            action = "No action required."
+        elif outcome in ("cancelled", "capture_aborted", "empty"):
+            status = "diagnostic"
+            title = "Transform did not make a change"
+            explanation = "The transform ended as %s." % outcome.replace("_", " ")
+            action = "No action required unless this was unexpected."
+        elif outcome in ("error", "failed", "transcription_error"):
+            status = "action"
+            title = "Transform failed"
+            explanation = "The selected-text transform did not complete."
+            action = "Retry once; inspect Technical details if it repeats."
+        else:
+            status = "diagnostic"
+            title = "Transform outcome recorded"
+            explanation = "Murmur recorded a transform outcome it cannot summarize safely."
+            action = "Inspect Technical details for the raw outcome."
+        return signal(
+            "transforms",
+            status,
+            code,
+            title,
+            explanation,
+            action,
+            [event],
+            group="transform.pass_outcome.%s" % outcome,
+        )
+    return None
+
+
+def correlation_key(event):
+    owner = event_value(event, "owner")
+    return str(owner) if owner is not None else "single-audio-owner"
+
+
+def build_health_signals(events):
+    """Build ordered health signals, correlating fallback with later readiness."""
+    signals = []
+    pending_timeouts = []
+    pending_fallbacks = {}
+    failure_signals = {}
+    for event in events:
+        code = event_code(event)
+        if code == "audio.capture_backend_timeout":
+            pending_timeouts.append(event)
+            continue
+        if code == "audio.fallback_started":
+            key = correlation_key(event)
+            evidence = []
+            if pending_timeouts:
+                evidence.append(pending_timeouts.pop())
+            evidence.append(event)
+            pending_fallbacks[key] = evidence
+            continue
+        if code == "audio.capture_ready":
+            key = correlation_key(event)
+            fallback = pending_fallbacks.pop(key, None)
+            if fallback:
+                source = event_value(fallback[-1], "from_backend", "primary")
+                target = event_value(fallback[-1], "to_backend", "backup")
+                signals.append(
+                    signal(
+                        "microphone",
+                        "recovered",
+                        "audio.fallback_recovered",
+                        "Microphone recovered with its backup backend",
+                        "The %s backend failed, Murmur switched to %s, and audio became ready."
+                        % (source, target),
+                        "No action required unless fallback happens repeatedly.",
+                        fallback + [event],
+                    )
+                )
+                continue
+        if code in ("audio.capture_failed", "audio.lifecycle_failed"):
+            key = correlation_key(event)
+            fallback = pending_fallbacks.pop(key, None)
+            existing_failure = failure_signals.get(key)
+            if existing_failure is not None:
+                existing_failure["events"].append(event)
+                existing_failure["last_epoch"] = max(
+                    existing_failure["last_epoch"], event_epoch(event)
+                )
+                continue
+            classified = classify_event(event)
+            if classified:
+                if fallback:
+                    classified["events"] = fallback + classified["events"]
+                    classified["first_epoch"] = min(
+                        event_epoch(e) for e in classified["events"]
+                    )
+                signals.append(classified)
+                failure_signals[key] = classified
+            continue
+        classified = classify_event(event)
+        if classified:
+            signals.append(classified)
+
+    for event in pending_timeouts:
+        classified = classify_event(event)
+        if classified:
+            signals.append(classified)
+    for evidence in pending_fallbacks.values():
+        classified = classify_event(evidence[-1])
+        if classified:
+            classified["events"] = evidence
+            classified["first_epoch"] = min(event_epoch(e) for e in evidence)
+            signals.append(classified)
+    signals.sort(key=lambda item: item["last_epoch"])
+    return signals
+
+
+def unknown_problem_signal(event):
+    level = str(event.get("level", "info"))
+    if level not in ("warn", "error"):
+        return None
+    summary = str(event.get("summary", ""))[:160] or "Unlabeled technical event"
+    status = "action" if level == "error" else "diagnostic"
+    return signal(
+        "technical",
+        status,
+        "unknown.%s" % level,
+        "Technical error" if level == "error" else "Technical warning",
+        summary,
+        "Review the raw event; Murmur has no safe plain-English mapping for it yet.",
+        [event],
+        group="unknown.%s.%s.%s"
+        % (level, str(event.get("stream", ""))[:40], summary),
+    )
+
+
+def group_problem_signals(events, signals):
+    recognized_ids = {id(event) for item in signals for event in item["events"]}
+    problem_signals = [item for item in signals if item["status"] != "healthy"]
+    for event in events:
+        if id(event) in recognized_ids:
+            continue
+        unknown = unknown_problem_signal(event)
+        if unknown:
+            problem_signals.append(unknown)
+
+    grouped = {}
+    for item in problem_signals:
+        key = item["group"]
+        existing = grouped.get(key)
+        if existing is None:
+            grouped[key] = dict(item)
+            grouped[key]["events"] = list(item["events"])
+            continue
+        existing["count"] += item["count"]
+        existing["first_epoch"] = min(existing["first_epoch"], item["first_epoch"])
+        existing["last_epoch"] = max(existing["last_epoch"], item["last_epoch"])
+        existing["events"].extend(item["events"])
+        if STATUS_PRIORITY[item["status"]] > STATUS_PRIORITY[existing["status"]]:
+            existing["status"] = item["status"]
+            existing["title"] = item["title"]
+            existing["explanation"] = item["explanation"]
+            existing["action"] = item["action"]
+
+    return sorted(
+        grouped.values(),
+        key=lambda item: (STATUS_PRIORITY[item["status"]], item["last_epoch"]),
+        reverse=True,
+    )
+
+
+def build_health_cards(signals, state):
+    cards = {
+        area: {
+            "area": area,
+            "label": label,
+            "status": "diagnostic",
+            "title": "No recent evidence",
+            "explanation": "No recognized health event is present in the loaded log window.",
+            "action": "Open the raw timeline for older or unmapped events.",
+            "last_epoch": 0,
+            "events": [],
+        }
+        for area, label in HEALTH_AREAS
+    }
+    if isinstance(state, dict) and "default_input_available" in state:
+        if state.get("input_enumeration_ok") is False:
+            cards["microphone"].update(
+                title="Microphone status unavailable",
+                explanation="Murmur could not enumerate audio inputs in the latest state check.",
+                action="Check again after capture is idle.",
+            )
+        elif state.get("default_input_available") is False:
+            cards["microphone"].update(
+                status="action",
+                title="No default microphone available",
+                explanation="The latest privacy-safe state snapshot found no default input.",
+                action="Connect or select a microphone, then retry.",
+            )
+    for item in signals:
+        area = item["area"]
+        if area not in cards:
+            continue
+        cards[area] = {
+            "area": area,
+            "label": dict(HEALTH_AREAS)[area],
+            "status": item["status"],
+            "title": item["title"],
+            "explanation": item["explanation"],
+            "action": item["action"],
+            "last_epoch": item["last_epoch"],
+            "events": item["events"],
+        }
+    return [cards[area] for area, _ in HEALTH_AREAS]
+
+
+def raw_event_row(event):
+    level = str(event.get("level", "info"))
+    row_class = level if level in ("warn", "error") else ""
+    data = event.get("data")
+    data = data if isinstance(data, dict) else {}
+    data_str = " ".join(
+        "%s=%s" % (key, value) for key, value in list(data.items())[:6]
+    )
+    return (
+        '<tr class="%s"><td class="num">%s</td>'
+        '<td><span class="stream">%s</span></td>'
+        '<td><span class="lvl %s">%s</span></td>'
+        '<td><code>%s</code><div class="meta">%s</div></td></tr>'
+        % (
+            row_class,
+            html.escape(eastern_time(str(event.get("timestamp", "")))),
+            html.escape(str(event.get("stream", ""))),
+            html.escape(level),
+            html.escape(level),
+            html.escape(str(event.get("summary", ""))[:160]),
+            html.escape(data_str[:160]),
+        )
+    )
+
+
+def compact_event(event):
+    level = str(event.get("level", "info"))
+    data = event.get("data")
+    data = data if isinstance(data, dict) else {}
+    data_str = " ".join(
+        "%s=%s" % (key, value) for key, value in list(data.items())[:6]
+    )
+    return (
+        '<div class="health-event %s"><div class="health-event-head">'
+        '<span class="num">%s</span><span class="stream">%s</span>'
+        '<span class="lvl %s">%s</span></div><code>%s</code>'
+        '<div class="meta">%s</div></div>'
+        % (
+            html.escape(level if level in ("warn", "error") else "info"),
+            html.escape(eastern_time(str(event.get("timestamp", "")))),
+            html.escape(str(event.get("stream", ""))),
+            html.escape(level),
+            html.escape(level),
+            html.escape(str(event.get("summary", ""))[:160]),
+            html.escape(data_str[:160]),
+        )
+    )
+
+
+def render_health_card(card):
+    seen = (
+        "Last evidence %s" % ago(card["last_epoch"])
+        if card["last_epoch"]
+        else "No recognized event in this window"
+    )
+    evidence = ""
+    if card.get("events"):
+        evidence = (
+            '<details class="health-evidence"><summary>Technical details</summary>'
+            '<div class="health-source">%s</div></details>'
+            % "".join(
+                compact_event(event)
+                for event in sorted(card["events"], key=event_epoch, reverse=True)
+            )
+        )
+    return (
+        '<article class="health-card %s">'
+        '<div class="health-head"><span class="health-area">%s</span>'
+        '<span class="status %s">%s</span></div>'
+        '<strong>%s</strong><p>%s</p>'
+        '<div class="meta">%s · %s</div>%s</article>'
+        % (
+            html.escape(card["status"]),
+            html.escape(card["label"]),
+            html.escape(card["status"]),
+            html.escape(STATUS_LABELS.get(card["status"], card["status"])),
+            html.escape(card["title"]),
+            html.escape(card["explanation"]),
+            html.escape(card["action"]),
+            html.escape(seen),
+            evidence,
+        )
+    )
+
+
+def render_problem_group(item):
+    evidence = sorted(item["events"], key=event_epoch, reverse=True)
+    shown = evidence[:20]
+    hidden_note = ""
+    if len(evidence) > len(shown):
+        hidden_note = (
+            '<p class="meta">Showing the newest %d of %d source events. '
+            "The raw timeline below retains the complete loaded evidence.</p>"
+            % (len(shown), len(evidence))
+        )
+    first_event = min(evidence, key=event_epoch) if evidence else {}
+    last_event = max(evidence, key=event_epoch) if evidence else {}
+    occurrence = "1 occurrence" if item["count"] == 1 else "%d occurrences" % item["count"]
+    return (
+        '<details class="problem-card %s"><summary>'
+        '<span><span class="status %s">%s</span><strong>%s</strong>'
+        '<span class="problem-copy">%s</span></span>'
+        '<span class="problem-count">%s</span></summary>'
+        '<div class="problem-detail"><p>%s</p><p><strong>%s</strong></p>'
+        '<p class="meta">First seen %s · Last seen %s</p>'
+        "%s<table><tbody>%s</tbody></table></div></details>"
+        % (
+            html.escape(item["status"]),
+            html.escape(item["status"]),
+            html.escape(STATUS_LABELS.get(item["status"], item["status"])),
+            html.escape(item["title"]),
+            html.escape(item["explanation"]),
+            html.escape(occurrence),
+            html.escape(item["explanation"]),
+            html.escape(item["action"]),
+            html.escape(display_event_time(first_event)),
+            html.escape(display_event_time(last_event)),
+            hidden_note,
+            "".join(raw_event_row(event) for event in shown),
+        )
+    )
+
+
 def render_dashboard():
     installs = collect_installs()
     now = time.time()
@@ -213,8 +858,9 @@ def render_dashboard():
 <meta http-equiv="refresh" content="30">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>murmur fleet logs</title><style>
-body{background:#0b1120;color:#e2e8f0;font:15px/1.5 -apple-system,system-ui,sans-serif;margin:2rem auto;max-width:70rem;padding:0 1rem}
+body{background:#0b1120;color:#e2e8f0;font:15px/1.5 -apple-system,system-ui,sans-serif;margin:2rem auto;max-width:78rem;padding:0 1rem}
 h1{font-size:1.3rem;margin:0}
+h2{font-size:1rem;margin:1.7rem 0 .7rem}
 .sub{color:#64748b;margin:.3rem 0 1.4rem;font-size:.85rem}
 table{border-collapse:collapse;width:100%%}
 th{text-align:left;color:#64748b;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;padding:.4rem .7rem;border-bottom:1px solid #1e293b}
@@ -234,6 +880,33 @@ tr.warn td{background:#2a1e0a}tr.error td{background:#2a0f14}
 .lvl.info{color:#94a3b8}.lvl.warn{background:#3b2f14;color:#fbbf24}.lvl.error{background:#450a0a;color:#f87171}
 .stream{color:#818cf8;font-size:.8em}
 .back{color:#64748b;font-size:.85rem}
+.health-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(13rem,1fr));gap:.7rem}
+.health-card{border:1px solid #1e293b;border-radius:12px;background:#111a2d;padding:.8rem .9rem;min-height:8.5rem}
+.health-card.healthy{border-color:#14532d}.health-card.recovered{border-color:#854d0e}
+.health-card.degraded{border-color:#92400e}.health-card.action{border-color:#7f1d1d}
+.health-head{display:flex;align-items:center;justify-content:space-between;gap:.5rem;margin-bottom:.55rem}
+.health-area{color:#94a3b8;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.05em}
+.health-card strong{display:block;font-size:.92rem}.health-card p{color:#cbd5e1;font-size:.82rem;margin:.3rem 0 .65rem}
+.health-evidence{margin-top:.65rem}.health-evidence>summary{color:#93c5fd;cursor:pointer;font-size:.73rem}
+.health-source{display:grid;gap:.35rem;margin-top:.45rem;max-height:14rem;overflow-x:hidden;overflow-y:auto}
+.health-event{border-left:2px solid #334155;padding:.35rem .45rem}.health-event.warn{border-color:#854d0e}.health-event.error{border-color:#7f1d1d}
+.health-event-head{align-items:center;display:flex;gap:.4rem;margin-bottom:.22rem}.health-event code{display:block;overflow-wrap:anywhere;white-space:normal;word-break:break-word}
+.status{display:inline-block;border-radius:99px;font-size:.65rem;font-weight:750;letter-spacing:.035em;padding:.12rem .42rem;text-transform:uppercase;white-space:nowrap}
+.status.healthy{background:#14532d;color:#86efac}.status.diagnostic{background:#1e293b;color:#94a3b8}
+.status.recovered{background:#713f12;color:#fde68a}.status.degraded{background:#78350f;color:#fbbf24}
+.status.action{background:#7f1d1d;color:#fecaca}
+.problem-list{display:grid;gap:.55rem}
+.problem-card{border:1px solid #1e293b;border-radius:10px;background:#111827;overflow:hidden}
+.problem-card.action{border-color:#7f1d1d}.problem-card.degraded{border-color:#92400e}
+.problem-card.recovered{border-color:#854d0e}
+.problem-card summary{align-items:center;cursor:pointer;display:flex;justify-content:space-between;gap:1rem;list-style:none;padding:.75rem .85rem}
+.problem-card summary::-webkit-details-marker{display:none}
+.problem-card summary>span:first-child{align-items:center;display:flex;flex-wrap:wrap;gap:.55rem;min-width:0}
+.problem-copy{color:#94a3b8;font-size:.8rem}.problem-count{color:#64748b;font-size:.76rem;white-space:nowrap}
+.problem-detail{border-top:1px solid #1e293b;padding:.15rem .85rem .85rem}
+.problem-detail p{font-size:.84rem;margin:.6rem 0}
+.raw-timeline{border-top:1px solid #1e293b;margin-top:1.8rem;padding-top:.6rem}
+.raw-timeline>summary{cursor:pointer;font-size:1rem;font-weight:700;margin:.6rem 0}
 </style></head><body>%s</body></html>""" % body
 
 
@@ -257,28 +930,6 @@ def render_install(install_id, kind, n=200):
             events.append(json.loads(line))
         except ValueError:
             continue
-    problems = [e for e in events if e.get("level") in ("warn", "error")]
-
-    def row(e):
-        lvl = e.get("level", "info")
-        cls = lvl if lvl in ("warn", "error") else ""
-        data = e.get("data") or {}
-        data_str = " ".join("%s=%s" % (k, v) for k, v in list(data.items())[:6])
-        return (
-            '<tr class="%s"><td class="num">%s</td>'
-            '<td><span class="stream">%s</span></td>'
-            '<td><span class="lvl %s">%s</span></td>'
-            '<td><code>%s</code><div class="meta">%s</div></td></tr>'
-            % (
-                cls,
-                html.escape(eastern_time(str(e.get("timestamp", "")))),
-                html.escape(str(e.get("stream", ""))),
-                lvl,
-                lvl,
-                html.escape(str(e.get("summary", ""))[:160]),
-                html.escape(data_str[:160]),
-            )
-        )
 
     title = meta.get("device_name") or install_id[:8]
     sub = " · ".join(
@@ -290,38 +941,96 @@ def render_install(install_id, kind, n=200):
             install_id,
         ) if x
     )
-    info_html = ""
+    state = {}
     try:
         with open(os.path.join(ROOT, install_id, "state.json")) as f:
             state = json.load(f)
-        others = [d for d in state.get("input_devices", []) if d != state.get("default_input")]
+    except (OSError, ValueError):
+        pass
+
+    signals = build_health_signals(events)
+    health_cards = build_health_cards(signals, state)
+    problem_groups = group_problem_signals(events, signals)
+    health_html = (
+        "<h2>Plain-English health</h2>"
+        "<div class='health-grid'>%s</div>"
+        "<p class='meta'>Based on the %d loaded events. Unknown events remain "
+        "visible in the technical timeline and are never guessed.</p>"
+        % ("".join(render_health_card(card) for card in health_cards), len(events))
+    )
+
+    info_html = ""
+    if state:
         chips = []
         for ev in reversed(events):
             if str(ev.get("summary", "")).startswith("configure_dictation"):
                 data = ev.get("data") or {}
                 chips = ["%s: %s" % (k, v) for k, v in sorted(data.items())][:12]
                 break
+        if "default_input_available" in state:
+            microphone = "Available" if state.get("default_input_available") else "Unavailable"
+            input_count = state.get("input_device_count")
+            inputs = (
+                "%s detected%s"
+                % (
+                    input_count,
+                    " (count capped)" if state.get("input_device_count_capped") else "",
+                )
+                if isinstance(input_count, int)
+                else "unknown"
+            )
+            enumeration = (
+                "Succeeded" if state.get("input_enumeration_ok") else "Failed"
+            )
+        else:
+            microphone = state.get("default_input") or "unknown"
+            others = [
+                device
+                for device in state.get("input_devices", [])
+                if device != state.get("default_input")
+            ]
+            inputs = ", ".join(others) or "unknown"
+            enumeration = "Legacy state snapshot"
         info_html = (
             '<h2>quick info</h2><table><tbody>'
             '<tr><td>Microphone</td><td><strong>%s</strong></td></tr>'
-            '<tr><td>Other inputs</td><td>%s</td></tr>'
+            '<tr><td>Inputs</td><td>%s</td></tr>'
+            '<tr><td>Enumeration</td><td>%s</td></tr>'
             '<tr><td>Settings</td><td class="meta">%s</td></tr>'
             '<tr><td>As of</td><td>%s</td></tr>'
             '</tbody></table>'
             % (
-                html.escape(state.get("default_input") or "unknown"),
-                html.escape(", ".join(others)) or "&mdash;",
+                html.escape(str(microphone)),
+                html.escape(str(inputs)),
+                html.escape(str(enumeration)),
                 html.escape(" · ".join(chips)) or "&mdash;",
                 ago(state.get("received_at", 0)),
             )
         )
-    except (OSError, ValueError):
-        pass
-    problems_html = ""
-    if problems:
-        problems_html = (
-            "<h2>recent warnings &amp; errors (%d)</h2><table><tbody>%s</tbody></table>"
-            % (len(problems), "".join(row(e) for e in reversed(problems[-25:])))
+
+    attention_groups = [
+        item for item in problem_groups if item["status"] in ("action", "degraded")
+    ]
+    explanation_groups = [
+        item for item in problem_groups if item["status"] in ("recovered", "diagnostic")
+    ]
+    if attention_groups:
+        attention_html = (
+            "<h2>What needs attention</h2><div class='problem-list'>%s</div>"
+            % "".join(render_problem_group(item) for item in attention_groups[:25])
+        )
+    else:
+        attention_html = (
+            "<h2>What needs attention</h2>"
+            "<p class='sub'>No recognized problems in the loaded event window.</p>"
+        )
+    explanations_html = ""
+    if explanation_groups:
+        explanations_html = (
+            "<h2>Recent explanations</h2>"
+            "<p class='sub'>Grouped background signals and incidents that recovered "
+            "without requiring action.</p><div class='problem-list'>%s</div>"
+            % "".join(render_problem_group(item) for item in explanation_groups[:25])
         )
     base = "/install/%s" % install_id
     body = (
@@ -331,19 +1040,21 @@ def render_install(install_id, kind, n=200):
         "show last <a href='%s?kind=%s&n=200'>200</a> / "
         "<a href='%s?kind=%s&n=1000'>1,000</a> / "
         "<a href='%s?kind=%s&n=5000'>5,000</a> &middot; "
-        "<a href='%s/raw?kind=%s'>&darr; download entire log (.jsonl)</a></p>%s%s"
-        "<h2>last %d events (newest first)</h2>"
-        "<table><tbody>%s</tbody></table>"
+        "<a href='%s/raw?kind=%s'>&darr; download entire log (.jsonl)</a></p>"
+        "%s%s%s"
+        "<details class='raw-timeline'><summary>Raw technical timeline "
+        "(%d loaded events)</summary><table><tbody>%s</tbody></table></details>"
         % (
             html.escape(title),
             html.escape(sub),
             "{:,}".format(total),
             size_mb,
             base, kind, base, kind, base, kind, base, kind,
+            health_html,
             info_html,
-            problems_html,
+            attention_html + explanations_html,
             len(events),
-            "".join(row(e) for e in reversed(events)),
+            "".join(raw_event_row(event) for event in reversed(events)),
         )
     )
     page = render_dashboard()  # reuse the <style> shell

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -253,6 +253,14 @@ def event_value(event, key, default=None):
     return data.get(key, default) if isinstance(data, dict) else default
 
 
+def event_label(event, key, default):
+    """Return a normalized, bounded label for one structured data value."""
+    value = event_value(event, key, default)
+    text = str(value if value not in (None, "") else default)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:40] or str(default)
+
+
 def format_duration_ms(value):
     try:
         milliseconds = max(0, int(value))
@@ -334,11 +342,11 @@ def classify_event(event):
             [event],
         )
     if code == "audio.capture_backend_timeout":
-        backend = event_value(event, "backend", "primary")
-        setup_step = event_value(event, "last_setup_step")
+        backend = event_label(event, "backend", "primary")
+        setup_step = event_label(event, "last_setup_step", "none")
         where = (
-            " while opening %s" % str(setup_step).replace("_", " ")
-            if setup_step and setup_step != "none"
+            " while opening %s" % setup_step.replace("_", " ")
+            if setup_step != "none"
             else ""
         )
         return signal(
@@ -351,8 +359,8 @@ def classify_event(event):
             [event],
         )
     if code == "audio.fallback_started":
-        source = event_value(event, "from_backend", "primary")
-        target = event_value(event, "to_backend", "backup")
+        source = event_label(event, "from_backend", "primary")
+        target = event_label(event, "to_backend", "backup")
         return signal(
             "microphone",
             "degraded",
@@ -378,10 +386,10 @@ def classify_event(event):
             [event],
         )
     if code in ("audio.capture_failed", "audio.lifecycle_failed"):
-        kind = event_value(event, "error_kind")
+        kind = event_label(event, "error_kind", "")
         detail = "Murmur could not start or retain microphone audio."
         if kind:
-            detail += " The reported failure was %s." % str(kind).replace("_", " ")
+            detail += " The reported failure was %s." % kind.replace("_", " ")
         return signal(
             "microphone",
             "action",
@@ -467,7 +475,7 @@ def classify_event(event):
             [event],
         )
     if code == "transform.pass_outcome":
-        outcome = str(event_value(event, "outcome", "unknown"))
+        outcome = event_label(event, "outcome", "unknown")
         if outcome in ("ok", "ready", "applied", "undone"):
             status = "healthy"
             title = "Transform completed"
@@ -488,6 +496,23 @@ def classify_event(event):
             title = "Transform outcome recorded"
             explanation = "Murmur recorded a transform outcome it cannot summarize safely."
             action = "Inspect Technical details for the raw outcome."
+        group_outcome = (
+            outcome
+            if outcome
+            in (
+                "ok",
+                "ready",
+                "applied",
+                "undone",
+                "cancelled",
+                "capture_aborted",
+                "empty",
+                "error",
+                "failed",
+                "transcription_error",
+            )
+            else "other"
+        )
         return signal(
             "transforms",
             status,
@@ -496,41 +521,57 @@ def classify_event(event):
             explanation,
             action,
             [event],
-            group="transform.pass_outcome.%s" % outcome,
+            group="transform.pass_outcome.%s" % group_outcome,
         )
     return None
 
 
 def correlation_key(event):
     owner = event_value(event, "owner")
-    return str(owner) if owner is not None else "single-audio-owner"
+    if isinstance(owner, int) and not isinstance(owner, bool) and 0 <= owner < 2**64:
+        return str(owner)
+    if isinstance(owner, str) and owner.isdigit() and len(owner) <= 20:
+        return str(int(owner))
+    return None
 
 
 def build_health_signals(events):
     """Build ordered health signals, correlating fallback with later readiness."""
     signals = []
-    pending_timeouts = []
+    pending_timeouts = {}
     pending_fallbacks = {}
     failure_signals = {}
     for event in events:
         code = event_code(event)
         if code == "audio.capture_backend_timeout":
-            pending_timeouts.append(event)
+            key = correlation_key(event)
+            if key is None:
+                classified = classify_event(event)
+                if classified:
+                    signals.append(classified)
+            else:
+                pending_timeouts[key] = event
             continue
         if code == "audio.fallback_started":
             key = correlation_key(event)
+            if key is None:
+                classified = classify_event(event)
+                if classified:
+                    signals.append(classified)
+                continue
             evidence = []
-            if pending_timeouts:
-                evidence.append(pending_timeouts.pop())
+            timeout = pending_timeouts.pop(key, None)
+            if timeout:
+                evidence.append(timeout)
             evidence.append(event)
             pending_fallbacks[key] = evidence
             continue
         if code == "audio.capture_ready":
             key = correlation_key(event)
-            fallback = pending_fallbacks.pop(key, None)
+            fallback = pending_fallbacks.pop(key, None) if key is not None else None
             if fallback:
-                source = event_value(fallback[-1], "from_backend", "primary")
-                target = event_value(fallback[-1], "to_backend", "backup")
+                source = event_label(fallback[-1], "from_backend", "primary")
+                target = event_label(fallback[-1], "to_backend", "backup")
                 signals.append(
                     signal(
                         "microphone",
@@ -546,8 +587,8 @@ def build_health_signals(events):
                 continue
         if code in ("audio.capture_failed", "audio.lifecycle_failed"):
             key = correlation_key(event)
-            fallback = pending_fallbacks.pop(key, None)
-            existing_failure = failure_signals.get(key)
+            fallback = pending_fallbacks.pop(key, None) if key is not None else None
+            existing_failure = failure_signals.get(key) if key is not None else None
             if existing_failure is not None:
                 existing_failure["events"].append(event)
                 existing_failure["last_epoch"] = max(
@@ -562,13 +603,14 @@ def build_health_signals(events):
                         event_epoch(e) for e in classified["events"]
                     )
                 signals.append(classified)
-                failure_signals[key] = classified
+                if key is not None:
+                    failure_signals[key] = classified
             continue
         classified = classify_event(event)
         if classified:
             signals.append(classified)
 
-    for event in pending_timeouts:
+    for event in pending_timeouts.values():
         classified = classify_event(event)
         if classified:
             signals.append(classified)
@@ -650,20 +692,6 @@ def build_health_cards(signals, state):
         }
         for area, label in HEALTH_AREAS
     }
-    if isinstance(state, dict) and "default_input_available" in state:
-        if state.get("input_enumeration_ok") is False:
-            cards["microphone"].update(
-                title="Microphone status unavailable",
-                explanation="Murmur could not enumerate audio inputs in the latest state check.",
-                action="Check again after capture is idle.",
-            )
-        elif state.get("default_input_available") is False:
-            cards["microphone"].update(
-                status="action",
-                title="No default microphone available",
-                explanation="The latest privacy-safe state snapshot found no default input.",
-                action="Connect or select a microphone, then retry.",
-            )
     for item in signals:
         area = item["area"]
         if area not in cards:
@@ -678,6 +706,30 @@ def build_health_cards(signals, state):
             "last_epoch": item["last_epoch"],
             "events": item["events"],
         }
+    if isinstance(state, dict) and "default_input_available" in state:
+        state_epoch = state.get("received_at", 0)
+        if not isinstance(state_epoch, (int, float)):
+            state_epoch = 0
+        microphone = cards["microphone"]
+        if state_epoch >= microphone["last_epoch"]:
+            if state.get("input_enumeration_ok") is False:
+                microphone.update(
+                    status="diagnostic",
+                    title="Microphone status unavailable",
+                    explanation="Murmur could not enumerate audio inputs in the latest state check.",
+                    action="Check again after capture is idle.",
+                    last_epoch=state_epoch,
+                    events=[],
+                )
+            elif state.get("default_input_available") is False:
+                microphone.update(
+                    status="action",
+                    title="No default microphone available",
+                    explanation="The latest privacy-safe state snapshot found no default input.",
+                    action="Connect or select a microphone, then retry.",
+                    last_epoch=state_epoch,
+                    events=[],
+                )
     return [cards[area] for area, _ in HEALTH_AREAS]
 
 

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -80,6 +80,7 @@ class LogReceiverHealthTests(unittest.TestCase):
                 level="warn",
                 stream="audio",
                 data={
+                    "owner": 44,
                     "backend": "auhal",
                     "capture_id": 10,
                     "last_setup_step": "stream_start",
@@ -115,6 +116,73 @@ class LogReceiverHealthTests(unittest.TestCase):
         self.assertEqual(len(groups), 1)
         microphone = next(card for card in cards if card["area"] == "microphone")
         self.assertEqual(microphone["status"], "recovered")
+
+    def test_interleaved_owners_keep_recovery_evidence_scoped(self) -> None:
+        events = [
+            event(
+                "capture backend exceeded its active initialization budget",
+                timestamp="2026-08-05T00:00:00Z",
+                level="warn",
+                stream="audio",
+                data={"owner": 44, "backend": "auhal"},
+            ),
+            event(
+                "capture backend exceeded its active initialization budget",
+                timestamp="2026-08-05T00:00:01Z",
+                level="warn",
+                stream="audio",
+                data={"owner": 55, "backend": "auhal"},
+            ),
+            event(
+                "capture backend failed before retained audio; trying bounded fallback",
+                timestamp="2026-08-05T00:00:02Z",
+                level="warn",
+                stream="audio",
+                data={
+                    "owner": 55,
+                    "from_backend": "auhal",
+                    "to_backend": "cpal",
+                },
+            ),
+            event(
+                "capture backend failed before retained audio; trying bounded fallback",
+                timestamp="2026-08-05T00:00:03Z",
+                level="warn",
+                stream="audio",
+                data={
+                    "owner": 44,
+                    "from_backend": "auhal",
+                    "to_backend": "cpal",
+                },
+            ),
+            event(
+                "audio readiness accepted",
+                timestamp="2026-08-05T00:00:04Z",
+                stream="audio",
+                data={"owner": 44, "startup_ms": 900},
+            ),
+            event(
+                "audio readiness accepted",
+                timestamp="2026-08-05T00:00:05Z",
+                stream="audio",
+                data={"owner": 55, "startup_ms": 1_100},
+            ),
+        ]
+
+        recovered = [
+            item
+            for item in receiver.build_health_signals(events)
+            if item["code"] == "audio.fallback_recovered"
+        ]
+
+        self.assertEqual(len(recovered), 2)
+        self.assertEqual(
+            [
+                {receiver.event_value(source, "owner") for source in item["events"]}
+                for item in recovered
+            ],
+            [{44}, {55}],
+        )
 
     def test_exhausted_fallback_is_one_actionable_failure(self) -> None:
         events = [
@@ -178,6 +246,69 @@ class LogReceiverHealthTests(unittest.TestCase):
         self.assertEqual(groups[0]["status"], "action")
         self.assertEqual(groups[0]["title"], "Technical error")
         self.assertIn("no safe plain-English mapping", groups[0]["action"])
+
+    def test_data_labels_are_bounded_and_unknown_outcomes_share_one_group(self) -> None:
+        backend = "unsafe\n" + "x" * 200
+        timeout = event(
+            "capture backend exceeded its active initialization budget",
+            timestamp="2026-08-05T00:00:00Z",
+            level="warn",
+            stream="audio",
+            data={"owner": 1, "backend": backend},
+        )
+        transform_events = [
+            event(
+                "transform_pass_outcome",
+                timestamp=f"2026-08-05T00:00:0{second}Z",
+                stream="transform",
+                data={"outcome": "unmapped-" + str(second) + "-" + "y" * 200},
+            )
+            for second in (1, 2)
+        ]
+
+        timeout_signal = receiver.classify_event(timeout)
+        groups = receiver.group_problem_signals(
+            transform_events,
+            receiver.build_health_signals(transform_events),
+        )
+
+        self.assertNotIn("\n", timeout_signal["explanation"])
+        self.assertLess(len(timeout_signal["explanation"]), 100)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["group"], "transform.pass_outcome.other")
+        self.assertEqual(groups[0]["count"], 2)
+
+    def test_newer_microphone_state_overrides_older_ready_event(self) -> None:
+        ready = event(
+            "audio readiness accepted",
+            timestamp="2026-08-05T00:00:00Z",
+            stream="audio",
+            data={"owner": 44, "startup_ms": 900},
+        )
+        state = {
+            "received_at": receiver.event_epoch(ready) + 1,
+            "default_input_available": False,
+            "input_enumeration_ok": True,
+        }
+
+        cards = receiver.build_health_cards(
+            receiver.build_health_signals([ready]),
+            state,
+        )
+        microphone = next(card for card in cards if card["area"] == "microphone")
+
+        self.assertEqual(microphone["status"], "action")
+        self.assertEqual(microphone["title"], "No default microphone available")
+
+        state["received_at"] = receiver.event_epoch(ready) - 1
+        older_state_cards = receiver.build_health_cards(
+            receiver.build_health_signals([ready]),
+            state,
+        )
+        older_state_microphone = next(
+            card for card in older_state_cards if card["area"] == "microphone"
+        )
+        self.assertEqual(older_state_microphone["status"], "healthy")
 
     def test_render_install_escapes_unknown_content_and_keeps_raw_timeline(self) -> None:
         install_id = "12345678-abcd"

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+RECEIVER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "infra"
+    / "log-receiver"
+    / "murmur-logs-receiver.py"
+)
+SPEC = importlib.util.spec_from_file_location("murmur_logs_receiver", RECEIVER_PATH)
+assert SPEC and SPEC.loader
+receiver = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(receiver)
+
+
+def event(
+    summary: str,
+    *,
+    timestamp: str,
+    level: str = "info",
+    stream: str = "system",
+    data: dict | None = None,
+) -> dict:
+    return {
+        "timestamp": timestamp,
+        "stream": stream,
+        "level": level,
+        "summary": summary,
+        "data": data or {},
+    }
+
+
+class LogReceiverHealthTests(unittest.TestCase):
+    def test_stable_event_code_takes_precedence_over_compatibility_summary(self) -> None:
+        item = event(
+            "listener heartbeat — no rdev callbacks observed",
+            timestamp="2026-08-05T00:00:00Z",
+            level="warn",
+            stream="keyboard",
+            data={"event_code": "keyboard.listener_failed"},
+        )
+
+        self.assertEqual(receiver.event_code(item), "keyboard.listener_failed")
+        self.assertEqual(receiver.classify_event(item)["status"], "action")
+
+    def test_listener_silence_is_diagnostic_and_deduplicated(self) -> None:
+        events = [
+            event(
+                "listener heartbeat — no rdev callbacks observed",
+                timestamp=f"2026-08-05T00:{minute:02d}:00Z",
+                level="warn",
+                stream="keyboard",
+                data={
+                    "silent_for_ms": 300_000 + minute * 60_000,
+                    "threshold_ms": 300_000,
+                },
+            )
+            for minute in range(20)
+        ]
+
+        signals = receiver.build_health_signals(events)
+        groups = receiver.group_problem_signals(events, signals)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["status"], "diagnostic")
+        self.assertEqual(groups[0]["count"], 20)
+        self.assertEqual(groups[0]["title"], "No recent shortcut activity")
+
+    def test_fallback_then_readiness_is_one_recovered_incident(self) -> None:
+        events = [
+            event(
+                "capture backend exceeded its active initialization budget",
+                timestamp="2026-08-05T00:00:00Z",
+                level="warn",
+                stream="audio",
+                data={
+                    "backend": "auhal",
+                    "capture_id": 10,
+                    "last_setup_step": "stream_start",
+                },
+            ),
+            event(
+                "capture backend failed before retained audio; trying bounded fallback",
+                timestamp="2026-08-05T00:00:01Z",
+                level="warn",
+                stream="audio",
+                data={
+                    "owner": 44,
+                    "from_backend": "auhal",
+                    "to_backend": "cpal",
+                },
+            ),
+            event(
+                "audio readiness accepted",
+                timestamp="2026-08-05T00:00:02Z",
+                stream="audio",
+                data={"owner": 44, "startup_ms": 8_400},
+            ),
+        ]
+
+        signals = receiver.build_health_signals(events)
+        groups = receiver.group_problem_signals(events, signals)
+        cards = receiver.build_health_cards(signals, {})
+
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(signals[0]["code"], "audio.fallback_recovered")
+        self.assertEqual(signals[0]["status"], "recovered")
+        self.assertEqual(len(signals[0]["events"]), 3)
+        self.assertEqual(len(groups), 1)
+        microphone = next(card for card in cards if card["area"] == "microphone")
+        self.assertEqual(microphone["status"], "recovered")
+
+    def test_exhausted_fallback_is_one_actionable_failure(self) -> None:
+        events = [
+            event(
+                "capture backend failed before retained audio; trying bounded fallback",
+                timestamp="2026-08-05T00:00:00Z",
+                level="warn",
+                stream="audio",
+                data={
+                    "owner": 45,
+                    "from_backend": "auhal",
+                    "to_backend": "cpal",
+                },
+            ),
+            event(
+                "both capture backend attempts failed before first PCM",
+                timestamp="2026-08-05T00:00:01Z",
+                level="error",
+                stream="audio",
+                data={"owner": 45, "error_kind": "initialization_timeout"},
+            ),
+            event(
+                "audio lifecycle failed",
+                timestamp="2026-08-05T00:00:02Z",
+                level="error",
+                stream="audio",
+                data={"owner": 45, "error_kind": "initialization_timeout"},
+            ),
+        ]
+
+        signals = receiver.build_health_signals(events)
+        groups = receiver.group_problem_signals(events, signals)
+
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(signals[0]["status"], "action")
+        self.assertEqual(len(signals[0]["events"]), 3)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["count"], 1)
+        self.assertEqual(groups[0]["title"], "Microphone failed")
+
+    def test_unknown_error_outranks_noisy_diagnostic_without_a_guess(self) -> None:
+        events = [
+            event(
+                "listener heartbeat — no rdev callbacks observed",
+                timestamp="2026-08-05T00:00:00Z",
+                level="warn",
+                stream="keyboard",
+            ),
+            event(
+                "<unsafe> opaque failure",
+                timestamp="2026-08-05T00:01:00Z",
+                level="error",
+                stream="system",
+                data={"detail": "<private>"},
+            ),
+        ]
+
+        signals = receiver.build_health_signals(events)
+        groups = receiver.group_problem_signals(events, signals)
+
+        self.assertEqual(groups[0]["status"], "action")
+        self.assertEqual(groups[0]["title"], "Technical error")
+        self.assertIn("no safe plain-English mapping", groups[0]["action"])
+
+    def test_render_install_escapes_unknown_content_and_keeps_raw_timeline(self) -> None:
+        install_id = "12345678-abcd"
+        events = [
+            event(
+                "<script>alert('summary')</script>",
+                timestamp="2026-08-05T00:00:00Z",
+                level="error",
+                stream="<audio>",
+                data={"detail": "<img src=x>"},
+            ),
+            event(
+                "listener heartbeat — no rdev callbacks observed",
+                timestamp="2026-08-05T00:01:00Z",
+                level="warn",
+                stream="keyboard",
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = receiver.ROOT
+            receiver.ROOT = directory
+            try:
+                install_dir = Path(directory) / install_id
+                install_dir.mkdir()
+                (install_dir / "events.jsonl").write_text(
+                    "\n".join(json.dumps(item) for item in events) + "\n",
+                    encoding="utf-8",
+                )
+                (install_dir / "meta.json").write_text(
+                    json.dumps({"device_name": "<Murmur Mac>", "last_version": "1.0"}),
+                    encoding="utf-8",
+                )
+                page = receiver.render_install(install_id, "prod", 200)
+            finally:
+                receiver.ROOT = original_root
+
+        self.assertIsNotNone(page)
+        self.assertIn("Plain-English health", page)
+        self.assertIn("What needs attention", page)
+        self.assertIn("Recent explanations", page)
+        self.assertIn('<span class="status action">Action</span>', page)
+        self.assertIn("Technical details", page)
+        self.assertIn("Raw technical timeline", page)
+        self.assertIn("&lt;script&gt;", page)
+        self.assertIn("&lt;Murmur Mac&gt;", page)
+        self.assertNotIn("<script>", page)
+        self.assertNotIn("<img src=x>", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add plain-English microphone, shortcut, dictation, updater, and transform health cards to each fleet installation page
- group repeated diagnostics, correlate microphone fallback recovery, separate action items from FYI/recovered explanations, and retain expandable raw evidence
- emit allowlisted privacy-safe event codes from the app with compatibility mappings for historical JSONL
- add receiver classification/rendering tests and operator/event-contract documentation
- address review findings with owner-scoped correlation, bounded labels, timestamp-aware state precedence, and direct frontend event-code tests

## Validation

- python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py tests/test_capture_agent_matrix.py tests/test_capture_worker_smoke.py tests/test_log_receiver.py (85 passed)
- cd app && npx tsc --noEmit
- cd app && npm test (all frontend tests passed)
- cd app/src-tauri && cargo test -- --test-threads=1 (all non-ignored tests passed)
- Safari visual smoke with healthy, recovered, diagnostic, grouped, and expandable evidence states
- native Local Dictation Dev.app launch smoke; frontend updater event code observed in events.dev.jsonl

Note: the local debug bundle was produced successfully; final updater archive signing stopped after bundling because the private Tauri release key is intentionally unavailable locally.

Closes #454