### PR TITLE
chore: remove obsolete audio states

### DIFF
--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -45,23 +45,17 @@ const CAPTURE_TERMINATION_BUDGET: Duration = Duration::from_secs(2);
 const CAPTURE_PROTOCOL_RESERVE: Duration = Duration::from_secs(2);
 const CAPTURE_ACTIVE_BUDGET: Duration = Duration::from_secs(30);
 const CAPTURE_WORKER_IDENTIFIER: &str = "com.localdictation.capture-worker";
-pub(crate) const STREAM_BUILD_TIMEOUT: Duration = Duration::from_secs(10);
 static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AudioFailureKind {
     PermissionDenied,
     DeviceUnavailable,
-    DeviceBusy,
-    DeviceChanged,
     HostUnavailable,
     InvalidInput,
     ResourceExhausted,
     StreamInvalidated,
     UnsupportedConfig,
-    UnsupportedOperation,
-    RealtimeDenied,
-    Xrun,
     BackendError,
     ProtocolError,
     FirstBufferTimeout,
@@ -77,16 +71,11 @@ impl AudioFailureKind {
         match self {
             Self::PermissionDenied => "permission_denied",
             Self::DeviceUnavailable => "device_unavailable",
-            Self::DeviceBusy => "device_busy",
-            Self::DeviceChanged => "device_changed",
             Self::HostUnavailable => "host_unavailable",
             Self::InvalidInput => "invalid_input",
             Self::ResourceExhausted => "resource_exhausted",
             Self::StreamInvalidated => "stream_invalidated",
             Self::UnsupportedConfig => "unsupported_config",
-            Self::UnsupportedOperation => "unsupported_operation",
-            Self::RealtimeDenied => "realtime_denied",
-            Self::Xrun => "xrun",
             Self::BackendError => "backend_error",
             Self::ProtocolError => "protocol_error",
             Self::FirstBufferTimeout => "first_buffer_timeout",
@@ -117,12 +106,6 @@ impl AudioFailure {
             }
             AudioFailureKind::DeviceUnavailable => {
                 "The selected microphone is unavailable. Choose another microphone and try again."
-            }
-            AudioFailureKind::DeviceBusy => {
-                "The selected microphone is busy. Close other audio apps and try again."
-            }
-            AudioFailureKind::DeviceChanged => {
-                "The microphone route changed while capture was starting."
             }
             AudioFailureKind::StreamInvalidated => {
                 "The microphone stream was invalidated. Try recording again."
@@ -204,7 +187,6 @@ pub(crate) enum AudioInitPhase {
     DeviceEnumeration,
     ConfigLookup,
     StreamBuild,
-    StreamPlay,
     FirstBufferWait,
     Runtime,
 }
@@ -215,7 +197,6 @@ impl AudioInitPhase {
             Self::DeviceEnumeration => "device_enumeration",
             Self::ConfigLookup => "config_lookup",
             Self::StreamBuild => "stream_build",
-            Self::StreamPlay => "stream_play",
             Self::FirstBufferWait => "first_buffer_wait",
             Self::Runtime => "runtime",
         }

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -1424,7 +1424,6 @@ mod tests {
                     AudioInitPhase::DeviceEnumeration,
                     AudioInitPhase::ConfigLookup,
                     AudioInitPhase::StreamBuild,
-                    AudioInitPhase::StreamPlay,
                 ] {
                     let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
                     let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
@@ -1499,7 +1498,7 @@ mod tests {
                 let _ = event_sender.send(AudioWorkerEvent::RuntimeFailed {
                     owner,
                     failure: AudioFailure::new(
-                        AudioFailureKind::DeviceBusy,
+                        AudioFailureKind::StreamInvalidated,
                         AudioInitPhase::Runtime,
                     ),
                 });
@@ -1768,7 +1767,7 @@ mod tests {
         for phase in [
             AudioInitPhase::DeviceEnumeration,
             AudioInitPhase::StreamBuild,
-            AudioInitPhase::StreamPlay,
+            AudioInitPhase::FirstBufferWait,
         ] {
             let (supervisor, gate, _, sink, active_flags) =
                 harness(phase, SupervisorConfig::default());
@@ -2010,7 +2009,7 @@ mod tests {
     #[test]
     fn empty_first_buffer_event_cannot_enter_recording() {
         let (supervisor, gate, _, sink, active_flags) =
-            harness(AudioInitPhase::StreamPlay, SupervisorConfig::default());
+            harness(AudioInitPhase::FirstBufferWait, SupervisorConfig::default());
         let owner = AudioOwner::Dictation(10);
         assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
         supervisor
@@ -2179,7 +2178,7 @@ mod tests {
     }
 
     #[test]
-    fn play_success_without_callback_fails_as_first_buffer_timeout() {
+    fn first_buffer_wait_without_callback_fails_as_timeout() {
         let sink = Arc::new(RecordingSink::default());
         let (phase_sender, phase_receiver) = mpsc::channel();
         let supervisor = spawn_supervisor(
@@ -2214,7 +2213,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|(_, event)| *event == AudioLifecycleEvent::Ready),
-            "play success cannot become Recording without retained PCM"
+            "first-buffer wait cannot become Recording without retained PCM"
         );
         wait_until("no-callback worker did not exit after timeout", || {
             !supervisor.public.is_active()
@@ -2237,7 +2236,7 @@ mod tests {
                 matches!(
                     event,
                     AudioLifecycleEvent::InitializationFailed {
-                        kind: AudioFailureKind::DeviceBusy,
+                        kind: AudioFailureKind::StreamInvalidated,
                         ..
                     }
                 )
@@ -2255,7 +2254,7 @@ mod tests {
                     matches!(
                         event,
                         AudioLifecycleEvent::InitializationFailed {
-                            kind: AudioFailureKind::DeviceBusy,
+                            kind: AudioFailureKind::StreamInvalidated,
                             ..
                         }
                     )

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -57,17 +57,18 @@ Transcription processing is local. Network access occurs for model setup and may
   in `Recovering` until the worker exits and is joined. Rapid retries therefore
   cannot create overlapping in-process CoreAudio owners.
 - Dictation start returns after ownership is accepted, without waiting for
-  Core Audio. The worker reports device enumeration, config lookup, stream
-  build, play, first-buffer wait, stop, runtime failure, and exit events back to
-  the supervisor.
+  Core Audio. The helper reports device enumeration, stream construction,
+  first-buffer wait, active capture, stop, runtime failure, and exit events back
+  to the supervisor.
 - `Starting` emits a still-connecting signal after 5 seconds and has a
   30-second active-time contract: AUHAL 8s, AUHAL termination 2s, CPAL 16s,
   CPAL termination 2s, and 2s reserve. A genuine pending macOS TCC prompt
   suspends active deadlines and has a separate 120-second watchdog. Denial and
-  Stop remain immediate. `stream.play()` means only that start was requested:
-  `Recording` is reached only after the callback has retained a nonempty mono
-  buffer. Play-success with no callback fails as `first_buffer_timeout`, so a
-  successful zero-sample recording cannot begin.
+  Stop remain immediate. A successfully opened and started native stream does
+  not imply readiness: `Recording` is reached only after the callback has
+  retained a nonempty mono buffer. Reaching first-buffer wait without a callback
+  fails as `first_buffer_timeout`, so a successful zero-sample recording cannot
+  begin.
 - PCM retention and waveform publication are separate gates. The callback
   retains the first buffer before signalling readiness and continues retaining
   this generation's PCM while the supervisor accepts it. Levels remain disabled
@@ -91,11 +92,11 @@ Transcription processing is local. Network access occurs for model setup and may
 - A timed-out backend can advance only after its owned helper process group is
   positively confirmed empty. Unconfirmed termination leaves the lifecycle in
   exclusive recovery and suppresses fallback and new starts.
-- CPAL errors are reduced immediately to stable content-free kinds
-  (`permission_denied`, `device_unavailable`, `device_busy`, `device_changed`,
-  `stream_invalidated`, `invalid_input`, `resource_exhausted`, and bounded
-  fallback kinds). Phase/error telemetry never includes a device label, UID,
-  raw backend message, or audio/transcript content.
+- Capture-worker errors are reduced immediately to stable content-free kinds
+  (`permission_denied`, `device_unavailable`, `stream_invalidated`,
+  `invalid_input`, `resource_exhausted`, and bounded fallback kinds).
+  Phase/error telemetry never includes a device label, UID, raw backend
+  message, or audio/transcript content.
 - Recording duration begins at accepted readiness, not at the user's initial
   activation.
 - Multi-channel to mono conversion (averages channels) supports every PCM


### PR DESCRIPTION
## Summary
- remove the unused stream-build timeout and capture failure kinds the helper protocol cannot emit
- remove the obsolete stream-play lifecycle phase and align synthetic coverage with first-buffer wait
- update runtime-failure coverage and transcription docs to match the production helper contract

## Validation
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib audio -- --test-threads=1` (49 passed)
- `cargo test --lib -- --test-threads=1` (742 passed, 5 ignored)
- `cargo test -- --test-threads=1`
- `npx tsc --noEmit`
- `git diff --check`