### PR TITLE
Enforce Murmur Bench before sensitive merges and releases

### DIFF
--- a/.codex/skills/murmur-feature/SKILL.md
+++ b/.codex/skills/murmur-feature/SKILL.md
@@ -6,7 +6,6 @@ description: >-
   smoke test via Computer Use, PR creation, validation, and merge when green.
   Use when the user invokes /feature, ships a feature from an issue number,
   or wants plan + build + review + test + merge in one workflow.
-disable-model-invocation: true
 ---
 
 # Murmur Feature — Plan → Ship → Merge
@@ -139,6 +138,7 @@ gh pr create \
 ## Test plan
 - [ ] cargo check / test / tsc
 - [ ] native app smoke (if applicable)
+- [ ] Murmur Bench gate (quick/standard, or N/A with reason)
 - [ ] <issue-specific steps>
 
 Closes #<issue-number>
@@ -149,6 +149,36 @@ EOF
 
 Note the PR number and URL.
 
+### Phase 6.5 — Murmur Bench gate
+
+After the exact candidate branch is pushed, inspect the changed files and run
+the private Fleet benchmark when the PR can change recognition latency,
+accuracy, delivered-text output, or memory. This includes VAD, transcription
+backends, model runtime, transcript transforms, benchmarked execution paths,
+and performance-sensitive Rust dependencies.
+
+Run the normal gate from the worktree with all installed models:
+
+```bash
+python3 scripts/murmur_bench_fleet.py \
+  --baseline origin/main \
+  --candidate origin/<branch-name> \
+  --preset quick
+```
+
+Use `standard` for shared cross-model or pipeline changes. Do not pass
+`--no-fail`. If the comparison fails, rerun once with `--candidate-first`; a
+repeated regression blocks merge, while mixed results are inconclusive and
+require investigation or explicit user acceptance. Never upload raw reports or
+personal transcript content from the trusted Mac. Add only a content-free
+metric/pass-fail receipt and the tested candidate commit SHA to the PR. Any
+later push, rebase, merge from main, or conflict resolution invalidates the
+result and requires a rerun.
+
+For an unrelated PR, record `Murmur Bench: N/A — <reason>` in the PR instead of
+silently skipping the gate. This replay benchmark does not replace native smoke
+testing for live capture, device, clipboard, or paste behavior.
+
 ---
 
 ## Phase 7 — PR validation & merge (murmur-pr-test)
@@ -156,13 +186,19 @@ Note the PR number and URL.
 Treat your PR like any other Murmur PR:
 
 1. `gh pr view <number> --repo georgenijo/murmur-app`
-2. If not mergeable, merge `origin/main` into the worktree, resolve conflicts, re-run Phase 5 checks, push.
-3. Re-read CI / checks on GitHub if present.
+2. If not mergeable, merge `origin/main` into the worktree, resolve conflicts,
+   re-run Phase 5 checks, and push the resolved candidate.
+3. After any candidate push, rerun the Phase 6.5 gate when applicable so the
+   receipt names the exact pushed commit.
+4. Re-read CI / checks on GitHub if present.
 
 **Merge only when:**
 
 - Phase 5 checks passed (re-run after any merge-from-main).
 - Native smoke passed when the feature touched user-visible behavior.
+- Murmur Bench passed when applicable, or the PR records a justified N/A.
+- No unresolved/inconclusive benchmark regression remains unless the user
+  explicitly accepted the measured risk.
 - No known blockers in the PR or issue.
 - User has not said "stop before merge" — default for `/feature` is to **merge when green**.
 
@@ -183,6 +219,7 @@ Keep it short:
 - Plan summary (one line)
 - Checks run (pass/fail)
 - Native smoke (what was tested, or N/A)
+- Murmur Bench result (preset and aggregate result, or N/A with reason)
 - PR URL
 - Merge result (commit SHA or "not merged" + why)
 

