### PR TITLE
CI: add advisory dependency vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,34 @@ jobs:
           LD_LIBRARY_PATH="$CUDA_DRIVER_STUB_DIR:${LD_LIBRARY_PATH:-}" \
             cargo test --lib -- --test-threads=1
 
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Audit Rust dependencies (advisory)
+        continue-on-error: true
+        run: |
+          cargo install cargo-audit --locked --version 0.22.2
+          cd app/src-tauri
+          cargo audit
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Audit npm dependencies (advisory)
+        continue-on-error: true
+        run: |
+          cd app
+          npm ci
+          npm audit --audit-level=high
+
   ci-pass:
     needs: [changes, typecheck, visual-regression, rust-macos, linux]
     # Keep this guard aligned with `changes`; otherwise the sentinel would turn

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -147,6 +147,14 @@ def validate_ci(ci: str) -> int:
     assert "binaries/murmur-capture-worker-aarch64-apple-darwin" in capture_build
     capture_tests = named_step_block(ci, "Run capture worker unit tests", 6)
     assert "cargo test -p murmur-capture-helper" in capture_tests
+    job_block(ci, "dependency-audit")
+    rust_audit = named_step_block(ci, "Audit Rust dependencies (advisory)", 6)
+    assert "continue-on-error: true" in rust_audit
+    assert "cargo install cargo-audit --locked --version 0.22.2" in rust_audit
+    assert "cargo audit" in rust_audit
+    npm_audit = named_step_block(ci, "Audit npm dependencies (advisory)", 6)
+    assert "continue-on-error: true" in npm_audit
+    assert "npm audit --audit-level=high" in npm_audit
     llm_target = "binaries/murmur-llm-sidecar-aarch64-apple-darwin"
     assert capture_build.count(f": > {llm_target}") == 1
     assert capture_build.count(f"chmod +x {llm_target}") == 1

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,6 +18,19 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_dependency_audits_are_present_and_advisory(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        for old in (
+            "          cargo audit\n",
+            "          npm audit --audit-level=high\n",
+            "        continue-on-error: true\n",
+        ):
+            with self.subTest(policy=old.strip()):
+                mutated = workflow.replace(old, "", 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_ci(mutated)
+
     def test_ci_runs_capture_worker_unit_tests(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
Closes #479.

## Summary

- add a dedicated `dependency-audit` CI job for Rust and npm advisories
- pin `cargo-audit` to 0.22.2 and scan the Rust workspace
- run `npm audit --audit-level=high` after a clean install
- keep both scans explicitly advisory with `continue-on-error`
- preserve the existing `ci-pass` dependency list so findings do not gate merges yet
- add mutation-tested workflow-policy assertions for both scanners and their advisory status

## Advisory baseline (2026-08-07)

Rust (`cargo audit`):

- 709 dependencies scanned
- 12 vulnerability instances across 10 unique RustSec advisories
- affected packages: `quick-xml` 0.37.5 and 0.38.4, `quinn-proto` 0.11.13, `rustls-webpki` 0.103.9, and `tar` 0.4.44
- 17 unmaintained warnings and 6 unsound warnings
- RustSec database commit: `1237bbe09d2701e14e6593a630fbaf28928df712`

npm (`npm audit --audit-level=high`):

- 328 dependencies scanned
- 6 vulnerable package entries: 1 low, 4 high, 1 critical
- affected entries: `@babel/core` (low), `picomatch`, `postcss`, `undici`, `vite` (high), and `vitest` (critical)

This PR intentionally records rather than remediates the baseline. Gating and dependency updates follow only after the baseline is understood and reduced.

## Verification

- `cd app/src-tauri && cargo check --all-targets`
- `cd app/src-tauri && cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `cd app && npx tsc --noEmit`
- `cd app && npm test` — 646 passed
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests/test_workflow_policy.py` — 27 passed

Base: `codex/health-sweep-integration` (stacked health-sweep branch). Do not merge this PR to `main`.
