### PR TITLE
fix: stop log shipper microphone enumeration

### DIFF
--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -397,7 +397,7 @@ fn hello(
     }
 }
 
-pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
+fn enumerate_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
     let (capture_id, nonce, nonce_hex) = capture_identity();
     let (mut child, mut input, output) =
         spawn_helper(capture_id, &nonce_hex).map_err(|failure| failure.to_string())?;
@@ -444,6 +444,14 @@ pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
         .wait_for_exit(Instant::now() + HELPER_STOP_DEADLINE)
         .or_else(|| child.hard_kill_confirmed(Instant::now() + HELPER_STOP_DEADLINE));
     Ok(devices)
+}
+
+pub fn list_input_devices() -> Result<Vec<AudioDeviceDescriptor>, String> {
+    let result = enumerate_input_devices();
+    crate::log_shipper::record_audio_input_enumeration(
+        result.as_ref().ok().map(|devices| devices.len()),
+    );
+    result
 }
 
 pub fn start_transform_capture_audio(

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -12,6 +12,9 @@
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use crate::MutexExt;
 
 const ENDPOINT: &str = "https://georgenijo.com/murmur/ingest";
 pub(crate) const TOKEN: &str = "a1b4068693a1f3868bcf03c01ebcf1e9f000080b3e8bfcb0";
@@ -21,6 +24,8 @@ const STARTUP_DELAY_SECS: u64 = 15;
 const MAX_BATCH_BYTES: usize = 1024 * 1024;
 /// Defensive bound for the aggregate input-device count shipped in `/state`.
 const MAX_AUDIO_INPUT_COUNT: usize = 256;
+
+static AUDIO_STATE_CACHE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
 
 #[derive(Serialize, Deserialize)]
 struct ShipperState {
@@ -278,14 +283,22 @@ fn aggregate_audio_state<T>(
     .to_string()
 }
 
-/// Current audio-input aggregate, serialized stably so a change is detectable
-/// by string comparison. Runs blocking Core Audio enumeration without reading
-/// any presentation labels or backend identifiers.
-fn audio_state() -> String {
-    match crate::audio::list_input_devices() {
-        Ok(inputs) => aggregate_audio_state(!inputs.is_empty(), inputs, true),
-        Err(_) => aggregate_audio_state(false, std::iter::empty::<()>(), false),
-    }
+fn audio_state_cache() -> &'static Mutex<Option<String>> {
+    AUDIO_STATE_CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Cache the privacy-safe aggregate produced by an explicit device-list
+/// request. The log shipper never initiates Core Audio enumeration itself.
+pub(crate) fn record_audio_input_enumeration(input_count: Option<usize>) {
+    let snapshot = match input_count {
+        Some(count) => aggregate_audio_state(count > 0, 0..count, true),
+        None => aggregate_audio_state(false, std::iter::empty::<()>(), false),
+    };
+    *audio_state_cache().lock_or_recover() = Some(snapshot);
+}
+
+fn cached_audio_state() -> Option<String> {
+    audio_state_cache().lock_or_recover().clone()
 }
 
 async fn ship_state(
@@ -364,7 +377,9 @@ pub fn start() {
         let mut last_snapshot: Option<String> = None;
         loop {
             tick(&client, &endpoint, &device).await;
-            // Event-driven device/state snapshot: POST only when it changes.
+            // Device/state snapshots are populated only by an existing explicit
+            // enumeration request (for example, when Settings opens). Reading
+            // this cache must never spawn a capture helper from the shipper.
             // The install id is re-read after tick(): the first tick persists
             // it, so a fresh install reports state under its real identity
             // instead of a throwaway UUID.
@@ -372,13 +387,19 @@ pub fn start() {
                 .filter(|p| p.exists())
                 .map(|p| load_state(&p).install_id);
             if let Some(install_id) = &state_install_id {
-                let snap = tokio::task::spawn_blocking(audio_state)
-                    .await
-                    .unwrap_or_default();
-                if !snap.is_empty() && last_snapshot.as_deref() != Some(snap.as_str()) {
-                    if ship_state(&client, &state_endpoint, install_id, &device, snap.clone()).await
-                    {
-                        last_snapshot = Some(snap);
+                if let Some(snap) = cached_audio_state() {
+                    if last_snapshot.as_deref() != Some(snap.as_str()) {
+                        if ship_state(
+                            &client,
+                            &state_endpoint,
+                            install_id,
+                            &device,
+                            snap.clone(),
+                        )
+                        .await
+                        {
+                            last_snapshot = Some(snap);
+                        }
                     }
                 }
             }
@@ -483,6 +504,23 @@ mod tests {
         // A second fresh load (different path) gets a different UUID.
         let other = load_state(&dir.join("nope.json"));
         assert_ne!(other.install_id, fresh.install_id);
+    }
+
+    #[test]
+    fn audio_state_cache_tracks_only_explicit_enumeration_results() {
+        record_audio_input_enumeration(Some(3));
+        let success: serde_json::Value =
+            serde_json::from_str(&cached_audio_state().unwrap()).unwrap();
+        assert_eq!(success["default_input_available"], true);
+        assert_eq!(success["input_device_count"], 3);
+        assert_eq!(success["input_enumeration_ok"], true);
+
+        record_audio_input_enumeration(None);
+        let failure: serde_json::Value =
+            serde_json::from_str(&cached_audio_state().unwrap()).unwrap();
+        assert_eq!(failure["default_input_available"], false);
+        assert_eq!(failure["input_device_count"], 0);
+        assert_eq!(failure["input_enumeration_ok"], false);
     }
 
     #[tokio::test]

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -16,8 +16,9 @@ install the app (or receive an auto-update) and logs flow.
   the fleet dashboard can label streams ("George's MacBook Pro · macOS 26.0").
   Username and any content-bearing identifiers are never sent.
 - The separate `/state` snapshot reports only whether a default audio input is
-  available, a bounded input count, and whether enumeration succeeded. It
-  never reads or sends microphone display labels or backend UIDs.
+  available, a bounded input count, and whether enumeration succeeded. It is
+  refreshed from explicit device-list requests, never by the shipper's timer,
+  and never reads or sends microphone display labels or backend UIDs.
 - Kill switch: launch with `MURMUR_LOG_SHIPPER=off` in the environment.
 
 ## Server-armed hang diagnostics (`hang_diagnostics.rs`)
@@ -66,6 +67,9 @@ events.jsonl  ──(log_shipper.rs, every 60s)──▶  POST https://georgenij
   shorter than the saved offset, it drains the tail of `events.jsonl.1` from
   that offset, then restarts at 0 on the fresh file.
 - Batches are cut at line boundaries, max 1 MB per POST, max 8 POSTs per tick.
+- Audio `/state` delivery reads a privacy-safe cached aggregate. The cache is
+  updated when another app flow explicitly enumerates inputs (for example,
+  opening Settings); the shipper never spawns a capture helper to refresh it.
 - Auth is a static bearer token baked into the binary — spam control for the
   public URL, not a security boundary.
 - Normal dev builds do not ship. The receiver acknowledges and discards


### PR DESCRIPTION
Closes #476.

## What changed

- remove periodic Core Audio enumeration from the 60-second log-shipper loop
- cache only the privacy-safe aggregate produced by existing explicit device-list requests
- keep `/state` change detection and delivery without microphone labels or UIDs
- document that shipper ticks never spawn the capture helper

## Verification

- `cargo check --all-targets`
- `cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `cargo test --lib log_shipper::tests -- --test-threads=1` — 9 passed
- `npx tsc --noEmit`
- `npm test` — 646 passed
- native debug `.app` smoke test with `MURMUR_LOG_ENDPOINT` pointed at a loopback receiver
- 30-minute idle acceptance window (Settings closed): app stayed alive, shipper POSTed throughout, 0 capture-helper children and 0 helper-spawn telemetry events

The debug bundle and DMG built successfully; the optional updater archive signing step then reported the expected missing private updater key.

## Code vs. issue

The issue suggested a Core Audio listener or a long TTL. The existing app already has explicit device-enumeration events, so this uses those as the cache writer and removes automatic enumeration entirely. That is narrower than adding a new Core Audio listener and directly satisfies the idle acceptance condition.