--- a/.codex/skills/murmur-feature/SKILL.md
+++ b/.codex/skills/murmur-feature/SKILL.md
@@ -160,18 +160,24 @@ and performance-sensitive Rust dependencies.
 Run the normal gate from the worktree with all installed models:
 
 ```bash
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
 python3 scripts/murmur_bench_fleet.py \
   --baseline origin/main \
-  --candidate origin/<branch-name> \
+  --candidate "$PR_HEAD_SHA" \
   --preset quick
 ```
+
+Before running, fetch `origin` on the trusted benchmark Mac and verify that it
+resolves `PR_HEAD_SHA`; do not substitute the local worktree branch or a moving
+branch name. Record this same candidate SHA in the benchmark receipt.
 
 Use `standard` for shared cross-model or pipeline changes. Do not pass
 `--no-fail`. If the comparison fails, rerun once with `--candidate-first`; a
 repeated regression blocks merge, while mixed results are inconclusive and
 require investigation or explicit user acceptance. Never upload raw reports or
 personal transcript content from the trusted Mac. Add only a content-free
-metric/pass-fail receipt and the tested candidate commit SHA to the PR. Any
+receipt containing the exact refs, candidate SHA, preset, model names,
+thresholds, aggregate deltas, and pass/fail to the PR. Any
 later push, rebase, merge from main, or conflict resolution invalidates the
 result and requires a rerun.
 

--- a/.codex/skills/murmur-pr-test/SKILL.md
+++ b/.codex/skills/murmur-pr-test/SKILL.md
@@ -62,6 +62,10 @@ Use the narrowest useful smoke test first, but always run the required checks be
 - Overlay or app UI behavior: test the real native app with Computer Use.
 - Docs-only changes: no native app required unless behavior is unclear.
 - Workflow/CI changes: inspect YAML and run local checks that approximate the workflow.
+- Benchmark-sensitive changes (VAD, transcription backends, model runtime,
+  transcript transforms, benchmarked execution paths, or performance-sensitive
+  Rust dependencies): run the Murmur Bench gate after resolving the exact
+  pushed PR head ref.
 
 ## Required Checks Before Merge
 
@@ -74,6 +78,32 @@ cd app && npx tsc --noEmit
 ```
 
 All checks must pass before merging. Fix only issues required to make the PR mergeable and verified.
+
+## Murmur Bench Performance Gate
+
+When the PR can change recognition latency, accuracy, delivered-text output, or
+memory, run the private benchmark from the PR worktree against the exact pushed
+candidate ref:
+
+```bash
+python3 scripts/murmur_bench_fleet.py \
+  --baseline origin/main \
+  --candidate origin/<headRefName> \
+  --preset quick
+```
+
+Use `standard` for shared cross-model or pipeline changes. Do not use
+`--no-fail`. If the comparison fails, rerun once with `--candidate-first`; a
+repeated regression blocks merge, while mixed results are inconclusive and
+require investigation or explicit user acceptance. Raw reports can contain
+personal transcript text and must remain on the trusted benchmark Mac. Put only
+a content-free aggregate result and the tested candidate commit SHA in the PR
+validation receipt. Any later push, rebase, merge from main, or conflict
+resolution invalidates the result and requires a rerun.
+
+For an unrelated PR, record `Murmur Bench: N/A — <reason>` rather than silently
+omitting the gate. Murmur Bench replays saved WAV files and does not replace a
+native smoke test for capture startup, device switching, clipboard, or paste.
 
 ## Native App Testing
 
@@ -117,6 +147,9 @@ Push to the PR head branch:
 git push origin HEAD:<headRefName>
 ```
 
+After pushing the changed candidate, rerun the Murmur Bench gate when
+applicable. Do not merge using a result from the pre-resolution commit.
+
 ## Merge
 
 Only merge when:
@@ -126,6 +159,9 @@ Only merge when:
 - `cargo check` passed.
 - `cargo test -- --test-threads=1` passed.
 - `npx tsc --noEmit` passed.
