### PR TITLE
docs(sidecar): restore helper-side chunk-invariant comment

### DIFF
--- a/app/src-tauri/sidecars/local-llm/src/main.rs
+++ b/app/src-tauri/sidecars/local-llm/src/main.rs
@@ -423,6 +423,11 @@ mod macos_arm64 {
                     break;
                 }
                 output.push_str(&piece);
+                // PROTOCOL INVARIANT: every non-empty piece is emitted as its
+                // own chunk, untrimmed, and the final Result carries exactly
+                // the concatenation of the emitted pieces trimmed. The host
+                // rejects the Result as OutputInvalid otherwise — do not
+                // batch, coalesce, or trim here.
                 if !piece.is_empty() {
                     on_chunk(started.elapsed().as_millis() as u64, sequence, &piece)?;
                     sequence += 1;


### PR DESCRIPTION
The #507 squash landed the host-side half of the chunk-replay invariant comment pair, but the helper-side half was lost to a concurrent-session cleanup before that branch's final push (my session's fault — it reverted an uncommitted edit it mistook for stray work). This restores it verbatim.

Comment-only: documents why the helper must never batch, coalesce, or trim chunk emission — the property the `chunk_mismatch` integration test enforces with a helper kill, and the mirror of the host-side note that the UI preview is the only layer allowed to coalesce.

Verified: `cargo fmt --all -- --check` clean; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)