### PR TITLE
chore: protect CI gates and reduce idle log noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
         # hardware or downloaded models and stay out of CI deliberately.
         run: >-
           cd app/src-tauri &&
+          cargo build --example mock_llm_helper &&
           cargo test --test llm_sidecar_integration --test transform_flow_integration
           -- --test-threads=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,9 @@ jobs:
           CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
           CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
-        run: cd app/src-tauri && cargo check
+        # --all-targets so `tests/` and `examples/` are type-checked too. Without
+        # it the integration suites below can rot without any signal.
+        run: cd app/src-tauri && cargo check --all-targets
 
       - name: Run tests
         env:
@@ -165,6 +167,20 @@ jobs:
           CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
         run: cd app/src-tauri && cargo test --lib -- --test-threads=1
+
+      - name: Run hardware-free integration suites
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+        # These two drive the real supervisors against mock helpers — no model,
+        # no microphone, no permissions. The remaining suites in `tests/` need
+        # hardware or downloaded models and stay out of CI deliberately.
+        run: >-
+          cd app/src-tauri &&
+          cargo test --test llm_sidecar_integration --test transform_flow_integration
+          -- --test-threads=1
 
       - name: Run deterministic dictation evaluation
         env:

--- a/app/src-tauri/src/keyboard.rs
+++ b/app/src-tauri/src/keyboard.rs
@@ -1305,7 +1305,14 @@ fn ensure_listener_thread_spawned(app_handle: tauri::AppHandle) {
                     || now.saturating_sub(last_warning_at) >= TAP_SILENCE_WARNING_MS;
                 if last_callback_at != 0 && silent_for_ms >= TAP_SILENCE_WARNING_MS && warning_due {
                     LAST_TAP_SILENCE_WARNING_AT_MS.store(now, Ordering::SeqCst);
-                    tracing::warn!(
+                    // Info, not warn: silence means "nobody touched the keyboard",
+                    // which is the normal state of an idle machine, not a fault. As
+                    // a warning this was 94% of all production warning volume and
+                    // buried the real ones (empty transcripts, AX focus failures, a
+                    // diagnostics-store failure). Info keeps the event in
+                    // events.jsonl — the subscriber filters at `info`, so debug
+                    // would drop it and orphan its `canonical_event_code` entry.
+                    tracing::info!(
                         target: "keyboard",
                         event_code = "keyboard.listener_silent",
                         silent_for_ms = silent_for_ms,


### PR DESCRIPTION
## Summary
- type-check all Rust targets in CI and run the two hardware-free supervisor integration suites
- build the protocol mock helper before running the sidecar integration suite
- demote the normal idle keyboard-listener heartbeat from warning to info
- preserve the original local-only commit while stacking it on the health-sweep integration branch

## Test plan
- [x] `python3 scripts/build_local_llm_sidecar.py`
- [x] `cargo check --all-targets`
- [x] `cargo test --lib -- --test-threads=1` (749 passed, 5 ignored)
- [x] `cargo build --example mock_llm_helper`
- [x] sidecar + transform-flow integration suites (22 passed)
- [x] `npx tsc --noEmit`
- [x] `npm test` (646 passed)

## Local-work protection
- `stash@{0}` is preserved unchanged and its reviewed snapshot is pushed as `issue/481-preserve-audio-lifecycle-work` at `bfb1076`
- the remaining four stashes were inventoried and none were dropped

## Code-vs-issue note
The saved CI commit assumed `cargo test --test …` would build the `mock_llm_helper` example. It does not; the first Actions run exposed handshake failures in 18/21 sidecar tests. The workflow now builds the example explicitly before executing the suites.

Closes #481