### PR TITLE
test: cover capture worker ring and framing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
           CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
         run: cd app/src-tauri && cargo test --lib -- --test-threads=1
 
+      - name: Run capture worker unit tests
+        run: cd app/src-tauri && cargo test -p murmur-capture-helper
+
       - name: Run hardware-free integration suites
         env:
           MACOSX_DEPLOYMENT_TARGET: "14.0"

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1672,6 +1672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2838,7 @@ dependencies = [
  "coreaudio-rs 0.11.3",
  "cpal",
  "libc",
+ "loom",
  "murmur-capture-helper-protocol",
 ]
 
@@ -4400,6 +4429,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/app/src-tauri/sidecars/capture/Cargo.toml
+++ b/app/src-tauri/sidecars/capture/Cargo.toml
@@ -12,3 +12,6 @@ murmur-capture-helper-protocol = { path = "../../crates/capture-helper-protocol"
 libc = "0.2"
 coreaudio-rs = "0.11.3"
 core-foundation-sys = "0.8"
+
+[dev-dependencies]
+loom = "0.7.2"

--- a/app/src-tauri/sidecars/capture/src/production.rs
+++ b/app/src-tauri/sidecars/capture/src/production.rs
@@ -21,11 +21,18 @@ use murmur_capture_helper_protocol::{
     CapturePhase, CaptureSetupStep, FailureCode, ProductionDevice, ProductionFrame,
     ProductionHelperMessage, ProductionHostMessage, SessionNonce, SetupTransition,
 };
-use std::cell::UnsafeCell;
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
+
+#[cfg(not(test))]
+use std::cell::UnsafeCell;
+#[cfg(not(test))]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+#[cfg(test)]
+use loom::cell::UnsafeCell;
+#[cfg(test)]
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 const RING_CAPACITY: usize = 48_000 * 8;
 const STOP_DEADLINE: Duration = Duration::from_secs(2);
@@ -42,8 +49,13 @@ unsafe impl Sync for SpscRing {}
 
 impl SpscRing {
     fn new() -> Self {
-        let mut slots = Vec::with_capacity(RING_CAPACITY);
-        slots.resize_with(RING_CAPACITY, || UnsafeCell::new(0.0));
+        Self::with_capacity(RING_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        assert!(capacity >= 2);
+        let mut slots = Vec::with_capacity(capacity);
+        slots.resize_with(capacity, || UnsafeCell::new(0.0));
         Self {
             slots: slots.into_boxed_slice(),
             head: AtomicUsize::new(0),
@@ -59,7 +71,14 @@ impl SpscRing {
             self.overflowed.store(true, Ordering::Release);
             return;
         }
-        unsafe { *self.slots[head].get() = value };
+        #[cfg(not(test))]
+        {
+            unsafe { *self.slots[head].get() = value };
+        }
+        #[cfg(test)]
+        {
+            self.slots[head].with_mut(|slot| unsafe { *slot = value });
+        }
         self.head.store(next, Ordering::Release);
     }
 
@@ -68,7 +87,16 @@ impl SpscRing {
         let mut tail = self.tail.load(Ordering::Relaxed);
         let head = self.head.load(Ordering::Acquire);
         while tail != head && count < output.len() {
-            output[count] = unsafe { *self.slots[tail].get() };
+            #[cfg(not(test))]
+            {
+                output[count] = unsafe { *self.slots[tail].get() };
+            }
+            #[cfg(test)]
+            {
+                self.slots[tail].with(|slot| {
+                    output[count] = unsafe { *slot };
+                });
+            }
             count += 1;
             tail = (tail + 1) % self.slots.len();
         }
@@ -397,6 +425,157 @@ fn read_control(
     match read_production_frame(reader, capture_id, nonce).map_err(|_| ())? {
         ProductionFrame::Control(message) => Ok(message),
         ProductionFrame::Pcm(_) => Err(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn spsc_ring_push_drain_wrap_and_overflow_are_bounded() {
+        loom::model(|| {
+            let ring = SpscRing::with_capacity(3);
+            ring.push(1.0);
+            ring.push(2.0);
+            assert_eq!(ring.producer_position(), 2);
+
+            ring.push(3.0);
+            assert!(ring.overflowed.load(Ordering::Acquire));
+
+            let mut first = [0.0];
+            assert_eq!(ring.drain(&mut first), 1);
+            assert_eq!(first, [1.0]);
+
+            ring.push(3.0);
+            let mut rest = [0.0; 2];
+            assert_eq!(ring.drain(&mut rest), 2);
+            assert_eq!(rest, [2.0, 3.0]);
+            assert_eq!(ring.producer_position(), 0);
+        });
+    }
+
+    #[test]
+    fn spsc_ring_publishes_samples_across_threads() {
+        loom::model(|| {
+            let ring = loom::sync::Arc::new(SpscRing::with_capacity(2));
+            let producer = loom::sync::Arc::clone(&ring);
+            let consumer = loom::sync::Arc::clone(&ring);
+
+            let push = loom::thread::spawn(move || producer.push(42.5));
+            let drain = loom::thread::spawn(move || {
+                let mut output = [0.0];
+                (consumer.drain(&mut output) == 1).then_some(output[0])
+            });
+
+            push.join().unwrap();
+            let concurrent = drain.join().unwrap();
+            let mut after_join = [0.0];
+            let remaining = ring.drain(&mut after_join);
+            match concurrent {
+                Some(value) => {
+                    assert_eq!(value, 42.5);
+                    assert_eq!(remaining, 0);
+                }
+                None => {
+                    assert_eq!(remaining, 1);
+                    assert_eq!(after_join, [42.5]);
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn spsc_ring_reuses_slots_across_threads() {
+        let mut model = loom::model::Builder::new();
+        model.preemption_bound = Some(3);
+        model.check(|| {
+            let ring = loom::sync::Arc::new(SpscRing::with_capacity(2));
+            let producer = loom::sync::Arc::clone(&ring);
+            let consumer = loom::sync::Arc::clone(&ring);
+
+            let push = loom::thread::spawn(move || {
+                for value in [1.0, 2.0, 3.0] {
+                    let prior_position = producer.producer_position();
+                    while producer.producer_position() == prior_position {
+                        producer.push(value);
+                        loom::thread::yield_now();
+                    }
+                }
+            });
+            let drain = loom::thread::spawn(move || {
+                let mut values = Vec::new();
+                while values.len() < 3 {
+                    let mut output = [0.0];
+                    if consumer.drain(&mut output) == 1 {
+                        values.push(output[0]);
+                    }
+                    loom::thread::yield_now();
+                }
+                values
+            });
+
+            push.join().unwrap();
+            assert_eq!(drain.join().unwrap(), vec![1.0, 2.0, 3.0]);
+        });
+    }
+
+    #[test]
+    fn parse_nonce_accepts_exact_hex_and_rejects_malformed_values() {
+        assert_eq!(
+            parse_nonce("00112233445566778899aAbBcCdDeEfF"),
+            Ok([
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+                0xcc, 0xdd, 0xee, 0xff,
+            ])
+        );
+        assert_eq!(parse_nonce("0011"), Err(()));
+        assert_eq!(parse_nonce("00112233445566778899aabbccddeefg"), Err(()));
+    }
+
+    #[test]
+    fn read_control_accepts_matching_control_frame() {
+        let capture_id = 42;
+        let nonce = [7; 16];
+        let mut bytes = Vec::new();
+        write_production_control(
+            &mut bytes,
+            capture_id,
+            nonce,
+            &ProductionHostMessage::Hello,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_control(&mut Cursor::new(bytes), capture_id, nonce),
+            Ok(ProductionHostMessage::Hello)
+        );
+    }
+
+    #[test]
+    fn read_control_rejects_pcm_and_mismatched_identity() {
+        let capture_id = 42;
+        let nonce = [7; 16];
+        let mut pcm = Vec::new();
+        write_production_pcm(&mut pcm, capture_id, nonce, 0, 48_000, &[0.25]).unwrap();
+        assert_eq!(
+            read_control(&mut Cursor::new(pcm), capture_id, nonce),
+            Err(())
+        );
+
+        let mut control = Vec::new();
+        write_production_control(
+            &mut control,
+            capture_id,
+            nonce,
+            &ProductionHostMessage::Stop,
+        )
+        .unwrap();
+        assert_eq!(
+            read_control(&mut Cursor::new(control), capture_id + 1, nonce),
+            Err(())
+        );
     }
 }
 

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -145,6 +145,8 @@ def validate_ci(ci: str) -> int:
     assert "CARGO_TARGET_DIR=target/capture-worker-build" in capture_build
     assert "target/capture-worker-build/debug/murmur-capture-helper" in capture_build
     assert "binaries/murmur-capture-worker-aarch64-apple-darwin" in capture_build
+    capture_tests = named_step_block(ci, "Run capture worker unit tests", 6)
+    assert "cargo test -p murmur-capture-helper" in capture_tests
     llm_target = "binaries/murmur-llm-sidecar-aarch64-apple-darwin"
     assert capture_build.count(f": > {llm_target}") == 1
     assert capture_build.count(f"chmod +x {llm_target}") == 1

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,6 +18,18 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_ci_runs_capture_worker_unit_tests(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        mutated = workflow.replace(
+            "      - name: Run capture worker unit tests\n"
+            "        run: cd app/src-tauri && cargo test -p murmur-capture-helper\n\n",
+            "",
+            1,
+        )
+        self.assertNotEqual(workflow, mutated)
+        with self.assertRaises(AssertionError):
+            validate_ci(mutated)
+
     def test_ci_pass_requires_visual_regression_result(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
Closes #478.

## What changed

- unit-test production nonce parsing and control-frame acceptance/rejection
- unit-test `SpscRing` capacity, overflow, drain, wrap, and producer position
- model both producer-to-consumer publication and consumer-to-producer slot reuse with Loom
- add an explicit macOS CI step for `cargo test -p murmur-capture-helper`
- add workflow-policy coverage so that CI step cannot silently disappear

The production build continues to use the same standard atomics, `UnsafeCell`, and Acquire/Release orderings. Test builds substitute Loom’s checked equivalents around the same ring implementation.

## Verification

- `cargo test -p murmur-capture-helper` — 6 passed
- Loom mutation proof: weakening either the `head` or `tail` publication store from `Release` to `Relaxed` makes the relevant model fail with an `UnsafeCell` causality violation; correct orderings restored
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests/test_workflow_policy.py` — 26 passed
- `cargo check -p murmur-capture-helper`
- `cargo check --all-targets`
- `cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `npx tsc --noEmit`
- `npm test` — 646 passed

## Code vs. issue

The issue correctly distinguished the existing Python protocol smoke tests from the missing in-process Rust coverage. Those smoke tests remain unchanged; this fills the pure-logic and memory-ordering gaps and makes CI execute the new crate tests.
