### PR TITLE
feat: schedule capture-startup regression watch

### DIFF
--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -54,6 +54,10 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
                                                    │
                                                    ▼
                                     ~/murmur-logs/<install-uuid>/events[.dev].jsonl
+                                                   │
+                                      hourly systemd timer
+                                                   ▼
+                                    capture-watch.json + dashboard alert
 ```
 
 ### Shipper (`app/src-tauri/src/log_shipper.rs`)
@@ -79,6 +83,10 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
   `127.0.0.1:8600`, run by systemd unit `murmur-logs.service` (user `george`).
 - Validates the bearer token, the `X-Install-Id` shape, and that every line
   parses as JSON before appending. 8 MB request cap, 200 MB per-install cap.
+- Adds a bounded `ingest_app_version` annotation from the app-version request
+  header to each accepted production event. This is receiver-side attribution
+  from an existing header, not a new client-collected field. Historical lines
+  remain untouched and are treated as an `unknown` non-comparable cohort.
 - Exposed at `https://georgenijo.com/murmur/ingest` via a `location` block in
   `/etc/nginx/sites-enabled/georgenijo.com`. Health: `/murmur/healthz`.
 - The ingest token is in fleet secrets: `fleet secret get murmur-log-ingest-token`.
@@ -117,6 +125,32 @@ telemetry rather than instructions. This is prompt-injection hardening, not a
 claim that event text is trusted: operators should attach the report as
 diagnostic data and ask the model to prioritize Action/Watch findings, correlate
 the ordered sequence, and cite event codes in its diagnosis.
+
+### Scheduled capture-startup watch
+
+`murmur-capture-watch.timer` runs an hourly, stdlib-only, line-by-line scan of
+the retained production JSONL. Its versioned report groups only privacy-safe
+capture metrics by install and receiver-observed app version:
+
+- readiness `startup_ms` p50/p95;
+- active initialization timeouts split by stable backend and
+  `last_setup_step`;
+- fallback and both-backends-failed counts;
+- ready-recording counts per completed attempted app session.
+
+The watch alerts when a newest comparable cohort (at least five readiness
+samples) has a p50 above twice the preceding version on the same install, or
+when the same install/version has two completed attempted sessions with zero
+ready recordings. An app session is delimited by `startup_baseline`; idle
+launches and the currently open session cannot create a zero-ready verdict.
+
+Reports contain no raw event summaries, device fields, content, paths, or free
+form errors. Backend/setup-step values are allowlisted and unknown values
+collapse to `unknown`. Memory is bounded to the newest 500 startup samples per
+cohort and 64 explicit versions per install; excess versions collapse into a
+non-comparable `overflow` cohort. The report is atomically replaced at
+`~/murmur-logs/capture-watch.json`; an alert also makes the one-shot exit
+nonzero for systemd/journal visibility and appears on the protected dashboard.
 
 ### Operator event semantics
 

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -10,6 +10,9 @@ the source of truth and redeploy from it.
 |---|---|---|
 | `murmur-logs-receiver.py` | `/home/george/murmur-logs-receiver.py` | stdlib HTTP server on `127.0.0.1:8600`: ingest, state, dashboard |
 | `murmur-logs.service` | `/etc/systemd/system/` | runs the receiver as `george`, restart-always |
+| `murmur-capture-watch.py` | `/home/george/murmur-capture-watch.py` | bounded stdlib aggregation of shipped capture-startup metrics |
+| `murmur-capture-watch.service` | `/etc/systemd/system/` | one-shot capture regression analysis |
+| `murmur-capture-watch.timer` | `/etc/systemd/system/` | runs the watch hourly with a randomized delay |
 | `nginx-murmur-site.conf` | `/etc/nginx/sites-available/murmur` (+ symlink in sites-enabled) | `murmur.georgenijo.com` → dashboard (own LE cert) |
 | `nginx-georgenijo-locations.snippet` | inside the `georgenijo.com` 443 server block | public `/murmur/ingest`, `/murmur/state`, `/murmur/healthz` |
 
@@ -27,9 +30,24 @@ the source of truth and redeploy from it.
 
 ```bash
 cat infra/log-receiver/murmur-logs-receiver.py | tailscale ssh george@whoop-vm "cat > /home/george/murmur-logs-receiver.py"
+cat infra/log-receiver/murmur-capture-watch.py | tailscale ssh george@whoop-vm "cat > /home/george/murmur-capture-watch.py"
+cat infra/log-receiver/murmur-capture-watch.service | tailscale ssh george@whoop-vm "cat > /tmp/murmur-capture-watch.service"
+cat infra/log-receiver/murmur-capture-watch.timer | tailscale ssh george@whoop-vm "cat > /tmp/murmur-capture-watch.timer"
+tailscale ssh ubuntu@whoop-vm "sudo install -m 0644 /tmp/murmur-capture-watch.service /etc/systemd/system/ && sudo install -m 0644 /tmp/murmur-capture-watch.timer /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now murmur-capture-watch.timer"
 tailscale ssh ubuntu@whoop-vm "sudo systemctl restart murmur-logs && systemctl is-active murmur-logs"
+tailscale ssh ubuntu@whoop-vm "sudo systemctl start murmur-capture-watch.service || true; systemctl status --no-pager murmur-capture-watch.service; systemctl list-timers --no-pager murmur-capture-watch.timer"
 curl -s https://georgenijo.com/murmur/healthz   # expect: ok
 ```
