### PR TITLE
Settings: migrate the stale 50 ms auto-paste delay

### DIFF
--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -105,6 +105,45 @@ describe('loadSettings', () => {
     }
   });
 
+  it('migrates the exact legacy 50 ms paste delay to zero once', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      autoPasteDelayMs: 50,
+    }));
+
+    expect(loadSettings().autoPasteDelayMs).toBe(0);
+    expect(JSON.parse(localStorage.getItem('dictation-settings') ?? '{}')).toMatchObject({
+      autoPasteDelayMs: 0,
+      settingsVersion: 1,
+    });
+
+    saveSettings({ ...loadSettings(), autoPasteDelayMs: 50 });
+    expect(loadSettings().autoPasteDelayMs).toBe(50);
+  });
+
+  it('preserves a deliberate 50 ms paste delay after the migration version', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      autoPasteDelayMs: 50,
+      settingsVersion: 1,
+    }));
+
+    expect(loadSettings().autoPasteDelayMs).toBe(50);
+  });
+
+  it('versions legacy settings even when their paste delay does not change', () => {
+    localStorage.setItem('dictation-settings', JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      autoPasteDelayMs: 23,
+    }));
+
+    expect(loadSettings().autoPasteDelayMs).toBe(23);
+    expect(JSON.parse(localStorage.getItem('dictation-settings') ?? '{}')).toMatchObject({
+      autoPasteDelayMs: 23,
+      settingsVersion: 1,
+    });
+  });
+
   it('migrates and validates per-app smart and CLI formatting overrides', () => {
     localStorage.setItem('dictation-settings', JSON.stringify({
       ...DEFAULT_SETTINGS,

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -409,6 +409,22 @@ export const DEFAULT_SETTINGS: Settings = {
 };
 
 export const STORAGE_KEY = 'dictation-settings';
+const SETTINGS_VERSION = 1;
+const ZERO_DELAY_MIGRATION_VERSION = 1;
+
+type PersistedSettings = Partial<Settings> & {
+  settingsVersion?: unknown;
+  hotkey?: string;
+  liveTranscriptPreview?: unknown;
+  recordingMode?: string;
+};
+
+function writePersistedSettings(settings: Settings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({
+    ...settings,
+    settingsVersion: SETTINGS_VERSION,
+  }));
+}
 
 /**
  * Validate a persisted code-vocab scan summary. Returns a clean
@@ -479,11 +495,24 @@ export function loadSettings(): Settings {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
-      const parsed = JSON.parse(stored) as Partial<Settings> & {
-        hotkey?: string;
-        liveTranscriptPreview?: unknown;
-        recordingMode?: string;
-      };
+      const parsed = JSON.parse(stored) as PersistedSettings;
+      const storedSettingsVersion =
+        typeof parsed.settingsVersion === 'number'
+        && Number.isInteger(parsed.settingsVersion)
+        && parsed.settingsVersion >= 0
+          ? parsed.settingsVersion
+          : 0;
+      delete parsed.settingsVersion;
+
+      // v1: installs that persisted the former 50 ms default should adopt the
+      // zero-delay fast path once. A user can set 50 ms again after migration,
+      // and saveSettings will retain it with the current settings version.
+      if (
+        storedSettingsVersion < ZERO_DELAY_MIGRATION_VERSION
+        && parsed.autoPasteDelayMs === 50
+      ) {
+        parsed.autoPasteDelayMs = DEFAULT_SETTINGS.autoPasteDelayMs;
+      }
 
       // Migrate: 'hotkey' mode no longer exists → default to 'hold_down'
       const validModes: RecordingMode[] = ['hold_down', 'double_tap', 'both'];
@@ -672,7 +701,15 @@ export function loadSettings(): Settings {
         parsed.correctionFuzzy = DEFAULT_SETTINGS.correctionFuzzy;
       }
 
-      return { ...DEFAULT_SETTINGS, ...parsed } as Settings;
+      const settings = { ...DEFAULT_SETTINGS, ...parsed } as Settings;
+      if (storedSettingsVersion < SETTINGS_VERSION) {
+        try {
+          writePersistedSettings(settings);
+        } catch (e) {
+          console.error('Failed to persist settings migration:', e);
+        }
+      }
+      return settings;
     }
   } catch (e) {
     console.error('Failed to load settings:', e);
@@ -682,7 +719,7 @@ export function loadSettings(): Settings {
 
 export function saveSettings(settings: Settings): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    writePersistedSettings(settings);
   } catch (e) {
     console.error('Failed to save settings:', e);
   }


### PR DESCRIPTION
Closes #480.

## Summary

- add a persisted settings schema version without exposing migration metadata through the runtime `Settings` type
- migrate only an unversioned, exact `autoPasteDelayMs: 50` value to the current zero-delay default
- persist the migrated, validated settings at version 1 so the migration runs once
- stamp all subsequent settings saves with the current version, allowing a user to deliberately select 50 ms again
- preserve every other valid delay while still advancing legacy settings to the current version

## Caveats retained

- 50 ms is genuinely user-selectable, so a pre-version deliberate 50 ms choice is indistinguishable from the stale default and will be migrated once
- this does not claim a zero-delay production soak result; post-release paste failure and retry telemetry still needs observation

## Verification

- `cd app && npx vitest run src/lib/settings.test.ts` — 51 passed
- `cd app && npx tsc --noEmit`
- `cd app && npm test` — 649 passed
- `cd app/src-tauri && cargo check --all-targets`
- `cd app/src-tauri && cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests/test_workflow_policy.py` — 27 passed

Base: `codex/health-sweep-integration` (stacked health-sweep branch). Do not merge this PR to `main`.
