### PR TITLE
feat: durable settings store — settings.json as source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (113 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (115 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -60,7 +60,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 113 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (113 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (115 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -64,13 +64,14 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 113 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |
 | `commands/permissions.rs` | Permission check/request/reset and audio device commands (incl. in-app mic TCC prompt) |
 | `commands/keyboard.rs` | Dictation + transform listener commands, global disable |
 | `commands/export.rs` | `save_text_export` — validated, atomic user-chosen text export sink |
+| `commands/settings_store.rs` | Durable `settings.json` in the app data dir: opaque bounded JSON-object blob, atomic write, corrupt-file quarantine |
 | `commands/logging.rs` | Log commands, delegates to telemetry.rs |
 | `commands/models.rs` | Model catalog/status queries and the download pipeline |
 | `commands/knowledge.rs` | Personal knowledge store CRUD, resolve, preview, export/import |

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod overlay;
 pub mod performance;
 pub mod permissions;
 pub mod recording;
+pub mod settings_store;
 pub mod theme;
 pub mod transform_diagnostics;
 pub mod transform_model;

--- a/app/src-tauri/src/commands/settings_store.rs
+++ b/app/src-tauri/src/commands/settings_store.rs
@@ -1,0 +1,310 @@
+//! Durable, host-owned home for the frontend's settings blob.
+//!
+//! The frontend owns the entire settings schema and every migration rule, so
+//! this module treats the payload as an opaque JSON object: it checks the
+//! container (bounded, parses as an object) and never inspects a field. That
+//! keeps a settings change from ever needing a Rust change, while moving the
+//! durable copy out of WKWebView localStorage — which a reinstall or a WebKit
+//! storage eviction can drop — into the per-bundle app data directory.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tauri::Manager;
+
+use crate::MutexExt;
+
+const SETTINGS_FILE_NAME: &str = "settings.json";
+
+/// Hard ceiling on one settings blob. The real object is a few KiB; the bound
+/// exists so a tampered or runaway writer cannot park an unbounded file in the
+/// app data directory, and so a load never reads an arbitrarily large file.
+const MAX_SETTINGS_BYTES: usize = 1024 * 1024;
+
+/// Serializes writers. The main and overlay windows can both persist settings,
+/// and two concurrent publishes share one temp sibling — without this, one
+/// writer's rename can consume the other's half-written temp file.
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+fn settings_path(dir: &Path) -> PathBuf {
+    dir.join(SETTINGS_FILE_NAME)
+}
+
+/// Temp sibling used for the atomic publish. Kept in the settings directory so
+/// the rename stays on one filesystem.
+fn temp_path_for(path: &Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(SETTINGS_FILE_NAME);
+    path.with_file_name(format!(".{name}.murmur-tmp"))
+}
+
+/// The only shape check the host makes: a bounded JSON object. Refused on save
+/// and treated as corruption on load.
+fn validate_blob(blob: &str) -> Result<(), String> {
+    if blob.len() > MAX_SETTINGS_BYTES {
+        return Err(format!(
+            "Settings blob is too large ({} bytes, limit {MAX_SETTINGS_BYTES})",
+            blob.len()
+        ));
+    }
+    match serde_json::from_str::<serde_json::Value>(blob) {
+        Ok(serde_json::Value::Object(_)) => Ok(()),
+        Ok(_) => Err("Settings blob must be a JSON object".to_string()),
+        Err(e) => Err(format!("Settings blob is not valid JSON: {e}")),
+    }
+}
+
+/// Rename a file we cannot trust aside instead of deleting it — settings a user
+/// spent time on are unrecoverable, so corruption becomes evidence, never loss.
+/// Best-effort: if the rename fails the load still falls back to localStorage.
+fn quarantine(path: &Path, reason: &str) {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0);
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(SETTINGS_FILE_NAME);
+    let target = path.with_file_name(format!("{name}.corrupt-{seconds}"));
+    match std::fs::rename(path, &target) {
+        // Content-free: why it was rejected, never what it contained.
+        Ok(()) => tracing::warn!(target: "system", reason, "settings file quarantined"),
+        Err(e) => {
+            tracing::warn!(target: "system", reason, "failed to quarantine settings file: {e}")
+        }
+    }
+}
+
+/// Read the stored blob from `dir`. `Ok(None)` means "no usable settings on
+/// disk" — either the file has never been written or it was just quarantined —
+/// so the caller falls back to its localStorage cache. `Err` is reserved for
+/// filesystem failures, where retrying later may succeed.
+pub(crate) fn read_settings_blob(dir: &Path) -> Result<Option<String>, String> {
+    let path = settings_path(dir);
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("Failed to read settings: {e}")),
+    };
+    // Bound before reading, so an oversized file is never pulled into memory.
+    if metadata.len() > MAX_SETTINGS_BYTES as u64 {
+        quarantine(&path, "over the size ceiling");
+        return Ok(None);
+    }
+
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("Failed to read settings: {e}")),
+    };
+    let contents = match String::from_utf8(bytes) {
+        Ok(contents) => contents,
+        Err(_) => {
+            quarantine(&path, "not valid UTF-8");
+            return Ok(None);
+        }
+    };
+    if let Err(reason) = validate_blob(&contents) {
+        quarantine(&path, &reason);
+        return Ok(None);
+    }
+    Ok(Some(contents))
+}
+
+/// Validate, then publish `blob` into `dir` atomically.
+pub(crate) fn write_settings_blob(dir: &Path, blob: &str) -> Result<(), String> {
+    validate_blob(blob)?;
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("Failed to create settings directory: {e}"))?;
+
+    let path = settings_path(dir);
+    let temp = temp_path_for(&path);
+    let _guard = WRITE_LOCK.lock_or_recover();
+    if let Err(e) = std::fs::write(&temp, blob) {
+        // A partial write (ENOSPC, permissions) must not leave a temp sibling
+        // behind, and must never replace the last good settings file.
+        let _ = std::fs::remove_file(&temp);
+        return Err(format!("Failed to write settings: {e}"));
+    }
+    if let Err(e) = std::fs::rename(&temp, &path) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(format!("Failed to publish settings: {e}"));
+    }
+    Ok(())
+}
+
+fn settings_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Settings directory unavailable: {e}"))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create settings directory: {e}"))?;
+    Ok(dir)
+}
+
+/// Load the durable settings blob, or `None` when there is nothing usable on
+/// disk. The frontend re-runs its own validation over whatever comes back.
+#[tauri::command]
+pub fn load_settings_blob(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    read_settings_blob(&settings_dir(&app)?)
+}
+
+/// Persist the frontend's serialized settings object.
+#[tauri::command]
+pub fn save_settings_blob(app: tauri::AppHandle, blob: String) -> Result<(), String> {
+    write_settings_blob(&settings_dir(&app)?, &blob)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur_settings_store_test_{}_{}",
+            std::process::id(),
+            tag
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn entries(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn round_trips_a_settings_blob() {
+        let dir = temp_dir("round_trip");
+        let blob = r#"{"model":"tiny.en","settingsVersion":1}"#;
+        write_settings_blob(&dir, blob).unwrap();
+        assert_eq!(read_settings_blob(&dir).unwrap().as_deref(), Some(blob));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn reports_no_settings_when_the_file_is_missing() {
+        let dir = temp_dir("missing");
+        assert_eq!(read_settings_blob(&dir).unwrap(), None);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn creates_the_settings_directory_on_first_write() {
+        let dir = temp_dir("create_dir").join("nested");
+        write_settings_blob(&dir, "{}").unwrap();
+        assert_eq!(read_settings_blob(&dir).unwrap().as_deref(), Some("{}"));
+        std::fs::remove_dir_all(dir.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn overwrites_atomically_and_leaves_no_temp_file() {
+        let dir = temp_dir("overwrite");
+        write_settings_blob(&dir, r#"{"autoPaste":false,"stale":"padding"}"#).unwrap();
+        write_settings_blob(&dir, r#"{"autoPaste":true}"#).unwrap();
+        assert_eq!(
+            read_settings_blob(&dir).unwrap().as_deref(),
+            Some(r#"{"autoPaste":true}"#)
+        );
+        assert_eq!(entries(&dir), vec![SETTINGS_FILE_NAME.to_string()]);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn quarantines_a_file_that_is_not_json() {
+        let dir = temp_dir("not_json");
+        std::fs::write(settings_path(&dir), "not json{{{").unwrap();
+        assert_eq!(read_settings_blob(&dir).unwrap(), None);
+        let names = entries(&dir);
+        assert_eq!(names.len(), 1, "unexpected entries: {names:?}");
+        assert!(names[0].starts_with("settings.json.corrupt-"), "{names:?}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn quarantines_json_that_is_not_an_object() {
+        let dir = temp_dir("not_object");
+        std::fs::write(settings_path(&dir), "[1, 2, 3]").unwrap();
+        assert_eq!(read_settings_blob(&dir).unwrap(), None);
+        let names = entries(&dir);
+        assert_eq!(names.len(), 1, "unexpected entries: {names:?}");
+        assert!(names[0].starts_with("settings.json.corrupt-"), "{names:?}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn quarantines_an_oversized_file() {
+        let dir = temp_dir("oversized");
+        let padding = "a".repeat(MAX_SETTINGS_BYTES);
+        std::fs::write(settings_path(&dir), format!(r#"{{"pad":"{padding}"}}"#)).unwrap();
+        assert_eq!(read_settings_blob(&dir).unwrap(), None);
+        let names = entries(&dir);
+        assert_eq!(names.len(), 1, "unexpected entries: {names:?}");
+        assert!(names[0].starts_with("settings.json.corrupt-"), "{names:?}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_save_that_is_not_a_json_object() {
+        let dir = temp_dir("reject_shape");
+        for blob in ["[1,2,3]", "\"text\"", "17", "not json{{{"] {
+            assert!(write_settings_blob(&dir, blob).is_err(), "{blob}");
+        }
+        assert!(entries(&dir).is_empty(), "nothing should be written");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_save_over_the_size_ceiling() {
+        let dir = temp_dir("reject_size");
+        let padding = "a".repeat(MAX_SETTINGS_BYTES);
+        let error = write_settings_blob(&dir, &format!(r#"{{"pad":"{padding}"}}"#)).unwrap_err();
+        assert!(error.contains("too large"), "{error}");
+        assert!(entries(&dir).is_empty(), "nothing should be written");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_rejected_save_leaves_the_previous_settings_intact() {
+        let dir = temp_dir("reject_keeps_previous");
+        write_settings_blob(&dir, r#"{"autoPaste":true}"#).unwrap();
+        assert!(write_settings_blob(&dir, "[]").is_err());
+        assert_eq!(
+            read_settings_blob(&dir).unwrap().as_deref(),
+            Some(r#"{"autoPaste":true}"#)
+        );
+        assert_eq!(entries(&dir), vec![SETTINGS_FILE_NAME.to_string()]);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_failed_write_leaves_no_temp_file_behind() {
+        // The temp sibling path is occupied by a directory, so `fs::write`
+        // itself fails rather than the rename.
+        let dir = temp_dir("write_failure");
+        std::fs::create_dir_all(temp_path_for(&settings_path(&dir))).unwrap();
+        assert!(write_settings_blob(&dir, "{}").is_err());
+        assert!(!settings_path(&dir).exists());
+        assert_eq!(entries(&dir).len(), 1, "unexpected leftovers");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn temp_path_stays_in_the_settings_directory() {
+        let path = settings_path(Path::new("/tmp/murmur"));
+        let temp = temp_path_for(&path);
+        assert_eq!(temp.parent(), path.parent());
+        assert_ne!(temp.file_name(), path.file_name());
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -319,6 +319,8 @@ pub fn run() {
             commands::knowledge::import_knowledge_from_file,
             commands::knowledge::delete_all_knowledge,
             commands::export::save_text_export,
+            commands::settings_store::load_settings_blob,
+            commands::settings_store::save_settings_blob,
             commands::theme::read_theme_file,
             commands::theme::write_theme_file,
             commands::logging::get_log_contents,

--- a/app/src/diagnostics.tsx
+++ b/app/src/diagnostics.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { DiagnosticsWindowApp } from './components/log-viewer/DiagnosticsWindowApp';
+import { hydrateSettingsFromDisk } from './lib/settings';
 import './styles.css';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <DiagnosticsWindowApp />
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+// Seed localStorage from the durable settings.json before the first render.
+hydrateSettingsFromDisk().finally(() => {
+  root.render(
+    <React.StrictMode>
+      <DiagnosticsWindowApp />
+    </React.StrictMode>,
+  );
+});

--- a/app/src/lib/settings.test.ts
+++ b/app/src/lib/settings.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  isTauri: vi.fn(() => false),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mocks.invoke(...args),
+  isTauri: () => mocks.isTauri(),
+}));
+
 import {
+  hydrateSettingsFromDisk,
   loadSettings,
   saveSettings,
   AUTO_STOP_SILENCE_OPTIONS,
@@ -10,6 +22,11 @@ import {
 
 beforeEach(() => {
   localStorage.clear();
+  mocks.invoke.mockReset();
+  mocks.invoke.mockResolvedValue(undefined);
+  // Default to "not running under Tauri" so the existing localStorage-only
+  // expectations below are unaffected by the durable store.
+  mocks.isTauri.mockReturnValue(false);
 });
 
 describe('loadSettings', () => {
@@ -736,5 +753,91 @@ describe('loadSettings', () => {
     }));
     const settings = loadSettings();
     expect(settings.codeVocabLastScan!.whisperCount).toBe(1);
+  });
+});
+
+describe('durable settings store', () => {
+  const STORAGE_KEY = 'dictation-settings';
+
+  beforeEach(() => {
+    mocks.isTauri.mockReturnValue(true);
+  });
+
+  it('seeds localStorage from the blob the backend returns', async () => {
+    const blob = JSON.stringify({ ...DEFAULT_SETTINGS, language: 'es', settingsVersion: 1 });
+    mocks.invoke.mockResolvedValue(blob);
+
+    await hydrateSettingsFromDisk();
+
+    expect(mocks.invoke).toHaveBeenCalledWith('load_settings_blob');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(blob);
+    expect(loadSettings().language).toBe('es');
+  });
+
+  it('overwrites a stale localStorage cache — disk is authoritative', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...DEFAULT_SETTINGS, language: 'fr' }));
+    mocks.invoke.mockResolvedValue(JSON.stringify({ ...DEFAULT_SETTINGS, language: 'de' }));
+
+    await hydrateSettingsFromDisk();
+
+    expect(loadSettings().language).toBe('de');
+  });
+
+  it('migrates an existing localStorage blob to disk when nothing is stored yet', async () => {
+    const cached = JSON.stringify({ ...DEFAULT_SETTINGS, language: 'it', settingsVersion: 1 });
+    localStorage.setItem(STORAGE_KEY, cached);
+    mocks.invoke.mockImplementation(async (command: string) =>
+      command === 'load_settings_blob' ? null : undefined);
+
+    await hydrateSettingsFromDisk();
+
+    expect(mocks.invoke).toHaveBeenCalledWith('save_settings_blob', { blob: cached });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(cached);
+  });
+
+  it('writes nothing on a first run with no cached settings', async () => {
+    mocks.invoke.mockResolvedValue(null);
+
+    await hydrateSettingsFromDisk();
+
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('leaves localStorage untouched when the backend rejects', async () => {
+    const cached = JSON.stringify({ ...DEFAULT_SETTINGS, language: 'ja' });
+    localStorage.setItem(STORAGE_KEY, cached);
+    mocks.invoke.mockRejectedValue(new Error('store unavailable'));
+
+    await expect(hydrateSettingsFromDisk()).resolves.toBeUndefined();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(cached);
+  });
+
+  it('does not touch the backend outside Tauri', async () => {
+    mocks.isTauri.mockReturnValue(false);
+
+    await hydrateSettingsFromDisk();
+    saveSettings(DEFAULT_SETTINGS);
+
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('writes localStorage synchronously and mirrors the same blob to disk', () => {
+    saveSettings({ ...DEFAULT_SETTINGS, language: 'ko' });
+
+    const written = localStorage.getItem(STORAGE_KEY);
+    expect(written).not.toBeNull();
+    expect(JSON.parse(written ?? '{}')).toMatchObject({ language: 'ko', settingsVersion: 1 });
+    expect(mocks.invoke).toHaveBeenCalledWith('save_settings_blob', { blob: written });
+  });
+
+  it('still persists to localStorage when the disk mirror fails', () => {
+    mocks.invoke.mockRejectedValue(new Error('disk full'));
+
+    saveSettings({ ...DEFAULT_SETTINGS, language: 'ru' });
+
+    expect(loadSettings().language).toBe('ru');
   });
 });

--- a/app/src/lib/settings.ts
+++ b/app/src/lib/settings.ts
@@ -1,3 +1,5 @@
+import { invoke, isTauri } from '@tauri-apps/api/core';
+
 export type RecordingMode = 'hold_down' | 'double_tap' | 'both';
 
 export type DoubleTapKey = 'shift_l' | 'alt_l' | 'ctrl_r';
@@ -422,11 +424,57 @@ type PersistedSettings = Partial<Settings> & {
   recordingMode?: string;
 };
 
+/**
+ * Mirror a serialized blob to the Rust-owned `settings.json`. Fire-and-forget:
+ * localStorage is the synchronous contract every caller depends on, and disk is
+ * the durable copy read back at the next window boot — a failed or unavailable
+ * bridge (plain browser, tests) must never surface as a settings-save failure.
+ */
+function mirrorToDisk(blob: string): void {
+  try {
+    if (!isTauri()) return;
+    void invoke('save_settings_blob', { blob }).catch(console.error);
+  } catch (e) {
+    console.error('Failed to persist settings to disk:', e);
+  }
+}
+
 function writePersistedSettings(settings: Settings): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({
+  const blob = JSON.stringify({
     ...settings,
     settingsVersion: SETTINGS_VERSION,
-  }));
+  });
+  localStorage.setItem(STORAGE_KEY, blob);
+  mirrorToDisk(blob);
+}
+
+/**
+ * Seed localStorage from the durable `settings.json` before any window renders.
+ * Disk wins: localStorage is a write-through cache that a reinstall or a WebKit
+ * eviction can silently drop. Idempotent, so every window entry can await it
+ * regardless of creation order.
+ */
+export async function hydrateSettingsFromDisk(): Promise<void> {
+  try {
+    if (!isTauri()) return;
+    const blob = await invoke<string | null>('load_settings_blob');
+    if (typeof blob === 'string') {
+      // `loadSettings()` re-runs the full validation gauntlet over whatever is
+      // in here, so no schema work belongs on this path.
+      localStorage.setItem(STORAGE_KEY, blob);
+      return;
+    }
+    // No durable copy: either a first run, or an existing install whose
+    // settings only ever lived in localStorage. Repair it once.
+    const cached = localStorage.getItem(STORAGE_KEY);
+    if (cached !== null) {
+      await invoke('save_settings_blob', { blob: cached });
+    }
+  } catch (e) {
+    // Boot must never block on the settings store; localStorage stays the
+    // fallback for this session.
+    console.error('Failed to hydrate settings from disk:', e);
+  }
 }
 
 /**

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -2,12 +2,19 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { AppearanceProvider } from "./lib/hooks/useAppearance";
+import { hydrateSettingsFromDisk } from "./lib/settings";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <AppearanceProvider>
-      <App />
-    </AppearanceProvider>
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+
+// Seed localStorage from the durable settings.json before the first render, so
+// every synchronous `loadSettings()` below sees the durable copy.
+hydrateSettingsFromDisk().finally(() => {
+  root.render(
+    <React.StrictMode>
+      <AppearanceProvider>
+        <App />
+      </AppearanceProvider>
+    </React.StrictMode>,
+  );
+});

--- a/app/src/overlay.tsx
+++ b/app/src/overlay.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { OverlayWidget } from "./components/OverlayWidget";
+import { hydrateSettingsFromDisk } from "./lib/settings";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <OverlayWidget />
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+
+// Seed localStorage from the durable settings.json before the first render, so
+// the overlay's synchronous settings mirror sees the durable copy.
+hydrateSettingsFromDisk().finally(() => {
+  root.render(
+    <React.StrictMode>
+      <OverlayWidget />
+    </React.StrictMode>,
+  );
+});

--- a/app/src/transform-review.tsx
+++ b/app/src/transform-review.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { TransformReviewApp } from "./components/transform-review/TransformReviewApp";
+import { hydrateSettingsFromDisk } from "./lib/settings";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <TransformReviewApp />
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+
+// Seed localStorage from the durable settings.json before the first render.
+hydrateSettingsFromDisk().finally(() => {
+  root.render(
+    <React.StrictMode>
+      <TransformReviewApp />
+    </React.StrictMode>,
+  );
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ deliberately escaped process group. See the
 
 | Module | Purpose |
 |--------|---------|
-| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 113 registered commands, setup, tray, run loop |
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, run loop |
 | `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
 | `audio.rs` | CPAL 0.18 capture worker, stable device-ID selection, typed error/phase telemetry, first-buffer readiness, mono mix, 16kHz resample, `audio-level` emission |
 | `audio_lifecycle.rs` | App-lifetime single-owner supervisor; async start, generation cancellation, deadlines, generation-gated publication, and strict worker ownership through exit |
@@ -350,7 +350,7 @@ Two rules keep the multi-window state coherent:
 
 ## Tauri Commands
 
-113 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
+115 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
 
 ## Events
 

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -6,6 +6,34 @@ Maintained via the `/decisions` skill. See `~/.claude/skills/decisions/SKILL.md`
 
 ---
 
+## 2026-08-09: Rust-owned settings.json is the source of truth; localStorage is a cache
+
+**Decision:** Frontend settings persist durably to `settings.json` in the
+per-bundle app data directory via two new commands (`load_settings_blob`,
+`save_settings_blob` in `commands/settings_store.rs`). Every window entry
+hydrates localStorage from the file before first render; every save writes
+localStorage synchronously and mirrors the same blob to disk. Rust validates
+only the container (≤1 MiB, JSON object) and never a field — the whole
+schema and every migration rule stay in `lib/settings.ts`. Corrupt files are
+quarantined to `settings.json.corrupt-<unix-seconds>`, never deleted.
+
+**Rationale:** localStorage lives in WKWebView's website-data store, which a
+manual reinstall or WebKit eviction can silently drop — this happened in
+practice (2026-08). The app data directory (knowledge store, diagnostics)
+survived the same reinstall. The opaque-blob split keeps settings changes
+frontend-only while gaining Rust's durability, and the boot-hydration design
+preserves the synchronous `loadSettings()` contract that overlay hooks
+depend on. Full source-of-truth migration was chosen over a backup/restore
+stopgap because the file format is identical either way and the flip cost
+was contained to entry-point gating.
+
+**Status:** active
+
+**References:** `commands/settings_store.rs`, `lib/settings.ts`,
+`docs/reference/settings.md` ("Persistence and Migration")
+
+---
+
 ## 2026-08-05: Spoken Structure is the single owner for dictated punctuation and layout
 
 **Decision:** Replace the overlapping Voice Commands and Smart Formatting

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Tauri Commands Reference
 
-The 113 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
+The 115 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
 Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
 
@@ -192,6 +192,18 @@ frontend.
 | Command | Parameters | Returns | Description |
 |---------|-----------|---------|-------------|
 | `save_text_export` | `path: String`, `contents: String` | `Result<u64, String>` | Writes a user-authored text export (transcript history today) to a path chosen in the native save dialog, returning bytes written. Refuses relative paths, directories, dotfiles, missing parents, extensions outside `.json`/`.md`/`.txt`, and payloads over 8 MB. The write is atomic (temp sibling, then rename). |
+
+## Settings store (`commands/settings_store.rs`)
+
+The durable home for the frontend's settings object, in `settings.json` under
+the per-bundle app data directory. The blob is opaque to Rust: only the
+container is checked (bounded, parses as a JSON object), so schema and
+migration rules stay entirely in `lib/settings.ts`.
+
+| Command | Parameters | Returns | Description |
+|---------|-----------|---------|-------------|
+| `load_settings_blob` | — | `Result<Option<String>, String>` | Reads `settings.json`, creating the directory if needed. `None` when the file is absent, or when it was over 1 MiB, not UTF-8, not valid JSON, or not a JSON object — those are renamed to `settings.json.corrupt-<unix-seconds>` and never deleted, so the caller falls back to its localStorage cache. `Err` is reserved for filesystem failures. |
+| `save_settings_blob` | `blob: String` | `Result<(), String>` | Refuses anything over 1 MiB or not a JSON object, then publishes atomically (temp sibling, then rename). Concurrent writers (main and overlay windows) are serialized; a failed write removes the temp file and preserves the previous settings. |
 
 ## Overlay (`commands/overlay.rs`)
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,6 +1,6 @@
 # User Settings Reference
 
-This document describes Murmur's user-configurable settings. Settings are managed on the frontend by the `useSettings` hook and persisted to `localStorage`. Relevant settings are pushed to the Rust backend via the `configure_dictation` command.
+This document describes Murmur's user-configurable settings. Settings are managed on the frontend by the `useSettings` hook, persisted durably to a Rust-owned `settings.json`, and cached in `localStorage` for synchronous reads. Relevant settings are pushed to the Rust backend via the `configure_dictation` command.
 
 For the hook that manages settings, see [hooks.md](hooks.md). For the backend command that receives configuration, see [commands.md](commands.md).
 
@@ -8,8 +8,8 @@ For the hook that manages settings, see [hooks.md](hooks.md). For the backend co
 
 ## Settings Overview
 
-Dictation settings are stored in `localStorage` under the key
-`dictation-settings` as a single JSON object. Appearance is an independent
+Dictation settings are one JSON object, stored durably in `settings.json` and
+cached in `localStorage` under the key `dictation-settings`. Appearance is an independent
 versioned document under `murmur-appearance`; it is never merged into this
 interface or emitted through `dictation-settings`.
 
@@ -209,14 +209,35 @@ New text replacements and snippets are Rust-owned knowledge records rather than 
 
 ### Storage
 
-- **Key:** `dictation-settings`
-- **Method:** `localStorage.setItem` / `localStorage.getItem`
-- **Format:** Full `Settings` object serialized as JSON
+- **Durable copy:** `settings.json` in the per-bundle app data directory, owned by `commands/settings_store.rs`. This is the source of truth: it survives a manual reinstall and WebKit storage eviction, which `localStorage` does not.
+- **Cache:** `localStorage` under the key `dictation-settings`, written through on every save so `loadSettings()` stays synchronous — its callers (overlay hooks in particular) read settings during render.
+- **Format:** Full `Settings` object serialized as JSON, plus `settingsVersion`. The same string is written to both places.
+
+The blob is opaque to Rust. The host validates only the container — at most 1 MiB, and it must parse as a JSON object — so every schema, default, and migration rule stays in `lib/settings.ts` and a settings change never requires a Rust change.
+
+### Boot Hydration
+
+Each window entry (`main.tsx`, `overlay.tsx`, `transform-review.tsx`, `diagnostics.tsx`) awaits `hydrateSettingsFromDisk()` before its first render:
+
+1. Outside Tauri (plain browser, tests) it is a no-op and `localStorage` remains the only store.
+2. `load_settings_blob` returns a blob → it is written into `localStorage` verbatim. Disk wins; the cache may be stale or evicted.
+3. `load_settings_blob` returns `null` → first run, or an existing install whose settings only ever lived in `localStorage`. A non-null cached blob is migrated to disk once via `save_settings_blob`.
+4. Any failure is logged and swallowed. Boot never blocks on the settings store, and `localStorage` stays the fallback for the session.
+
+Hydration is idempotent, so every window can run it regardless of creation order; concurrent first-run writes are serialized in Rust and write identical content.
+
+### Saving
+
+`saveSettings()` (and the migration re-persist inside `loadSettings()`) serializes once, writes `localStorage` synchronously, then fires `save_settings_blob` without awaiting it. A rejected or unavailable backend is logged and never fails the save — the cache is already written and the next boot repairs the durable copy.
+
+### Corruption
+
+A `settings.json` that is oversized, not UTF-8, not valid JSON, or not a JSON object is renamed to `settings.json.corrupt-<unix-seconds>` and reported as "no settings on disk", so the window falls back to its `localStorage` cache. Corrupt files are never deleted.
 
 ### Loading Behavior
 
 `loadSettings()` performs the following:
-1. Reads from `localStorage` under `dictation-settings`.
+1. Reads from `localStorage` under `dictation-settings` (seeded from disk at boot).
 2. If found, parses as JSON and merges with `DEFAULT_SETTINGS` (stored values override defaults). Legacy comma/newline-separated `customVocabulary` values migrate to enabled global `vocabularyEntries` with no aliases.
 3. Applies migration: if `recordingMode` is missing or invalid (including the legacy `'hotkey'` value), resets to `'hold_down'`.
 4. Strips the legacy `hotkey` field if present.

--- a/tests/test_reference_docs.py
+++ b/tests/test_reference_docs.py
@@ -28,7 +28,7 @@ def copy_reference_fixture(root: Path) -> None:
 
 class ReferenceDocsTests(unittest.TestCase):
     def test_repository_reference_docs_match_registered_commands(self) -> None:
-        self.assertEqual(validate_reference_docs(), 113)
+        self.assertEqual(validate_reference_docs(), 115)
 
     def test_missing_command_row_fails_even_when_prose_count_is_current(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -54,7 +54,7 @@ class ReferenceDocsTests(unittest.TestCase):
             architecture = root / "docs/ARCHITECTURE.md"
             architecture.write_text(
                 architecture.read_text().replace(
-                    "113 registered commands", "112 registered commands", 1
+                    "115 registered commands", "112 registered commands", 1
                 )
             )
 


### PR DESCRIPTION
## Summary

App settings currently live only in WKWebView localStorage, which a manual reinstall or WebKit storage eviction can silently drop (this happened in practice — settings were lost on a manual version install while the app-data-dir SQLite stores survived). This PR moves the durable copy into a Rust-owned `settings.json` in the per-bundle app data directory.

**Design (opaque-blob):**
- New `commands/settings_store.rs`: `load_settings_blob` / `save_settings_blob`. Atomic temp+rename writes under a poison-recovering mutex, 1 MiB bound, JSON-object container validation, corrupt files quarantined to `settings.json.corrupt-<unix-seconds>` (never deleted). Registered commands: 113 → 115.
- Rust never inspects a field — the entire schema and every migration rule stay in `lib/settings.ts`, so settings changes remain frontend-only.
- Every window entry awaits `hydrateSettingsFromDisk()` before first render: disk seeds localStorage (disk wins), or on first launch an existing localStorage blob migrates to disk once. localStorage becomes a write-through cache, so every synchronous `loadSettings()` caller (overlay hooks in particular) is unchanged.
- `saveSettings` dual-writes: localStorage synchronously, disk fire-and-forget — a store failure can never break a save or block boot.

## Testing

- `cargo test -- --test-threads=1`: 769 + 12 new settings-store tests pass, no warnings
- `npx tsc --noEmit`: clean
- `npm test`: 697/697 (8 new vitest cases: disk-authoritative hydration, one-time migration, failure isolation both directions, non-Tauri no-op)

Docs updated: `docs/reference/settings.md` persistence section, `commands.md`/`CLAUDE.md`/`ARCHITECTURE.md` counts, decision logged in `DECISIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Settings now persist durably across app launches and windows.
  - Settings are loaded before the interface appears, with local caching for responsive saves.
  - Invalid or corrupted settings files are safely quarantined and recovered without blocking startup.

- **Bug Fixes**
  - Improved resilience when settings storage or synchronization fails.

- **Documentation**
  - Updated settings, architecture, and command reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->