+- Murmur Bench passed when applicable, or the PR has a justified N/A receipt.
+- No unresolved/inconclusive benchmark regression remains unless the user
+  explicitly accepted the measured risk.
 - There are no known blockers.
 
 Merge with:
@@ -144,6 +180,7 @@ Report:
 - Worktree path.
 - What was tested in the native app.
 - Exact checks run and whether they passed.
+- Murmur Bench preset and aggregate result, or N/A with reason.
 - Any blockers, with the command error or file conflict.
 - Merge commit or PR URL if merged.
 

--- a/.codex/skills/murmur-pr-test/SKILL.md
+++ b/.codex/skills/murmur-pr-test/SKILL.md
@@ -82,23 +82,29 @@ All checks must pass before merging. Fix only issues required to make the PR mer
 ## Murmur Bench Performance Gate
 
 When the PR can change recognition latency, accuracy, delivered-text output, or
-memory, run the private benchmark from the PR worktree against the exact pushed
-candidate ref:
+memory, resolve the immutable pushed PR-head commit and run the private
+benchmark from the PR worktree against that SHA:
 
 ```bash
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
 python3 scripts/murmur_bench_fleet.py \
   --baseline origin/main \
-  --candidate origin/<headRefName> \
+  --candidate "$PR_HEAD_SHA" \
   --preset quick
 ```
+
+Before running, fetch `origin` on the trusted benchmark Mac and verify that it
+resolves `PR_HEAD_SHA`; do not substitute a moving branch name. Record this
+same candidate SHA in the validation receipt.
 
 Use `standard` for shared cross-model or pipeline changes. Do not use
 `--no-fail`. If the comparison fails, rerun once with `--candidate-first`; a
 repeated regression blocks merge, while mixed results are inconclusive and
 require investigation or explicit user acceptance. Raw reports can contain
 personal transcript text and must remain on the trusted benchmark Mac. Put only
-a content-free aggregate result and the tested candidate commit SHA in the PR
-validation receipt. Any later push, rebase, merge from main, or conflict
+a content-free receipt containing the exact refs, candidate SHA, preset, model
+names, thresholds, aggregate deltas, and pass/fail in the PR. Any later push,
+rebase, merge from main, or conflict
 resolution invalidates the result and requires a rerun.
 
 For an unrelated PR, record `Murmur Bench: N/A — <reason>` rather than silently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
 cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
+python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate origin/<branch> --preset quick  # Trusted-Mac PR performance gate
 ```
 
 > **macOS note:** `tauri.macos.conf.json` declares the local-LLM and capture helpers as externalBin, so
@@ -18,6 +19,34 @@ cd app && npm test                 # Frontend vitest — CI runs this too; tsc a
 > `app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. Run
 > `python3 scripts/build_local_llm_sidecar.py` once first (it is a no-op on non-arm64-macOS).
 > The binaries are gitignored; release CI builds them before bundling.
+
+## Murmur Bench Gate
+
+Murmur Bench is the private, repeatable personal-corpus harness documented in
+`docs/features/internal-performance-harness.md`. Raw reports can contain
+reference and recognized transcript text: keep them on the trusted benchmark
+Mac and put only a content-free metric summary in GitHub.
+
+- Before merging a PR that can change recognition latency, accuracy,
+  delivered-text output, or memory, run `scripts/murmur_bench_fleet.py` against
+  `origin/main` and the exact pushed candidate ref. This includes changes to
+  VAD, transcription backends, model runtime, transcript transforms, benchmarked
+  execution paths, or performance-sensitive Rust dependencies.
+- Use `quick` for the normal PR gate and `standard` for shared cross-model or
+  pipeline changes. Record an explicit `Murmur Bench: N/A — <reason>` for PRs
+  that cannot affect benchmarked behavior.
+- Record the tested candidate commit SHA. Any later push, rebase, merge from
+  main, or conflict resolution invalidates the result and requires a rerun.
+- Before every release, compare the previous release tag with `origin/main` on
+  `standard`. Use `thorough` when the release contains any benchmark-sensitive
+  change.
+- Never use `--no-fail` to satisfy a merge or release gate. If a comparison
+  fails, rerun once with `--candidate-first` to expose order/thermal bias. A
+  repeated regression blocks the operation; mixed results are inconclusive and
+  also require investigation or explicit user acceptance before continuing.
+- Murmur Bench replays saved WAV files. It does not replace native capture
+  smoke tests or the post-release production check for Core Audio startup,
+  device switching, first PCM, clipboard, or paste behavior.
 
 ## Docs
 
