### PR TITLE
Fleet logs: show last activation and transcription times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Fleet log install pages now show the last proven microphone activation and
+  last non-empty live transcription with relative and exact Eastern timestamps,
+  derived from the complete retained event stream with bounded memory (#459).
 - Fleet log install pages now offer exact latest-200/latest-500 JSONL downloads
   and LLM-ready Markdown reports with plain-English event meanings, grouped
   findings, bounded device context, and untrusted-telemetry guidance (#457).

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -95,6 +95,16 @@ events remain available in an expandable technical timeline and as exact
 latest-200, latest-500, or complete JSONL downloads. Served by the same receiver
 process.
 
+The per-install **quick info** table shows two retained-log activity metrics:
+**Last activated** is the newest native recording event that proves microphone
+audio became ready, while **Last successful transcription** is the newest
+completed live dictation with a positive character count. Start requests,
+failed initialization, cancelled/no-speech runs, empty output, and imported-file
+transcription do not advance those metrics. Each value includes relative age and
+an exact Eastern timestamp. The receiver scans the complete retained JSONL with
+a strict per-record memory bound, independent of the visible 200/1,000/5,000
+event window; an absent match is reported as not found in the retained log.
+
 Each install page also offers latest-200 and latest-500 **LLM-ready Markdown**
 reports. The versioned `murmur-fleet-llm/v1` format includes bounded device and
 microphone-state context, current health, deduplicated findings, and the original

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -42,7 +42,8 @@ Dev-tagged batches are acked and discarded.
 
 The receiver stays stdlib-only. Its plain-English classification, recovery
 correlation, grouping, unknown-event fallback, exact newest-N downloads,
-LLM-ready Markdown rendering, route bounds, and HTML escaping are covered by:
+LLM-ready Markdown rendering, bounded retained-log activity metrics, route
+bounds, and HTML escaping are covered by:
 
 ```bash
 python3 -m unittest tests/test_log_receiver.py
@@ -52,3 +53,5 @@ Install pages expose raw JSONL downloads for the latest 200, latest 500, or the
 complete stream. The LLM-ready latest-200/latest-500 downloads use the versioned
 `murmur-fleet-llm/v1` Markdown format documented in
 [`docs/features/log-shipping.md`](../../docs/features/log-shipping.md).
+Quick info also reports the latest proven microphone activation and latest
+non-empty live transcription across the complete retained stream.

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -750,7 +750,7 @@ def bounded_jsonl_events_reverse(
                     if raw:
                         try:
                             event = json.loads(raw)
-                        except (TypeError, ValueError):
+                        except (TypeError, ValueError, RecursionError):
                             event = None
                         if isinstance(event, dict):
                             yield event
@@ -763,7 +763,7 @@ def bounded_jsonl_events_reverse(
             if raw:
                 try:
                     event = json.loads(raw)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, RecursionError):
                     event = None
                 if isinstance(event, dict):
                     yield event

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -40,6 +40,7 @@ MAX_INSTALLS = 150
 MAX_TOTAL = 10 * 1024 * 1024 * 1024  # 10 GB across all installs
 EXPORT_LIMITS = (200, 500)
 MAX_SCOPED_EXPORT_BYTES = 32 * 1024 * 1024
+MAX_ACTIVITY_EVENT_BYTES = 512 * 1024
 LLM_REPORT_FORMAT = "murmur-fleet-llm/v1"
 _usage_cache = {"t": 0.0, "bytes": 0, "dirs": 0}
 
@@ -227,6 +228,7 @@ EVENT_CODE_COMPATIBILITY = (
         "audio.capture_failed",
     ),
     ("audio lifecycle failed", "audio.lifecycle_failed"),
+    ("start_native_recording: audio ready", "recording.native_audio_ready"),
     ("transcription complete", "pipeline.dictation_completed"),
     ("stop_native_recording: pipeline failed:", "pipeline.dictation_failed"),
     ("transform_pass_outcome", "transform.pass_outcome"),
@@ -705,6 +707,131 @@ def event_epoch(event):
         ).timestamp()
     except (ValueError, TypeError):
         return 0.0
+
+
+def bounded_jsonl_events_reverse(
+    path,
+    max_line_bytes=MAX_ACTIVITY_EVENT_BYTES,
+    block_bytes=64 * 1024,
+):
+    """Yield newest JSON objects first with fixed block and record bounds."""
+    if max_line_bytes <= 0 or block_bytes <= 0:
+        return
+    try:
+        remaining = os.path.getsize(path)
+        handle = open(path, "rb")
+    except OSError:
+        return
+    with handle:
+        parts = []
+        line_bytes = 0
+        oversized = False
+        while remaining > 0:
+            read_size = min(block_bytes, remaining)
+            remaining -= read_size
+            handle.seek(remaining)
+            block = handle.read(read_size)
+            block_end = len(block)
+            while True:
+                newline = block.rfind(b"\n", 0, block_end)
+                segment = block[newline + 1:block_end]
+                if not oversized:
+                    if line_bytes + len(segment) > max_line_bytes:
+                        parts.clear()
+                        line_bytes = 0
+                        oversized = True
+                    elif segment:
+                        parts.append(segment)
+                        line_bytes += len(segment)
+                if newline < 0:
+                    break
+                if not oversized and line_bytes:
+                    raw = b"".join(reversed(parts)).strip()
+                    if raw:
+                        try:
+                            event = json.loads(raw)
+                        except (TypeError, ValueError):
+                            event = None
+                        if isinstance(event, dict):
+                            yield event
+                parts = []
+                line_bytes = 0
+                oversized = False
+                block_end = newline
+        if not oversized and line_bytes:
+            raw = b"".join(reversed(parts)).strip()
+            if raw:
+                try:
+                    event = json.loads(raw)
+                except (TypeError, ValueError):
+                    event = None
+                if isinstance(event, dict):
+                    yield event
+
+
+def find_activity_metrics(path, max_line_bytes=MAX_ACTIVITY_EVENT_BYTES):
+    """Find the newest proven activation and non-empty live transcription."""
+    metrics = {
+        "last_activated": None,
+        "last_successful_transcription": None,
+    }
+    for event in bounded_jsonl_events_reverse(
+        path,
+        max_line_bytes=max_line_bytes,
+    ):
+        epoch = event_epoch(event)
+        if epoch <= 0:
+            continue
+        code = event_code(event)
+        metric = None
+        if code == "recording.native_audio_ready":
+            metric = "last_activated"
+        elif code == "pipeline.dictation_completed":
+            data = event.get("data")
+            data = data if isinstance(data, dict) else {}
+            char_count = data.get("char_count")
+            if (
+                isinstance(char_count, int)
+                and not isinstance(char_count, bool)
+                and char_count > 0
+            ):
+                metric = "last_successful_transcription"
+        if metric is not None and metrics[metric] is None:
+            metrics[metric] = {"timestamp": str(event.get("timestamp", ""))[:80]}
+        if all(value is not None for value in metrics.values()):
+            break
+    return metrics
+
+
+def render_activity_time(event):
+    """Render relative and exact Eastern time for one activity event."""
+    epoch = event_epoch(event) if isinstance(event, dict) else 0.0
+    if epoch <= 0:
+        return '<span class="meta">Not found in retained log</span>'
+    try:
+        dt = datetime.fromtimestamp(epoch, EASTERN)
+    except (OverflowError, OSError, ValueError):
+        return '<span class="meta">Not found in retained log</span>'
+    hour = dt.strftime("%I").lstrip("0") or "0"
+    exact = "%s %d, %d at %s:%s %s %s" % (
+        dt.strftime("%b"),
+        dt.day,
+        dt.year,
+        hour,
+        dt.strftime("%M:%S"),
+        dt.strftime("%p"),
+        dt.tzname() or "ET",
+    )
+    timestamp = str(event.get("timestamp", ""))[:80]
+    return (
+        '<time datetime="%s"><strong>%s</strong>'
+        '<span class="meta"> &middot; %s</span></time>'
+        % (
+            html.escape(timestamp),
+            html.escape(ago(epoch)),
+            html.escape(exact),
+        )
+    )
 
 
 def display_event_time(event):
@@ -1757,6 +1884,7 @@ def render_install(install_id, kind, n=200):
             state = json.load(f)
     except (OSError, ValueError):
         pass
+    activity = find_activity_metrics(path)
 
     signals = build_health_signals(events)
     health_cards = build_health_cards(signals, state)
@@ -1769,14 +1897,17 @@ def render_install(install_id, kind, n=200):
         % ("".join(render_health_card(card) for card in health_cards), len(events))
     )
 
-    info_html = ""
+    chips = []
+    for ev in reversed(events):
+        if str(ev.get("summary", "")).startswith("configure_dictation"):
+            data = ev.get("data") or {}
+            chips = ["%s: %s" % (k, v) for k, v in sorted(data.items())][:12]
+            break
+    microphone = "unknown"
+    inputs = "unknown"
+    enumeration = "No device state received"
+    state_age = "Unavailable"
     if state:
-        chips = []
-        for ev in reversed(events):
-            if str(ev.get("summary", "")).startswith("configure_dictation"):
-                data = ev.get("data") or {}
-                chips = ["%s: %s" % (k, v) for k, v in sorted(data.items())][:12]
-                break
         if "default_input_available" in state:
             microphone = "Available" if state.get("default_input_available") else "Unavailable"
             input_count = state.get("input_device_count")
@@ -1801,22 +1932,33 @@ def render_install(install_id, kind, n=200):
             ]
             inputs = ", ".join(others) or "unknown"
             enumeration = "Legacy state snapshot"
-        info_html = (
-            '<h2>quick info</h2><table><tbody>'
-            '<tr><td>Microphone</td><td><strong>%s</strong></td></tr>'
-            '<tr><td>Inputs</td><td>%s</td></tr>'
-            '<tr><td>Enumeration</td><td>%s</td></tr>'
-            '<tr><td>Settings</td><td class="meta">%s</td></tr>'
-            '<tr><td>As of</td><td>%s</td></tr>'
-            '</tbody></table>'
-            % (
-                html.escape(str(microphone)),
-                html.escape(str(inputs)),
-                html.escape(str(enumeration)),
-                html.escape(" · ".join(chips)) or "&mdash;",
-                ago(state.get("received_at", 0)),
-            )
+        received_at = state.get("received_at")
+        if (
+            isinstance(received_at, (int, float))
+            and not isinstance(received_at, bool)
+            and received_at > 0
+        ):
+            state_age = ago(received_at)
+    info_html = (
+        '<h2>quick info</h2><table><tbody>'
+        '<tr><td>Microphone</td><td><strong>%s</strong></td></tr>'
+        '<tr><td>Inputs</td><td>%s</td></tr>'
+        '<tr><td>Enumeration</td><td>%s</td></tr>'
+        '<tr><td>Settings</td><td class="meta">%s</td></tr>'
+        '<tr><td>Last activated</td><td>%s</td></tr>'
+        '<tr><td>Last successful transcription</td><td>%s</td></tr>'
+        '<tr><td>Device state as of</td><td>%s</td></tr>'
+        '</tbody></table>'
+        % (
+            html.escape(str(microphone)),
+            html.escape(str(inputs)),
+            html.escape(str(enumeration)),
+            html.escape(" · ".join(chips)) or "&mdash;",
+            render_activity_time(activity["last_activated"]),
+            render_activity_time(activity["last_successful_transcription"]),
+            html.escape(state_age),
         )
+    )
 
     attention_groups = [
         item for item in problem_groups if item["status"] in ("action", "degraded")

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -365,6 +365,123 @@ class LogReceiverHealthTests(unittest.TestCase):
         self.assertNotIn("<img src=x>", page)
 
 
+class LogReceiverActivityMetricTests(unittest.TestCase):
+    def test_activity_metrics_require_proven_activation_and_nonempty_dictation(
+        self,
+    ) -> None:
+        events = [
+            event(
+                "start_native_recording: starting",
+                timestamp="2026-08-05T00:00:00Z",
+                stream="pipeline",
+            ),
+            event(
+                "start_native_recording: audio ready",
+                timestamp="2026-08-05T00:01:00Z",
+                stream="pipeline",
+            ),
+            event(
+                "transcription complete",
+                timestamp="2026-08-05T00:02:00Z",
+                stream="pipeline",
+                data={"char_count": 24, "word_count": 4},
+            ),
+            event(
+                "transcription complete",
+                timestamp="2026-08-05T00:03:00Z",
+                stream="pipeline",
+                data={"char_count": 0, "word_count": 0},
+            ),
+            event(
+                "file transcription complete",
+                timestamp="2026-08-05T00:04:00Z",
+                stream="pipeline",
+                data={"char_count": 100, "word_count": 18},
+            ),
+            event(
+                "start_native_recording: starting",
+                timestamp="2026-08-05T00:05:00Z",
+                stream="pipeline",
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                "\n".join(json.dumps(item) for item in events)
+                + "\n{malformed json}\n",
+                encoding="utf-8",
+            )
+
+            metrics = receiver.find_activity_metrics(str(path))
+
+        self.assertEqual(
+            metrics["last_activated"]["timestamp"],
+            "2026-08-05T00:01:00Z",
+        )
+        self.assertEqual(
+            metrics["last_successful_transcription"]["timestamp"],
+            "2026-08-05T00:02:00Z",
+        )
+
+    def test_activity_scan_handles_cross_buffer_records_and_skips_oversized_lines(
+        self,
+    ) -> None:
+        activation = event(
+            "start_native_recording: audio ready",
+            timestamp="2026-08-05T00:01:00Z",
+            stream="pipeline",
+            data={"padding": "x" * 70_000},
+        )
+        success = event(
+            "transcription complete",
+            timestamp="2026-08-05T00:02:00Z",
+            stream="pipeline",
+            data={"char_count": 8, "padding": "y" * 70_000},
+        )
+        oversized = event(
+            "start_native_recording: audio ready",
+            timestamp="2026-08-05T00:03:00Z",
+            stream="pipeline",
+            data={"padding": "z" * 600_000},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                "\n".join(json.dumps(item) for item in (activation, success, oversized))
+                + "\n",
+                encoding="utf-8",
+            )
+
+            metrics = receiver.find_activity_metrics(str(path))
+
+        self.assertEqual(
+            metrics["last_activated"]["timestamp"],
+            "2026-08-05T00:01:00Z",
+        )
+        self.assertEqual(
+            metrics["last_successful_transcription"]["timestamp"],
+            "2026-08-05T00:02:00Z",
+        )
+
+    def test_activity_time_shows_relative_and_exact_eastern_time(self) -> None:
+        item = event(
+            "start_native_recording: audio ready",
+            timestamp="2026-08-05T00:00:00Z",
+        )
+        now = receiver.event_epoch(item) + 120
+
+        with mock.patch.object(receiver.time, "time", return_value=now):
+            rendered = receiver.render_activity_time(item)
+
+        self.assertIn("<strong>2m ago</strong>", rendered)
+        self.assertIn("Aug 4, 2026 at 8:00:00 PM EDT", rendered)
+        self.assertIn('datetime="2026-08-05T00:00:00Z"', rendered)
+        self.assertIn(
+            "Not found in retained log",
+            receiver.render_activity_time(None),
+        )
+
+
 class LogReceiverExportTests(unittest.TestCase):
     def test_tail_raw_lines_returns_exact_newest_records_across_blocks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -524,13 +641,20 @@ class LogReceiverExportRouteTests(unittest.TestCase):
         install_dir.mkdir()
         with (install_dir / "events.jsonl").open("w", encoding="utf-8") as handle:
             for sequence in range(600):
+                summary = "heartbeat"
+                data = {"sequence": sequence}
+                if sequence == 0:
+                    summary = "start_native_recording: audio ready"
+                elif sequence == 1:
+                    summary = "transcription complete"
+                    data["char_count"] = 42
                 handle.write(
                     json.dumps(
                         event(
-                            "heartbeat",
+                            summary,
                             timestamp="2026-08-05T00:00:00Z",
                             stream="system",
-                            data={"sequence": sequence},
+                            data=data,
                         )
                     )
                     + "\n"
@@ -657,6 +781,9 @@ class LogReceiverExportRouteTests(unittest.TestCase):
         self.assertIn(
             f"/install/{self.install_id}/llm?kind=prod&amp;limit=500", page
         )
+        self.assertIn("Last activated", page)
+        self.assertIn("Last successful transcription", page)
+        self.assertNotIn("Not found in retained log", page)
 
 
 if __name__ == "__main__":

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -463,6 +463,64 @@ class LogReceiverActivityMetricTests(unittest.TestCase):
             "2026-08-05T00:02:00Z",
         )
 
+    def test_activity_scan_skips_deeply_nested_json_and_continues(self) -> None:
+        activation = event(
+            "start_native_recording: audio ready",
+            timestamp="2026-08-05T00:01:00Z",
+            stream="pipeline",
+        )
+        success = event(
+            "transcription complete",
+            timestamp="2026-08-05T00:02:00Z",
+            stream="pipeline",
+            data={"char_count": 8},
+        )
+        deeply_nested = '{"value":' * 1_100 + "0" + "}" * 1_100
+        deeply_nested_bytes = deeply_nested.encode("utf-8")
+        original_json_loads = receiver.json.loads
+
+        def loads_with_recursion_guard(raw):
+            if raw == deeply_nested_bytes:
+                raise RecursionError("synthetic decoder nesting limit")
+            return original_json_loads(raw)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                "\n".join(
+                    (
+                        json.dumps(activation),
+                        json.dumps(success),
+                        deeply_nested,
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            no_newline_path = Path(directory) / "nested-only.jsonl"
+            no_newline_path.write_text(deeply_nested, encoding="utf-8")
+            with mock.patch.object(
+                receiver.json,
+                "loads",
+                side_effect=loads_with_recursion_guard,
+            ):
+                metrics = receiver.find_activity_metrics(str(path))
+                nested_only_events = list(
+                    receiver.bounded_jsonl_events_reverse(str(no_newline_path))
+                )
+
+        self.assertFalse(nested_only_events)
+
+        self.assertEqual(
+            metrics["last_activated"]["timestamp"],
+            "2026-08-05T00:01:00Z",
+        )
+        self.assertEqual(
+            metrics["last_successful_transcription"]["timestamp"],
+            "2026-08-05T00:02:00Z",
+        )
+
     def test_activity_time_shows_relative_and_exact_eastern_time(self) -> None:
         item = event(
             "start_native_recording: audio ready",


### PR DESCRIPTION
## Summary
- add retained-log metrics for the latest proven microphone activation and latest non-empty live transcription
- show relative age plus the exact Eastern timestamp in per-device quick info
- scan newest-first with fixed block/record memory bounds, including historical events outside the visible timeline

## Test plan
- [x] Python infrastructure suite: 96 passed
- [x] cargo check (existing main-branch dead-code warnings only)
- [x] cargo test -- --test-threads=1: 711 passed, 5 ignored; integrations passed
- [x] npx tsc --noEmit
- [x] npm test: 630 passed
- [x] Safari visual smoke of both quick-info timestamp rows

Closes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quick Info metrics for the latest proven microphone activation and successful live transcription.
  * Displays relative and exact Eastern timestamps, plus the age of the latest received device state.
  * Handles missing, malformed, or oversized log entries gracefully.

* **Documentation**
  * Documented activity metric definitions, retained-log coverage, timestamp formats, and route behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->