### PR TITLE
fix: align title bar content with traffic lights

### DIFF
--- a/app/src/components/SonicCanvasComponents.test.tsx
+++ b/app/src/components/SonicCanvasComponents.test.tsx
@@ -200,6 +200,7 @@ describe('Sonic Canvas component details', () => {
       const elements = await renderHeader(status);
       expect(elements.header.classList).toContain('ui-window-header');
       expect(elements.header.classList).not.toContain('border-b');
+      expect(elements.header.querySelector(':scope > .ui-window-header-content')).not.toBeNull();
       expect(elements.statusChip.classList).toContain('ui-status-chip');
       expect(elements.record.classList).toContain('ui-record-pill');
       if (status === 'processing') {

--- a/app/src/components/ui/WindowHeader.tsx
+++ b/app/src/components/ui/WindowHeader.tsx
@@ -21,16 +21,18 @@ export function WindowHeader({
       className={`ui-window-header bg-background/95 backdrop-blur-xl ${className}`}
       {...props}
     >
-      <span data-tauri-drag-region className="ui-window-wordmark">Murmur</span>
-      {contextLabel && (
-        <span
-          data-tauri-drag-region
-          className="select-none text-xs font-medium text-on-surface-variant"
-        >
-          {contextLabel}
-        </span>
-      )}
-      {children}
+      <div data-tauri-drag-region className="ui-window-header-content">
+        <span data-tauri-drag-region className="ui-window-wordmark">Murmur</span>
+        {contextLabel && (
+          <span
+            data-tauri-drag-region
+            className="select-none text-xs font-medium text-on-surface-variant"
+          >
+            {contextLabel}
+          </span>
+        )}
+        {children}
+      </div>
     </header>
   );
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -58,6 +58,7 @@
      therefore own the full mockup height and center itself on the native
      traffic lights instead of assuming AppKit contributes a top inset. */
   --ui-window-header-height: 2.625rem;
+  --ui-window-content-offset-y: -0.125rem;
   /* The native controls end around x=68px with the configured 10px inset.
      Start web chrome at 80px to preserve a deliberate 12px wordmark gap. */
   --ui-window-controls-inset: 5rem;
@@ -145,9 +146,16 @@ textarea {
   height: var(--ui-window-header-height);
   flex-shrink: 0;
   align-items: center;
-  gap: var(--ui-space-4);
   padding: var(--ui-space-4) var(--ui-space-5);
   padding-left: var(--ui-window-controls-inset);
+}
+
+.ui-window-header-content {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--ui-space-4);
+  transform: translateY(var(--ui-window-content-offset-y));
 }
 
 .ui-window-wordmark {

--- a/app/src/styles.test.ts
+++ b/app/src/styles.test.ts
@@ -109,6 +109,7 @@ describe('Murmur layout contracts', () => {
     expect(css).toContain('--ui-font-label: 0.8125rem;');
     expect(css).toContain('--ui-font-body: 0.875rem;');
     expect(css).toContain('--ui-window-header-height: 2.625rem;');
+    expect(css).toContain('--ui-window-content-offset-y: -0.125rem;');
     expect(css).toContain('--ui-record-width: 4.5rem;');
     expect(css).toContain('--ui-status-min-width: 4.5rem;');
     expect(css).toContain('--ui-history-gap: 0.3125rem;');

--- a/app/visual-tests/main-window.spec.ts
+++ b/app/visual-tests/main-window.spec.ts
@@ -72,6 +72,38 @@ test('the window header flows into the history toolbar without a divider', async
   ))).toBe(80);
 });
 
+for (const state of ['recording', 'update-recovering', 'settings'] as const) {
+  test(`${state} title-bar controls share the native traffic-light centerline`, async ({ page }) => {
+    await page.goto(`/visual-fixtures.html?state=${state}&appearance=light`);
+
+    const header = page.locator('.ui-window-header');
+    const items = [
+      header.locator('.ui-window-wordmark'),
+      header.getByTestId('main-status-chip'),
+      ...(state === 'settings'
+        ? [
+            header.getByText('Settings', { exact: true }),
+            header.getByRole('button', { name: 'Done' }),
+          ]
+        : [
+            header.getByTestId('record-pill'),
+            header.getByRole('button', { name: 'Open settings' }),
+          ]),
+    ];
+    const [headerBox, centers] = await Promise.all([
+      header.boundingBox(),
+      Promise.all(items.map((item) => item.evaluate((element) => {
+        const box = element.getBoundingClientRect();
+        return box.top + box.height / 2;
+      }))),
+    ]);
+
+    expect(Math.max(...centers) - Math.min(...centers)).toBeLessThanOrEqual(0.5);
+    expect(headerBox).not.toBeNull();
+    expect((headerBox!.y + headerBox!.height / 2) - centers[0]).toBeCloseTo(2, 1);
+  });
+}
+
 test('update discovery cannot expand or wrap the recovering header', async ({ page }) => {
   await page.goto('/visual-fixtures.html?state=update-recovering&appearance=light');
 


### PR DESCRIPTION
## Summary
- move all shared web title-bar content onto one calibrated wrapper
- align Murmur, status, recording, Settings, and Done with native macOS traffic lights
- add geometry coverage for recording, recovering, and settings states

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1`
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run test:visual`
- [x] bundled native app smoke with AppKit frame verification

Closes #471