### PR TITLE
chore: bump version to 0.27.0

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -6049,7 +6049,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.26.0"
+version = "0.27.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Murmur from 0.26.0 to 0.27.0
- synchronize the Tauri configuration, Cargo package, and lockfile versions
- trigger the trusted signed release-build and automatic promotion workflow after merge

## Validation
- release workflow policy validation passed
- 65 release artifact and workflow-policy tests passed
- cargo metadata resolves the ui package as 0.27.0
- version fields match across all three release inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->