### PR TITLE
Add persistent onboarding back navigation

### DIFF
--- a/app/src/components/onboarding/OnboardingFlow.test.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.test.tsx
@@ -23,10 +23,21 @@ vi.mock('../../lib/modelRuntime', () => ({
 
 vi.mock('../ModelDownloader', () => ({
   DOWNLOAD_MODEL_KEYS: ['base.en'],
-  ModelDownloadPanel: ({ onComplete }: { onComplete: (model: 'base.en') => void }) => (
-    <button type="button" onClick={() => onComplete('base.en')}>
-      Continue with model
-    </button>
+  ModelDownloadPanel: ({
+    onComplete,
+    onDownloadingChange,
+  }: {
+    onComplete: (model: 'base.en') => void;
+    onDownloadingChange: (downloading: boolean) => void;
+  }) => (
+    <>
+      <button type="button" onClick={() => onDownloadingChange(true)}>
+        Start model download
+      </button>
+      <button type="button" onClick={() => onComplete('base.en')}>
+        Continue with model
+      </button>
+    </>
   ),
 }));
 
@@ -89,6 +100,12 @@ describe('OnboardingFlow', () => {
 
     await clickButton('Continue');
     expect(container.textContent).toContain('Transcription Model');
+
+    await clickButton('Start model download');
+    const backButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Go back to the previous setup step"]',
+    );
+    expect(backButton?.disabled).toBe(true);
 
     await clickButton('Continue with model');
     expect(container.textContent).toContain('Recording Shortcut');

--- a/app/src/components/onboarding/OnboardingFlow.test.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.test.tsx
@@ -1,0 +1,104 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OnboardingFlow } from './OnboardingFlow';
+
+const mocks = vi.hoisted(() => ({
+  getModelRuntimeCatalog: vi.fn(),
+}));
+
+vi.mock('../../lib/dictation', () => ({
+  checkAccessibilityPermission: vi.fn().mockResolvedValue(true),
+  checkMicrophonePermissionStatus: vi.fn().mockResolvedValue('granted'),
+  openMicrophoneSettings: vi.fn().mockResolvedValue(undefined),
+  requestAccessibilityPermission: vi.fn().mockResolvedValue(undefined),
+  requestMicrophoneAccess: vi.fn().mockResolvedValue(undefined),
+  resetAccessibilityPermission: vi.fn().mockResolvedValue(undefined),
+  resetMicrophonePermission: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../lib/modelRuntime', () => ({
+  getModelRuntimeCatalog: () => mocks.getModelRuntimeCatalog(),
+}));
+
+vi.mock('../ModelDownloader', () => ({
+  DOWNLOAD_MODEL_KEYS: ['base.en'],
+  ModelDownloadPanel: ({ onComplete }: { onComplete: (model: 'base.en') => void }) => (
+    <button type="button" onClick={() => onComplete('base.en')}>
+      Continue with model
+    </button>
+  ),
+}));
+
+vi.mock('../ui/WindowHeader', () => ({
+  WindowHeader: () => <div>Window header</div>,
+}));
+
+describe('OnboardingFlow', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const settle = async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+
+  const clickButton = async (label: string) => {
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent?.trim() === label,
+    );
+    expect(button, `Expected a button labeled "${label}"`).toBeDefined();
+    await act(async () => button!.click());
+    await settle();
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.getModelRuntimeCatalog.mockResolvedValue([
+      { modelName: 'base.en', installState: 'installed' },
+    ]);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('keeps Back available through the final step without replacing the primary action', async () => {
+    await act(async () => root.render(
+      <OnboardingFlow
+        initialModel="base.en"
+        recordingMode="hold_down"
+        triggerKey="shift_l"
+        onComplete={vi.fn()}
+      />,
+    ));
+    await settle();
+
+    expect(container.querySelector('[aria-label="Go back to the previous setup step"]')).toBeNull();
+
+    await clickButton('Get Started');
+    expect(container.querySelector('[aria-label="Go back to the previous setup step"]')).not.toBeNull();
+
+    await clickButton('Continue');
+    expect(container.textContent).toContain('Accessibility Access');
+
+    await clickButton('Continue');
+    expect(container.textContent).toContain('Transcription Model');
+
+    await clickButton('Continue with model');
+    expect(container.textContent).toContain('Recording Shortcut');
+
+    await clickButton('Continue');
+    expect(container.textContent).toContain("You're all set");
+    expect(container.textContent).toContain('Start Using Murmur');
+    expect(container.querySelector('[aria-label="Go back to the previous setup step"]')).not.toBeNull();
+
+    await clickButton('Back');
+    expect(container.textContent).toContain('Recording Shortcut');
+  });
+});

--- a/app/src/components/onboarding/OnboardingFlow.tsx
+++ b/app/src/components/onboarding/OnboardingFlow.tsx
@@ -220,20 +220,47 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
       <WindowHeader />
       <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-8">
       <div className="w-full max-w-lg">
-        {/* Progress dots */}
-        <div className="mb-10 flex items-center justify-center gap-2" aria-label={`Step ${stepIndex + 1} of ${STEP_ORDER.length}`}>
-          {STEP_ORDER.map((s, i) => (
-            <span
-              key={s}
-              className={`h-1.5 rounded-full transition-all duration-300 ${
-                i === stepIndex
-                  ? 'w-6 bg-primary'
-                  : i < stepIndex
-                  ? 'w-1.5 bg-primary/60'
-                  : 'w-1.5 bg-surface-container-highest '
-              }`}
-            />
-          ))}
+        {/* Persistent wizard navigation */}
+        <div className="relative mb-10 flex min-h-8 items-center justify-center">
+          {step !== 'welcome' && (
+            <button
+              type="button"
+              onClick={goBack}
+              disabled={modelDownloading}
+              aria-label="Go back to the previous setup step"
+              title={modelDownloading ? 'Please wait for the model download to finish' : undefined}
+              className="absolute left-0 inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-medium text-on-surface-variant transition-colors hover:bg-surface-container-high hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <svg
+                aria-hidden="true"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="m15 18-6-6 6-6" />
+              </svg>
+              Back
+            </button>
+          )}
+          <div
+            className="flex items-center justify-center gap-2"
+            aria-label={`Step ${stepIndex + 1} of ${STEP_ORDER.length}`}
+          >
+            {STEP_ORDER.map((s, i) => (
+              <span
+                key={s}
+                className={`h-1.5 rounded-full transition-all duration-300 ${
+                  i === stepIndex
+                    ? 'w-6 bg-primary'
+                    : i < stepIndex
+                    ? 'w-1.5 bg-primary/60'
+                    : 'w-1.5 bg-surface-container-highest '
+                }`}
+              />
+            ))}
+          </div>
         </div>
 
         {step === 'welcome' && (
@@ -315,7 +342,6 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
             )}
 
             <WizardFooter
-              onBack={goBack}
               onNext={goNext}
               nextEnabled={micGranted}
               nextLabel="Continue"
@@ -369,7 +395,6 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
             )}
 
             <WizardFooter
-              onBack={goBack}
               onNext={goNext}
               nextEnabled={axGranted === true}
               nextLabel="Continue"
@@ -404,16 +429,6 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
                     goNext();
                   }}
                 />