@@ -48,6 +77,7 @@ Read these before working on a feature:
 - **[docs/features/correct-and-teach.md](docs/features/correct-and-teach.md)** — Bounded learned corrections, exact-term teaching, scope and fail-closed rules
 - **[docs/features/personal-knowledge-store.md](docs/features/personal-knowledge-store.md)** — Local SQLite store, migrations, backup/recovery, export/import
 - **[docs/features/performance-lab.md](docs/features/performance-lab.md)** — Benchmarking, WER tiers, recommendation contract
+- **[docs/features/internal-performance-harness.md](docs/features/internal-performance-harness.md)** — Private personal-corpus build, Fleet runner, and mandatory PR/release performance gates
 - **[docs/features/diagnostic-report-comparison.md](docs/features/diagnostic-report-comparison.md)** — Session-only Reports workspace and comparison
 - **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
 - **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
 cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
-python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate origin/<branch> --preset quick  # Trusted-Mac PR performance gate
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
+python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate "$PR_HEAD_SHA" --preset quick  # Trusted-Mac PR performance gate
 ```
 
 > **macOS note:** `tauri.macos.conf.json` declares the local-LLM and capture helpers as externalBin, so
@@ -28,14 +29,18 @@ reference and recognized transcript text: keep them on the trusted benchmark
 Mac and put only a content-free metric summary in GitHub.
 
 - Before merging a PR that can change recognition latency, accuracy,
-  delivered-text output, or memory, run `scripts/murmur_bench_fleet.py` against
-  `origin/main` and the exact pushed candidate ref. This includes changes to
+  delivered-text output, or memory, resolve the pushed PR head with
+  `gh pr view --json headRefOid --jq .headRefOid`, verify the trusted benchmark
+  Mac can resolve that commit after fetching `origin`, and run
+  `scripts/murmur_bench_fleet.py` against `origin/main` and that immutable SHA.
+  This includes changes to
   VAD, transcription backends, model runtime, transcript transforms, benchmarked
   execution paths, or performance-sensitive Rust dependencies.
 - Use `quick` for the normal PR gate and `standard` for shared cross-model or
   pipeline changes. Record an explicit `Murmur Bench: N/A — <reason>` for PRs
   that cannot affect benchmarked behavior.
-- Record the tested candidate commit SHA. Any later push, rebase, merge from
+- Record the exact baseline ref, candidate SHA, preset, models, thresholds,
+  aggregate deltas, and pass/fail. Any later push, rebase, merge from
   main, or conflict resolution invalidates the result and requires a rerun.
 - Before every release, compare the previous release tag with `origin/main` on
   `standard`. Use `thorough` when the release contains any benchmark-sensitive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
 cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
-python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate origin/<branch> --preset quick  # Trusted-Mac PR performance gate
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
+python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate "$PR_HEAD_SHA" --preset quick  # Trusted-Mac PR performance gate
 ```
 
 > **macOS note:** `tauri.macos.conf.json` declares the local-LLM and capture helpers as externalBin, so