+
+The one-shot exits `2` after atomically writing its report when it finds an
+alert. That intentionally leaves an operator-visible failed unit and journal
+entry; the timer continues to run on schedule. The fleet dashboard reads the
+same report and shows the bounded alert details. A healthy later run clears the
+failed state and replaces the report.
+
+Rollback stops/disables the timer, removes its two units and script, reloads
+systemd, and redeploys the preceding receiver. Retained `events.jsonl` remains
+valid: `ingest_app_version` is an additive receiver annotation.
 
 ## Data layout
 
@@ -37,6 +55,38 @@ curl -s https://georgenijo.com/murmur/healthz   # expect: ok
 `meta.json` (device identity), `state.json` (latest mic/device snapshot).
 Caps: 8 MB/request, 200 MB/install, 10 GB global, 150 installs.
 Dev-tagged batches are acked and discarded.
+
+Accepted production events are annotated with the bounded
+`ingest_app_version` already supplied in the request header. This adds no
+client-collected field. Pre-deployment retained lines remain unmodified and the
+watch groups them under `unknown`, which is never used for version comparisons.
+
+`capture-watch.json` is a versioned, atomically replaced derived report. It
+contains no source event text or device metadata: only install UUID, bounded app
+version/backend/setup-step labels, counts, and startup durations.
+
+## Capture regression watch
+
+The hourly watch scans production JSONL line-by-line and keeps at most the
+newest 500 readiness samples per install/version cohort and 64 explicit version
+cohorts per install. Further versions collapse into a non-comparable
+`overflow` cohort. It reports:
+
+- `startup_ms` p50 and p95;
+- active-budget timeouts split by stable backend and native setup step;
+- fallback and both-backends-failed counts;
+- a histogram of ready recordings per completed, attempted app session.
+
+`startup_baseline` begins an app session. A session contributes to the
+zero-ready signal only after a later baseline proves it ended and only when it
+contained `audio initialization accepted`; idle launches and the currently open
+session are excluded.
+
+An alert is created when the newest comparable version has at least five
+readiness samples and its p50 is more than twice the preceding comparable
+version on the same install, or when one install/version has at least two
+completed attempted sessions with zero ready recordings. Thresholds live in the
+watch script and are fixture-tested.
 
 ## Tests
 
@@ -47,6 +97,7 @@ bounds, and HTML escaping are covered by:
 
 ```bash
 python3 -m unittest tests/test_log_receiver.py
+python3 -m unittest tests/test_capture_regression_watch.py
 ```
 
 Install pages expose raw JSONL downloads for the latest 200, latest 500, or the

