### PR TITLE
ci: include visual regression in ci-pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
             cargo test --lib -- --test-threads=1
 
   ci-pass:
-    needs: [changes, typecheck, rust-macos, linux]
+    needs: [changes, typecheck, visual-regression, rust-macos, linux]
     # Keep this guard aligned with `changes`; otherwise the sentinel would turn
     # an intentionally skipped release-bump run into a failure.
     if: "${{ always() && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: bump version')) }}"
@@ -230,6 +230,7 @@ jobs:
 
           for result in \
             "${{ needs.typecheck.result }}" \
+            "${{ needs.visual-regression.result }}" \
             "${{ needs.rust-macos.result }}" \
             "${{ needs.linux.result }}"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -121,12 +121,14 @@ def validate_ci(ci: str) -> int:
     assert "push:\n    branches: [main]" in ci
     assert "\n  pull_request:" in ci
     assert scalar(job_block(ci, "changes"), "if") == CI_GUARD
-    for job in ("typecheck", "rust-macos", "linux"):
+    for job in ("typecheck", "visual-regression", "rust-macos", "linux"):
         assert scalar(job_block(ci, job), "needs") == "changes"
     assert scalar(job_block(ci, "ci-pass"), "needs") == (
-        "[changes, typecheck, rust-macos, linux]"
+        "[changes, typecheck, visual-regression, rust-macos, linux]"
     )
     assert scalar(job_block(ci, "ci-pass"), "if") == CI_PASS_GUARD
+    ci_pass_step = named_step_block(ci, "Check CI result", 6)
+    assert "${{ needs.visual-regression.result }}" in ci_pass_step
     assert "scripts/validate_workflow_policy.py" in ci
     assert "scripts/release_artifacts.py" in ci
     assert "scripts/capture_agent_matrix.py" in ci

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,6 +18,17 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_ci_pass_requires_visual_regression_result(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        mutated = workflow.replace(
+            '            "${{ needs.visual-regression.result }}" \\\n',
+            "",
+            1,
+        )
+        self.assertNotEqual(workflow, mutated)
+        with self.assertRaises(AssertionError):
+            validate_ci(mutated)
+
     def test_macos_compile_check_builds_capture_worker(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
Closes #477.

## What changed

- add `visual-regression` to `ci-pass.needs`
- include `needs.visual-regression.result` in the sentinel result loop
- update workflow policy validation to enforce both links
- add a mutation test that proves removing the visual result fails validation

The duplicate `push`-to-`main` CI trigger remains in place because strict status checks are not enabled.

## Verification

- `python3 scripts/validate_workflow_policy.py` — 5 CI policy cases passed
- `python3 -m unittest tests/test_workflow_policy.py` — 25 passed
- `cargo check --all-targets`
- `cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `npx tsc --noEmit`
- `npm test` — 646 passed

## Repository settings report (not applied)

Current `main` protection:

- `required_status_checks: null`
- `required_approving_review_count: 1`
- `require_last_push_approval: true`
- `enforce_admins: false`

Exact follow-up settings described by the issue:

- set required approving reviews to `0`
- require the `ci-pass` status context
- set required status checks to strict/up-to-date mode

The health-sweep prompt explicitly reserves repository-setting mutations outside this code PR, so no settings were changed here.