@@ -28,14 +29,18 @@ reference and recognized transcript text: keep them on the trusted benchmark
 Mac and put only a content-free metric summary in GitHub.
 
 - Before merging a PR that can change recognition latency, accuracy,
-  delivered-text output, or memory, run `scripts/murmur_bench_fleet.py` against
-  `origin/main` and the exact pushed candidate ref. This includes changes to
+  delivered-text output, or memory, resolve the pushed PR head with
+  `gh pr view --json headRefOid --jq .headRefOid`, verify the trusted benchmark
+  Mac can resolve that commit after fetching `origin`, and run
+  `scripts/murmur_bench_fleet.py` against `origin/main` and that immutable SHA.
+  This includes changes to
   VAD, transcription backends, model runtime, transcript transforms, benchmarked
   execution paths, or performance-sensitive Rust dependencies.
 - Use `quick` for the normal PR gate and `standard` for shared cross-model or
   pipeline changes. Record an explicit `Murmur Bench: N/A — <reason>` for PRs
   that cannot affect benchmarked behavior.
-- Record the tested candidate commit SHA. Any later push, rebase, merge from
+- Record the exact baseline ref, candidate SHA, preset, models, thresholds,
+  aggregate deltas, and pass/fail. Any later push, rebase, merge from
   main, or conflict resolution invalidates the result and requires a rerun.
 - Before every release, compare the previous release tag with `origin/main` on
   `standard`. Use `thorough` when the release contains any benchmark-sensitive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ cd app && npm run tauri build      # Production .app and .dmg
 cd app/src-tauri && cargo test -- --test-threads=1  # Rust unit tests
 cd app && npx tsc --noEmit         # TypeScript check
 cd app && npm test                 # Frontend vitest — CI runs this too; tsc alone is not enough
