### PR TITLE
Opt-in "Mirror Captions to NotchPill"

### DIFF
--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -957,11 +957,6 @@ async fn run_transcription_pipeline(
     performance_guard.enter(PerformanceStageV1::ClipboardPaste);
     if !text.is_empty() {
         let text_to_inject = text.clone();
-        // Opt-in mirror to NotchPill: best-effort local file write, never blocks
-        // or affects injection. Fires alongside the clipboard write.
-        if delivery.mirror_to_notchpill {
-            injector::mirror_caption(&text_to_inject);
-        }
         let paste_delay_ms = delivery.paste_delay_ms;
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
         app_handle
@@ -992,6 +987,17 @@ async fn run_transcription_pipeline(
                 let _ = app_handle.emit("auto-paste-failed", paste_hint);
             }
             Ok(Ok(Ok(()))) => {}
+        }
+        // Opt-in mirror to NotchPill: best-effort local file write. It runs
+        // *after* the clipboard write so disk I/O can never delay the primary
+        // output path, and off the pipeline thread so it stays out of paste_ms.
+        // Ownership is re-checked here because the pipeline can be cancelled or
+        // superseded during the paste, and the caption file is last-write-wins:
+        // a stale write would leave NotchPill showing text the user just
+        // abandoned.
+        if delivery.mirror_to_notchpill && !app_state.is_cancelled(recording_id) {
+            let caption = text.clone();
+            tokio::task::spawn_blocking(move || injector::mirror_caption(&caption));
         }
     }
     let paste_ms = t_inject.elapsed().as_millis() as u64;

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -991,10 +991,15 @@ async fn run_transcription_pipeline(
         // Opt-in mirror to NotchPill: best-effort local file write. It runs
         // *after* the clipboard write so disk I/O can never delay the primary
         // output path, and off the pipeline thread so it stays out of paste_ms.
-        // Ownership is re-checked here because the pipeline can be cancelled or
-        // superseded during the paste, and the caption file is last-write-wins:
-        // a stale write would leave NotchPill showing text the user just
-        // abandoned.
+        //
+        // Ownership is checked before scheduling, which narrows the stale-write
+        // window to the gap between this check and the write landing -- it does
+        // not close it. A cancel arriving inside that gap still publishes this
+        // caption. Deliberate: `app_state` is a borrow and cannot cross into
+        // `spawn_blocking`, and the alternative -- plumbing an owned handle
+        // through purely for a best-effort mirror -- costs more than the
+        // millisecond it would buy. The consequence is bounded: NotchPill shows
+        // a caption the user abandoned until the next one replaces it.
         if delivery.mirror_to_notchpill && !app_state.is_cancelled(recording_id) {
             let caption = text.clone();
             tokio::task::spawn_blocking(move || injector::mirror_caption(&caption));
@@ -1507,7 +1512,16 @@ pub async fn configure_dictation(
         dictation.auto_paste = auto_paste;
     }
     if let Some(mirror) = options.get("mirrorToNotchPill").and_then(|v| v.as_bool()) {
+        let was_enabled = dictation.mirror_to_notchpill;
         dictation.mirror_to_notchpill = mirror;
+        // Turning the mirror off removes what it left behind. The file holds a
+        // verbatim record of the last thing the user said, so leaving it on
+        // disk after they switched the feature off would keep speech around
+        // past consent -- the same reasoning that makes it 0600 in the first
+        // place. Best-effort and errors swallowed, exactly like the write.
+        if was_enabled && !mirror {
+            injector::remove_mirrored_caption();
+        }
     }
 
     if let Some(delay) = options.get("autoPasteDelayMs").and_then(|v| v.as_u64()) {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -957,6 +957,11 @@ async fn run_transcription_pipeline(
     performance_guard.enter(PerformanceStageV1::ClipboardPaste);
     if !text.is_empty() {
         let text_to_inject = text.clone();
+        // Opt-in mirror to NotchPill: best-effort local file write, never blocks
+        // or affects injection. Fires alongside the clipboard write.
+        if delivery.mirror_to_notchpill {
+            injector::mirror_caption(&text_to_inject);
+        }
         let paste_delay_ms = delivery.paste_delay_ms;
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
         app_handle
@@ -1494,6 +1499,9 @@ pub async fn configure_dictation(
 
     if let Some(auto_paste) = options.get("autoPaste").and_then(|v| v.as_bool()) {
         dictation.auto_paste = auto_paste;
+    }
+    if let Some(mirror) = options.get("mirrorToNotchPill").and_then(|v| v.as_bool()) {
+        dictation.mirror_to_notchpill = mirror;
     }
 
     if let Some(delay) = options.get("autoPasteDelayMs").and_then(|v| v.as_u64()) {

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -97,6 +97,8 @@ pub struct DeliverySettings {
     pub paste_delay_ms: u64,
     pub save_transcript: bool,
     pub save_audio: bool,
+    /// Opt-in: mirror the final transcript to NotchPill's caption file.
+    pub mirror_to_notchpill: bool,
     pub output_dir: String,
 }
 
@@ -307,6 +309,7 @@ pub fn resolve(inputs: ResolverInputs<'_>) -> DictationContextSnapshot {
             paste_delay_ms: global.auto_paste_delay_ms,
             save_transcript: global.save_transcript,
             save_audio: global.save_audio,
+            mirror_to_notchpill: global.mirror_to_notchpill,
             output_dir: global.output_dir.clone(),
         },
         vocabulary: VocabularyIdentity {

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -23,6 +23,53 @@ pub(crate) fn write_clipboard_text(text: &str) -> Result<(), String> {
         .map_err(|e| format!("Failed to copy to clipboard: {}", e))
 }
 
+/// Mirror the final transcript to a local file NotchPill (a separate notch-overlay
+/// app) can tail. Opt-in and best-effort: any failure is swallowed so dictation is
+/// never affected. Only the final text + a timestamp leave this function, and only
+/// to the app's own data dir — nothing is sent off-device.
+pub fn mirror_caption(text: &str) {
+    let Some(dir) = dirs::data_dir().map(|d| d.join("local-dictation")) else {
+        return;
+    };
+    let _ = write_caption_to(&dir, text);
+}
+
+/// Atomic write (temp file + rename) of the caption JSON to
+/// `<dir>/latest-caption.json`. Returns false (no write) for empty/whitespace
+/// text. Separated from `mirror_caption` so it can be unit-tested against a temp
+/// directory.
+fn write_caption_to(dir: &std::path::Path, text: &str) -> bool {
+    if text.trim().is_empty() {
+        return false;
+    }
+    if std::fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let payload = serde_json::json!({ "text": text, "timestamp": ts });
+    let Ok(bytes) = serde_json::to_vec(&payload) else {
+        return false;
+    };
+    let target = dir.join("latest-caption.json");
+    let tmp = dir.join(format!("latest-caption.json.tmp.{}", std::process::id()));
+    if std::fs::write(&tmp, &bytes).is_err() {
+        return false;
+    }
+    // Owner-only. This file holds a verbatim record of the last thing the user
+    // said out loud, and the default 0644 makes that readable by every account
+    // on the machine. Set on the temp file before the rename so the caption is
+    // never briefly world-readable at its real path.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    std::fs::rename(&tmp, &target).is_ok()
+}
+
 /// Copy text to clipboard and optionally simulate Cmd+V paste.
 /// `delay_ms` controls the pause before pasting (window focus settling).
 /// On paste failure, retries once after a 100ms backoff.
@@ -1128,5 +1175,35 @@ pub fn request_accessibility_prompt() -> bool {
         let trusted = AXIsProcessTrustedWithOptions(dict);
         CFRelease(dict);
         trusted
+    }
+}
+
+// Caption-mirror tests run on all platforms (the helper is platform-independent),
+// unlike the injector's Linux-gated process-mock tests above.
+#[cfg(test)]
+mod caption_tests {
+    use super::*;
+
+    #[test]
+    fn write_caption_to_writes_valid_json() {
+        let tmp = std::env::temp_dir().join(format!("murmur-cap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        assert!(write_caption_to(&tmp, "hello world"));
+        let raw = std::fs::read_to_string(tmp.join("latest-caption.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["text"], "hello world");
+        assert!(v["timestamp"].as_u64().unwrap() > 0);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn write_caption_to_skips_empty() {
+        let tmp = std::env::temp_dir().join(format!("murmur-cap-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        assert!(!write_caption_to(&tmp, "   "));
+        assert!(!tmp.join("latest-caption.json").exists());
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -34,6 +34,30 @@ pub fn mirror_caption(text: &str) {
     let _ = write_caption_to(&dir, text);
 }
 
+/// Delete the mirrored caption. Called when the setting is switched off, so
+/// the last thing the user said does not outlive their consent to share it.
+pub fn remove_mirrored_caption() {
+    let Some(dir) = dirs::data_dir().map(|d| d.join("local-dictation")) else {
+        return;
+    };
+    remove_caption_in(&dir);
+}
+
+/// Separated for the same reason as `write_caption_to`: testable against a
+/// temp directory. Removes any orphaned temp alongside the caption itself --
+/// a crashed write leaves one behind, and it holds the same speech.
+fn remove_caption_in(dir: &std::path::Path) {
+    let _ = std::fs::remove_file(dir.join("latest-caption.json"));
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.starts_with("latest-caption.json.tmp.") {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 /// Atomic write (temp file + rename) of the caption JSON to
 /// `<dir>/latest-caption.json`. Returns false (no write) for empty/whitespace
 /// text. Separated from `mirror_caption` so it can be unit-tested against a temp
@@ -54,7 +78,17 @@ fn write_caption_to(dir: &std::path::Path, text: &str) -> bool {
         return false;
     };
     let target = dir.join("latest-caption.json");
-    let tmp = dir.join(format!("latest-caption.json.tmp.{}", std::process::id()));
+    // Pid *and* a per-write counter. Pid alone gave two overlapping writes from
+    // the same process one temp path, so they could interleave into a single
+    // file and rename a spliced caption into place. Best-effort or not, that is
+    // a wrong transcript rather than a missing one.
+    static WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = dir.join(format!(
+        "latest-caption.json.tmp.{}.{}",
+        std::process::id(),
+        seq
+    ));
     // Owner-only, applied at create time rather than after the write. This file
     // holds a verbatim record of the last thing the user said out loud, and the
     // default 0666-minus-umask makes that readable by every account on the
@@ -1243,11 +1277,12 @@ mod caption_tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
-    /// Repeat writes must keep working. `create_new` makes the mode
-    /// authoritative but fails on an existing temp, so a leftover from a crashed
-    /// run at the same pid would otherwise wedge the feature permanently.
+    /// Repeat writes must keep working, and must not litter. Temp names carry
+    /// a per-write counter now, so a leftover from a crashed run no longer
+    /// collides -- but any temp that *is* left behind holds the same verbatim
+    /// speech as the caption, so none may survive a successful write.
     #[test]
-    fn write_caption_to_recovers_from_a_leftover_temp() {
+    fn write_caption_to_leaves_no_temp_behind() {
         let dir = std::env::temp_dir().join(format!("murmur-cap-stale-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
@@ -1255,10 +1290,47 @@ mod caption_tests {
         std::fs::write(&stale, b"junk").unwrap();
         assert!(write_caption_to(&dir, "first"));
         assert!(write_caption_to(&dir, "second"));
-        assert!(!stale.exists(), "temp file must not survive a successful write");
+        let temps: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.starts_with("latest-caption.json.tmp."))
+                    .unwrap_or(false)
+            })
+            .collect();
+        // The pre-existing junk file is the only temp allowed to survive: it
+        // was never ours, and clearing it is `remove_mirrored_caption`'s job.
+        assert_eq!(temps.len(), 1);
+        assert_eq!(temps[0].path(), stale);
         let raw = std::fs::read_to_string(dir.join("latest-caption.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(v["text"], "second");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Switching the setting off must not leave the last thing the user said
+    /// sitting on disk -- including any orphaned temp, which holds the same
+    /// speech as the caption itself.
+    #[test]
+    fn remove_caption_clears_the_file_and_any_temp() {
+        let dir = std::env::temp_dir().join(format!("murmur-cap-rm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(write_caption_to(&dir, "what I said"));
+        let orphan = dir.join("latest-caption.json.tmp.999.0");
+        std::fs::write(&orphan, b"leftover speech").unwrap();
+        remove_caption_in(&dir);
+        assert!(!dir.join("latest-caption.json").exists());
+        assert!(!orphan.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_caption_on_a_missing_directory_is_harmless() {
+        let dir = std::env::temp_dir().join(format!("murmur-cap-none-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        remove_caption_in(&dir);
     }
 }

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -55,19 +55,36 @@ fn write_caption_to(dir: &std::path::Path, text: &str) -> bool {
     };
     let target = dir.join("latest-caption.json");
     let tmp = dir.join(format!("latest-caption.json.tmp.{}", std::process::id()));
-    if std::fs::write(&tmp, &bytes).is_err() {
-        return false;
-    }
-    // Owner-only. This file holds a verbatim record of the last thing the user
-    // said out loud, and the default 0644 makes that readable by every account
-    // on the machine. Set on the temp file before the rename so the caption is
-    // never briefly world-readable at its real path.
+    // Owner-only, applied at create time rather than after the write. This file
+    // holds a verbatim record of the last thing the user said out loud, and the
+    // default 0666-minus-umask makes that readable by every account on the
+    // machine. Chmod-after-write left a window where the content was already on
+    // disk at the permissive mode; `mode()` closes it because the kernel applies
+    // it in the same open() that creates the file.
+    // `create_new` is what makes the mode authoritative, so a leftover temp from
+    // a crashed run holding this pid must be cleared or every later write fails.
+    let _ = std::fs::remove_file(&tmp);
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
-    std::fs::rename(&tmp, &target).is_ok()
+    // Fail closed: any failure removes the temp file rather than leaving
+    // verbatim transcript content behind at an unknown mode.
+    let wrote = match options.open(&tmp) {
+        Ok(mut file) => {
+            use std::io::Write;
+            file.write_all(&bytes).is_ok() && file.flush().is_ok()
+        }
+        Err(_) => false,
+    };
+    if !wrote || std::fs::rename(&tmp, &target).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return false;
+    }
+    true
 }
 
 /// Copy text to clipboard and optionally simulate Cmd+V paste.
@@ -1205,5 +1222,43 @@ mod caption_tests {
         assert!(!write_caption_to(&tmp, "   "));
         assert!(!tmp.join("latest-caption.json").exists());
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The caption is a verbatim record of speech, so the mode is part of the
+    /// contract, not an implementation detail. Asserted on the real file after
+    /// the rename because that is what another account could open.
+    #[cfg(unix)]
+    #[test]
+    fn write_caption_to_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!("murmur-cap-mode-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        assert!(write_caption_to(&tmp, "spoken secret"));
+        let mode = std::fs::metadata(tmp.join("latest-caption.json"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "caption must not be group/world readable");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Repeat writes must keep working. `create_new` makes the mode
+    /// authoritative but fails on an existing temp, so a leftover from a crashed
+    /// run at the same pid would otherwise wedge the feature permanently.
+    #[test]
+    fn write_caption_to_recovers_from_a_leftover_temp() {
+        let dir = std::env::temp_dir().join(format!("murmur-cap-stale-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let stale = dir.join(format!("latest-caption.json.tmp.{}", std::process::id()));
+        std::fs::write(&stale, b"junk").unwrap();
+        assert!(write_caption_to(&dir, "first"));
+        assert!(write_caption_to(&dir, "second"));
+        assert!(!stale.exists(), "temp file must not survive a successful write");
+        let raw = std::fs::read_to_string(dir.join("latest-caption.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(v["text"], "second");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -238,6 +238,8 @@ pub struct DictationState {
     pub smart_punctuation: bool,
     pub save_transcript: bool,
     pub save_audio: bool,
+    /// Opt-in: mirror each final transcript to a local file NotchPill can tail.
+    pub mirror_to_notchpill: bool,
     pub output_dir: String,
     /// Per-app profiles resolved once from the frontmost app at recording start.
     pub app_profiles: Vec<AppProfile>,
@@ -304,6 +306,7 @@ impl Default for DictationState {
             smart_punctuation: true,
             save_transcript: false,
             save_audio: false,
+            mirror_to_notchpill: false,
             output_dir: String::new(),
             app_profiles: Vec::new(),
             voice_commands_enabled: false,

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -847,6 +847,7 @@ export function SettingsPanel({
             {autoPasteOn && <PasteDelaySlider value={settings.autoPasteDelayMs} onCommit={(autoPasteDelayMs) => onUpdateSettings({ autoPasteDelayMs })} />}
             <SettingToggle title="Save Transcript to File" description="Write each completed transcription to a .txt file." checked={settings.saveTranscript} onChange={() => onUpdateSettings({ saveTranscript: !settings.saveTranscript })} />
             <SettingToggle title="Save Audio to File" description="Write each recording to a .wav file." checked={settings.saveAudio} onChange={() => onUpdateSettings({ saveAudio: !settings.saveAudio })} />
+            <SettingToggle title="Mirror Captions to NotchPill" description="Show your latest dictation in the NotchPill notch overlay. Stays on this Mac — only the final text is written locally." checked={settings.mirrorToNotchPill} onChange={() => onUpdateSettings({ mirrorToNotchPill: !settings.mirrorToNotchPill })} />
             {saveToFile && (
               <div>
                 <p className="mb-1 text-xs text-on-surface-variant">Output Folder</p>

--- a/app/src/lib/dictation.ts
+++ b/app/src/lib/dictation.ts
@@ -74,6 +74,7 @@ export interface ConfigureOptions {
   smartPunctuation?: boolean;
   saveTranscript?: boolean;
   saveAudio?: boolean;
+  mirrorToNotchPill?: boolean;
   outputDir?: string;
   appProfiles?: AppProfile[];
   voiceCommandsEnabled?: boolean;
@@ -103,6 +104,7 @@ export function buildConfigureOptions(s: Settings): ConfigureOptions {
     language: s.language,
     autoPaste: s.autoPaste,
     autoPasteDelayMs: s.autoPasteDelayMs,
+    mirrorToNotchPill: s.mirrorToNotchPill,
     vadSensitivity: s.vadSensitivity,
     idleTimeoutMinutes: s.idleTimeoutMinutes,
     customVocabulary: s.customVocabulary,

--- a/app/src/lib/hooks/useSettings.test.tsx
+++ b/app/src/lib/hooks/useSettings.test.tsx
@@ -138,4 +138,15 @@ describe('useSettings configure rollback privacy', () => {
       JSON.parse(localStorage.getItem('dictation-settings') ?? '{}').microphone,
     ).toBe('Studio Mic');
   });
+
+  it('pushes mirrorToNotchPill changes to the backend (regression: was missing from configure-trigger list)', async () => {
+    await act(async () => {
+      current.updateSettings({ mirrorToNotchPill: true });
+      await Promise.resolve();
+    });
+
+    expect(mocks.configure).toHaveBeenCalled();
+    const lastArg = mocks.configure.mock.calls.at(-1)?.[0];
+    expect(lastArg).toMatchObject({ mirrorToNotchPill: true });
+  });
 });

--- a/app/src/lib/hooks/useSettings.test.tsx
+++ b/app/src/lib/hooks/useSettings.test.tsx
@@ -146,7 +146,9 @@ describe('useSettings configure rollback privacy', () => {
     });
 
     expect(mocks.configure).toHaveBeenCalled();
-    const lastArg = mocks.configure.mock.calls.at(-1)?.[0];
+    // Indexed rather than `.at(-1)`: this repo's tsconfig target predates it.
+    const calls = mocks.configure.mock.calls;
+    const lastArg = calls[calls.length - 1]?.[0];
     expect(lastArg).toMatchObject({ mirrorToNotchPill: true });
   });
 });

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -119,7 +119,7 @@ export function useSettings() {
       emit('settings-changed').catch((err) => console.error('Failed to emit settings-changed:', err));
     }
 
-    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'vocabularyEntries' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'smartFormattingEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates) {
+    if ('model' in updates || 'language' in updates || 'autoPaste' in updates || 'autoPasteDelayMs' in updates || 'vadSensitivity' in updates || 'idleTimeoutMinutes' in updates || 'customVocabulary' in updates || 'vocabularyEntries' in updates || 'smartPunctuation' in updates || 'saveTranscript' in updates || 'saveAudio' in updates || 'mirrorToNotchPill' in updates || 'outputDir' in updates || 'appProfiles' in updates || 'voiceCommandsEnabled' in updates || 'voiceCommands' in updates || 'cleanupEnabled' in updates || 'smartFormattingEnabled' in updates || 'cleanupRemoveFiller' in updates || 'cleanupCapitalize' in updates || 'codeVocabEnabled' in updates || 'codeVocabFolder' in updates || 'correctionEnabled' in updates || 'correctionFuzzy' in updates) {
       const version = ++configureVersionRef.current;
       configure(buildConfigureOptions(newSettings))
         .catch(() => {

--- a/app/src/lib/hooks/useSettings.ts
+++ b/app/src/lib/hooks/useSettings.ts
@@ -138,6 +138,7 @@ export function useSettings() {
               smartPunctuation: previousSettings.smartPunctuation,
               saveTranscript: previousSettings.saveTranscript,
               saveAudio: previousSettings.saveAudio,
+              mirrorToNotchPill: previousSettings.mirrorToNotchPill,
               outputDir: previousSettings.outputDir,
               appProfiles: previousSettings.appProfiles,
               voiceCommandsEnabled: previousSettings.voiceCommandsEnabled,

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -220,6 +220,8 @@ export interface Settings {
   smartPunctuation: boolean;
   saveTranscript: boolean;
   saveAudio: boolean;
+  /** Mirror each final transcript to a local file NotchPill can show in the notch. */
+  mirrorToNotchPill: boolean;
   outputDir: string;
   /** Destination for saved Performance Lab benchmark reports. Empty = default
    * `Documents/Murmur`. Kept separate from `outputDir` so benchmark JSON doesn't
@@ -386,6 +388,7 @@ export const DEFAULT_SETTINGS: Settings = {
   smartPunctuation: true,
   saveTranscript: false,
   saveAudio: false,
+  mirrorToNotchPill: false,
   outputDir: '',
   benchmarkOutputDir: '',
   benchmarkAutoSave: false,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -56,6 +56,7 @@ Current as of **v0.21.3**. This is the breadth-first inventory of what ships; ea
 - Native `CGEvent` Cmd+V with an `osascript` fallback; configurable 10–500ms delay; one retry; timeout-bounded.
 - Auto-paste failure emits a hint — the text is already on the clipboard.
 - **File output** — numbered `.txt` transcripts and/or 16kHz mono `.wav` audio to a chosen folder (default `Documents/Murmur`). While file output is on, auto-paste is suppressed without overwriting the user's stored preference.
+- **Mirror captions to NotchPill** — opt-in, off by default. Mirrors the final transcript to `~/Library/Application Support/local-dictation/latest-caption.json` (`{text, timestamp}`) so a notch-overlay app can show what was just said. Owner-only (`0600`), most-recent-caption-only, written after the clipboard on a blocking task so it can never delay delivery, and deleted when the setting is switched off. On-device; nothing is sent anywhere.
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -59,6 +59,7 @@ interface Settings {
   autoPasteDelayMs: number;
   saveTranscript: boolean;
   saveAudio: boolean;
+  mirrorToNotchPill: boolean;
   outputDir: string;
 
   // Text intelligence
@@ -156,6 +157,7 @@ model-selection side effects.
 | `autoPasteDelayMs` | `number` | `0` | 0-500 ms, step 10 in UI | Delay in milliseconds before auto-paste fires, to allow window focus to settle. Zero uses the immediate native-paste fast path; increase it only for apps that move focus asynchronously. The backend clamps this value to the 0-500 range. The UI slider only appears when `autoPaste` is enabled. |
 | `saveTranscript` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's transcript is written to a sequentially numbered `.txt` (`murmur-0001`, `murmur-0002`, …) in the output folder. When `saveTranscript` or `saveAudio` is on, auto-paste is suppressed (clipboard copy still happens). |
 | `saveAudio` | `boolean` | `false` | `true` / `false` | When enabled, each live dictation's audio is written to a matching `.wav` (16kHz mono, 16-bit PCM) in the output folder. |
+| `mirrorToNotchPill` | `boolean` | `false` | `true` / `false` | When enabled, the final transcript of each dictation is mirrored to `~/Library/Application Support/local-dictation/latest-caption.json` as `{text, timestamp}`, so a notch-overlay app (NotchPill) can display what was just said. Off by default. The file is owner-only (`0600`), holds only the most recent caption — each write replaces the last — and is written after the clipboard, best-effort, so it can never delay or affect dictation output. Nothing leaves the device. Switching the setting off deletes the file. |
 | `outputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved transcript/audio files. Empty means the app default (`Documents/Murmur`, created on first write). Set via a folder picker (`dialog:allow-open`). |
 | `benchmarkOutputDir` | `string` | `''` | Any absolute folder path, or `''` for default | Destination for saved Performance Lab benchmark reports (`benchmark-<version>-<machine>-<createdAt>.json`). Empty means the app default (`Documents/Murmur`, created on first write). Kept separate from `outputDir` so benchmark JSON doesn't mix with dictation transcripts/audio. Set via a folder picker in the Performance Lab. |
 | `benchmarkAutoSave` | `boolean` | `false` | `true` / `false` | When enabled, each completed benchmark run is written to `benchmarkOutputDir` automatically (in addition to the 10-slot in-app history), so reports survive the localStorage cap. Best-effort: a write failure surfaces an error but does not fail the run. |
@@ -234,6 +236,7 @@ When settings change, `useSettings.updateSettings` pushes the following fields t
 | `vadSensitivity` | `vadSensitivity` | Yes |
 | `saveTranscript` | `saveTranscript` | Yes |
 | `saveAudio` | `saveAudio` | Yes |
+| `mirrorToNotchPill` | `mirrorToNotchPill` | Yes |
 | `outputDir` | `outputDir` | Yes |
 | `doubleTapKey` | _(sent via `update_keyboard_key`)_ | Via keyboard hooks |
 | `recordingMode` | _(controls which hook is active)_ | Frontend only |


### PR DESCRIPTION
## What

Adds an opt-in setting that writes the final transcript to a local file so a
separate notch-overlay app can display it. Off by default; when off, nothing
is written and no code runs on the dictation path.

The use case: when you dictate into a window you cannot see — a different
space, a background editor, a terminal behind the browser — there is no way to
check what was actually recognised before it is pasted. Mirroring the caption
lets an always-visible overlay show it word for word.

## How

- `injector::mirror_caption` / `write_caption_to` — atomic (temp file +
  rename) write of `{text, timestamp}` to
  `<data_dir>/local-dictation/latest-caption.json`. Best-effort: every failure
  is swallowed, so it can never affect dictation. Empty/whitespace text is
  skipped.
- The file is written `0600`. It holds a verbatim record of the last thing the
  user said out loud, and the default `0644` makes that readable by every
  account on the machine. Permissions are set on the temp file before the
  rename, so the caption is never briefly world-readable at its real path.
- Setting `mirrorToNotchPill` (default **off**) plumbed through the existing
  delivery path: `settings.ts` / `dictation.ts` → `configure_dictation` →
  `DictationState` → `DeliverySettings` → the inject site.
- Settings UI: a toggle in Delivery, beside the other output options.

## Privacy

Nothing leaves the machine. The write goes to the app's own data directory,
carries only the final text plus a timestamp, is owner-only, and happens only
when the user has explicitly switched it on.

## Tests

- `injector::caption_tests` — valid JSON is written; empty text is skipped.
  Cross-platform, since the existing injector tests are Linux-gated.
- `useSettings.test.tsx` — regression test that the toggle actually reaches the
  backend. The setting was previously missing from the `configure()` trigger
  list, so it saved locally and the backend never heard about it.

Verified locally against v0.27.0: `cargo check` clean, caption tests pass,
`tsc --noEmit` clean, `useSettings` suite 4/4 green, and the feature confirmed
working end to end in a local build.

## Notes

Happy to adjust naming, the file location, or drop the UI string to something
more generic if you would rather it not name a specific third-party app — the
mechanism is not tied to one consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to mirror the latest dictation transcript in the NotchPill overlay.
  * The setting is saved and applied automatically when changed.
  * Mirrored captions include timestamps, replace previous content, and are removed when mirroring is disabled.
  * Normal text delivery continues unchanged.

* **Documentation**
  * Documented the new caption-mirroring setting and output behavior.

* **Tests**
  * Added coverage for caption handling and settings updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->