### PR TITLE
fix: clear Processing after late audio teardown

### DIFF
--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -869,8 +869,16 @@ fn finish_attempt(attempt: &mut Option<Attempt>, sink: &dyn LifecycleSink, publi
     match finished.phase {
         AttemptPhase::Stopping => {
             let samples = take_samples(&mut finished);
-            if let Some(response) = finished.stop_response.take() {
-                let _ = response.send(Ok(samples));
+            let response_delivered = finished
+                .stop_response
+                .take()
+                .is_some_and(|response| response.send(Ok(samples)).is_ok());
+            if !response_delivered {
+                sink.notify(
+                    finished.app_handle.as_ref(),
+                    finished.owner,
+                    AudioLifecycleEvent::Idle,
+                );
             }
         }
         AttemptPhase::Starting => {
@@ -2488,6 +2496,73 @@ mod tests {
             Ok(vec![0.25])
         );
         wait_until("stopping worker was not joined", || {
+            !supervisor.public.is_active()
+        });
+        shutdown(&supervisor);
+    }
+
+    #[test]
+    fn completed_teardown_notifies_idle_when_the_stop_caller_timed_out() {
+        let gate = Gate::closed();
+        let sink = Arc::new(RecordingSink::default());
+        let supervisor = spawn_supervisor(
+            Arc::new(BlockingTeardownFactory { gate: gate.clone() }),
+            sink.clone(),
+            SupervisorConfig::default(),
+        );
+        let owner = AudioOwner::Dictation(99);
+        assert_eq!(start(&supervisor, owner).recv().unwrap(), Ok(()));
+        wait_until("worker never reached recording", || {
+            supervisor.public.is_recording_for(owner)
+        });
+
+        let (response_sender, response_receiver) = mpsc::channel();
+        supervisor
+            .sender
+            .send(SupervisorMessage::Stop {
+                owner: Some(owner),
+                response: response_sender,
+            })
+            .unwrap();
+        drop(response_receiver);
+
+        assert_eq!(
+            start(&supervisor, AudioOwner::Dictation(100))
+                .recv()
+                .unwrap(),
+            Err(AudioStartError::AudioRecovering),
+            "the blocked worker must retain exclusive ownership"
+        );
+
+        gate.open();
+        wait_until("joined teardown did not publish idle", || {
+            sink.events
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(event_owner, event)| {
+                    *event_owner == owner && *event == AudioLifecycleEvent::Idle
+                })
+        });
+        wait_until("stopping worker was not joined", || {
+            !supervisor.public.is_active()
+        });
+
+        let retry_owner = AudioOwner::Dictation(101);
+        assert_eq!(start(&supervisor, retry_owner).recv().unwrap(), Ok(()));
+        wait_until("fresh owner never reached recording", || {
+            supervisor.public.is_recording_for(retry_owner)
+        });
+        let (retry_stop_sender, retry_stop_receiver) = mpsc::channel();
+        supervisor
+            .sender
+            .send(SupervisorMessage::Stop {
+                owner: Some(retry_owner),
+                response: retry_stop_sender,
+            })
+            .unwrap();
+        assert_eq!(retry_stop_receiver.recv().unwrap(), Ok(vec![0.25]));
+        wait_until("retry worker was not joined", || {
             !supervisor.public.is_active()
         });
         shutdown(&supervisor);

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -2422,6 +2422,7 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                     dictation.status,
                     DictationStatus::Starting
                         | DictationStatus::Recording
+                        | DictationStatus::Processing
                         | DictationStatus::Recovering
                 )
             {
@@ -3538,6 +3539,58 @@ mod tests {
                 error_code: StableRunErrorV1::AudioCaptureFailed,
             }
         );
+    }
+
+    #[test]
+    fn idle_after_a_timed_out_stop_clears_processing_for_the_current_recording() {
+        let recording_id = 384;
+        let app_state = AppState::default();
+        app_state.recording_id.store(recording_id, Ordering::SeqCst);
+        app_state.dictation.lock_or_recover().status = DictationStatus::Processing;
+        keyboard::set_processing(true);
+
+        let app = tauri::test::mock_builder()
+            .manage(State {
+                app_state,
+                benchmark: Arc::new(crate::benchmark::BenchmarkCoordinator::new()),
+                knowledge: crate::knowledge_store::KnowledgeStore::default(),
+                correct_and_teach: crate::correct_and_teach::CorrectAndTeachState::default(),
+                performance: crate::performance_metrics::PerformanceMetrics::default(),
+                transform_diagnostics: crate::transform_diagnostics::TransformDiagnostics::default(
+                ),
+                notch_info: std::sync::Mutex::new(None),
+                display_snapshot: std::sync::Mutex::new(None),
+                transform_popover_anchor: std::sync::Mutex::new(None),
+                transform_main_was_visible: std::sync::Mutex::new(None),
+                transform_runtime: Arc::new(crate::llm_sidecar::LlmSidecar::new()),
+            })
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock Tauri app");
+        let app_handle = app.handle().clone();
+        let emitted_idle = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let emitted_idle = Arc::clone(&emitted_idle);
+            app_handle.listen_any("recording-status-changed", move |event| {
+                if event.payload() == "\"idle\"" {
+                    emitted_idle.store(true, Ordering::SeqCst);
+                }
+            });
+        }
+
+        handle_audio_lifecycle_with(
+            app_handle.clone(),
+            recording_id,
+            AudioLifecycleEvent::Idle,
+            |_, _| {},
+        );
+
+        let state = app_handle.state::<State>();
+        assert_eq!(
+            state.app_state.dictation.lock_or_recover().status,
+            DictationStatus::Idle
+        );
+        assert!(!keyboard::is_processing());
+        assert!(emitted_idle.load(Ordering::SeqCst));
     }
 
     struct RetryTestBackend {

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -92,6 +92,9 @@ Transcription processing is local. Network access occurs for model setup and may
 - A timed-out backend can advance only after its owned helper process group is
   positively confirmed empty. Unconfirmed termination leaves the lifecycle in
   exclusive recovery and suppresses fallback and new starts.
+- If a stop caller times out first, the helper remains exclusively owned until
+  it exits and is joined. That late completion publishes Idle to clear the
+  current dictation's Processing state before a new recording can start.
 - Capture-worker errors are reduced immediately to stable content-free kinds
   (`permission_denied`, `device_unavailable`, `stream_invalidated`,
   `invalid_input`, `resource_exhausted`, and bounded fallback kinds).


### PR DESCRIPTION
## Summary
- publish lifecycle Idle when a stopped worker has exited and joined after its stop caller already timed out
- allow that current-owner Idle notification to clear dictation Processing and the keyboard processing gate
- prove the blocked worker remains exclusively owned until join, then a fresh recording succeeds
- document the late-teardown status contract

## Failure mode fixed
stop_native_recording commits Processing before waiting for the audio supervisor. If the stop response exceeds its timeout, the caller disappears while the supervisor correctly retains the Stopping owner. When the worker later exited, the response send failed silently and no lifecycle event reset backend Processing, leaving the next recording busy until Escape or restart.

The fix does not detach or overlap workers: Idle is published only after ThreadExited has been joined and only when the stop result cannot be delivered to its original caller.

## Production evidence
Current fleet MacBook logs show recent teardown-and-resample operations consistently completing in roughly 8-22 ms and no retained 12-second stop-timeout occurrence. This remains a latent double-failure guard, covered through the deterministic BlockingTeardownFactory seam.

## Verification
- cargo check --all-targets
- cargo test -- --test-threads=1 (751 unit passed, 5 ignored; 12 capture-helper integration passed; 21 sidecar integration passed; transcription and transform-flow integration passed)
- npx tsc --noEmit
- npm test (70 files, 649 tests)
- native debug app opened Ready; two consecutive recording attempts were accepted and returned to Ready with the local actionable microphone error, with no lingering Processing gate
- debug app and DMG were produced; packaging stopped only at the expected missing release signing private key

Closes #384
Related to #486