### PR TITLE
feat: surface on-device capture startup health

### DIFF
--- a/app/src/components/log-viewer/DiagnosticsWorkspace.test.tsx
+++ b/app/src/components/log-viewer/DiagnosticsWorkspace.test.tsx
@@ -31,6 +31,16 @@ vi.mock('../../lib/hooks/usePerformanceHealth', () => ({
     dictationStatus: 'idle',
     transformStatus: 'idle',
     runtime: null,
+    capture: {
+      status: 'insufficientData',
+      sampleCount: 0,
+      requiredSamples: 5,
+      medianStartupMs: null,
+      fallbackCount: 0,
+      chronicFallback: false,
+      slowStartup: false,
+      degradedBackend: null,
+    },
     refresh: vi.fn(),
   }),
 }));

--- a/app/src/components/log-viewer/PerformanceView.test.tsx
+++ b/app/src/components/log-viewer/PerformanceView.test.tsx
@@ -34,6 +34,16 @@ const HEALTH: PerformanceHealth = {
     lifecycleState: 'ready',
     failurePresent: false,
   },
+  capture: {
+    status: 'healthy',
+    sampleCount: 5,
+    requiredSamples: 5,
+    medianStartupMs: 240,
+    fallbackCount: 0,
+    chronicFallback: false,
+    slowStartup: false,
+    degradedBackend: null,
+  },
 };
 
 describe('PerformanceView', () => {
@@ -80,6 +90,69 @@ describe('PerformanceView', () => {
     expect(container.textContent).not.toMatch(/GPU utilization\s+\d/);
     expect(container.querySelectorAll('svg[role="img"]')).toHaveLength(2);
     expect(container.querySelector('[aria-label="Shared resource chart timeline cursor"]')).not.toBeNull();
+    expect(container.textContent).toContain('Microphone startup looks healthy');
+    expect(container.textContent).toContain('240 ms');
+  });
+
+  it('explains chronic fallback without restart advice', async () => {
+    await act(async () => {
+      root.render(
+        <PerformanceView
+          samples={[]}
+          loading={false}
+          error={null}
+          health={{
+            ...HEALTH,
+            capture: {
+              status: 'degraded',
+              sampleCount: 5,
+              requiredSamples: 5,
+              medianStartupMs: 8_400,
+              fallbackCount: 5,
+              chronicFallback: true,
+              slowStartup: true,
+              degradedBackend: 'auhal',
+            },
+          }}
+          onRetry={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Microphone startup is degraded');
+    expect(container.textContent).toContain('AUHAL failed before first audio');
+    expect(container.textContent).toContain('Murmur recovered through fallback');
+    expect(container.textContent).toContain('8.4 s');
+    expect(container.textContent).not.toMatch(/restart/i);
+  });
+
+  it('shows how many recordings remain before making a judgment', async () => {
+    await act(async () => {
+      root.render(
+        <PerformanceView
+          samples={[]}
+          loading={false}
+          error={null}
+          health={{
+            ...HEALTH,
+            capture: {
+              status: 'insufficientData',
+              sampleCount: 3,
+              requiredSamples: 5,
+              medianStartupMs: 220,
+              fallbackCount: 0,
+              chronicFallback: false,
+              slowStartup: false,
+              degradedBackend: null,
+            },
+          }}
+          onRetry={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Microphone startup health is collecting data');
+    expect(container.textContent).toContain('2 more successful recordings');
   });
 
   it('distinguishes loading, empty, and error states', async () => {

--- a/app/src/components/log-viewer/PerformanceView.tsx
+++ b/app/src/components/log-viewer/PerformanceView.tsx
@@ -59,6 +59,61 @@ function pipelineLabel(health: PerformanceHealth): string | null {
   return null;
 }
 
+function captureBackendLabel(backend: PerformanceHealth['capture']['degradedBackend']): string {
+  if (backend === 'auhal') return 'AUHAL';
+  if (backend === 'cpal') return 'CPAL';
+  return 'The primary capture backend';
+}
+
+function formatStartup(milliseconds: number | null): string {
+  if (milliseconds === null) return 'unavailable';
+  if (milliseconds < 1_000) return `${Math.round(milliseconds)} ms`;
+  return `${(milliseconds / 1_000).toFixed(1)} s`;
+}
+
+function CaptureHealthLine({ health }: { health: PerformanceHealth }) {
+  const capture = health.capture;
+  if (health.loading && capture.sampleCount === 0) {
+    return (
+      <div className="mb-3 rounded-xl border border-outline-variant/15 bg-surface-container-low px-3 py-2">
+        <div className="text-xs font-medium text-on-surface">Checking microphone startup health…</div>
+      </div>
+    );
+  }
+  if (capture.status === 'insufficientData') {
+    const remaining = capture.requiredSamples - capture.sampleCount;
+    return (
+      <div role="status" className="mb-3 rounded-xl border border-outline-variant/15 bg-surface-container-low px-3 py-2">
+        <div className="text-xs font-medium text-on-surface">Microphone startup health is collecting data</div>
+        <p className="mt-0.5 text-[11px] text-on-surface-variant">
+          {remaining} more successful {remaining === 1 ? 'recording' : 'recordings'} needed for a local five-recording signal.
+        </p>
+      </div>
+    );
+  }
+  if (capture.status === 'degraded') {
+    const startup = formatStartup(capture.medianStartupMs);
+    return (
+      <div role="alert" className="mb-3 rounded-xl border border-warning/20 bg-warning/10 px-3 py-2">
+        <div className="text-xs font-semibold text-warning">Microphone startup is degraded</div>
+        <p className="mt-0.5 text-[11px] text-on-surface-variant">
+          {capture.chronicFallback
+            ? `${captureBackendLabel(capture.degradedBackend)} failed before first audio in all five recent recordings. Murmur recovered through fallback; median startup was ${startup}.`
+            : `Median start-to-audio was ${startup} across the five most recent recordings.`}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div role="status" className="mb-3 rounded-xl border border-success/20 bg-success/10 px-3 py-2">
+      <div className="text-xs font-semibold text-success">Microphone startup looks healthy</div>
+      <p className="mt-0.5 text-[11px] text-on-surface-variant">
+        Median start-to-audio was {formatStartup(capture.medianStartupMs)} across five recent recordings; {capture.fallbackCount} required fallback.
+      </p>
+    </div>
+  );
+}
+
 function currentMeasurement(
   sample: ResourceSampleV1 | undefined,
   select: (value: ResourceSampleV1) => MeasurementV1<number>,
@@ -191,6 +246,7 @@ export function PerformanceView({
             Some live diagnostics could not be refreshed. Existing measured data remains visible.
           </div>
         )}
+        <CaptureHealthLine health={health} />
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
           {healthCards.map(card => <MetricCard key={card.label} {...card} />)}
         </div>

--- a/app/src/lib/captureHealth.test.ts
+++ b/app/src/lib/captureHealth.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { AppEvent } from './events';
+import {
+  CAPTURE_HEALTH_WINDOW,
+  deriveCaptureHealth,
+  SLOW_CAPTURE_STARTUP_MS,
+} from './captureHealth';
+
+function event(
+  seconds: number,
+  summary: string,
+  data: Record<string, unknown>,
+): AppEvent {
+  return {
+    timestamp: new Date(Date.UTC(2026, 7, 7, 12, 0, seconds)).toISOString(),
+    stream: 'audio',
+    level: 'info',
+    summary,
+    data,
+  };
+}
+
+function ready(seconds: number, owner: number, startupMs: number): AppEvent {
+  return event(seconds, 'audio readiness accepted', {
+    event_code: 'audio.capture_ready',
+    owner,
+    owner_kind: 'dictation',
+    startup_ms: startupMs,
+  });
+}
+
+function fallback(seconds: number, owner: number, fromBackend = 'auhal'): AppEvent {
+  return event(seconds, 'capture backend failed before retained audio; trying bounded fallback', {
+    event_code: 'audio.fallback_started',
+    owner,
+    from_backend: fromBackend,
+    to_backend: 'cpal',
+  });
+}
+
+describe('deriveCaptureHealth', () => {
+  it('requires five successful dictation captures before judging health', () => {
+    const health = deriveCaptureHealth([
+      ready(1, 1, 180),
+      ready(2, 2, 220),
+      ready(3, 3, 240),
+      ready(4, 4, 260),
+    ]);
+
+    expect(health.status).toBe('insufficientData');
+    expect(health.sampleCount).toBe(CAPTURE_HEALTH_WINDOW - 1);
+    expect(health.medianStartupMs).toBe(230);
+  });
+
+  it('reports a healthy rolling median and occasional fallback honestly', () => {
+    const health = deriveCaptureHealth([
+      ready(1, 1, 180),
+      ready(2, 2, 220),
+      fallback(3, 3),
+      ready(4, 3, 320),
+      ready(5, 4, 240),
+      ready(6, 5, 260),
+    ]);
+
+    expect(health.status).toBe('healthy');
+    expect(health.medianStartupMs).toBe(240);
+    expect(health.fallbackCount).toBe(1);
+    expect(health.chronicFallback).toBe(false);
+  });
+
+  it('flags five consecutive recovered fallbacks and names the failed backend', () => {
+    const events: AppEvent[] = [];
+    for (let owner = 1; owner <= CAPTURE_HEALTH_WINDOW; owner += 1) {
+      events.push(fallback(owner * 2, owner));
+      events.push(ready(owner * 2 + 1, owner, 700 + owner));
+    }
+
+    const health = deriveCaptureHealth(events);
+    expect(health.status).toBe('degraded');
+    expect(health.chronicFallback).toBe(true);
+    expect(health.slowStartup).toBe(false);
+    expect(health.degradedBackend).toBe('auhal');
+  });
+
+  it('flags a slow rolling median without inventing a degraded backend', () => {
+    const health = deriveCaptureHealth([
+      ready(1, 1, SLOW_CAPTURE_STARTUP_MS - 1),
+      ready(2, 2, SLOW_CAPTURE_STARTUP_MS),
+      ready(3, 3, 2_500),
+      ready(4, 4, 2_800),
+      ready(5, 5, 3_100),
+    ]);
+
+    expect(health.status).toBe('degraded');
+    expect(health.slowStartup).toBe(true);
+    expect(health.chronicFallback).toBe(false);
+    expect(health.degradedBackend).toBeNull();
+  });
+
+  it('does not correlate a stale fallback across a fresh owner start', () => {
+    const health = deriveCaptureHealth([
+      fallback(1, 1),
+      event(2, 'audio initialization accepted', { owner: 1 }),
+      ready(3, 1, 200),
+      ready(4, 2, 210),
+      ready(5, 3, 220),
+      ready(6, 4, 230),
+      ready(7, 5, 240),
+    ]);
+
+    expect(health.status).toBe('healthy');
+    expect(health.fallbackCount).toBe(0);
+  });
+
+  it('accepts exact historical summaries when stable event codes are absent', () => {
+    const events: AppEvent[] = [];
+    for (let owner = 1; owner <= CAPTURE_HEALTH_WINDOW; owner += 1) {
+      events.push(event(owner * 2, 'capture backend failed before retained audio; trying bounded fallback', {
+        owner,
+        from_backend: 'auhal',
+      }));
+      events.push(event(owner * 2 + 1, 'audio readiness accepted', {
+        owner,
+        owner_kind: 'dictation',
+        startup_ms: 650,
+      }));
+    }
+
+    expect(deriveCaptureHealth(events).chronicFallback).toBe(true);
+  });
+});

--- a/app/src/lib/captureHealth.ts
+++ b/app/src/lib/captureHealth.ts
@@ -1,0 +1,148 @@
+import type { AppEvent } from './events';
+
+export const CAPTURE_HEALTH_WINDOW = 5;
+export const SLOW_CAPTURE_STARTUP_MS = 2_000;
+
+const FALLBACK_CORRELATION_WINDOW_MS = 35_000;
+const READY_SUMMARY = 'audio readiness accepted';
+const FALLBACK_SUMMARY = 'capture backend failed before retained audio; trying bounded fallback';
+const START_SUMMARY = 'audio initialization accepted';
+
+export type CaptureBackendName = 'auhal' | 'cpal';
+
+export interface CaptureHealth {
+  status: 'insufficientData' | 'healthy' | 'degraded';
+  sampleCount: number;
+  requiredSamples: number;
+  medianStartupMs: number | null;
+  fallbackCount: number;
+  chronicFallback: boolean;
+  slowStartup: boolean;
+  degradedBackend: CaptureBackendName | null;
+}
+
+interface PendingFallback {
+  atMs: number;
+  fromBackend: CaptureBackendName | null;
+}
+
+interface CaptureObservation {
+  startupMs: number;
+  fallback: PendingFallback | null;
+}
+
+function eventCode(event: AppEvent): string | null {
+  return typeof event.data.event_code === 'string' ? event.data.event_code : null;
+}
+
+function numericField(event: AppEvent, key: string): number | null {
+  const value = event.data[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function backendField(event: AppEvent, key: string): CaptureBackendName | null {
+  const value = event.data[key];
+  return value === 'auhal' || value === 'cpal' ? value : null;
+}
+
+function observedAtMs(event: AppEvent): number | null {
+  const value = Date.parse(event.timestamp);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isReady(event: AppEvent): boolean {
+  return eventCode(event) === 'audio.capture_ready' || event.summary === READY_SUMMARY;
+}
+
+function isFallback(event: AppEvent): boolean {
+  return eventCode(event) === 'audio.fallback_started' || event.summary === FALLBACK_SUMMARY;
+}
+
+function isCaptureFailed(event: AppEvent): boolean {
+  return eventCode(event) === 'audio.capture_failed';
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[midpoint]
+    : (sorted[midpoint - 1] + sorted[midpoint]) / 2;
+}
+
+export function deriveCaptureHealth(events: AppEvent[]): CaptureHealth {
+  const pendingFallbacks = new Map<number, PendingFallback>();
+  const observations: CaptureObservation[] = [];
+
+  for (const event of events) {
+    const owner = numericField(event, 'owner');
+    if (owner === null) continue;
+
+    if (event.summary === START_SUMMARY) {
+      pendingFallbacks.delete(owner);
+      continue;
+    }
+    if (isFallback(event)) {
+      const atMs = observedAtMs(event);
+      if (atMs !== null) {
+        pendingFallbacks.set(owner, {
+          atMs,
+          fromBackend: backendField(event, 'from_backend'),
+        });
+      }
+      continue;
+    }
+    if (isCaptureFailed(event)) {
+      pendingFallbacks.delete(owner);
+      continue;
+    }
+    if (!isReady(event) || event.data.owner_kind !== 'dictation') continue;
+
+    const startupMs = numericField(event, 'startup_ms');
+    const readyAtMs = observedAtMs(event);
+    if (startupMs === null || startupMs < 0 || readyAtMs === null) continue;
+
+    const pending = pendingFallbacks.get(owner) ?? null;
+    const fallback = pending
+      && readyAtMs >= pending.atMs
+      && readyAtMs - pending.atMs <= FALLBACK_CORRELATION_WINDOW_MS
+      ? pending
+      : null;
+    observations.push({ startupMs, fallback });
+    pendingFallbacks.delete(owner);
+  }
+
+  const recent = observations.slice(-CAPTURE_HEALTH_WINDOW);
+  const sampleCount = recent.length;
+  const medianStartupMs = sampleCount > 0
+    ? median(recent.map(observation => observation.startupMs))
+    : null;
+  const fallbacks = recent.filter(observation => observation.fallback !== null);
+  const fallbackCount = fallbacks.length;
+  const enoughData = sampleCount === CAPTURE_HEALTH_WINDOW;
+  const chronicFallback = enoughData && fallbackCount === CAPTURE_HEALTH_WINDOW;
+  const slowStartup = enoughData
+    && medianStartupMs !== null
+    && medianStartupMs >= SLOW_CAPTURE_STARTUP_MS;
+  const degradedBackends = fallbacks.map(observation => observation.fallback?.fromBackend ?? null);
+  const degradedBackend = chronicFallback
+    && degradedBackends[0] !== null
+    && degradedBackends.every(backend => backend === degradedBackends[0])
+    ? degradedBackends[0]
+    : null;
+
+  return {
+    status: !enoughData
+      ? 'insufficientData'
+      : chronicFallback || slowStartup
+        ? 'degraded'
+        : 'healthy',
+    sampleCount,
+    requiredSamples: CAPTURE_HEALTH_WINDOW,
+    medianStartupMs,
+    fallbackCount,
+    chronicFallback,
+    slowStartup,
+    degradedBackend,
+  };
+}

--- a/app/src/lib/hooks/usePerformanceHealth.ts
+++ b/app/src/lib/hooks/usePerformanceHealth.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import { useCallback, useEffect, useState } from 'react';
 import { getStatus } from '../dictation';
+import { deriveCaptureHealth, type CaptureHealth } from '../captureHealth';
+import type { AppEvent } from '../events';
 import {
   getModelRuntimeStatus,
   type ModelRuntimeSnapshot,
@@ -22,6 +24,7 @@ export interface PerformanceHealth {
   dictationStatus: DictationStatus | null;
   transformStatus: TransformPipelineStatus | null;
   runtime: ModelRuntimeSnapshot | null;
+  capture: CaptureHealth;
 }
 
 function isDictationStatus(value: unknown): value is DictationStatus {
@@ -45,15 +48,17 @@ export function usePerformanceHealth(enabled: boolean): PerformanceHealth & { re
     dictationStatus: null,
     transformStatus: null,
     runtime: null,
+    capture: deriveCaptureHealth([]),
   });
 
   const refresh = useCallback(() => {
     if (!enabled) return;
     void (async () => {
       try {
-        const [status, transformStatus] = await Promise.all([
+        const [status, transformStatus, events] = await Promise.all([
           getStatus(),
           invoke<unknown>('transform_status'),
+          invoke<AppEvent[]>('get_event_history'),
         ]);
         const modelName = typeof status.model === 'string' ? status.model : null;
         const runtime = modelName ? await getModelRuntimeStatus(modelName) : null;
@@ -64,6 +69,7 @@ export function usePerformanceHealth(enabled: boolean): PerformanceHealth & { re
           dictationStatus: isDictationStatus(status.state) ? status.state : null,
           transformStatus: isTransformStatus(transformStatus) ? transformStatus : null,
           runtime,
+          capture: deriveCaptureHealth(events),
         });
       } catch (reason) {
         setHealth(current => ({

--- a/docs/features/performance-diagnostics.md
+++ b/docs/features/performance-diagnostics.md
@@ -143,3 +143,18 @@ bounded records directly, then uses `get_performance_run` for detail. Its phase
 waterfall preserves canonical stage order and availability but does not infer
 absolute offsets that V1 does not record. Correlated Events navigation matches
 the structured canonical correlation field rather than parsing event summaries.
+
+## Capture startup health
+
+The Performance tab also derives a read-only, on-device microphone startup
+signal from the existing bounded event history. It considers the five newest
+successful dictation `audio.capture_ready` events and correlates a preceding
+`audio.fallback_started` only for the same owner within the bounded capture
+contract. It reports degraded health when all five captures required fallback
+or their median `startup_ms` is at least two seconds.
+
+This judgment does not change backend order, retry budgets, or any capture-path
+behavior. It accepts only the stable `auhal` and `cpal` backend labels and exact
+event codes (plus exact historical summaries); it never reads device labels,
+UIDs, transcript content, or free-form errors. Fewer than five successful
+captures is reported as insufficient data rather than healthy or degraded.


### PR DESCRIPTION
## Summary
- derive a bounded five-recording microphone startup signal from existing on-device capture events
- flag chronic backend fallback or a median start-to-audio time of at least two seconds
- surface healthy, degraded, and insufficient-data states in Diagnostics > Performance without changing capture behavior
- accept only stable AUHAL/CPAL labels and content-free event fields

## Failure mode fixed
Production dogfood history showed repeated AUHAL-to-CPAL rescue episodes, but users had no durable on-device indication that the primary backend was chronically failing. The performance-run schema does not currently store capture startup fields, so this reads the bounded cross-launch event history already emitted by the capture path and correlates fallback to readiness by owner and time window.

## Verification
- `cd app/src-tauri && cargo check --all-targets`
- `cd app/src-tauri && cargo test -- --test-threads=1` (749 unit passed, 5 ignored; integrations passed)
- `cd app && npx tsc --noEmit`
- `cd app && npm test` (657 passed)
- focused component tests render healthy, degraded, and insufficient-data copy
- production telemetry checked on the fleet MacBook; recent starts were healthy (~198-276 ms), while retained historical logs contained repeated AUHAL-to-CPAL fallback episodes

Native visual attachment was blocked because the separate health-sweep dev app owns the shared dev single-instance slot; that process was left untouched per coordination instructions.

Closes #446
Related to #486