+python3 scripts/murmur_bench_fleet.py --baseline origin/main --candidate origin/<branch> --preset quick  # Trusted-Mac PR performance gate
 ```
 
 > **macOS note:** `tauri.macos.conf.json` declares the local-LLM and capture helpers as externalBin, so
@@ -18,6 +19,34 @@ cd app && npm test                 # Frontend vitest — CI runs this too; tsc a
 > `app/src-tauri/binaries/murmur-llm-sidecar-aarch64-apple-darwin`. Run
 > `python3 scripts/build_local_llm_sidecar.py` once first (it is a no-op on non-arm64-macOS).
 > The binaries are gitignored; release CI builds them before bundling.
+
+## Murmur Bench Gate
+
+Murmur Bench is the private, repeatable personal-corpus harness documented in
+`docs/features/internal-performance-harness.md`. Raw reports can contain
+reference and recognized transcript text: keep them on the trusted benchmark
+Mac and put only a content-free metric summary in GitHub.
+
+- Before merging a PR that can change recognition latency, accuracy,
+  delivered-text output, or memory, run `scripts/murmur_bench_fleet.py` against
+  `origin/main` and the exact pushed candidate ref. This includes changes to
+  VAD, transcription backends, model runtime, transcript transforms, benchmarked
+  execution paths, or performance-sensitive Rust dependencies.
+- Use `quick` for the normal PR gate and `standard` for shared cross-model or
+  pipeline changes. Record an explicit `Murmur Bench: N/A — <reason>` for PRs
+  that cannot affect benchmarked behavior.
+- Record the tested candidate commit SHA. Any later push, rebase, merge from
+  main, or conflict resolution invalidates the result and requires a rerun.
+- Before every release, compare the previous release tag with `origin/main` on
+  `standard`. Use `thorough` when the release contains any benchmark-sensitive
+  change.
+- Never use `--no-fail` to satisfy a merge or release gate. If a comparison
+  fails, rerun once with `--candidate-first` to expose order/thermal bias. A
+  repeated regression blocks the operation; mixed results are inconclusive and
+  also require investigation or explicit user acceptance before continuing.
+- Murmur Bench replays saved WAV files. It does not replace native capture
+  smoke tests or the post-release production check for Core Audio startup,
+  device switching, first PCM, clipboard, or paste behavior.
 
 ## Docs
 
@@ -52,6 +81,7 @@ Read these before working on a feature:
 - **[docs/features/correct-and-teach.md](docs/features/correct-and-teach.md)** — Bounded learned corrections, exact-term teaching, scope and fail-closed rules
 - **[docs/features/personal-knowledge-store.md](docs/features/personal-knowledge-store.md)** — Local SQLite store, migrations, backup/recovery, export/import
 - **[docs/features/performance-lab.md](docs/features/performance-lab.md)** — Benchmarking, WER tiers, recommendation contract
+- **[docs/features/internal-performance-harness.md](docs/features/internal-performance-harness.md)** — Private personal-corpus build, Fleet runner, and mandatory PR/release performance gates
 - **[docs/features/diagnostic-report-comparison.md](docs/features/diagnostic-report-comparison.md)** — Session-only Reports workspace and comparison
 - **[docs/features/selected-text-transform.md](docs/features/selected-text-transform.md)** — Local selected-text rewrite (hold key, sidecar LLM, review popover, approve/undo)
 - **[docs/features/evaluation-harness.md](docs/features/evaluation-harness.md)** — Versioned local fixtures, deterministic CI, opt-in hardware evaluation, reports, and deletion

--- a/docs/features/internal-performance-harness.md
+++ b/docs/features/internal-performance-harness.md
@@ -118,6 +118,50 @@ and Thorough (20 × 3) before a release. Alternate `--candidate-first` between
 repeat comparisons when investigating small deltas to reduce order/thermal
 bias.
 
+## Required PR and release gates
+
+For a PR that can change recognition latency, accuracy, delivered-text output,
+or memory, run the Fleet wrapper after pushing the exact candidate branch:
+
+```bash
+python3 scripts/murmur_bench_fleet.py \
+  --baseline origin/main \
+  --candidate origin/<branch> \
+  --preset quick
+```
+
+The gate applies to VAD, transcription backends, model runtime, transcript
+transforms, benchmarked execution paths, and performance-sensitive Rust
+dependencies. Use Standard for shared cross-model or pipeline changes. A PR
+outside that surface records `Murmur Bench: N/A — <reason>` in its validation
+receipt instead of running an irrelevant benchmark.
+
+Record the tested candidate commit SHA in the receipt. Any later push, rebase,
+merge from main, or conflict resolution invalidates the result and requires a
+rerun against the new exact candidate ref before merge.
+
+Before every release, compare the previous release tag with the exact
+`origin/main` release candidate using Standard. Use Thorough when any commit
+since the tag touches the benchmark-sensitive surface:
+
+```bash
+python3 scripts/murmur_bench_fleet.py \
+  --baseline v<previous-version> \
+  --candidate origin/main \
+  --preset standard
+```
+
+Do not use `--no-fail` for either gate. On a failed comparison, repeat once
+with `--candidate-first`. A repeated regression blocks merge or release. Mixed
+results are inconclusive rather than a pass and require investigation or the
+user's explicit acceptance of the measured risk. Keep raw reports and personal
+transcript content on the trusted Mac; report only model names, aggregate
+deltas, thresholds, and pass/fail in GitHub.
+
+This replay gate does not exercise live Core Audio startup, device switching,
+first PCM, or real clipboard/paste delivery. Native smoke tests and the
+post-release production-latency check remain mandatory where applicable.
+
 ## CI policy
 
 Do not upload raw personal reports as CI artifacts: they contain real reference

--- a/docs/features/internal-performance-harness.md
+++ b/docs/features/internal-performance-harness.md
@@ -121,14 +121,20 @@ bias.
 ## Required PR and release gates
 
 For a PR that can change recognition latency, accuracy, delivered-text output,
-or memory, run the Fleet wrapper after pushing the exact candidate branch:
+or memory, resolve the immutable PR-head SHA after pushing the exact candidate
+branch, then run the Fleet wrapper against that SHA:
 
 ```bash
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
 python3 scripts/murmur_bench_fleet.py \
   --baseline origin/main \
