### PR TITLE
Release: cut CHANGELOG version sections as part of release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,10 @@ jobs:
               - 'scripts/capture_agent_matrix.py'
               - 'scripts/smoke_test_capture_worker.py'
               - 'scripts/validate_capture_boundary.py'
+              - 'scripts/release_version.py'
               - 'infra/log-receiver/**'
               - 'tests/test_release_artifacts.py'
+              - 'tests/test_release_version.py'
               - 'tests/test_workflow_policy.py'
               - 'tests/test_capture_agent_matrix.py'
               - 'tests/test_capture_worker_smoke.py'
@@ -62,6 +64,7 @@ jobs:
           python3 scripts/validate_capture_boundary.py
           python3 -m unittest \
             tests/test_release_artifacts.py \
+            tests/test_release_version.py \
             tests/test_workflow_policy.py \
             tests/test_capture_agent_matrix.py \
             tests/test_capture_worker_smoke.py \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,7 +84,10 @@ jobs:
       - name: Workflow and artifact policy tests
         run: |
           python3 scripts/validate_workflow_policy.py
-          python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py
+          python3 -m unittest \
+            tests/test_release_artifacts.py \
+            tests/test_release_version.py \
+            tests/test_workflow_policy.py
 
   release-macos:
     needs: context

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Workflow and artifact policy tests
         run: |
           python3 scripts/validate_workflow_policy.py
-          python3 -m unittest tests/test_release_artifacts.py tests/test_workflow_policy.py
+          python3 -m unittest \
+            tests/test_release_artifacts.py \
+            tests/test_release_version.py \
+            tests/test_workflow_policy.py
 
   rehearse-macos:
     needs: context

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,47 +183,9 @@ jobs:
               exit 1
             fi
 
-            if ! VERSIONS=$(python3 - "$SOURCE_SHA" <<'PY'
-          import json
-          import re
-          import subprocess
-          import sys
-
-          sha = sys.argv[1]
-
-          def at(path: str) -> str:
-              return subprocess.check_output(
-                  ["git", "show", f"{sha}:{path}"], text=True
-              )
-
-          tauri_version = json.loads(at("app/src-tauri/tauri.conf.json"))["version"]
-          cargo = at("app/src-tauri/Cargo.toml")
-          package = re.search(r"^\[package\]\s*(.*?)(?=^\[|\Z)", cargo, re.M | re.S)
-          cargo_version = re.search(
-              r'^version\s*=\s*"([^"]+)"', package.group(1), re.M
-          ).group(1)
-          lock = at("app/src-tauri/Cargo.lock")
-          ui_package = next(
-              block
-              for block in re.split(r"^\[\[package\]\]\s*$", lock, flags=re.M)
-              if re.search(r'^name\s*=\s*"ui"\s*$', block, re.M)
-          )
-          lock_version = re.search(
-              r'^version\s*=\s*"([^"]+)"', ui_package, re.M
-          ).group(1)
-          print(tauri_version, cargo_version, lock_version)
-          PY
-            ); then
-              echo "ERROR: could not read release versions from $SOURCE_SHA"
-              exit 1
-            fi
-            read -r VERSION CARGO_VERSION LOCK_VERSION <<< "$VERSIONS"
-            if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-              echo "ERROR: invalid release version: $VERSION"
-              exit 1
-            fi
-            if [ "$CARGO_VERSION" != "$VERSION" ] || [ "$LOCK_VERSION" != "$VERSION" ]; then
-              echo "ERROR: release versions differ: tauri=$VERSION cargo=$CARGO_VERSION lock=$LOCK_VERSION"
+            if ! VERSION=$(python3 scripts/release_version.py check \
+                --git-ref "$SOURCE_SHA"); then
+              echo "ERROR: release versions or CHANGELOG differ at $SOURCE_SHA"
               exit 1
             fi
             RESOLVED_TAG="v$VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-08-07
