### PR TITLE
fix(transform): keep ASR warm through instruction capture on prewarm

### DIFF
--- a/app/src-tauri/src/llm_sidecar.rs
+++ b/app/src-tauri/src/llm_sidecar.rs
@@ -944,7 +944,14 @@ mod supported {
             if inner.child.is_none() {
                 let model_path = self.plan.model_path()?;
                 let mut diagnostics = SidecarDiagnostics::default();
-                self.guard().release_asr();
+                // Deliberately NOT releasing the ASR model here: the pass that
+                // armed this prewarm still needs it to transcribe the spoken
+                // instruction after key-release, and unloading it now would put
+                // a cold ASR reload on that critical path. The single-heavy-
+                // runtime rule is restored by the release in
+                // finish_transform_instruction once the instruction ASR is
+                // done; until then the two runtimes briefly co-reside while
+                // the helper loads under the held key.
                 match self.spawn_and_handshake(&model_path, cancel, &mut diagnostics) {
                     Ok(child) => inner.child = Some(child),
                     Err(TransformError::ModelMismatch) => {

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -2193,6 +2193,19 @@ pub(crate) async fn finish_transform_instruction(
         };
     let audio_duration_ms = samples.len() as u64 * 1_000 / crate::state::WHISPER_SAMPLE_RATE as u64;
     let input_bytes = original.len();
+    // Instruction ASR is done; release the ASR model before generation so at
+    // most one heavy runtime is resident from here on. A prewarmed helper
+    // (child already spawned) skips the request path's own release, so this is
+    // the only site that restores the invariant on that path; on the cold path
+    // the request-time release is an idempotent no-op after this one. Skipped
+    // on transcription failure — the pass ends or retries instruction capture,
+    // and both need ASR again.
+    if instruction.is_ok() {
+        let _ = state.app_state.model_runtime.unload(
+            Some(&app_handle),
+            crate::model_runtime::UnloadReason::MemoryPressure,
+        );
+    }
     if let Some(guard) = performance_guard.as_mut() {
         guard.enter(PerformanceStageV1::SidecarSpawnLoad);
     }


### PR DESCRIPTION
## Problem

`prewarm_blocking` (llm_sidecar.rs) called `release_asr()` at transform key-down. The pass that armed the prewarm still needs ASR **after key-release** to transcribe the spoken instruction (`finish_transform_instruction` → `transcribe_instruction` → `with_ready_backend`), so on the standard first-transform flow — dictation model warm, sidecar cold, exactly the scenario prewarm targets — the instruction stage paid a full cold whisper reload on the key-release critical path (1–3 s before Thinking). And because that reload happened after the LLM helper was already up, generation ran with **both** heavy runtimes resident anyway, defeating the single-heavy-runtime rule the release exists to enforce. Aborted key-taps also paid the ASR unload for nothing.

## Fix

- `prewarm_blocking` no longer releases ASR — the helper loads under the held key while ASR stays warm (bounded, deliberate co-residency during the hold).
- `finish_transform_instruction` releases ASR once instruction transcription succeeds, before generation, restoring the single-heavy-runtime invariant for the generation window.
- Non-prewarmed cold path unchanged: the request-time release at spawn still fires (idempotent no-op when the new site already ran).
- Transcription failure skips the release — the pass either ends or re-records the instruction, and both need ASR again.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --all-targets`
- `cargo test --lib -- --test-threads=1` — 754 passed
- `cargo build --example mock_llm_helper && cargo test --test llm_sidecar_integration --test transform_flow_integration -- --test-threads=1` — 25 passed

Found in the post-merge fable review of #506 (transform-latency group, finding F1, confidence 8/10). Touches `llm_sidecar.rs` in a different function than the streaming coalescing work on `fix/post-506-review-followups`; no textual overlap expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)