### PR TITLE
fix: make blocked audio recovery exercise the killable helper

### DIFF
--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -447,6 +447,11 @@ pub fn run(arguments: &[String]) -> Result<(), ()> {
                 },
             )
             .map_err(|_| ())?;
+            if fault == Some("hang-stream-build") {
+                loop {
+                    std::thread::park();
+                }
+            }
             let ring = Arc::new(SpscRing::new());
             let failed = Arc::new(AtomicBool::new(false));
             let mut emit_setup = |step: CaptureSetupStep, transition: SetupTransition| {

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -185,7 +185,6 @@ pub(crate) enum AudioCommand {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AudioInitPhase {
     DeviceEnumeration,
-    ConfigLookup,
     StreamBuild,
     FirstBufferWait,
     Runtime,
@@ -195,7 +194,6 @@ impl AudioInitPhase {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::DeviceEnumeration => "device_enumeration",
-            Self::ConfigLookup => "config_lookup",
             Self::StreamBuild => "stream_build",
             Self::FirstBufferWait => "first_buffer_wait",
             Self::Runtime => "runtime",
@@ -285,9 +283,41 @@ fn helper_path() -> Result<std::path::PathBuf, String> {
         .map_err(|_| "The signed capture worker is missing from the app bundle.".to_string())
 }
 
+#[cfg(debug_assertions)]
+fn capture_fault_for_scenario(
+    scenario: Option<&str>,
+    create_sentinel: impl FnOnce() -> bool,
+) -> Option<&'static str> {
+    match scenario {
+        Some("hang_stream_build") => Some("hang-stream-build"),
+        Some("hang_stream_build_once") if create_sentinel() => Some("hang-stream-build"),
+        _ => None,
+    }
+}
+
+#[cfg(debug_assertions)]
+fn requested_capture_fault() -> Option<&'static str> {
+    let scenario = std::env::var("MURMUR_AUDIO_TEST_SCENARIO").ok();
+    capture_fault_for_scenario(scenario.as_deref(), || {
+        std::env::var_os("MURMUR_AUDIO_TEST_SENTINEL").is_some_and(|path| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+                .is_ok()
+        })
+    })
+}
+
+#[cfg(not(debug_assertions))]
+fn requested_capture_fault() -> Option<&'static str> {
+    None
+}
+
 fn spawn_helper(
     capture_id: u64,
     nonce_hex: &str,
+    fault: Option<&str>,
 ) -> Result<
     (
         ManagedChild,
@@ -317,13 +347,12 @@ fn spawn_helper(
     }
     let signature_ms = signature_started.elapsed().as_millis() as u64;
     let capture_id_text = capture_id.to_string();
+    let mut arguments = vec!["--production-v3", capture_id_text.as_str(), nonce_hex];
+    if let Some(fault) = fault {
+        arguments.extend(["--fault", fault]);
+    }
     let spawn_started = Instant::now();
-    let child = ManagedChild::spawn_with_arguments(
-        &path,
-        &["--production-v3", &capture_id_text, nonce_hex],
-        &[],
-    )
-    .map_err(|_| {
+    let child = ManagedChild::spawn_with_arguments(&path, &arguments, &[]).map_err(|_| {
         AudioFailure::new(
             AudioFailureKind::HostUnavailable,
             AudioInitPhase::StreamBuild,
@@ -400,7 +429,7 @@ fn hello(
 pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
     let (capture_id, nonce, nonce_hex) = capture_identity();
     let (mut child, mut input, output) =
-        spawn_helper(capture_id, &nonce_hex).map_err(|failure| failure.to_string())?;
+        spawn_helper(capture_id, &nonce_hex, None).map_err(|failure| failure.to_string())?;
     let output = match hello(&mut input, output, capture_id, nonce) {
         Ok(output) => output,
         Err(failure) => {
@@ -794,7 +823,11 @@ fn run_backend(
     }
 
     let (capture_id, nonce, nonce_hex) = capture_identity();
-    let (child, mut input, output) = match spawn_helper(capture_id, &nonce_hex) {
+    let (child, mut input, output) = match spawn_helper(
+        capture_id,
+        &nonce_hex,
+        requested_capture_fault(),
+    ) {
         Ok(value) => value,
         Err(failure) => {
             end_permission_prompt_pause(
@@ -1747,6 +1780,39 @@ mod tests {
                 !AudioFailure::new(kind, AudioInitPhase::StreamBuild).permits_backend_fallback()
             );
         }
+    }
+
+    #[test]
+    fn stream_build_faults_run_inside_the_killable_capture_process() {
+        let mut sentinel_creations = 0;
+        assert_eq!(
+            capture_fault_for_scenario(Some("hang_stream_build"), || {
+                sentinel_creations += 1;
+                true
+            }),
+            Some("hang-stream-build")
+        );
+        assert_eq!(sentinel_creations, 0);
+
+        assert_eq!(
+            capture_fault_for_scenario(Some("hang_stream_build_once"), || {
+                sentinel_creations += 1;
+                true
+            }),
+            Some("hang-stream-build")
+        );
+        assert_eq!(
+            capture_fault_for_scenario(Some("hang_stream_build_once"), || {
+                sentinel_creations += 1;
+                false
+            }),
+            None
+        );
+        assert_eq!(sentinel_creations, 2);
+        assert_eq!(
+            capture_fault_for_scenario(Some("unrelated"), || panic!("must not create sentinel")),
+            None
+        );
     }
 
     #[test]

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -224,51 +224,7 @@ impl WorkerFactory for ProductionWorkerFactory {
         spec: AudioWorkerSpec,
         event_sender: AudioWorkerEventSender,
     ) -> Result<JoinHandle<()>, String> {
-        #[cfg(debug_assertions)]
-        if should_inject_hung_stream_build() {
-            let owner = spec.owner;
-            return std::thread::Builder::new()
-                .name("murmur-audio-fault".to_string())
-                .spawn(move || {
-                    for phase in [
-                        audio::AudioInitPhase::DeviceEnumeration,
-                        audio::AudioInitPhase::ConfigLookup,
-                    ] {
-                        let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
-                        let _ = event_sender.send(AudioWorkerEvent::PhaseExited {
-                            owner,
-                            phase,
-                            elapsed_ms: 0,
-                        });
-                    }
-                    let _ = event_sender.send(AudioWorkerEvent::PhaseEntered {
-                        owner,
-                        phase: audio::AudioInitPhase::StreamBuild,
-                    });
-                    // Model a synchronous Core Audio call that never returns.
-                    loop {
-                        std::thread::park();
-                    }
-                })
-                .map_err(|error| format!("Failed to spawn audio fault worker: {error}"));
-        }
         audio::spawn_capture_worker(spec, event_sender)
-    }
-}
-
-#[cfg(debug_assertions)]
-fn should_inject_hung_stream_build() -> bool {
-    match std::env::var("MURMUR_AUDIO_TEST_SCENARIO").ok().as_deref() {
-        Some("hang_stream_build") => true,
-        Some("hang_stream_build_once") => std::env::var_os("MURMUR_AUDIO_TEST_SENTINEL")
-            .is_some_and(|path| {
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(path)
-                    .is_ok()
-            }),
-        _ => false,
     }
 }
 
@@ -1422,7 +1378,6 @@ mod tests {
                 let owner = spec.owner;
                 for phase in [
                     AudioInitPhase::DeviceEnumeration,
-                    AudioInitPhase::ConfigLookup,
                     AudioInitPhase::StreamBuild,
                 ] {
                     let _ = event_sender.send(AudioWorkerEvent::PhaseEntered { owner, phase });
@@ -1844,7 +1799,7 @@ mod tests {
                 retry_gate: Some(retry_gate.clone()),
                 spawn_count: Arc::clone(&spawn_count),
                 active_flags,
-                phase: AudioInitPhase::ConfigLookup,
+                phase: AudioInitPhase::StreamBuild,
                 phase_entered: Some(phase_sender),
             }),
             sink.clone(),
@@ -1979,7 +1934,7 @@ mod tests {
     #[test]
     fn stale_worker_generation_cannot_activate_current_attempt() {
         let (supervisor, gate, _, sink, active_flags) =
-            harness(AudioInitPhase::ConfigLookup, SupervisorConfig::default());
+            harness(AudioInitPhase::StreamBuild, SupervisorConfig::default());
         let owner = AudioOwner::Dictation(9);
         assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
         supervisor

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -89,6 +89,10 @@ Transcription processing is local. Network access occurs for model setup and may
   step with elapsed time since start and repeats the last step and transition
   in the attempt-budget-exceeded event. These events contain no device label,
   UID, raw backend error, or content.
+- Debug fault scenarios `hang_stream_build` and `hang_stream_build_once` run
+  inside the capture worker process. They exercise the same bounded
+  terminate/kill/reap boundary as a real blocked HAL call instead of parking an
+  unkillable thread in the app process.
 - A timed-out backend can advance only after its owned helper process group is
   positively confirmed empty. Unconfirmed termination leaves the lifecycle in
   exclusive recovery and suppresses fallback and new starts.


### PR DESCRIPTION
## Summary
- move the debug stream-build hang fault into the real capture worker process, so the production terminate/kill/reap boundary owns the simulated blocked HAL call
- keep device enumeration from consuming the one-shot fault sentinel, allowing the first capture start to exercise recovery
- remove the obsolete in-process parked-thread path and document the fault contract

## Failure mode fixed
The existing hang_stream_build fault parked an app-process Rust thread forever. That bypassed the process-isolated capture path shipped by #421 and left the supervisor in exclusive recovery, so dogfood acceptance could not prove that a blocked stream build was killable or that a fresh start was accepted without restarting Murmur.

## Production evidence
Fleet MacBook logs retained from 2026-07-30 through 2026-08-07 contain 200 recent audio.capture_ready events (224 ms average, 591 ms maximum, two above 400 ms). The older blocked/reaper warnings stop after the capture-helper rollout; later backend failures do not leave capture stuck in recovery. This PR turns the rollout acceptance case into a faithful helper-process fault path.

## Verification
- cargo check --all-targets
- cargo test -- --test-threads=1 (750 unit passed, 5 ignored; 12 capture-helper integration passed; 21 sidecar integration passed; transcription and transform-flow integration passed)
- npx tsc --noEmit
- npm test (70 files, 649 tests)
- debug app bundle produced; packaging stopped only at the expected missing release signing key
- native smoke with hang_stream_build_once: first owner entered StreamOpen, cancellation hard-stopped and reaped the helper in 257 ms, UI returned to Ready, and a second recording owner was accepted immediately without process overlap

Closes #388
Related to #486