### PR TITLE
chore: bump version to 0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-08-09
+
+### Fixed
+
+- Update checks now retry transient release-feed and minimum-version policy
+  failures before showing actionable connection guidance.
+
 ## [0.30.0] - 2026-08-07
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.30.0"
+version = "0.30.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "identifier": "com.localdictation",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- bump Murmur from v0.30.0 to v0.30.1 across all synchronized release surfaces
- cut the updater retry fix from `[Unreleased]` into the v0.30.1 changelog section
- keep the updater minimum-version policy optional

## Release contents

- retry transient updater-feed failures once
- retry transient minimum-version policy failures once
- show actionable connection guidance after persistent failures

## Validation

- `python3 scripts/release_version.py check 0.30.1`
- `python3 scripts/validate_workflow_policy.py`
- release artifact/version/workflow policy tests: 79 passed
- `cd app && npx tsc --noEmit`
- `cd app && npm test`: 689 passed
- fix PR #518 passed GitHub CI, complete Rust tests, and native Tauri smoke testing