--- a/infra/log-receiver/murmur-capture-watch.py
+++ b/infra/log-receiver/murmur-capture-watch.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Scheduled capture-startup regression watch for shipped Murmur logs.
+
+The watch reads the already privacy-stripped per-install JSONL retained by the
+log receiver. It never reads diagnostic bundles, transcript history, audio, or
+device identifiers. Reports are written atomically so the dashboard never sees
+a partial run.
+"""
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import tempfile
+from collections import Counter, deque
+from datetime import datetime, timezone
+
+
+SCHEMA_VERSION = 1
+REPORT_NAME = "capture-watch.json"
+MAX_STARTUP_SAMPLES = 500
+MAX_VERSIONS_PER_INSTALL = 64
+MIN_COMPARISON_SAMPLES = 5
+STARTUP_REGRESSION_RATIO = 2.0
+REPEATED_ZERO_READY_SESSIONS = 2
+
+VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,39}$")
+INSTALL_RE = re.compile(r"^[0-9a-fA-F-]{8,64}$")
+BACKENDS = {"auhal", "cpal"}
+SETUP_STEPS = {
+    "device_resolution",
+    "audio_unit_creation",
+    "audio_unit_new",
+    "enable_input_io",
+    "disable_output_io",
+    "set_current_device",
+    "format_configuration",
+    "callback_installation",
+    "default_config",
+    "stream_build",
+    "stream_start",
+    "awaiting_first_callback",
+}
+
+SUMMARY_CODES = {
+    "audio initialization accepted": "audio.capture_started",
+    "capture backend exceeded its active initialization budget": (
+        "audio.capture_backend_timeout"
+    ),
+    "capture backend failed before retained audio; trying bounded fallback": (
+        "audio.fallback_started"
+    ),
+    "audio readiness accepted": "audio.capture_ready",
+    "both capture backend attempts failed before first PCM": "audio.capture_failed",
+}
+
+
+def event_code(event):
+    data = event.get("data")
+    if isinstance(data, dict):
+        code = data.get("event_code")
+        if isinstance(code, str):
+            return code
+    return SUMMARY_CODES.get(event.get("summary"))
+
+
+def event_data(event):
+    data = event.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def event_version(event):
+    value = event.get("ingest_app_version")
+    return value if isinstance(value, str) and VERSION_RE.fullmatch(value) else "unknown"
+
+
+def event_timestamp(event):
+    value = event.get("timestamp")
+    return value if isinstance(value, str) and len(value) <= 40 else ""
+
+
+def bounded_backend(value):
+    return value if value in BACKENDS else "unknown"
+
+
+def bounded_setup_step(value):
+    return value if value in SETUP_STEPS else "unknown"
+
+
+def numeric_startup(event):
+    value = event_data(event).get("startup_ms")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value) or value < 0 or value > 120_000:
+        return None
+    return float(value)
+
+
+def percentile(values, percentile_value):
+    """Nearest-rank percentile, stable for small bounded operational cohorts."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile_value / 100) * len(ordered)))
+    return ordered[min(rank - 1, len(ordered) - 1)]
+
+
+def new_cohort(install_id, version):
+    return {
+        "install_id": install_id,
+        "app_version": version,
+        "startup_samples": deque(maxlen=MAX_STARTUP_SAMPLES),
+        "startup_sample_total": 0,
+        "timeouts": Counter(),
+        "fallback_count": 0,
+        "both_backends_failed_count": 0,
+        "attempted_sessions": 0,
+        "zero_ready_sessions": 0,
+        "session_ready_histogram": Counter(),
+        "first_event_at": "",
+        "last_event_at": "",
+    }
+
+
+def cohort_for(cohorts, install_id, version):
+    key = (install_id, version)
+    if key not in cohorts and version not in ("unknown", "overflow"):
+        known_versions = sum(
+            1
+            for cohort_install, cohort_version in cohorts
+            if cohort_install == install_id
+            and cohort_version not in ("unknown", "overflow")
+        )
+        if known_versions >= MAX_VERSIONS_PER_INSTALL:
+            version = "overflow"
+    key = (install_id, version)
+    if key not in cohorts:
+        cohorts[key] = new_cohort(install_id, version)
+    return cohorts[key]
+
+
+def touch_cohort(cohort, timestamp):
+    if not timestamp:
+        return
+    if not cohort["first_event_at"] or timestamp < cohort["first_event_at"]:
+        cohort["first_event_at"] = timestamp
+    if not cohort["last_event_at"] or timestamp > cohort["last_event_at"]:
+        cohort["last_event_at"] = timestamp
+
+
+def finish_session(session, cohorts, install_id):
+    if not session or not session["attempted"]:
+        return
+    cohort = cohort_for(cohorts, install_id, session["version"])
+    cohort["attempted_sessions"] += 1
+    cohort["session_ready_histogram"][session["ready_count"]] += 1
+    if session["ready_count"] == 0:
+        cohort["zero_ready_sessions"] += 1
+
+
+def scan_install(path, install_id, cohorts):
+    malformed = 0
+    session = None
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                event = json.loads(line)
+            except (ValueError, TypeError):
+                malformed += 1
+                continue
+            if not isinstance(event, dict):
+                malformed += 1
+                continue
+
+            version = event_version(event)
+            timestamp = event_timestamp(event)
+            cohort = cohort_for(cohorts, install_id, version)
+            touch_cohort(cohort, timestamp)
+
+            if event.get("summary") == "startup_baseline":
+                finish_session(session, cohorts, install_id)
+                session = {
+                    "version": version,
+                    "attempted": False,
+                    "ready_count": 0,
+                }
+                continue
+
+            code = event_code(event)
+            data = event_data(event)
+            if code == "audio.capture_started":
+                if session is not None and session["version"] == version:
+                    session["attempted"] = True
+                continue
+            if code == "audio.capture_ready":
+                startup_ms = numeric_startup(event)
+                if startup_ms is not None:
+                    cohort["startup_samples"].append(startup_ms)
+                    cohort["startup_sample_total"] += 1
+                if session is not None and session["version"] == version:
+                    session["ready_count"] += 1
+                continue
+            if code == "audio.capture_backend_timeout":
+                key = (
+                    bounded_backend(data.get("backend")),
+                    bounded_setup_step(data.get("last_setup_step")),
+                )
+                cohort["timeouts"][key] += 1
+                continue
+            if code == "audio.fallback_started":
+                cohort["fallback_count"] += 1
+                continue
+            if code == "audio.capture_failed":
+                cohort["both_backends_failed_count"] += 1
+
+    # An open app session is deliberately not classified as zero-ready. A later
+    # startup boundary proves that the preceding session ended and makes the
+    # verdict deterministic.
+    return malformed
+
+
+def serialize_cohort(cohort):
+    samples = list(cohort["startup_samples"])
+    timeout_rows = [
+        {
+            "backend": backend,
+            "last_setup_step": setup_step,
+            "count": count,
+        }
+        for (backend, setup_step), count in sorted(
+            cohort["timeouts"].items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+    return {
+        "install_id": cohort["install_id"],
+        "app_version": cohort["app_version"],
+        "first_event_at": cohort["first_event_at"],
+        "last_event_at": cohort["last_event_at"],
+        "startup_sample_count": len(samples),
+        "startup_sample_total": cohort["startup_sample_total"],
+        "startup_samples_truncated": cohort["startup_sample_total"] > len(samples),
+        "startup_p50_ms": percentile(samples, 50),
+        "startup_p95_ms": percentile(samples, 95),
+        "capture_backend_timeouts": timeout_rows,
+        "fallback_count": cohort["fallback_count"],
+        "both_backends_failed_count": cohort["both_backends_failed_count"],
+        "attempted_sessions": cohort["attempted_sessions"],
+        "zero_ready_sessions": cohort["zero_ready_sessions"],
+        "ready_recordings_per_session": [
+            {"ready_recordings": ready_count, "sessions": session_count}
+            for ready_count, session_count in sorted(
+                cohort["session_ready_histogram"].items()
+            )
+        ],
+    }
+
+
+def regression_alerts(cohort_rows):
+    alerts = []
+    by_install = {}
+    for row in cohort_rows:
+        if row["app_version"] in ("unknown", "overflow"):
+            continue
+        by_install.setdefault(row["install_id"], []).append(row)
+
+        if row["zero_ready_sessions"] >= REPEATED_ZERO_READY_SESSIONS:
+            alerts.append(
+                {
+                    "kind": "repeated_zero_ready_sessions",
+                    "install_id": row["install_id"],
+                    "app_version": row["app_version"],
+                    "zero_ready_sessions": row["zero_ready_sessions"],
+                    "attempted_sessions": row["attempted_sessions"],
+                }
+            )
+
+    for install_id, rows in by_install.items():
+        eligible = [
+            row
+            for row in rows
+            if row["startup_sample_count"] >= MIN_COMPARISON_SAMPLES
+            and row["startup_p50_ms"] is not None
+        ]
+        eligible.sort(key=lambda row: row["last_event_at"])
+        if len(eligible) < 2:
+            continue
+        baseline, candidate = eligible[-2:]
+        baseline_p50 = baseline["startup_p50_ms"]
+        candidate_p50 = candidate["startup_p50_ms"]
+        if baseline_p50 > 0 and candidate_p50 > baseline_p50 * STARTUP_REGRESSION_RATIO:
+            alerts.append(
+                {
+                    "kind": "startup_p50_regression",
+                    "install_id": install_id,
+                    "baseline_version": baseline["app_version"],
+                    "candidate_version": candidate["app_version"],
+                    "baseline_p50_ms": baseline_p50,
+                    "candidate_p50_ms": candidate_p50,
+                    "ratio": round(candidate_p50 / baseline_p50, 3),
+                    "baseline_samples": baseline["startup_sample_count"],
+                    "candidate_samples": candidate["startup_sample_count"],
+                }
+            )
+    return alerts
+
+
+def build_report(root):
+    cohorts = {}
+    malformed_lines = 0
+    scanned_installs = 0
+    if os.path.isdir(root):
+        for install_id in sorted(os.listdir(root)):
+            if not INSTALL_RE.fullmatch(install_id):
+                continue
+            path = os.path.join(root, install_id, "events.jsonl")
+            if not os.path.isfile(path):
+                continue
+            scanned_installs += 1
+            malformed_lines += scan_install(path, install_id, cohorts)
+
+    rows = [serialize_cohort(cohort) for cohort in cohorts.values()]
+    rows.sort(key=lambda row: (row["install_id"], row["last_event_at"], row["app_version"]))
+    alerts = regression_alerts(rows)
+    known_rows = [
+        row
+        for row in rows
+        if row["app_version"] not in ("unknown", "overflow")
+    ]
+    evaluable_rows = [
+        row
+        for row in known_rows
+        if row["startup_sample_count"] >= MIN_COMPARISON_SAMPLES
+        or row["attempted_sessions"] >= REPEATED_ZERO_READY_SESSIONS
+    ]
+    status = "alert" if alerts else "healthy" if evaluable_rows else "insufficient_data"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "status": status,
+        "scanned_installs": scanned_installs,
+        "malformed_lines": malformed_lines,
+        "policy": {
+            "minimum_comparison_samples": MIN_COMPARISON_SAMPLES,
+            "startup_p50_regression_ratio": STARTUP_REGRESSION_RATIO,
+            "repeated_zero_ready_sessions": REPEATED_ZERO_READY_SESSIONS,
+            "maximum_startup_samples_per_cohort": MAX_STARTUP_SAMPLES,
+            "maximum_versions_per_install": MAX_VERSIONS_PER_INSTALL,
+        },
+        "alerts": alerts,
+        "cohorts": rows,
+    }
+
+
+def atomic_write_report(path, report):
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=".capture-watch-", dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=os.path.expanduser("~/murmur-logs"),
+        help="receiver log root",
+    )
+    parser.add_argument(
+        "--output",
+        help="report path (defaults to <root>/%s)" % REPORT_NAME,
+    )
+    parser.add_argument(
+        "--fail-on-alert",
+        action="store_true",
+        help="exit 2 after writing the report when alerts are present",
+    )
+    args = parser.parse_args(argv)
+    output = args.output or os.path.join(args.root, REPORT_NAME)
+    report = build_report(args.root)
+    atomic_write_report(output, report)
+    print(
+        "capture watch: %s, %d install(s), %d cohort(s), %d alert(s)"
+        % (
+            report["status"],
+            report["scanned_installs"],
+            len(report["cohorts"]),
+            len(report["alerts"]),
+        )
+    )
+    return 2 if args.fail_on_alert and report["alerts"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/log-receiver/murmur-capture-watch.service
+++ b/infra/log-receiver/murmur-capture-watch.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Murmur capture-startup regression watch
+After=murmur-logs.service
+
+[Service]
+Type=oneshot
+User=george
+ExecStart=/usr/bin/python3 /home/george/murmur-capture-watch.py --root /home/george/murmur-logs --output /home/george/murmur-logs/capture-watch.json --fail-on-alert
+Nice=10
+IOSchedulingClass=idle
+MemoryMax=256M
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/george/murmur-logs
+PrivateTmp=true

--- a/infra/log-receiver/murmur-capture-watch.timer
+++ b/infra/log-receiver/murmur-capture-watch.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Murmur capture-startup regression watch hourly
+
+[Timer]
+OnBootSec=10m
+OnUnitActiveSec=1h
+RandomizedDelaySec=5m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -42,6 +42,8 @@ EXPORT_LIMITS = (200, 500)
 MAX_SCOPED_EXPORT_BYTES = 32 * 1024 * 1024
 MAX_ACTIVITY_EVENT_BYTES = 512 * 1024
 LLM_REPORT_FORMAT = "murmur-fleet-llm/v1"
+CAPTURE_WATCH_REPORT = "capture-watch.json"
+APP_VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,39}$")
 _usage_cache = {"t": 0.0, "bytes": 0, "dirs": 0}
 
 