-  --candidate origin/<branch> \
+  --candidate "$PR_HEAD_SHA" \
   --preset quick
 ```
+
+Fetch `origin` on the trusted benchmark Mac first and verify that it resolves
+`PR_HEAD_SHA`; do not substitute a moving branch name. The same SHA must appear
+in the validation receipt.
 
 The gate applies to VAD, transcription backends, model runtime, transcript
 transforms, benchmarked execution paths, and performance-sensitive Rust
@@ -138,7 +144,7 @@ receipt instead of running an irrelevant benchmark.
 
 Record the tested candidate commit SHA in the receipt. Any later push, rebase,
 merge from main, or conflict resolution invalidates the result and requires a
-rerun against the new exact candidate ref before merge.
+rerun against the new immutable candidate SHA before merge.
 
 Before every release, compare the previous release tag with the exact
 `origin/main` release candidate using Standard. Use Thorough when any commit
@@ -155,8 +161,9 @@ Do not use `--no-fail` for either gate. On a failed comparison, repeat once
 with `--candidate-first`. A repeated regression blocks merge or release. Mixed
 results are inconclusive rather than a pass and require investigation or the
 user's explicit acceptance of the measured risk. Keep raw reports and personal
-transcript content on the trusted Mac; report only model names, aggregate
-deltas, thresholds, and pass/fail in GitHub.
+transcript content on the trusted Mac. GitHub receipts may contain only
+content-free provenance and results: exact refs, candidate SHA where applicable,
+preset, model names, thresholds, aggregate deltas, and pass/fail.
 
 This replay gate does not exercise live Core Audio startup, device switching,
 first PCM, or real clipboard/paste delivery. Native smoke tests and the

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -50,11 +50,43 @@ policy and emits the immutable updater manifest.
 
 Include the min_version decision in the release summary.
 
-## 4. Summarise the Build Plan
+## 4. Run the Pre-Release Murmur Bench Gate
+
+Before asking for release authorization, compare the previous release tag with
+the exact `origin/main` release candidate on the trusted benchmark Mac:
+
+```bash
+python3 scripts/murmur_bench_fleet.py \
+  --baseline v{previous_version} \
+  --candidate origin/main \
+  --preset standard
+```
+
+Use `thorough` instead of `standard` when any commit since the tag can change
+recognition latency, accuracy, delivered-text output, or memory. This includes
+VAD, transcription backends, model runtime, transcript transforms, benchmarked
+execution paths, and performance-sensitive Rust dependencies.
+
+This gate is mandatory for every release. Do not use `--no-fail`. If the
+comparison fails, rerun once with `--candidate-first` to expose order/thermal
+bias. A repeated regression blocks the release. Mixed results are inconclusive
+and also block the release until investigated or explicitly accepted by the
+user. If the trusted Mac, corpus, or comparable baseline is unavailable, stop
+and report the missing prerequisite rather than silently skipping the gate.
+
+Raw reports can contain personal reference and recognized transcript text.
+Leave them on the trusted benchmark Mac and include only model names, aggregate
+metric deltas, configured thresholds, and pass/fail in the release summary.
+Murmur Bench replays saved WAV files, so it does not replace the post-release
+production check for live Core Audio startup, first PCM, device behavior,
+clipboard, or paste.
+
+## 5. Summarise the Build Plan
 
 Present a concise release summary:
 - Current version → New version (and why: major/minor/patch)
 - Bullet list of what's included (one line per meaningful commit, skip chores/docs)
+- Murmur Bench preset, compared refs, and aggregate pass/fail result
 - Explain that pushing the version-bump commit starts the signed `Release Build`
   and that a successful build automatically creates `v{new_version}` and publishes
   its exact artifacts. A failed build never creates a tag or release.
@@ -63,7 +95,7 @@ Present a concise release summary:
 Stop and wait for confirmation. This is the release confirmation: it authorizes
 the version bump, main push, and automatic tag/publish after all gates pass.
 
-## 5. Build Trusted Artifacts
+## 6. Build Trusted Artifacts
 
 Run these steps in order:
 
@@ -85,7 +117,7 @@ Run these steps in order:
 If the build fails, use the cold fallback in `docs/release.md`. Automation will
 not create a tag or release for a failed build.
 
-## 6. Verify Automatic Promotion
+## 7. Verify Automatic Promotion
 
 Wait for the `Release` workflow started by the completed `Release Build`. Verify
 that it used the exact build run ID and commit SHA, created `v{new_version}` at
@@ -115,7 +147,7 @@ Then update its notes:
    ```
    Write the notes yourself from the commit list in Step 3 — use clear, user-facing language (not raw commit messages). Omit any section that has no entries. Skip `chore:`, `docs:`, `test:` commits.
 