-                {!modelDownloading && (
-                  <div className="mt-3 text-center">
-                    <button
-                      onClick={goBack}
-                      className="text-xs text-on-surface-variant hover:text-on-surface-variant transition-colors"
-                    >
-                      Back
-                    </button>
-                  </div>
-                )}
               </div>
             )}
           </div>
@@ -465,7 +480,7 @@ export function OnboardingFlow({ initialModel, recordingMode, triggerKey, onComp
               </div>
             </div>
 
-            <WizardFooter onBack={goBack} onNext={goNext} nextEnabled nextLabel="Continue" />
+            <WizardFooter onNext={goNext} nextEnabled nextLabel="Continue" />
           </div>
         )}
 
@@ -550,14 +565,12 @@ function SummaryRow({ ok, label, okText, missingText }: { ok: boolean; label: st
 }
 
 function WizardFooter({
-  onBack,
   onNext,
   nextEnabled,
   nextLabel,
   skippable = false,
   skipLabel = 'Skip',
 }: {
-  onBack: () => void;
   onNext: () => void;
   nextEnabled: boolean;
   nextLabel: string;
@@ -565,13 +578,7 @@ function WizardFooter({
   skipLabel?: string;
 }) {
   return (
-    <div className="flex items-center justify-between">
-      <button
-        onClick={onBack}
-        className="text-xs text-on-surface-variant hover:text-on-surface-variant transition-colors"
-      >
-        Back
-      </button>
+    <div className="flex items-center justify-end">
       <div className="flex items-center gap-3">
         {skippable && (
           <button

--- a/docs/features/onboarding-flow.md
+++ b/docs/features/onboarding-flow.md
@@ -6,8 +6,10 @@ permissions were a dismissible banner.
 
 ## Flow
 
-Six steps, forward-only with Back links and per-step Skip where the app can
-partially function without the grant:
+Six steps with a persistent top-left Back control after Welcome and per-step
+Skip where the app can partially function without the grant. Back remains
+visible but disabled while a model download is active, because leaving the
+step cannot cancel the underlying download safely:
 
 1. **Welcome** — privacy pitch (local-only processing), what setup covers.
 2. **Microphone** — fires the *native* macOS permission dialog in-app via the


### PR DESCRIPTION
## What changed

- add a persistent top-left Back control to every onboarding step after Welcome
- keep the final Start Using Murmur action unchanged
- disable Back only while a model download is active
- add regression coverage for navigating back from the final step
- document the navigation behavior

## Why

The completion screen had no way to return to an earlier setup step, and Back placement varied across the rest of onboarding. This makes navigation consistent and gives users a clear way to review or change setup choices before finishing.

## Validation

- `npx tsc --noEmit`
- `npm test` (73 files, 674 tests)
- browser walkthrough through all six steps, including Back from the final screen to Recording Shortcut

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent Back button to onboarding after the Welcome step.
  * Back navigation returns to the previous onboarding step, including from the final step.
  * Added download progress indicators beside the Back button.

* **Bug Fixes**
  * Disabled Back navigation during model downloads to prevent unsafe interruption.

* **Documentation**
  * Updated onboarding documentation to reflect the revised six-step flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->