+
+### Fixed
+
+- Main-window title-bar content now aligns with the native macOS traffic lights
+  without crowding the recording controls (#471).
+- The NotchPill caption-mirroring toggle now appears only when macOS finds the
+  companion app. Removing NotchPill makes mirroring dormant and deletes the
+  stale caption while preserving the preference for a later reinstall (#474).
+
+## [0.28.0] - 2026-08-06
+
+### Added
+
+- An opt-in integration mirrors live Murmur captions to NotchPill while keeping
+  the feature disabled by default and deleting the caption when switched off
+  (#468).
+
+### Changed
+
+- Header, settings-navigation, native-spacing, and waveform fixes complete the
+  history-workspace redesign introduced in 0.27.0 (#469).
+
+## [0.27.1] - 2026-08-06
+
+### Fixed
+
+- Main-window chrome, transcript cards, and Settings now follow shared geometry
+  tokens: native traffic lights align with the single header row, Record and
+  status controls remain stable across recording states, and Copy no longer
+  reserves space in transcript metadata (#466).
+
+## [0.27.0] - 2026-08-06
+
 ### Changed
 
 - The main window now uses one line of recording chrome and gives the transcript
@@ -15,6 +49,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   consolidated six-tab editor window, onboarding includes explicit hotkey setup,
   diagnostics uses the Events / Runs / Performance / Compare / Transform order,
   and the notch overlay supports persisted vertical calibration.
+- Spoken structure and number formatting now share one deterministic transform,
+  and obsolete audio states have been removed (#462, #463).
+
+### Added
+
+- Fleet log install pages now show the last proven microphone activation and
+  last non-empty live transcription with relative and exact Eastern timestamps,
+  derived from the complete retained event stream with bounded memory (#459).
+- Fleet log install pages now offer exact latest-200/latest-500 JSONL downloads
+  and LLM-ready Markdown reports with plain-English event meanings, grouped
+  findings, bounded device context, and untrusted-telemetry guidance (#457).
+
+## [0.26.0] - 2026-08-04
+
+### Added
+
+- The fleet diagnostics dashboard now leads with privacy-safe plain-English
+  health for microphone capture, shortcuts, dictation, updates, and transforms;
+  repeated warnings collapse into counted incidents, recovered fallback is
+  distinguished from failure, and raw technical evidence remains expandable
+  (#454).
+- The vocabulary editor is more compact and easier to scan and edit (#453).
+
+### Changed
+
+- Dictation no longer pays the previous fixed latency floor after capture
+  completes (#456).
+
+## [0.25.4] - 2026-08-04
+
+### Added
+
+- Maintainers can request bounded, on-demand diagnostic probes from installs
+  that explicitly opted into remote hang diagnostics (#452).
+
+## [0.25.3] - 2026-08-04
+
+### Added
+
+- Consented installs can be armed for privacy-bounded microphone hang
+  diagnostics, with safe truncation and explicit server control (#451).
+
+## [0.25.2] - 2026-08-04
+
+### Fixed
+
+- Capture remembers first-attempt backend hangs, gives the primary attempt a
+  bounded budget, and safely resets the slow-rescue preference (#450).
+
+## [0.25.1] - 2026-08-04
+
+### Fixed
+
+- A session-scoped backend preference skips repeated AUHAL timeouts and records
+  per-call capture timing without leaking device details (#445).
+
+## [0.25.0] - 2026-08-03
+
+### Changed
+
 - Settings now uses the full workspace below the status bar: dashboard usage
   cards hide while Settings is open, and Performance begins directly with its
   diagnostics tabs instead of repeating a page title (#441).
@@ -25,45 +119,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- The NotchPill caption-mirroring toggle now appears only when macOS finds the
-  companion app. Removing NotchPill makes mirroring dormant and deletes the
-  stale caption while preserving the preference for a later reinstall (#474).
-- Main-window chrome, transcript cards, and Settings now follow shared geometry
-  tokens: native traffic lights align with the single header row, Record and
-  status controls remain stable across recording states, and Copy no longer
-  reserves space in transcript metadata (#466).
 - Microphone initialization now gives AUHAL and CPAL separate bounded attempts,
   requires confirmed helper termination before fallback, honors Stop between
   attempts, suspends active deadlines during a pending macOS permission prompt,
   and reports privacy-safe setup sub-phases for root-cause attribution. This is
   a capture-contract repair, not a claim that the underlying Core Audio hang is
   eliminated (#436).
+
+## [0.24.2] - 2026-08-02
+
+### Fixed
+
 - In-app updates now detect macOS Gatekeeper App Translocation before
   downloading, explain how to reinstall Murmur from Finder, and distinguish
   installation failures from update-check failures (#432).
+
+## [0.24.1] - 2026-08-02
+
+### Fixed
+
 - The signed production capture worker now uses standalone microphone sandbox
   entitlements instead of invalid inheritance, preventing macOS from terminating
   it before protocol startup. Release builds execute the final packaged worker's
   hello/start handshake, and protocol startup failures no longer appear as
   unsupported microphone configurations or retry another backend (#428).
-- macOS microphone startup now tries the direct AUHAL capture path before CPAL,
-  avoiding an unbounded CPAL stream-open stall observed with healthy USB default
-  inputs. Content-free phase timings distinguish helper launch, stream open,
-  first callback, first retained PCM, and stop-to-exit latency (#426).
+
+## [0.24.0] - 2026-08-01
 
 ### Added
 
-- Fleet log install pages now show the last proven microphone activation and
-  last non-empty live transcription with relative and exact Eastern timestamps,
-  derived from the complete retained event stream with bounded memory (#459).
-- Fleet log install pages now offer exact latest-200/latest-500 JSONL downloads
-  and LLM-ready Markdown reports with plain-English event meanings, grouped
-  findings, bounded device context, and untrusted-telemetry guidance (#457).
-- The fleet diagnostics dashboard now leads with privacy-safe plain-English
-  health for microphone capture, shortcuts, dictation, updates, and transforms;
-  repeated warnings collapse into counted incidents, recovered fallback is
-  distinguished from failure, and raw technical evidence remains expandable
-  (#454).
 - Production microphone capture now runs behind a signed, killable helper with
   capture-scoped binary PCM framing, an allocation-free SPSC callback boundary,
   CPAL and direct AUHAL backends, exact-device pre-buffer failover, deterministic
@@ -75,6 +159,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   the signed/notarized TCC matrix (#407).
 - Update availability now stays visible without a backend or disruptive optional-update modal: Murmur performs due-gated checks on macOS wake and foreground activation, adds a native menu-bar check/update action, and keeps a versioned pill beside Record and Transcribe File until the release is installed or skipped.
 - Dictated prose can now include bounded inline slash-command references such as `slash command chat` → `/chat` without reformatting the surrounding sentence.
+
+### Fixed
+
+- macOS microphone startup now tries the direct AUHAL capture path before CPAL,
+  avoiding an unbounded CPAL stream-open stall observed with healthy USB default
+  inputs. Content-free phase timings distinguish helper launch, stream open,
+  first callback, first retained PCM, and stop-to-exit latency (#426).
+- Clipboard auto-paste bypasses the slow accessibility no-value fallback when
+  an application does not expose a writable accessibility target (#394).
 
 ## [0.23.9] - 2026-07-30
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.1.0",
+      "version": "0.28.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.28.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/release.md
+++ b/docs/release.md
@@ -48,8 +48,10 @@ run ID, platform/updater names, sizes, and SHA-256 hashes. Promotion accepts one
 unexpired macOS artifact and one unexpired Linux artifact from a successful
 `Release Build` on `main` for the exact source commit. Automatic promotion also
 requires a successful `push` event, the version-bump commit prefix, and matching
-semver values in `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`. Any tag, run,
-filename, version, hash, or updater-signature mismatch fails before publication.
+semver values in `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `package.json`,
+and `package-lock.json`. The newest dated CHANGELOG section must match that same
+version. Any tag, run, filename, version, changelog, hash, or updater-signature
+mismatch fails before publication.
 
 The modern updater manifest is generated from the downloaded `.sig` files.
 After release-asset upload, the workflow downloads the remote `.sig` assets and
@@ -105,10 +107,13 @@ SHA-named artifacts exist for the version-bump commit.
 ## Release authorization and recovery
 
 `prompts/PROMPT_RELEASE.md` requires explicit confirmation before pushing the
-version-bump commit. That push is the release action: after its exact trusted
-build succeeds, `Release` validates the run and three synchronized version files,
-downloads and verifies the immutable artifacts, creates `vX.Y.Z`, prepares the
-release, verifies remote updater integrity, and publishes.
+version-bump commit. `scripts/release_version.py prepare X.Y.Z` synchronizes the
+five version surfaces and cuts `[Unreleased]` into the dated release section;
+its `check` command enforces the same contract locally and during promotion.
+That push is the release action: after its exact trusted build succeeds,
+`Release` validates the run, synchronized versions, and CHANGELOG, downloads and
+verifies the immutable artifacts, creates `vX.Y.Z`, prepares the release,
+verifies remote updater integrity, and publishes.
 
 Manual `Release Build` dispatches remain non-publishing rehearsals, even when
 they succeed. The tag trigger remains an operator recovery path for an automatic

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -7,6 +7,8 @@ You are starting a release session for the Murmur project. Work autonomously thr
 Read silently:
 - `app/src-tauri/tauri.conf.json` — current version
 - `app/src-tauri/Cargo.toml` — current version (must stay in sync)
+- `app/package.json` — current frontend package version (must stay in sync)
+- `app/package-lock.json` — current frontend lockfile version (must stay in sync)
 - `CHANGELOG.md` — version history
 
 ## 2. Assess Current State
@@ -59,13 +61,16 @@ the version bump, main push, and automatic tag/publish after all gates pass.
 
 Run these steps in order:
 
-1. Bump `"version"` in `app/src-tauri/tauri.conf.json`
-2. Bump `version` (package field only) in `app/src-tauri/Cargo.toml`
-3. Update the `ui` package version in `app/src-tauri/Cargo.lock`
-4. Commit all three version files with: `chore: bump version to {new_version}`
-5. Push: `git push origin main`
-6. Wait for the `Release Build` workflow on that exact commit to succeed.
-7. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
+1. Run `python3 scripts/release_version.py prepare {new_version}`. This updates
+   `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `package.json`, and
+   `package-lock.json`, cuts the current `[Unreleased]` notes into a dated
+   `{new_version}` section, and opens a fresh empty `[Unreleased]` section.
+2. Review the version-file and CHANGELOG diff, then run
+   `python3 scripts/release_version.py check {new_version}`.
+3. Commit all six release files with: `chore: bump version to {new_version}`
+4. Push: `git push origin main`
+5. Wait for the `Release Build` workflow on that exact commit to succeed.
+6. Verify its `typecheck`, `release-macos`, and `release-linux` jobs, signed
    artifacts named with the exact 40-character commit SHA, package smoke tests,
    and cache summaries. Do not continue if any job or artifact is missing.
 

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Prepare and validate Murmur's synchronized release version surfaces."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+PATHS = {
+    "tauri": Path("app/src-tauri/tauri.conf.json"),
+    "cargo": Path("app/src-tauri/Cargo.toml"),
+    "lock": Path("app/src-tauri/Cargo.lock"),
+    "package": Path("app/package.json"),
+    "package_lock": Path("app/package-lock.json"),
+    "changelog": Path("CHANGELOG.md"),
+}
+
+
+class ReleaseVersionError(ValueError):
+    """A release version surface is missing, malformed, or inconsistent."""
+
+
+def _read(root: Path, relative: Path, git_ref: str | None = None) -> str:
+    if git_ref is None:
+        return (root / relative).read_text()
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(root), "show", f"{git_ref}:{relative.as_posix()}"],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or str(error)
+        raise ReleaseVersionError(
+            f"could not read {relative} at {git_ref}: {detail}"
+        ) from error
+
+
+def _cargo_package_version(text: str, path: Path) -> str:
+    package = re.search(r"^\[package\]\s*(.*?)(?=^\[|\Z)", text, re.M | re.S)
+    if package is None:
+        raise ReleaseVersionError(f"{path}: missing [package] block")
+    version = re.search(r'^version\s*=\s*"([^"]+)"', package.group(1), re.M)
+    if version is None:
+        raise ReleaseVersionError(f"{path}: missing package version")
+    return version.group(1)
+
+
+def _cargo_lock_version(text: str, path: Path) -> str:
+    for block in re.split(r"^\[\[package\]\]\s*$", text, flags=re.M):
+        if re.search(r'^name\s*=\s*"ui"\s*$', block, re.M):
+            version = re.search(r'^version\s*=\s*"([^"]+)"', block, re.M)
+            if version is None:
+                break
+            return version.group(1)
+    raise ReleaseVersionError(f"{path}: missing ui package version")
+
+
+def _json(text: str, path: Path) -> dict:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ReleaseVersionError(f"{path}: invalid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseVersionError(f"{path}: expected a JSON object")
+    return value
+
+
+def _package_lock_version(value: dict, path: Path) -> str:
+    root_package = value.get("packages", {}).get("", {})
+    top = value.get("version")
+    nested = root_package.get("version")
+    if not isinstance(top, str) or not isinstance(nested, str):
+        raise ReleaseVersionError(f"{path}: missing root package versions")
+    if top != nested:
+        raise ReleaseVersionError(
+            f"{path}: top-level version {top!r} differs from root package {nested!r}"
+        )
+    return top
+
+
+def _latest_changelog_version(text: str, path: Path) -> str:
+    headings = list(
+        re.finditer(
+            r"^## \[([^\]]+)\](?: - (\d{4}-\d{2}-\d{2}))?\s*$",
+            text,
+            re.M,
+        )
+    )
+    if not headings or headings[0].group(1) != "Unreleased":
+        raise ReleaseVersionError(f"{path}: missing top-level [Unreleased] section")
+    if len(headings) < 2 or headings[1].group(2) is None:
+        raise ReleaseVersionError(
+            f"{path}: [Unreleased] must be followed by a dated release section"
+        )
+    try:
+        date.fromisoformat(headings[1].group(2))
+    except ValueError as error:
+        raise ReleaseVersionError(
+            f"{path}: invalid release date {headings[1].group(2)!r}"
+        ) from error
+    return headings[1].group(1)
+
+
+def release_versions(
+    root: Path = ROOT, git_ref: str | None = None
+) -> dict[str, str]:
+    tauri_path = PATHS["tauri"]
+    cargo_path = PATHS["cargo"]
+    lock_path = PATHS["lock"]
+    package_path = PATHS["package"]
+    package_lock_path = PATHS["package_lock"]
+    changelog_path = PATHS["changelog"]
+
+    tauri = _json(_read(root, tauri_path, git_ref), tauri_path)
+    package = _json(_read(root, package_path, git_ref), package_path)
+    package_lock = _json(
+        _read(root, package_lock_path, git_ref), package_lock_path
+    )
+    versions = {
+        "tauri.conf.json": tauri.get("version"),
+        "Cargo.toml": _cargo_package_version(
+            _read(root, cargo_path, git_ref), cargo_path
+        ),
+        "Cargo.lock": _cargo_lock_version(
+            _read(root, lock_path, git_ref), lock_path
+        ),
+        "package.json": package.get("version"),
+        "package-lock.json": _package_lock_version(
+            package_lock, package_lock_path
+        ),
+        "CHANGELOG.md": _latest_changelog_version(
+            _read(root, changelog_path, git_ref), changelog_path
+        ),
+    }
+    for surface, version in versions.items():
+        if not isinstance(version, str):
+            raise ReleaseVersionError(f"{surface}: missing version")
+    return versions
+
+
+def check_release(
+    expected: str | None = None,
+    *,
+    root: Path = ROOT,
+    git_ref: str | None = None,
+) -> str:
+    versions = release_versions(root, git_ref)
+    expected = expected or versions["tauri.conf.json"]
+    if not SEMVER.fullmatch(expected):
+        raise ReleaseVersionError(f"invalid release version: {expected}")
+    mismatches = {
+        surface: version
+        for surface, version in versions.items()
+        if version != expected
+    }
+    if mismatches:
+        detail = ", ".join(
+            f"{surface}={version}" for surface, version in mismatches.items()
+        )
+        raise ReleaseVersionError(
+            f"release versions differ from expected {expected}: {detail}"
+        )
+    return expected
+
+
+def _replace_package_version(text: str, version: str, path: Path) -> str:
+    package = re.search(r"^\[package\]\s*(.*?)(?=^\[|\Z)", text, re.M | re.S)
+    if package is None:
+        raise ReleaseVersionError(f"{path}: missing [package] block")
+    block = package.group(0)
+    replaced, count = re.subn(
+        r'(^version\s*=\s*")[^"]+(")',
+        rf"\g<1>{version}\g<2>",
+        block,
+        count=1,
+        flags=re.M,
+    )
+    if count != 1:
+        raise ReleaseVersionError(f"{path}: missing package version")
+    return text[: package.start()] + replaced + text[package.end() :]
+
+
+def _replace_lock_version(text: str, version: str, path: Path) -> str:
+    blocks = list(re.finditer(r"^\[\[package\]\]\s*$", text, re.M))
+    for index, marker in enumerate(blocks):
+        end = blocks[index + 1].start() if index + 1 < len(blocks) else len(text)
+        block = text[marker.start() : end]
+        if not re.search(r'^name\s*=\s*"ui"\s*$', block, re.M):
+            continue
+        replaced, count = re.subn(
+            r'(^version\s*=\s*")[^"]+(")',
+            rf"\g<1>{version}\g<2>",
+            block,
+            count=1,
+            flags=re.M,
+        )
+        if count != 1:
+            break
+        return text[: marker.start()] + replaced + text[end:]
+    raise ReleaseVersionError(f"{path}: missing ui package version")
+
+
+def _cut_changelog(text: str, version: str, release_date: str, path: Path) -> str:
+    _latest_changelog_version(text, path)
+    if re.search(rf"^## \[{re.escape(version)}\](?:\s|$)", text, re.M):
+        raise ReleaseVersionError(f"{path}: release section {version} already exists")
+    unreleased = re.search(
+        r"^## \[Unreleased\]\s*\n(?P<body>.*?)(?=^## \[)",
+        text,
+        re.M | re.S,
+    )
+    if unreleased is None:
+        raise ReleaseVersionError(f"{path}: missing [Unreleased] section")
+    if not unreleased.group("body").strip():
+        raise ReleaseVersionError(f"{path}: [Unreleased] has no release notes")
+    return (
+        text[: unreleased.start()]
+        + "## [Unreleased]\n\n"
+        + f"## [{version}] - {release_date}\n\n"
+        + unreleased.group("body").lstrip("\n")
+        + text[unreleased.end() :]
+    )
+
+
+def prepare_release(
+    version: str,
+    release_date: str,
+    *,
+    root: Path = ROOT,
+) -> None:
+    if not SEMVER.fullmatch(version):
+        raise ReleaseVersionError(f"invalid release version: {version}")
+    try:
+        date.fromisoformat(release_date)
+    except ValueError as error:
+        raise ReleaseVersionError(f"invalid release date: {release_date}") from error
+
+    originals = {name: _read(root, path) for name, path in PATHS.items()}
+    tauri = _json(originals["tauri"], PATHS["tauri"])
+    package = _json(originals["package"], PATHS["package"])
+    package_lock = _json(originals["package_lock"], PATHS["package_lock"])
+
+    tauri["version"] = version
+    package["version"] = version
+    package_lock["version"] = version
+    root_package = package_lock.get("packages", {}).get("")
+    if not isinstance(root_package, dict):
+        raise ReleaseVersionError(
+            f"{PATHS['package_lock']}: missing root package metadata"
+        )
+    root_package["version"] = version
+
+    updated = {
+        "tauri": json.dumps(tauri, indent=2) + "\n",
+        "cargo": _replace_package_version(
+            originals["cargo"], version, PATHS["cargo"]
+        ),
+        "lock": _replace_lock_version(originals["lock"], version, PATHS["lock"]),
+        "package": json.dumps(package, indent=2) + "\n",
+        "package_lock": json.dumps(package_lock, indent=2) + "\n",
+        "changelog": _cut_changelog(
+            originals["changelog"], version, release_date, PATHS["changelog"]
+        ),
+    }
+    for name, content in updated.items():
+        (root / PATHS[name]).write_text(content)
+    check_release(version, root=root)
+
+
+def _run(action: Callable[[], str | None]) -> int:
+    try:
+        result = action()
+    except (OSError, ReleaseVersionError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if result is not None:
+        print(result)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser(
+        "prepare", help="bump every version surface and cut [Unreleased]"
+    )
+    prepare.add_argument("version")
+    prepare.add_argument("--date", default=date.today().isoformat())
+    check = subparsers.add_parser(
+        "check", help="verify every version surface at the worktree or a git ref"
+    )
+    check.add_argument("version", nargs="?")
+    check.add_argument("--git-ref")
+    args = parser.parse_args()
+
+    if args.command == "prepare":
+        return _run(lambda: prepare_release(args.version, args.date))
+    return _run(lambda: check_release(args.version, git_ref=args.git_ref))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -100,12 +100,26 @@ def should_auto_promote(
 
 
 def release_tag_for_versions(
-    tauri_version: str, cargo_version: str, lock_version: str
+    tauri_version: str,
+    cargo_version: str,
+    lock_version: str,
+    package_version: str,
+    package_lock_version: str,
+    changelog_version: str,
 ) -> str:
     if not SEMVER.fullmatch(tauri_version):
         raise AssertionError(f"invalid release version: {tauri_version}")
-    if cargo_version != tauri_version or lock_version != tauri_version:
-        raise AssertionError("tauri.conf.json, Cargo.toml, and Cargo.lock differ")
+    if any(
+        version != tauri_version
+        for version in (
+            cargo_version,
+            lock_version,
+            package_version,
+            package_lock_version,
+            changelog_version,
+        )
+    ):
+        raise AssertionError("release version surfaces differ")
     return f"v{tauri_version}"
 
 
@@ -132,7 +146,9 @@ def validate_ci(ci: str) -> int:
     assert "scripts/validate_workflow_policy.py" in ci
     assert "scripts/release_artifacts.py" in ci
     assert "scripts/capture_agent_matrix.py" in ci
+    assert "'scripts/release_version.py'" in ci
     assert "tests/test_release_artifacts.py" in ci
+    assert "tests/test_release_version.py" in ci
     assert "tests/test_workflow_policy.py" in ci
     assert "tests/test_capture_agent_matrix.py" in ci
     capture_build = named_step_block(
@@ -182,6 +198,7 @@ def validate_release_build(workflow: str) -> int:
     assert "pull_request" not in workflow
     assert "self-hosted" not in workflow
     assert "contents: write" not in workflow
+    assert "tests/test_release_version.py" in workflow
     assert scalar(job_block(workflow, "context"), "if") == RELEASE_BUILD_GUARD
     for job in ("typecheck", "release-macos", "release-linux"):
         assert scalar(job_block(workflow, job), "needs") == "context"
@@ -278,6 +295,7 @@ def validate_release_rehearsal(workflow: str) -> int:
     for forbidden_trigger in ("\n  push:", "\n  pull_request:", "\n  workflow_run:"):
         assert forbidden_trigger not in workflow
     assert "permissions:\n  contents: read" in workflow
+    assert "tests/test_release_version.py" in workflow
     for forbidden in (
         "secrets.",
         "GITHUB_TOKEN",
@@ -473,13 +491,12 @@ def validate_promotion_policy(workflow: str) -> int:
     assert 'split("@")[0]) == ".github/workflows/release-build.yml"' in workflow
     assert "expired == false" in workflow
     assert "scripts/release_artifacts.py validate" in workflow
+    assert "scripts/release_version.py check" in workflow
+    assert '--git-ref "$SOURCE_SHA"' in workflow
     assert "--require-macos-capture-helper" in workflow
     assert "--require-macos-capture-agent" in workflow
     assert "--require-macos-capture-worker" in workflow
-    assert 'at("app/src-tauri/tauri.conf.json")' in workflow
-    assert 'at("app/src-tauri/Cargo.toml")' in workflow
-    assert 'at("app/src-tauri/Cargo.lock")' in workflow
-    assert "release versions differ" in workflow
+    assert "release versions or CHANGELOG differ" in workflow
     assert "already_published=true" in workflow
     assert "contains unexpected asset" in workflow
     assert 'gh release view "$TAG"' in workflow
@@ -524,7 +541,7 @@ def validate_promotion_policy(workflow: str) -> int:
     expected = (True, False, False, False, False)
     for case, result in zip(auto_cases, expected):
         assert should_auto_promote(**case) is result
-    assert release_tag_for_versions("0.18.0", "0.18.0", "0.18.0") == "v0.18.0"
+    assert release_tag_for_versions(*(["0.18.0"] * 6)) == "v0.18.0"
     assert tag_action(None, "a" * 40) == "create"
     assert tag_action("a" * 40, "a" * 40) == "reuse"
     return len(publish_steps) + len(auto_cases)

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+import json
+import tempfile
+import unittest
+
+from scripts.release_version import (
+    ReleaseVersionError,
+    check_release,
+    prepare_release,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_fixture(root: Path, *, package_version: str = "1.2.3") -> None:
+    paths = (
+        root / "app/src-tauri",
+        root / "app",
+    )
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+    (root / "app/src-tauri/tauri.conf.json").write_text(
+        json.dumps({"version": "1.2.3"}, indent=2) + "\n"
+    )
+    (root / "app/src-tauri/Cargo.toml").write_text(
+        '[package]\nname = "ui"\nversion = "1.2.3"\n\n[dependencies]\n'
+    )
+    (root / "app/src-tauri/Cargo.lock").write_text(
+        'version = 4\n\n[[package]]\nname = "ui"\nversion = "1.2.3"\n'
+    )
+    (root / "app/package.json").write_text(
+        json.dumps(
+            {"name": "ui", "version": package_version, "private": True}, indent=2
+        )
+        + "\n"
+    )
+    (root / "app/package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "ui",
+                "version": package_version,
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"name": "ui", "version": package_version},
+                },
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Fixed\n\n"
+        "- A user-visible fix.\n\n"
+        "## [1.2.3] - 2026-01-01\n\n"
+        "- Previous release.\n"
+    )
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def test_prepare_updates_all_surfaces_and_cuts_changelog(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root)
+
+            prepare_release("1.3.0", "2026-02-03", root=root)
+
+            self.assertEqual(check_release(root=root), "1.3.0")
+            changelog = (root / "CHANGELOG.md").read_text()
+            self.assertIn(
+                "## [Unreleased]\n\n## [1.3.0] - 2026-02-03\n\n### Fixed",
+                changelog,
+            )
+
+    def test_check_rejects_each_stale_version_surface(self) -> None:
+        surfaces = (
+            "app/src-tauri/tauri.conf.json",
+            "app/src-tauri/Cargo.toml",
+            "app/src-tauri/Cargo.lock",
+            "app/package.json",
+            "app/package-lock.json",
+            "CHANGELOG.md",
+        )
+        for surface in surfaces:
+            with (
+                self.subTest(surface=surface),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                write_fixture(root)
+                path = root / surface
+                path.write_text(path.read_text().replace("1.2.3", "1.2.2"))
+                with self.assertRaises(ReleaseVersionError):
+                    check_release("1.2.3", root=root)
+
+    def test_check_requires_unreleased_then_current_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root)
+            changelog = root / "CHANGELOG.md"
+            text = changelog.read_text()
+            changelog.write_text(
+                text.replace(
+                    "## [Unreleased]\n\n### Fixed",
+                    "## [1.2.2] - 2025-12-31\n\n## [Unreleased]\n\n### Fixed",
+                )
+            )
+
+            with self.assertRaisesRegex(
+                ReleaseVersionError, r"top-level \[Unreleased\]"
+            ):
+                check_release("1.2.3", root=root)
+
+    def test_prepare_refuses_empty_unreleased_section(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_fixture(root)
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text(
+                changelog.read_text().replace(
+                    "### Fixed\n\n- A user-visible fix.\n\n", ""
+                )
+            )
+
+            with self.assertRaisesRegex(
+                ReleaseVersionError, r"\[Unreleased\] has no release notes"
+            ):
+                prepare_release("1.3.0", "2026-02-03", root=root)
+
+    def test_repository_release_surfaces_are_synchronized(self) -> None:
+        self.assertEqual(check_release("0.28.1", root=ROOT), "0.28.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -126,16 +126,30 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
 
     def test_release_versions_must_match(self) -> None:
         self.assertEqual(
-            release_tag_for_versions("0.18.0", "0.18.0", "0.18.0"), "v0.18.0"
+            release_tag_for_versions(*(["0.18.0"] * 6)), "v0.18.0"
         )
         for versions in (
-            ("0.18", "0.18", "0.18"),
-            ("0.18.0", "0.17.1", "0.18.0"),
-            ("0.18.0", "0.18.0", "0.17.1"),
+            ("0.18",) * 6,
+            ("0.18.0", "0.17.1", "0.18.0", "0.18.0", "0.18.0", "0.18.0"),
+            ("0.18.0", "0.18.0", "0.18.0", "0.17.1", "0.18.0", "0.18.0"),
+            ("0.18.0", "0.18.0", "0.18.0", "0.18.0", "0.17.1", "0.18.0"),
+            ("0.18.0", "0.18.0", "0.18.0", "0.18.0", "0.18.0", "0.17.1"),
         ):
             with self.subTest(versions=versions):
                 with self.assertRaises(AssertionError):
                     release_tag_for_versions(*versions)
+
+    def test_promotion_requires_release_version_and_changelog_gate(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        for marker in (
+            "scripts/release_version.py check",
+            '--git-ref "$SOURCE_SHA"',
+        ):
+            with self.subTest(marker=marker):
+                mutated = workflow.replace(marker, "echo skipped", 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_promotion_policy(mutated)
 
     def test_existing_tag_must_match_source_commit(self) -> None:
         source = "a" * 40


### PR DESCRIPTION
Closes #484

## Summary
- backfill dated CHANGELOG sections for every release from v0.24.0 through the current v0.28.1 tag
- add a single release-version tool that synchronizes Tauri, Cargo, npm, both lockfiles, and cuts `[Unreleased]`
- make promotion validate all version surfaces plus the newest dated CHANGELOG section at the exact source SHA
- align the existing npm package metadata from 0.1.0 to 0.28.1
- update release operator docs and add mutation/fixture coverage so drift fails mechanically

## Validation
- `python3 scripts/release_version.py check 0.28.1`
- `python3 scripts/release_version.py check --git-ref HEAD`
- 106 Python release, workflow-policy, capture, and log-receiver tests
- workflow policy and capture-boundary validators
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --all-targets`
- `cargo test --lib -- --test-threads=1` (750 passed, 5 ignored)
- `cargo test -p murmur-capture-helper` (6 passed)
- `npx tsc --noEmit`
- `npm test` (652 passed)
- `git diff --check`

## Issue accuracy
The issue correctly identified a process bug rather than missing changelog authorship. The repository had advanced to v0.28.1 while this work was in flight, so the backfill and synchronization target include that patch release as well as the requested v0.24-v0.28 range.