### PR TITLE
CI: clear the clippy baseline and gate on a pinned toolchain

### DIFF
--- a/.github/actions/setup-linux-build/action.yml
+++ b/.github/actions/setup-linux-build/action.yml
@@ -33,7 +33,7 @@ runs:
       run: echo "CUDA_MM=$(echo '${{ inputs.cuda-version }}' | cut -d. -f1,2)" >> "$GITHUB_ENV"
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Install Linux system dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: clippy
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -159,6 +161,14 @@ jobs:
         # --all-targets so `tests/` and `examples/` are type-checked too. Without
         # it the integration suites below can rot without any signal.
         run: cd app/src-tauri && cargo check --all-targets
+
+      - name: Lint Rust
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"
+          CMAKE_C_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+          CMAKE_CXX_FLAGS: "-march=armv8.5-a -mmacosx-version-min=14.0"
+        run: cd app/src-tauri && cargo clippy --all-targets -- -D warnings
 
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -223,7 +223,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Audit Rust dependencies (advisory)
         continue-on-error: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -101,7 +101,7 @@ jobs:
           cache-dependency-path: app/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Restore release-profile Rust cache
         id: rust-cache

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -116,7 +116,7 @@ jobs:
           cache-dependency-path: app/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Restore isolated macOS release cache
         id: rust-cache

--- a/.github/workflows/sidecar-signing-rehearsal.yml
+++ b/.github/workflows/sidecar-signing-rehearsal.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: app/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install frontend dependencies
         run: cd app && npm ci