@@ -71,6 +73,96 @@ def atomic_write_json(path, obj):
         os.replace(tmp, path)
     except OSError:
         pass
+
+
+def ingest_app_version(value):
+    """Accept only the bounded release identifier already sent by the shipper."""
+    return value if isinstance(value, str) and APP_VERSION_RE.fullmatch(value) else None
+
+
+def annotate_ingested_event(event, app_version):
+    """Attach receiver-observed version without changing event content fields."""
+    if isinstance(event, dict):
+        event = dict(event)
+        event.pop("ingest_app_version", None)
+        if app_version:
+            event["ingest_app_version"] = app_version
+    return event
+
+
+def load_capture_watch_report():
+    try:
+        with open(os.path.join(ROOT, CAPTURE_WATCH_REPORT)) as handle:
+            report = json.load(handle)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(report, dict) or report.get("schema_version") != 1:
+        return None
+    if report.get("status") not in ("healthy", "alert", "insufficient_data"):
+        return None
+    if not isinstance(report.get("alerts"), list):
+        return None
+    return report
+
+
+def render_capture_watch(report):
+    if report is None:
+        return (
+            "<div class='watch-banner diagnostic'><strong>Capture regression watch</strong>"
+            "<span>No scheduled report is available yet.</span></div>"
+        )
+    generated = html.escape(str(report.get("generated_at", ""))[:40])
+    alerts = report["alerts"][:20]
+    if not alerts:
+        label = (
+            "Insufficient versioned data"
+            if report["status"] == "insufficient_data"
+            else "No capture-startup regressions detected"
+        )
+        return (
+            "<div class='watch-banner healthy'><strong>Capture regression watch</strong>"
+            "<span>%s · last run %s</span></div>" % (label, generated or "unknown")
+        )
+
+    rows = []
+    for alert in alerts:
+        if not isinstance(alert, dict):
+            continue
+        install = html.escape(str(alert.get("install_id", ""))[:8])
+        if alert.get("kind") == "startup_p50_regression":
+            rows.append(
+                "<li><code>%s</code> v%s → v%s: p50 %s ms → %s ms (%sx)</li>"
+                % (
+                    install,
+                    html.escape(str(alert.get("baseline_version", ""))[:40]),
+                    html.escape(str(alert.get("candidate_version", ""))[:40]),
+                    html.escape(str(alert.get("baseline_p50_ms", ""))[:20]),
+                    html.escape(str(alert.get("candidate_p50_ms", ""))[:20]),
+                    html.escape(str(alert.get("ratio", ""))[:20]),
+                )
+            )
+        elif alert.get("kind") == "repeated_zero_ready_sessions":
+            rows.append(
+                "<li><code>%s</code> v%s: %s attempted sessions ended with zero "
+                "ready recordings</li>"
+                % (
+                    install,
+                    html.escape(str(alert.get("app_version", ""))[:40]),
+                    html.escape(str(alert.get("zero_ready_sessions", ""))[:20]),
+                )
+            )
+    return (
+        "<div class='watch-banner alert'><strong>Capture regression watch · "
+        "%d alert%s</strong><span>Last run %s</span><ul>%s</ul></div>"
+        % (
+            len(alerts),
+            "" if len(alerts) == 1 else "s",
+            generated or "unknown",
+            "".join(rows) or "<li>Unrecognized bounded alert record</li>",
+        )
+    )
+
+
 EASTERN = ZoneInfo("America/New_York")
 
 
