### PR TITLE
fix(release): unpin hardcoded version from release-surface test

### DIFF
--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -130,7 +130,13 @@ class ReleaseVersionTests(unittest.TestCase):
                 prepare_release("1.3.0", "2026-02-03", root=root)
 
     def test_repository_release_surfaces_are_synchronized(self) -> None:
-        self.assertEqual(check_release("0.28.1", root=ROOT), "0.28.1")
+        # No pinned literal: check_release() self-validates every release
+        # surface against tauri.conf.json. Pinning the current version here
+        # would make this test fail at the next version-bump commit — which
+        # release-build.yml runs it on — and block the release after the bump
+        # is already on main.
+        version = check_release(root=ROOT)
+        self.assertRegex(version, r"^\d+\.\d+\.\d+$")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`tests/test_release_version.py` pinned `check_release("0.28.1")`. `release-build.yml` and `release-rehearsal.yml` run this test **at the version-bump commit**, so the next release (0.28.2, 0.29.0, anything) would fail its own Release Build typecheck job and be rejected by promotion — and the failure only surfaces after the bump is already pushed to main. Nothing in the release docs says to update the constant, and the release session's local gate (`release_version.py check <new>`) passes, so this was a guaranteed future release-breaker.

## Fix

Call `check_release(root=ROOT)` with no expected argument — it already self-validates that all six release surfaces match `tauri.conf.json`, which is the synchronization property this test exists to pin. Assert the result is a semver instead of a specific version.

## Verification

- `python3 -m unittest tests/test_release_version.py` — 5 tests OK
- `python3 -m unittest discover -s tests` — full suite OK

Found in the post-merge fable review of #506 (health-sweep group, finding F1, confidence 9/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)