-## 7. Validate Post-Release Production Latency
+## 8. Validate Post-Release Production Latency
 
 For any release that changes capture, transcription, delivery, model runtime,
 or performance-sensitive dependencies, the release is published but its
@@ -164,11 +196,12 @@ Follow `docs/features/performance-diagnostics.md` for the local run contract and
 privacy boundaries. Never inspect or report transcript, clipboard, or audio
 content while doing this comparison.
 
-## 8. Hand Off
+## 9. Hand Off
 
 Tell the user:
 - Exact commit, build run, promotion run, tag, and release URLs
 - The signed build passed and GitHub automatically promoted its exact artifacts
 - The release is published at: `https://github.com/georgenijo/murmur-app/releases`
+- The pre-release Murmur Bench refs, preset, and aggregate result
 - The production-latency comparison result, or clearly state that it is pending
   natural prompts on an explicitly authorized updated machine

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -75,8 +75,9 @@ user. If the trusted Mac, corpus, or comparable baseline is unavailable, stop
 and report the missing prerequisite rather than silently skipping the gate.
 
 Raw reports can contain personal reference and recognized transcript text.
-Leave them on the trusted benchmark Mac and include only model names, aggregate
-metric deltas, configured thresholds, and pass/fail in the release summary.
+Leave them on the trusted benchmark Mac. The release summary may contain only
+content-free provenance and results: exact refs, candidate SHA where applicable,
+preset, model names, configured thresholds, aggregate deltas, and pass/fail.
 Murmur Bench replays saved WAV files, so it does not replace the post-release
 production check for live Core Audio startup, first PCM, device behavior,
 clipboard, or paste.


### PR DESCRIPTION
## Summary
- require Murmur Bench for benchmark-sensitive PRs and record justified N/A receipts for unrelated work
- require a previous-tag versus `origin/main` benchmark before every release
- mirror the policy across Codex skills, `AGENTS.md`, `CLAUDE.md`, release instructions, and harness documentation

## Why
The private benchmark harness existed, but the agent workflows did not require it. A performance-sensitive PR or release could proceed without a comparable baseline/candidate run.

## Validation
- both Codex skills pass `quick_validate.py`
- murmur-feature helper tests: 10 passed
- Fleet benchmark CLI arguments verified with `--help`
- `git diff --check`
- Murmur Bench: N/A — instruction and documentation changes only; no benchmarked runtime behavior changed

Raw personal-corpus reports remain confined to the trusted benchmark Mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance benchmark gates for applicable pull requests and releases.
  * Added quick, standard, and thorough benchmark procedures with regression handling and rerun requirements.
  * Added benchmark results and references to validation and release reports.

* **Documentation**
  * Documented benchmark commands, privacy requirements, failure handling, reporting expectations, and remaining smoke-test requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->