--- a/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
+++ b/app/src-tauri/crates/capture-helper-protocol/src/lib.rs
@@ -102,8 +102,8 @@ pub enum ProductionHelperMessage {
 /// that hung. Step names are content-free: no device identity ever rides on
 /// this message. AUHAL steps map to native Core Audio calls as follows:
 ///
-/// - `AudioUnitNew`: `AudioComponentFindNext` + `AudioComponentInstanceNew`
-///   + `AudioUnitInitialize` (one bracket; the safe wrapper creates and
+/// - `AudioUnitNew`: `AudioComponentFindNext`, `AudioComponentInstanceNew`,
+///   and `AudioUnitInitialize` (one bracket; the safe wrapper creates and
 ///   initializes in a single call)
 /// - `EnableInputIo` / `DisableOutputIo`:
 ///   `AudioUnitSetProperty(kAudioOutputUnitProperty_EnableIO)` on the input /
@@ -451,7 +451,7 @@ pub fn write_production_pcm(
     if samples.is_empty() || samples.len() > MAX_PCM_SAMPLES {
         return Err(FrameError::InvalidPcm);
     }
-    let payload_len = 16 + samples.len() * std::mem::size_of::<f32>();
+    let payload_len = 16 + std::mem::size_of_val(samples);
     write_production_header(writer, 1, payload_len, capture_id, nonce)?;
     writer
         .write_all(&sequence.to_le_bytes())

--- a/app/src-tauri/examples/transcription_bench.rs
+++ b/app/src-tauri/examples/transcription_bench.rs
@@ -125,7 +125,7 @@ fn word_error_rate(reference: &str, hypothesis: &str) -> Option<f64> {
 fn median(values: &mut [f64]) -> f64 {
     values.sort_by(f64::total_cmp);
     let middle = values.len() / 2;
-    if values.len() % 2 == 0 {
+    if values.len().is_multiple_of(2) {
         (values[middle - 1] + values[middle]) / 2.0
     } else {
         values[middle]

--- a/app/src-tauri/src/audio.rs
+++ b/app/src-tauri/src/audio.rs
@@ -606,6 +606,9 @@ fn quarantine_unconfirmed_child(
     }
 }
 
+// These arguments mirror the authenticated helper shutdown frame plus the
+// ownership evidence needed when termination cannot be confirmed.
+#[allow(clippy::too_many_arguments)]
 fn terminate_or_quarantine(
     child: ManagedChild,
     input: Option<std::process::ChildStdin>,
@@ -767,6 +770,9 @@ fn stop_requested_between_attempts(command_receiver: &Receiver<AudioCommand>) ->
     )
 }
 
+// Keep the attempt's ownership, cancellation, buffer, application, and event
+// channels explicit; bundling them would obscure the capture lifecycle.
+#[allow(clippy::too_many_arguments)]
 fn run_backend(
     owner: crate::audio_lifecycle::AudioOwner,
     backend: CaptureBackend,
@@ -1539,7 +1545,7 @@ pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     // integer downsampling (48k -> 16k, 32k -> 16k), linear interpolation lands
     // on an original sample every time, so step_by is bit-for-bit equivalent
     // without per-sample floating-point position and interpolation work.
-    if from_rate > to_rate && from_rate % to_rate == 0 {
+    if from_rate > to_rate && from_rate.is_multiple_of(to_rate) {
         let step = (from_rate / to_rate) as usize;
         let new_len = samples.len() / step;
         return samples.iter().step_by(step).take(new_len).copied().collect();

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -321,6 +321,9 @@ struct StartRequest {
     response: Sender<Result<(), AudioStartError>>,
 }
 
+// StartRequest is intentionally owned as one message so the supervisor can
+// accept or reject an immutable capture request without shared mutable state.
+#[allow(clippy::large_enum_variant)]
 enum SupervisorMessage {
     Start(StartRequest),
     Stop {
@@ -1509,8 +1512,10 @@ mod tests {
         }
     }
 
+    type CapturedSpecs = Arc<Mutex<Vec<(AudioOwner, Option<String>)>>>;
+
     struct SpecCaptureFactory {
-        specs: Arc<Mutex<Vec<(AudioOwner, Option<String>)>>>,
+        specs: CapturedSpecs,
     }
 
     impl WorkerFactory for SpecCaptureFactory {
@@ -1616,16 +1621,19 @@ mod tests {
         }
     }
 
-    fn harness(
-        phase: AudioInitPhase,
-        config: SupervisorConfig,
-    ) -> (
+    type ActiveFlags = Arc<Mutex<Vec<Arc<AtomicBool>>>>;
+    type Harness = (
         AudioSupervisor,
         Gate,
         Arc<AtomicUsize>,
         Arc<RecordingSink>,
-        Arc<Mutex<Vec<Arc<AtomicBool>>>>,
-    ) {
+        ActiveFlags,
+    );
+
+    fn harness(
+        phase: AudioInitPhase,
+        config: SupervisorConfig,
+    ) -> Harness {
         let gate = Gate::closed();
         let spawn_count = Arc::new(AtomicUsize::new(0));
         let sink = Arc::new(RecordingSink::default());

--- a/app/src-tauri/src/capture_helper_probe.rs
+++ b/app/src-tauri/src/capture_helper_probe.rs
@@ -286,6 +286,12 @@ pub struct CaptureProbeSupervisor {
     ownership: Mutex<Option<ManagedChild>>,
 }
 
+impl Default for CaptureProbeSupervisor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CaptureProbeSupervisor {
     pub fn new() -> Self {
         Self::with_observe_for(DEFAULT_OBSERVE)

--- a/app/src-tauri/src/cli_command.rs
+++ b/app/src-tauri/src/cli_command.rs
@@ -136,7 +136,7 @@ impl CliLexicon {
             }
         }
 
-        aliases.sort_by(|a, b| b.spoken.len().cmp(&a.spoken.len()));
+        aliases.sort_by_key(|alias| std::cmp::Reverse(alias.spoken.len()));
         let mut seen = std::collections::HashSet::new();
         aliases.retain(|alias| seen.insert(alias.spoken.clone()));
         Self { aliases }

--- a/app/src-tauri/src/commands/permissions.rs
+++ b/app/src-tauri/src/commands/permissions.rs
@@ -15,9 +15,13 @@ fn open_system_preference_pane(pane: &str) -> Result<(), String> {
 #[tauri::command]
 pub fn open_system_preferences() -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    { return open_system_preference_pane("Privacy_Microphone"); }
+    {
+        open_system_preference_pane("Privacy_Microphone")
+    }
     #[cfg(not(target_os = "macos"))]
-    { Err("System preferences shortcut not supported on this platform".to_string()) }
+    {
+        Err("System preferences shortcut not supported on this platform".to_string())
+    }
 }
 
 /// Check if accessibility permission is granted (macOS)
@@ -35,7 +39,7 @@ pub fn request_accessibility_permission() -> Result<(), String> {
         // Return value is the current trust status — we proceed to open System Settings
         // regardless, so the result is intentionally discarded here.
         let _ = injector::request_accessibility_prompt();
-        return open_system_preference_pane("Privacy_Accessibility");
+        open_system_preference_pane("Privacy_Accessibility")
     }
     #[cfg(not(target_os = "macos"))]
     { Ok(()) }
@@ -107,7 +111,7 @@ pub fn reset_accessibility_permission() -> Result<(), String> {
             return Err(format!("tccutil reset failed: {}", stderr.trim()));
         }
 
-        return open_system_preference_pane("Privacy_Accessibility");
+        open_system_preference_pane("Privacy_Accessibility")
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -119,9 +123,13 @@ pub fn reset_accessibility_permission() -> Result<(), String> {
 #[tauri::command]
 pub fn request_microphone_permission() -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    { return open_system_preference_pane("Privacy_Microphone"); }
+    {
+        open_system_preference_pane("Privacy_Microphone")
+    }
     #[cfg(not(target_os = "macos"))]
-    { Ok(()) }
+    {
+        Ok(())
+    }
 }
 
 /// Trigger the native macOS microphone permission prompt (TCC) in-flow.
@@ -208,7 +216,7 @@ pub fn reset_microphone_permission() -> Result<(), String> {
             return Err(format!("tccutil reset failed: {}", stderr.trim()));
         }
 
-        return open_system_preference_pane("Privacy_Microphone");
+        open_system_preference_pane("Privacy_Microphone")
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -254,7 +254,7 @@ fn dedupe_prompt_terms(prompt: &str) -> String {
 /// Entries are separated by commas or newlines (not spaces) so multi-word terms
 /// like "API Gateway" survive as one entry. Blank entries are dropped.
 fn parse_vocab_terms(s: &str) -> Vec<String> {
-    s.split(|c| c == ',' || c == '\n' || c == '\r')
+    s.split([',', '\n', '\r'])
         .map(|t| t.trim())
         .filter(|t| !t.is_empty())
         .map(String::from)
@@ -385,7 +385,7 @@ fn status_allows_model_preparation(status: DictationStatus) -> bool {
 /// short recording ends before preparation completes.
 fn spawn_model_preparation(app_handle: tauri::AppHandle, model_name: String, recording_id: u64) {
     let queued_at = std::time::Instant::now();
-    let _ = tauri::async_runtime::spawn_blocking(move || {
+    drop(tauri::async_runtime::spawn_blocking(move || {
         let queue_ms = queued_at.elapsed().as_millis() as u64;
         let state = app_handle.state::<State>();
         let is_active = {
@@ -475,7 +475,7 @@ fn spawn_model_preparation(app_handle: tauri::AppHandle, model_name: String, rec
                 "model_prepare_failed"
             ),
         }
-    });
+    }));
 }
 
 /// Warm an installed Core ML model after startup configuration. A newly linked
@@ -489,7 +489,7 @@ fn spawn_idle_model_preparation(
     change_guard: SharedBackendChangeGuard,
 ) {
     let queued_at = std::time::Instant::now();
-    let _ = tauri::async_runtime::spawn_blocking(move || {
+    drop(tauri::async_runtime::spawn_blocking(move || {
         let _change_guard = change_guard;
         let state = app_handle.state::<State>();
         let is_current = {
@@ -535,7 +535,7 @@ fn spawn_idle_model_preparation(
                 "model_prepare_skipped"
             ),
         }
-    });
+    }));
 }
 
 #[derive(Default)]
@@ -1118,11 +1118,10 @@ pub async fn process_audio(
             }
             format!("Failed to decode base64: {}", e)
         })?;
-    let samples = transcriber::parse_wav_to_samples(&wav_bytes).map_err(|e| {
+    let samples = transcriber::parse_wav_to_samples(&wav_bytes).inspect_err(|_e| {
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
-        e
     })?;
     tracing::info!(target: "pipeline", "audio parse (base64 + WAV): {:?}", t_parse.elapsed());
     performance_guard.record(StageTimingV1::measured(
@@ -3636,19 +3635,21 @@ mod tests {
 
     #[test]
     fn rejected_command_alias_conflict_leaves_prior_backend_state_unchanged() {
-        let mut dictation = crate::state::DictationState::default();
-        dictation.custom_vocabulary = "Tauri".to_string();
-        dictation.vocabulary_entries = vec![crate::state::VocabularyEntry {
-            id: "tauri".to_string(),
-            written: "Tauri".to_string(),
-            aliases: vec!["Tori".to_string()],
-            enabled: true,
-            scope: crate::state::VocabularyScope::Global,
-        }];
-        dictation.voice_command_pairs = vec![crate::state::VoiceCommand {
-            phrase: "ship it".to_string(),
-            replacement: "deploy".to_string(),
-        }];
+        let mut dictation = crate::state::DictationState {
+            custom_vocabulary: "Tauri".to_string(),
+            vocabulary_entries: vec![crate::state::VocabularyEntry {
+                id: "tauri".to_string(),
+                written: "Tauri".to_string(),
+                aliases: vec!["Tori".to_string()],
+                enabled: true,
+                scope: crate::state::VocabularyScope::Global,
+            }],
+            voice_command_pairs: vec![crate::state::VoiceCommand {
+                phrase: "ship it".to_string(),
+                replacement: "deploy".to_string(),
+            }],
+            ..Default::default()
+        };
         let before = dictation.clone();
         let options = serde_json::json!({
             "voiceCommands": [{ "phrase": "Tori", "replacement": "override" }],
@@ -3875,7 +3876,7 @@ mod tests {
         // The two budgets are intentionally distinct; Whisper's is the smaller.
         assert_eq!(WHISPER_PROMPT_TERMS, 96);
         assert_eq!(CORRECTION_TERMS, 500);
-        assert!(WHISPER_PROMPT_TERMS < CORRECTION_TERMS);
+        const { assert!(WHISPER_PROMPT_TERMS < CORRECTION_TERMS) };
     }
 
     #[test]

--- a/app/src-tauri/src/commands/theme.rs
+++ b/app/src-tauri/src/commands/theme.rs
@@ -346,7 +346,7 @@ mod tests {
             |parent| {
                 sync_called = true;
                 assert_eq!(parent, temp.path());
-                Err(io::Error::new(io::ErrorKind::Other, "test"))
+                Err(io::Error::other("test"))
             },
         )
         .unwrap_err();

--- a/app/src-tauri/src/commands/transform_model.rs
+++ b/app/src-tauri/src/commands/transform_model.rs
@@ -122,9 +122,8 @@ pub async fn download_transform_model(
     // Clean any residue from a previous interrupted attempt.
     let _ = tokio::fs::remove_file(&partial).await;
 
-    let (size, sha) = stream_verified_download(&app_handle, &partial).await.map_err(|e| {
+    let (size, sha) = stream_verified_download(&app_handle, &partial).await.inspect_err(|_e| {
         let _ = std::fs::remove_file(&partial);
-        e
     })?;
 
     if size != TRANSFORM_MODEL_SIZE_BYTES || sha != TRANSFORM_MODEL_SHA256 {

--- a/app/src-tauri/src/correction.rs
+++ b/app/src-tauri/src/correction.rs
@@ -452,7 +452,7 @@ impl CorrectionMatcher {
                 continue;
             }
             let phonetic_ok = dist <= 1 || phrase_key == phonetic_key_phrase(&term.spoken);
-            if phonetic_ok && best.map_or(true, |(d, _)| dist < d) {
+            if phonetic_ok && best.is_none_or(|(d, _)| dist < d) {
                 best = Some((dist, term));
             }
         }

--- a/app/src-tauri/src/dictation_context.rs
+++ b/app/src-tauri/src/dictation_context.rs
@@ -997,8 +997,10 @@ mod tests {
         app.writing_style = Some(WritingStyle::Verbatim);
         app.smart_formatting_override = Some(true);
         app.cli_formatting_override = Some(true);
-        let mut global = DictationState::default();
-        global.app_profiles = vec![app];
+        let global = DictationState {
+            app_profiles: vec![app],
+            ..Default::default()
+        };
 
         let snapshot = resolve_test(
             &global,
@@ -1028,8 +1030,10 @@ mod tests {
     fn resolved_style_snapshot_is_immutable() {
         let mut app = profile("com.example.Editor", None, None);
         app.writing_style = Some(WritingStyle::Polished);
-        let mut global = DictationState::default();
-        global.app_profiles = vec![app];
+        let mut global = DictationState {
+            app_profiles: vec![app],
+            ..Default::default()
+        };
         let snapshot = resolve_test(
             &global,
             Some("com.example.Editor"),

--- a/app/src-tauri/src/evaluation.rs
+++ b/app/src-tauri/src/evaluation.rs
@@ -67,6 +67,9 @@ struct EvaluationFixture {
 
 #[derive(Deserialize)]
 #[serde(untagged)]
+// Boxing either variant would only trade stack size for allocation while
+// fixture documents are short-lived inputs to the offline evaluator.
+#[allow(clippy::large_enum_variant)]
 enum FixtureDocument {
     One(EvaluationFixture),
     Many(Vec<EvaluationFixture>),
@@ -155,18 +158,13 @@ fn default_fixed_now() -> String {
     "2026-07-20T09:07:00-04:00".to_string()
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 enum FixtureCliMode {
+    #[default]
     Auto,
     Enabled,
     Disabled,
-}
-
-impl Default for FixtureCliMode {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 impl From<FixtureCliMode> for CliFormattingMode {

--- a/app/src-tauri/src/hang_diagnostics.rs
+++ b/app/src-tauri/src/hang_diagnostics.rs
@@ -270,6 +270,37 @@ fn collect_bundle(
     bundle
 }
 
+fn ship_bundle(capture_id: u64, bundle: String) {
+    let Some((install_id, endpoint)) = config_cell().lock_or_recover().clone() else {
+        return;
+    };
+    let outcome = tauri::async_runtime::block_on(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .ok()?;
+        client
+            .post(&endpoint)
+            .header(
+                "Authorization",
+                format!("Bearer {}", crate::log_shipper::TOKEN),
+            )
+            .header("X-Install-Id", install_id)
+            .header("Content-Type", "text/plain")
+            .body(bundle)
+            .send()
+            .await
+            .ok()
+            .map(|response| response.status().is_success())
+    });
+    tracing::info!(
+        target: "audio",
+        capture_id,
+        shipped = outcome.unwrap_or(false),
+        "hang diagnostics: bundle upload finished"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,35 +348,4 @@ mod tests {
         assert!(run_capped("/nonexistent-binary", &[], Duration::from_secs(1))
             .starts_with("<spawn failed"));
     }
-}
-
-fn ship_bundle(capture_id: u64, bundle: String) {
-    let Some((install_id, endpoint)) = config_cell().lock_or_recover().clone() else {
-        return;
-    };
-    let outcome = tauri::async_runtime::block_on(async move {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .ok()?;
-        client
-            .post(&endpoint)
-            .header(
-                "Authorization",
-                format!("Bearer {}", crate::log_shipper::TOKEN),
-            )
-            .header("X-Install-Id", install_id)
-            .header("Content-Type", "text/plain")
-            .body(bundle)
-            .send()
-            .await
-            .ok()
-            .map(|response| response.status().is_success())
-    });
-    tracing::info!(
-        target: "audio",
-        capture_id,
-        shipped = outcome.unwrap_or(false),
-        "hang diagnostics: bundle upload finished"
-    );
 }

--- a/app/src-tauri/src/injector.rs
+++ b/app/src-tauri/src/injector.rs
@@ -556,7 +556,7 @@ fn focused_role_native() -> Result<String, String> {
     let focused_attribute = unsafe {
         CFStringCreateWithCString(
             std::ptr::null(),
-            b"AXFocusedUIElement\0".as_ptr().cast(),
+            c"AXFocusedUIElement".as_ptr(),
             UTF8_ENCODING,
         )
     };
@@ -586,7 +586,7 @@ fn focused_role_native() -> Result<String, String> {
     let role_attribute = unsafe {
         CFStringCreateWithCString(
             std::ptr::null(),
-            b"AXRole\0".as_ptr().cast(),
+            c"AXRole".as_ptr(),
             UTF8_ENCODING,
         )
     };

--- a/app/src-tauri/src/knowledge_store/repository.rs
+++ b/app/src-tauri/src/knowledge_store/repository.rs
@@ -1165,7 +1165,7 @@ fn read_import(path: &Path) -> Result<KnowledgeExport, String> {
         .map_err(|_| "Murmur could not read the selected knowledge import.".to_string())?;
     let bundle: KnowledgeExport = serde_json::from_slice(&bytes)
         .map_err(|_| "The selected file is not a valid Murmur knowledge export.".to_string())?;
-    if bundle.format != EXPORT_FORMAT || !matches!(bundle.version, 1 | 2 | 3) {
+    if bundle.format != EXPORT_FORMAT || !matches!(bundle.version, 1..=3) {
         return Err(
             "The selected knowledge export format is not supported by this Murmur build."
                 .to_string(),

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -388,8 +388,8 @@ pub fn start() {
                 .map(|p| load_state(&p).install_id);
             if let Some(install_id) = &state_install_id {
                 if let Some(snap) = cached_audio_state() {
-                    if last_snapshot.as_deref() != Some(snap.as_str()) {
-                        if ship_state(
+                    if last_snapshot.as_deref() != Some(snap.as_str())
+                        && ship_state(
                             &client,
                             &state_endpoint,
                             install_id,
@@ -400,7 +400,6 @@ pub fn start() {
                         {
                             last_snapshot = Some(snap);
                         }
-                    }
                 }
             }
             tokio::time::sleep(std::time::Duration::from_secs(TICK_SECS)).await;

--- a/app/src-tauri/src/managed_child.rs
+++ b/app/src-tauri/src/managed_child.rs
@@ -194,6 +194,9 @@ impl Drop for ManagedChild {
     }
 }
 
+// Callers deliberately collapse every lookup failure to their own
+// content-free error; exposing filesystem detail here would weaken that seam.
+#[allow(clippy::result_unit_err)]
 pub fn bundled_sibling(name: &str) -> Result<PathBuf, ()> {
     let executable = std::env::current_exe().map_err(|_| ())?;
     let directory = executable.parent().ok_or(())?;

--- a/app/src-tauri/src/platform/mod.rs
+++ b/app/src-tauri/src/platform/mod.rs
@@ -42,9 +42,7 @@ pub(super) fn update_cpu_percent(
     previous: &mut Option<CpuTicks>,
     current: Option<CpuTicks>,
 ) -> Option<f32> {
-    let Some(current) = current else {
-        return None;
-    };
+    let current = current?;
     let percent = previous.map(|sample| cpu_percent_between(sample, current));
     *previous = Some(current);
     percent

--- a/app/src-tauri/src/resource_monitor.rs
+++ b/app/src-tauri/src/resource_monitor.rs
@@ -251,7 +251,7 @@ pub fn start_heartbeat(app_handle: tauri::AppHandle) {
                 );
             }
 
-            if ticks % 60 == 0 {
+            if ticks.is_multiple_of(60) {
                 let rss = get_process_rss_mb();
                 let rust = crate::rust_heap_mb();
                 let ffi = crate::ffi_heap_mb();

--- a/app/src-tauri/src/smart_formatting.rs
+++ b/app/src-tauri/src/smart_formatting.rs
@@ -66,7 +66,7 @@ fn apply_bounded_backtrack(input: &str) -> String {
         .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ':' | '-' | '—'))
         .trim();
     let replacement =
-        replacement_raw.trim_end_matches(|ch: char| matches!(ch, '.' | ',' | ';' | '!' | '?'));
+        replacement_raw.trim_end_matches(['.', ',', ';', '!', '?']);
     let replacement_words = replacement.split_whitespace().count();
     if replacement.is_empty()
         || replacement.len() > MAX_BACKTRACK_REPLACEMENT_CHARS
@@ -199,7 +199,7 @@ fn format_spoken_enumeration(input: &str) -> String {
 
     let mut output = String::new();
     if !prefix.is_empty() {
-        output.push_str(prefix.trim_end_matches(|ch: char| matches!(ch, ':' | ',' | ';')));
+        output.push_str(prefix.trim_end_matches([':', ',', ';']));
         output.push(':');
         output.push('\n');
     }
@@ -219,7 +219,7 @@ fn valid_list_prefix(prefix: &str) -> bool {
         return true;
     }
     let normalized = prefix
-        .trim_end_matches(|ch: char| matches!(ch, ':' | ',' | ';'))
+        .trim_end_matches([':', ',', ';'])
         .to_ascii_lowercase();
     normalized.ends_with(" are")
         || normalized.ends_with(" include")
@@ -380,7 +380,7 @@ fn format_explicit_url(input: &str) -> String {
     } else {
         return input.to_string();
     };
-    let body = body.trim_end_matches(|ch: char| matches!(ch, '.' | ',' | ';' | '!' | '?'));
+    let body = body.trim_end_matches(['.', ',', ';', '!', '?']);
     let words = body
         .split_whitespace()
         .map(|word| word.to_ascii_lowercase())

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -7,9 +7,10 @@ use std::time::Instant;
 
 pub use crate::transcriber::WHISPER_SAMPLE_RATE;
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DictationStatus {
+    #[default]
     Idle,
     Starting,
     Recording,
@@ -17,19 +18,14 @@ pub enum DictationStatus {
     Processing,
 }
 
-impl Default for DictationStatus {
-    fn default() -> Self {
-        Self::Idle
-    }
-}
-
 /// Status of the AX-selection transform pipeline (issue #312). Deliberately a
 /// separate field on `AppState`, NOT a `DictationStatus` variant — dictation
 /// recording/processing and a transform pass are independent activities that
 /// each need to know about (and block) the other, not a shared state machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TransformStatus {
+    #[default]
     Idle,
     /// Reading the AX selection (`selection::capture_selection`).
     Capturing,
@@ -43,12 +39,6 @@ pub enum TransformStatus {
     ReviewPending,
     /// Writing the accepted result back (clipboard/injection).
     Applying,
-}
-
-impl Default for TransformStatus {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 impl TransformStatus {
@@ -186,9 +176,10 @@ pub struct VoiceCommand {
     pub replacement: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum VocabularyScope {
+    #[default]
     Global,
     App {
         #[serde(rename = "bundleId")]
@@ -199,12 +190,6 @@ pub enum VocabularyScope {
         bundle_id: String,
         root: String,
     },
-}
-
-impl Default for VocabularyScope {
-    fn default() -> Self {
-        Self::Global
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/app/src-tauri/src/transcriber/coreml.rs
+++ b/app/src-tauri/src/transcriber/coreml.rs
@@ -28,7 +28,7 @@ fn model_dir() -> Option<PathBuf> {
 }
 
 fn nonempty_file(path: &Path) -> bool {
-    path.is_file() && path.metadata().map_or(false, |metadata| metadata.len() > 0)
+    path.is_file() && path.metadata().is_ok_and(|metadata| metadata.len() > 0)
 }
 
 fn model_exists_at(path: &Path) -> bool {
@@ -58,7 +58,7 @@ fn remove_incomplete_cache(path: &Path) -> Result<(), String> {
 pub fn specific_model_exists(model_name: &str) -> bool {
     is_coreml_model(model_name)
         && cfg!(target_arch = "aarch64")
-        && model_dir().as_deref().map_or(false, model_exists_at)
+        && model_dir().as_deref().is_some_and(model_exists_at)
 }
 
 fn new_engine() -> Result<FluidAudio, String> {
@@ -96,6 +96,7 @@ pub fn prepare_model(model_name: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Default)]
 pub struct CoreMlBackend {
     engine: Option<FluidAudio>,
     loaded_model_name: Option<String>,
@@ -104,15 +105,6 @@ pub struct CoreMlBackend {
 impl CoreMlBackend {
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-impl Default for CoreMlBackend {
-    fn default() -> Self {
-        Self {
-            engine: None,
-            loaded_model_name: None,
-        }
     }
 }
 

--- a/app/src-tauri/src/transcriber/parakeet.rs
+++ b/app/src-tauri/src/transcriber/parakeet.rs
@@ -56,7 +56,7 @@ impl ParakeetVariant {
             .iter()
             .all(|f| {
                 let p = dir.join(f);
-                p.is_file() && p.metadata().map_or(false, |m| m.len() > 0)
+                p.is_file() && p.metadata().is_ok_and(|m| m.len() > 0)
             })
     }
 }
@@ -122,6 +122,7 @@ pub fn download_spec(model_name: &str) -> Option<(String, String)> {
     Some((url, v.dir.to_string()))
 }
 
+#[derive(Default)]
 pub struct ParakeetBackend {
     recognizer: Option<OfflineRecognizer>,
     loaded_model_name: Option<String>,
@@ -130,15 +131,6 @@ pub struct ParakeetBackend {
 impl ParakeetBackend {
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-impl Default for ParakeetBackend {
-    fn default() -> Self {
-        Self {
-            recognizer: None,
-            loaded_model_name: None,
-        }
     }
 }
 
@@ -247,7 +239,7 @@ impl TranscriptionBackend for ParakeetBackend {
         };
         KNOWN_MODELS
             .iter()
-            .any(|m| variant_for(m).map_or(false, |v| v.is_complete(&models_dir)))
+            .any(|m| variant_for(m).is_some_and(|v| v.is_complete(&models_dir)))
     }
 
     fn models_dir(&self) -> Result<PathBuf, String> {

--- a/app/src-tauri/src/transcriber/whisper.rs
+++ b/app/src-tauri/src/transcriber/whisper.rs
@@ -81,6 +81,7 @@ pub fn specific_model_exists(model_name: &str) -> bool {
     get_model_path(model_name).is_ok()
 }
 
+#[derive(Default)]
 pub struct WhisperBackend {
     context: Option<WhisperContext>,
     state: Option<WhisperState>,
@@ -165,16 +166,6 @@ fn append_segment(text: &mut String, segment_text: &str) {
         text.push(' ');
     }
     text.push_str(segment_text);
-}
-
-impl Default for WhisperBackend {
-    fn default() -> Self {
-        Self {
-            context: None,
-            state: None,
-            loaded_model_name: None,
-        }
-    }
 }
 
 impl TranscriptionBackend for WhisperBackend {

--- a/app/src-tauri/src/transform_apply.rs
+++ b/app/src-tauri/src/transform_apply.rs
@@ -569,6 +569,9 @@ fn validate_undo(
 /// scheduled on a background task rather than awaited here, so this future
 /// resolves promptly instead of blocking on the ~300ms paste-restore delay.
 #[cfg(target_os = "macos")]
+// The write contract keeps each security-sensitive input visible at the call
+// site instead of hiding selection ownership inside a loosely typed bundle.
+#[allow(clippy::too_many_arguments)]
 async fn run_apply(
     app_handle: &tauri::AppHandle,
     pid: i32,
@@ -1561,7 +1564,8 @@ mod tests {
     #[test]
     fn pre_write_guard_table() {
         // (frontmost, range_restore_ok, current_matches) -> expected
-        let cases: &[((bool, bool, bool), Result<(), ApplyError>)] = &[
+        type GuardCase = ((bool, bool, bool), Result<(), ApplyError>);
+        let cases: &[GuardCase] = &[
             ((false, false, false), Err(ApplyError::TargetGone)),
             ((false, true, true), Err(ApplyError::TargetGone)), // frontmost check wins even if everything else looks fine
             ((true, true, true), Ok(())),

--- a/app/src-tauri/src/vocab.rs
+++ b/app/src-tauri/src/vocab.rs
@@ -902,9 +902,11 @@ mod tests {
     #[test]
     fn guard_constants_are_sane() {
         // Sanity-check the guard values so an accidental edit to 0 is caught.
-        assert!(MAX_FILE_BYTES > 0);
-        assert!(MAX_FILES > 0);
-        assert!(MAX_TOTAL_BYTES >= MAX_FILE_BYTES);
+        const {
+            assert!(MAX_FILE_BYTES > 0);
+            assert!(MAX_FILES > 0);
+            assert!(MAX_TOTAL_BYTES >= MAX_FILE_BYTES);
+        }
         assert!(!SOURCE_EXTENSIONS.is_empty());
         // Caps were raised to accommodate the decoupled correction budget (top
         // 500 terms) without scanning unbounded repos: 1000 files / 32MB total /

--- a/app/src-tauri/src/voice_commands.rs
+++ b/app/src-tauri/src/voice_commands.rs
@@ -730,7 +730,7 @@ mod tests {
         let missed = apply_voice_commands_with_resolved(
             "ordinary prose",
             true,
-            &[command.clone()],
+            std::slice::from_ref(&command),
             &runtime,
         );
         assert_eq!(missed.text, "ordinary prose");

--- a/app/src-tauri/tests/support/mock_llm_helper.rs
+++ b/app/src-tauri/tests/support/mock_llm_helper.rs
@@ -12,12 +12,12 @@
 //! - `oversized_on_transform` — emit a length prefix over the 64 KiB frame cap
 //! - `slow_ack_cancel`     — never Result; reply Cancelled to a Cancel
 //! - `slow_honor_cancel`   — alias of `slow_ack_cancel` (cancel-honoring slow path
-//!                           for host-side cooperative-cancel tests)
+//!   for host-side cooperative-cancel tests)
 //! - `slow_ignore_cancel`  — never Result; ignore Cancel (forces a kill)
 //! - `slow_diagnostic_no_cancel_ack` — emit a diagnostic after Cancel, but no
-//!                           matching Cancelled acknowledgement
+//!   matching Cancelled acknowledgement
 //! - `diagnostic_before_cancel_ack_then_happy` — first request emits a
-//!                           diagnostic then Cancelled; later requests succeed
+//!   diagnostic then Cancelled; later requests succeed
 //! - `wrong_nonce_on_startup_phase` — a startup completion has a bad nonce
 //! - `wrong_version_on_startup_phase` — a later startup completion has a bad version
 //!

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -138,6 +138,11 @@ def validate_ci(ci: str) -> int:
     capture_build = named_step_block(
         ci, "Build capture isolation helpers and stub local-LLM externalBin", 6
     )
+    rust_install = named_step_block(ci, "Install Rust", 6)
+    assert "uses: dtolnay/rust-toolchain@1.96.0" in rust_install
+    assert "components: clippy" in rust_install
+    rust_lint = named_step_block(ci, "Lint Rust", 6)
+    assert "cargo clippy --all-targets -- -D warnings" in rust_lint
     assert "swiftc -warnings-as-errors" in capture_build
     assert "sidecars/capture-agent/main.swift" in capture_build
     assert "cargo build -p murmur-capture-helper" in capture_build

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,6 +18,19 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_ci_pins_and_enforces_clippy(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        for old in (
+            "        uses: dtolnay/rust-toolchain@1.96.0\n",
+            "          components: clippy\n",
+            "        run: cd app/src-tauri && cargo clippy --all-targets -- -D warnings\n",
+        ):
+            with self.subTest(policy=old.strip()):
+                mutated = workflow.replace(old, "", 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_ci(mutated)
+
     def test_dependency_audits_are_present_and_advisory(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         for old in (


### PR DESCRIPTION
Closes #482.

## Summary

This PR preserves the required order in three commits:

1. pin every Rust-installing CI/release workflow to Rust 1.96.0
2. clear the inherited Clippy warning baseline
3. add the Clippy merge gate only after the baseline is clean

The cleanup applies Clippy's 29 automatic suggestions, resolves the remaining mechanical findings directly, and uses only narrow item-level allowances where changing argument bundles or enum layout would become an out-of-scope structural refactor. Each allowance includes its local rationale.

The macOS Rust job now installs the pinned Clippy component and runs:

```text
cargo clippy --all-targets -- -D warnings
```

Workflow-policy mutation tests fail if the compiler pin, Clippy component, or gating command is removed.

## Verification

- `cd app/src-tauri && cargo clippy --all-targets -- -D warnings`
- `cd app/src-tauri && cargo check --all-targets`
- `cd app/src-tauri && cargo test --lib -- --test-threads=1` — 750 passed, 5 ignored
- `cd app/src-tauri && cargo test -p murmur-capture-helper` — 6 passed
- `cd app && npx tsc --noEmit`
- `cd app && npm test` — 649 passed
- `python3 scripts/validate_workflow_policy.py`
- `python3 -m unittest tests/test_workflow_policy.py` — 28 passed

Rustfmt is deliberately untouched here; issue #483 remains absolutely last in the health-sweep queue.

Base: `codex/health-sweep-integration` (stacked health-sweep branch). Do not merge this PR to `main`.
