### PR TITLE
Fix updater check retries

### DIFF
--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -1079,7 +1079,7 @@ export const SettingsPanel = memo(function SettingsPanel({
               {updateStatus.phase === 'error' && (
                 <p className="mt-1.5 text-xs text-error">
                   {updateStatus.stage === 'check'
-                    ? 'Update check failed.'
+                    ? 'Couldn\u2019t check for updates. Check your connection and try again.'
                     : 'Update installation needs attention.'}
                 </p>
               )}

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -137,6 +137,7 @@ describe('useAutoUpdater presentation state', () => {
       message: 'Error: offline',
     });
     expect(current.isUpdateDialogOpen).toBe(false);
+    expect(mocks.check).toHaveBeenCalledTimes(2);
     expect(mocks.flogError).toHaveBeenCalledWith(
       'updater',
       'check failed',
@@ -145,6 +146,34 @@ describe('useAutoUpdater presentation state', () => {
         error: 'Error: offline',
       },
     );
+  });
+
+  it('recovers from a transient updater-feed failure before showing an error', async () => {
+    mocks.check
+      .mockRejectedValueOnce(new Error('temporary feed failure'))
+      .mockResolvedValueOnce({
+        available: true,
+        version: '0.23.0',
+        body: 'Release notes',
+        downloadAndInstall: vi.fn(),
+      });
+
+    await act(async () => current.checkForUpdate());
+
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+    expect(current.updateStatus).toMatchObject({
+      phase: 'available',
+      version: '0.23.0',
+    });
+    expect(mocks.flogWarn).toHaveBeenCalledWith(
+      'updater',
+      'check failed; retrying',
+      {
+        attempt: 1,
+        error: 'Error: temporary feed failure',
+      },
+    );
+    expect(mocks.flogError).not.toHaveBeenCalled();
   });
 
   it('fails closed when update availability is known but policy cannot be verified', async () => {
@@ -164,6 +193,36 @@ describe('useAutoUpdater presentation state', () => {
       message: expect.stringContaining('verify the update policy'),
     });
     expect(localStorage.getItem('updater-last-check')).toBeNull();
+  });
+
+  it('recovers from a transient update-policy fetch failure', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.24.2',
+      body: 'Release notes',
+      downloadAndInstall: vi.fn(),
+    });
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary policy failure'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => current.checkForUpdate());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(current.updateStatus).toMatchObject({
+      phase: 'available',
+      version: '0.24.2',
+      isForced: false,
+    });
+    expect(mocks.flogWarn).toHaveBeenCalledWith(
+      'updater',
+      'policy check failed; retrying',
+      { error: 'Error: temporary policy failure' },
+    );
   });
 
   it('opens a required update when the verified policy is above the installed version', async () => {

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -33,6 +33,8 @@ const UPDATE_POLICY_UNAVAILABLE_MESSAGE =
 
 type UpdaterOperation = 'idle' | 'checking' | 'installing';
 
+const UPDATE_CHECK_ATTEMPTS = 2;
+
 interface UseAutoUpdaterOptions {
   automaticChecksEnabled?: boolean;
 }
@@ -112,7 +114,25 @@ export function useAutoUpdater(
       !opts.isBackground || manualPresentationRequestedRef.current;
 
     try {
-      const update = await check();
+      let update: Update | null = null;
+      let lastCheckError: unknown;
+      let checkSucceeded = false;
+      for (let attempt = 1; attempt <= UPDATE_CHECK_ATTEMPTS; attempt += 1) {
+        try {
+          update = await check();
+          checkSucceeded = true;
+          break;
+        } catch (error) {
+          lastCheckError = error;
+          if (attempt < UPDATE_CHECK_ATTEMPTS) {
+            flog.warn('updater', 'check failed; retrying', {
+              attempt,
+              error: String(error),
+            });
+          }
+        }
+      }
+      if (!checkSucceeded) throw lastCheckError;
 
       if (!update?.available || !update.version) {
         setLastCheckTimestamp(Date.now());
@@ -132,7 +152,13 @@ export function useAutoUpdater(
 
       // Check min_version (custom field not exposed by Tauri updater)
       const currentVersion = await getVersion();
-      const policy = await fetchMinVersionPolicy();
+      let policy = await fetchMinVersionPolicy();
+      if (policy.status === 'unavailable') {
+        flog.warn('updater', 'policy check failed; retrying', {
+          error: policy.message,
+        });
+        policy = await fetchMinVersionPolicy();
+      }
       if (policy.status === 'unavailable') {
         flog.warn('updater', 'could not verify update policy', {
           error: policy.message,


### PR DESCRIPTION
## Summary

- retry the native updater feed check once before surfacing an error
- retry the minimum-version policy fetch once before failing closed
- replace the generic inline failure with actionable connection guidance

## Root cause

A single transient release-feed or policy request failure was immediately presented as a persistent-looking update failure even though later background checks could succeed.

## User impact

Transient GitHub or network failures now recover automatically. Persistent failures remain visible with a clear retry instruction.

## Validation

- `cd app && npm test` (689 tests passed)
- `cd app && npx tsc --noEmit`
- current production update feed resolves successfully and the installed app detects v0.30.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update checks now automatically retry once after a temporary connection or service failure.
  * Temporary failures can recover without showing an unnecessary error, while persistent failures continue to provide clear feedback.
  * Improved update-check error messaging includes more specific guidance for connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->