@@ -1737,6 +1829,7 @@ def render_problem_group(item):
 
 def render_dashboard():
     installs = collect_installs()
+    capture_watch = render_capture_watch(load_capture_watch_report())
     now = time.time()
     rows = []
     for i in installs:
@@ -1775,6 +1868,7 @@ def render_dashboard():
     body = (
         "<h1>murmur fleet logs</h1>"
         "<p class='sub'>%d install stream%s · refreshes every 30s · %s</p>"
+        "%s"
         "<table><thead><tr><th>device</th><th>version</th>"
         "<th>last event</th></tr></thead>"
         "<tbody>%s</tbody></table>"
@@ -1782,6 +1876,7 @@ def render_dashboard():
             len(installs),
             "" if len(installs) == 1 else "s",
             datetime.now(EASTERN).strftime("%Y-%m-%d %-I:%M %p ET"),
+            capture_watch,
             "".join(rows) or '<tr><td colspan="3">no installs yet</td></tr>',
         )
     )
@@ -1805,6 +1900,10 @@ code{color:#93c5fd;font-size:.85em}
 .badge.dev{background:#3b2f14;color:#fbbf24}
 .new{font-size:.65rem;color:#0b1120;background:#4ade80;border-radius:99px;padding:.1rem .4rem;margin-left:.5rem;font-weight:700}
 .meta{color:#64748b;font-size:.75rem;margin-top:.15rem}
+.watch-banner{border:1px solid #1e293b;border-radius:10px;display:grid;gap:.3rem;margin:0 0 1.2rem;padding:.7rem .85rem}
+.watch-banner span{color:#94a3b8;font-size:.78rem}.watch-banner ul{margin:.25rem 0 0;padding-left:1.25rem}
+.watch-banner.healthy{border-color:#14532d}.watch-banner.diagnostic{border-color:#334155}
+.watch-banner.alert{background:#2a0f14;border-color:#7f1d1d}
 a{color:#e2e8f0;text-decoration:none}a:hover{text-decoration:underline}
 tr.warn td{background:#2a1e0a}tr.error td{background:#2a0f14}
 .lvl{font-size:.7rem;padding:.05rem .4rem;border-radius:4px}
@@ -2087,15 +2186,23 @@ class Handler(BaseHTTPRequestHandler):
             return self._reply(204)
 
         lines = []
+        app_version = ingest_app_version(self.headers.get("X-App-Version", ""))
         for raw in body.split(b"\n"):
             raw = raw.strip()
             if not raw:
                 continue
             try:
-                json.loads(raw)
+                event = json.loads(raw)
             except ValueError:
                 return self._reply(400, b"bad json line")
-            lines.append(raw)
+            event = annotate_ingested_event(event, app_version)
+            lines.append(
+                json.dumps(
+                    event,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            )
         if not lines:
             return self._reply(400, b"empty")
 

--- a/tests/test_capture_regression_watch.py
+++ b/tests/test_capture_regression_watch.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+WATCH_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "infra"
+    / "log-receiver"
+    / "murmur-capture-watch.py"
+)
+SPEC = importlib.util.spec_from_file_location("murmur_capture_watch", WATCH_PATH)
+assert SPEC and SPEC.loader
+watch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(watch)
+
+
+def event(
+    summary: str,
+    timestamp: str,
+    *,
+    version: str | None = None,
+    data: dict | None = None,
+) -> dict:
+    item = {
+        "timestamp": timestamp,
+        "stream": "audio",
+        "level": "info",
+        "summary": summary,
+        "data": data or {},
+    }
+    if version is not None:
+        item["ingest_app_version"] = version
+    return item
+
+
+class CaptureRegressionWatchTests(unittest.TestCase):
+    def write_install(self, root: str, install_id: str, events: list[dict]) -> None:
+        directory = Path(root) / install_id
+        directory.mkdir()
+        (directory / "events.jsonl").write_text(
+            "\n".join(json.dumps(item) for item in events) + "\n",
+            encoding="utf-8",
+        )
+
+    def ready_events(
+        self,
+        version: str,
+        prefix: str,
+        startup_values: list[int],
+    ) -> list[dict]:
+        return [
+            event(
+                "audio readiness accepted",
+                f"2026-08-{prefix}T00:00:{index:02d}Z",
+                version=version,
+                data={"event_code": "audio.capture_ready", "startup_ms": value},
+            )
+            for index, value in enumerate(startup_values)
+        ]
+
+    def test_aggregates_percentiles_timeouts_fallbacks_and_failures(self) -> None:
+        install_id = "12345678-abcd"
+        events = self.ready_events("1.2.3", "01", [100, 200, 300, 400, 500])
+        events.extend(
+            [
+                event(
+                    "capture backend exceeded its active initialization budget",
+                    "2026-08-01T00:01:00Z",
+                    version="1.2.3",
+                    data={
+                        "event_code": "audio.capture_backend_timeout",
+                        "backend": "auhal",
+                        "last_setup_step": "stream_start",
+                    },
+                ),
+                event(
+                    "capture backend failed before retained audio; trying bounded fallback",
+                    "2026-08-01T00:01:01Z",
+                    version="1.2.3",
+                    data={"event_code": "audio.fallback_started"},
+                ),
+                event(
+                    "both capture backend attempts failed before first PCM",
+                    "2026-08-01T00:01:02Z",
+                    version="1.2.3",
+                    data={"event_code": "audio.capture_failed"},
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, install_id, events)
+            report = watch.build_report(root)
+
+        cohort = report["cohorts"][0]
+        self.assertEqual(cohort["startup_p50_ms"], 300)
+        self.assertEqual(cohort["startup_p95_ms"], 500)
+        self.assertEqual(cohort["fallback_count"], 1)
+        self.assertEqual(cohort["both_backends_failed_count"], 1)
+        self.assertEqual(
+            cohort["capture_backend_timeouts"],
+            [{"backend": "auhal", "last_setup_step": "stream_start", "count": 1}],
+        )
+
+    def test_alerts_when_newest_version_p50_is_more_than_twice_baseline(self) -> None:
+        events = self.ready_events("1.0.0", "01", [180, 190, 200, 210, 220])
+        events += self.ready_events("1.1.0", "02", [500, 520, 540, 560, 580])
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        self.assertEqual(report["status"], "alert")
+        self.assertEqual(len(report["alerts"]), 1)
+        alert = report["alerts"][0]
+        self.assertEqual(alert["kind"], "startup_p50_regression")
+        self.assertEqual(alert["baseline_version"], "1.0.0")
+        self.assertEqual(alert["candidate_version"], "1.1.0")
+        self.assertEqual(alert["baseline_p50_ms"], 200)
+        self.assertEqual(alert["candidate_p50_ms"], 540)
+
+    def test_small_or_cross_install_cohorts_never_form_a_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(
+                root,
+                "12345678-abcd",
+                self.ready_events("1.0.0", "01", [100, 100, 100, 100]),
+            )
+            self.write_install(
+                root,
+                "87654321-abcd",
+                self.ready_events("1.1.0", "02", [900, 900, 900, 900, 900]),
+            )
+            report = watch.build_report(root)
+
+        self.assertEqual(report["alerts"], [])
+        self.assertEqual(report["status"], "healthy")
+
+    def test_repeated_completed_attempted_sessions_without_ready_alert(self) -> None:
+        version = "1.2.3"
+        events = []
+        for day in ("01", "02", "03"):
+            events.extend(
+                [
+                    event("startup_baseline", f"2026-08-{day}T00:00:00Z", version=version),
+                    event(
+                        "audio initialization accepted",
+                        f"2026-08-{day}T00:00:01Z",
+                        version=version,
+                    ),
+                ]
+            )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohort = report["cohorts"][0]
+        self.assertEqual(cohort["attempted_sessions"], 2)
+        self.assertEqual(cohort["zero_ready_sessions"], 2)
+        self.assertEqual(
+            cohort["ready_recordings_per_session"],
+            [{"ready_recordings": 0, "sessions": 2}],
+        )
+        self.assertEqual(report["alerts"][0]["kind"], "repeated_zero_ready_sessions")
+
+    def test_idle_and_still_open_sessions_are_not_zero_ready(self) -> None:
+        version = "1.2.3"
+        events = [
+            event("startup_baseline", "2026-08-01T00:00:00Z", version=version),
+            event("heartbeat", "2026-08-01T00:01:00Z", version=version),
+            event("startup_baseline", "2026-08-02T00:00:00Z", version=version),
+            event(
+                "audio initialization accepted",
+                "2026-08-02T00:00:01Z",
+                version=version,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohort = report["cohorts"][0]
+        self.assertEqual(cohort["attempted_sessions"], 0)
+        self.assertEqual(cohort["zero_ready_sessions"], 0)
+        self.assertEqual(report["alerts"], [])
+        self.assertEqual(report["status"], "insufficient_data")
+
+    def test_historical_unversioned_events_remain_unknown_and_noncomparable(self) -> None:
+        events = self.ready_events("1.2.3", "02", [900, 900, 900, 900, 900])
+        events += [
+            event(
+                "audio readiness accepted",
+                f"2026-08-01T00:00:0{index}Z",
+                data={"startup_ms": 100},
+            )
+            for index in range(5)
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        self.assertEqual(
+            {row["app_version"] for row in report["cohorts"]},
+            {"1.2.3", "unknown"},
+        )
+        self.assertEqual(report["alerts"], [])
+
+    def test_untrusted_labels_are_collapsed_and_malformed_lines_are_counted(self) -> None:
+        item = event(
+            "capture backend exceeded its active initialization budget",
+            "2026-08-01T00:00:00Z",
+            version="1.2.3",
+            data={
+                "backend": "private-device-name",
+                "last_setup_step": "unsafe\nstep",
+            },
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", [item])
+            path = Path(root) / "12345678-abcd" / "events.jsonl"
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write("{broken\n")
+            report = watch.build_report(root)
+
+        self.assertEqual(report["malformed_lines"], 1)
+        timeout = report["cohorts"][0]["capture_backend_timeouts"][0]
+        self.assertEqual(timeout["backend"], "unknown")
+        self.assertEqual(timeout["last_setup_step"], "unknown")
+
+    def test_version_cohort_cardinality_is_bounded(self) -> None:
+        events = [
+            event(
+                "audio readiness accepted",
+                f"2026-08-01T00:{index:02d}:00Z",
+                version=f"1.0.{index}",
+                data={"startup_ms": index},
+            )
+            for index in range(watch.MAX_VERSIONS_PER_INSTALL + 3)
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        versions = {row["app_version"] for row in report["cohorts"]}
+        self.assertEqual(len(versions), watch.MAX_VERSIONS_PER_INSTALL + 1)
+        self.assertIn("overflow", versions)
+
+    def test_cli_writes_report_before_returning_alert_exit(self) -> None:
+        events = self.ready_events("1.0.0", "01", [100] * 5)
+        events += self.ready_events("1.1.0", "02", [300] * 5)
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            output = Path(root) / "watch.json"
+            result = watch.main(
+                [
+                    "--root",
+                    root,
+                    "--output",
+                    str(output),
+                    "--fail-on-alert",
+                ]
+            )
+            saved = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 2)
+        self.assertEqual(saved["schema_version"], 1)
+        self.assertEqual(saved["status"], "alert")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -40,6 +40,64 @@ def event(
 
 
 class LogReceiverHealthTests(unittest.TestCase):
+    def test_ingest_version_annotation_is_bounded_and_content_preserving(self) -> None:
+        item = event(
+            "audio readiness accepted",
+            timestamp="2026-08-05T00:00:00Z",
+            stream="audio",
+            data={"startup_ms": 240},
+        )
+
+        annotated = receiver.annotate_ingested_event(
+            item,
+            receiver.ingest_app_version("1.2.3"),
+        )
+
+        self.assertNotIn("ingest_app_version", item)
+        self.assertEqual(annotated["ingest_app_version"], "1.2.3")
+        self.assertEqual(annotated["data"], item["data"])
+        self.assertIsNone(receiver.ingest_app_version("unsafe/version\nprivate"))
+        self.assertEqual(
+            receiver.annotate_ingested_event(
+                {**item, "ingest_app_version": "forged"},
+                None,
+            ),
+            item,
+        )
+
+    def test_dashboard_surfaces_bounded_capture_watch_alerts(self) -> None:
+        report = {
+            "schema_version": 1,
+            "generated_at": "2026-08-05T00:00:00Z",
+            "status": "alert",
+            "alerts": [
+                {
+                    "kind": "startup_p50_regression",
+                    "install_id": "12345678-abcd",
+                    "baseline_version": "1.0.0",
+                    "candidate_version": "1.1.0",
+                    "baseline_p50_ms": 200,
+                    "candidate_p50_ms": 520,
+                    "ratio": 2.6,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = receiver.ROOT
+            receiver.ROOT = directory
+            try:
+                (Path(directory) / receiver.CAPTURE_WATCH_REPORT).write_text(
+                    json.dumps(report),
+                    encoding="utf-8",
+                )
+                page = receiver.render_dashboard()
+            finally:
+                receiver.ROOT = original_root
+
+        self.assertIn("Capture regression watch · 1 alert", page)
+        self.assertIn("v1.0.0 → v1.1.0", page)
+        self.assertIn("p50 200 ms → 520 ms (2.6x)", page)
+
     def test_stable_event_code_takes_precedence_over_compatibility_summary(self) -> None:
         item = event(
             "listener heartbeat — no rdev callbacks observed",
@@ -754,6 +812,47 @@ class LogReceiverExportRouteTests(unittest.TestCase):
         status = response.status
         connection.close()
         return status, headers, body
+
+    def post(
+        self,
+        path: str,
+        body: bytes,
+        headers: dict[str, str],
+    ) -> tuple[int, bytes]:
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", self.server.server_address[1], timeout=5
+        )
+        connection.request("POST", path, body=body, headers=headers)
+        response = connection.getresponse()
+        payload = response.read()
+        status = response.status
+        connection.close()
+        return status, payload
+
+    def test_ingest_stamps_receiver_observed_app_version_on_each_event(self) -> None:
+        item = event(
+            "audio readiness accepted",
+            timestamp="2026-08-05T00:00:00Z",
+            stream="audio",
+            data={"event_code": "audio.capture_ready", "startup_ms": 240},
+        )
+        status, body = self.post(
+            "/ingest",
+            (json.dumps(item) + "\n").encode("utf-8"),
+            {
+                "Authorization": "Bearer " + receiver.TOKEN,
+                "X-Install-Id": self.install_id,
+                "X-App-Version": "1.2.4",
+                "Content-Type": "application/x-ndjson",
+            },
+        )
+        path = Path(receiver.ROOT) / self.install_id / "events.jsonl"
+        saved = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
+
+        self.assertEqual(status, 204)
+        self.assertEqual(body, b"")
+        self.assertEqual(saved["ingest_app_version"], "1.2.4")
+        self.assertEqual(saved["data"]["startup_ms"], 240)
 
     def test_recent_raw_routes_return_exact_windows_and_safe_filenames(self) -> None:
         for limit, first_sequence in ((200, 400), (500, 100)):


### PR DESCRIPTION
## Summary
- stamp accepted receiver events with the bounded app-version header already shipped with each batch
- add an hourly, stdlib-only systemd watch over retained capture-startup telemetry
- aggregate per install/version p50/p95, backend/setup-step timeout histograms, fallback/failure counts, and ready recordings per completed attempted session
- alert on >2x p50 regressions with at least five samples per cohort and repeated completed zero-ready sessions
- surface the atomically written report on the protected receiver dashboard

## Failure mode fixed
The v0.24.2 zero-ready install and v0.25.0 startup regression were found only through manual JSONL greps. This makes the same privacy-stripped signals a scheduled operational check. Idle launches and the currently open session cannot create zero-ready alerts; historical unversioned events remain `unknown` and never enter version comparisons.

## Privacy and bounds
- no new client-collected fields; version attribution comes from the existing ingest header
- client-supplied `ingest_app_version` is removed so it cannot spoof cohorts
- backend/setup-step labels are allowlisted and source summaries/content are excluded from reports
- scanning is line-by-line with 500 readiness samples per cohort and 64 explicit versions per install

## Verification
- `python3 -m unittest discover -s tests` (108 passed)
- `cd app/src-tauri && cargo check --all-targets`
- `cd app/src-tauri && cargo test -- --test-threads=1` (749 unit passed, 5 ignored; integrations passed)
- `cd app && npx tsc --noEmit`
- `cd app && npm test` (649 passed)
- real MacBook dogfood telemetry confirmed stable `startup_baseline`, `audio.capture_ready`, `startup_ms`, and capture fallback/timeout event shapes; current starts were ~198-276 ms

Deployment and rollback commands for the receiver script, service, and timer are documented; production is intentionally not changed before review/merge.

Closes #447
Related to #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hourly monitoring for capture startup performance and regressions.
  * Added dashboard health and alert indicators based on capture-watch reports.
  * Ingested events now record validated app-version information when available.
  * Added metrics for startup timing, timeouts, fallbacks, failures, and session readiness.
* **Documentation**
  * Added deployment, rollback, retention, privacy, and alert-threshold guidance.
* **Tests**
  * Added coverage for regression detection, malformed events, version handling, and dashboard alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->