### PR TITLE
Fix capture-watch alert lifecycles

### DIFF
--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -142,25 +142,34 @@ the ordered sequence, and cite event codes in its diagnosis.
 the retained production JSONL. Its versioned report groups only privacy-safe
 capture metrics by install and receiver-observed app version:
 
-- readiness `startup_ms` p50/p95;
+- dictation readiness `startup_ms` p50/p95;
 - active initialization timeouts split by stable backend and
   `last_setup_step`;
 - fallback and both-backends-failed counts;
-- ready-recording counts per completed attempted app session.
+- ready-recording counts for the five most recent completed attempted
+  dictation sessions per cohort.
 
 The watch alerts when a newest comparable cohort (at least five readiness
-samples) has a p50 above twice the preceding version on the same install, or
-when the same install/version has two completed attempted sessions with zero
-ready recordings. An app session is delimited by `startup_baseline`; idle
-launches and the currently open session cannot create a zero-ready verdict.
+samples) has a p50 above twice the best retained earlier eligible cohort on the
+same install. Anchoring to that healthy baseline keeps an equally slow later
+release from masking an unresolved regression. It also alerts when the latest
+version cohort with a completed attempted dictation session has two zero-ready
+outcomes among its five most recent attempts. A newer healthy cohort supersedes
+an older failed cohort, and enough later healthy attempts age failures out of
+the window. An app session is delimited by `startup_baseline`; idle launches,
+transform captures, and the currently open session cannot create a zero-ready
+verdict.
 
 Reports contain no raw event summaries, device fields, content, paths, or free
-form errors. Backend/setup-step values are allowlisted and unknown values
-collapse to `unknown`. Memory is bounded to the newest 500 startup samples per
-cohort and 64 explicit versions per install; excess versions collapse into a
-non-comparable `overflow` cohort. The report is atomically replaced at
-`~/murmur-logs/capture-watch.json`; an alert also makes the one-shot exit
-nonzero for systemd/journal visibility and appears on the protected dashboard.
+form errors. Backend/setup-step values are allowlisted (including the explicit
+pre-native-call `none` setup step) and unknown values collapse to `unknown`.
+Memory is bounded to the newest 500 startup samples and five attempted-session
+outcomes per cohort, with ready counts at or above 20 combined into one capped
+tail bucket. Each install has at most 64 explicit versions; excess versions
+collapse into a non-comparable `overflow` cohort. The report is atomically
+replaced at `~/murmur-logs/capture-watch.json`; an alert also makes the one-shot
+exit nonzero for systemd/journal visibility and appears on the protected
+dashboard.
 
 ### Operator event semantics
 

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -136,21 +136,28 @@ newest 500 readiness samples per install/version cohort and 64 explicit version
 cohorts per install. Further versions collapse into a non-comparable
 `overflow` cohort. It reports:
 
-- `startup_ms` p50 and p95;
+- dictation `startup_ms` p50 and p95;
 - active-budget timeouts split by stable backend and native setup step;
 - fallback and both-backends-failed counts;
-- a histogram of ready recordings per completed, attempted app session.
+- a histogram of ready recordings for the five most recent completed,
+  attempted dictation sessions in each cohort.
 
 `startup_baseline` begins an app session. A session contributes to the
 zero-ready signal only after a later baseline proves it ended and only when it
-contained `audio initialization accepted`; idle launches and the currently open
-session are excluded.
+contained a dictation `audio initialization accepted`; idle launches, transform
+captures, and the currently open session are excluded. Per-session ready counts
+at or above 20 share one capped tail bucket, bounding both memory and report
+cardinality.
 
 An alert is created when the newest comparable version has at least five
-readiness samples and its p50 is more than twice the preceding comparable
-version on the same install, or when one install/version has at least two
-completed attempted sessions with zero ready recordings. Thresholds live in the
-watch script and are fixture-tested.
+dictation readiness samples and its p50 is more than twice the best retained
+earlier eligible cohort on the same install. This baseline remains anchored
+across equally slow later releases. A zero-ready alert is created only for the
+latest version cohort with a completed attempted dictation session when at
+least two of its five most recent attempts had no ready recording; a newer
+healthy cohort supersedes stale failures and later healthy attempts age them
+out. Thresholds live in the watch script and are fixture-tested. The allowlist
+preserves `last_setup_step: "none"` as the explicit pre-native-call state.
 
 ## Tests
 

--- a/infra/log-receiver/murmur-capture-watch.py
+++ b/infra/log-receiver/murmur-capture-watch.py
@@ -25,11 +25,15 @@ MAX_VERSIONS_PER_INSTALL = 64
 MIN_COMPARISON_SAMPLES = 5
 STARTUP_REGRESSION_RATIO = 2.0
 REPEATED_ZERO_READY_SESSIONS = 2
+RECENT_ATTEMPTED_SESSION_WINDOW = 5
+MAX_READY_RECORDINGS_PER_SESSION = 20
+CAPTURE_HEALTH_OWNER_KIND = "dictation"
 
 VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,39}$")
 INSTALL_RE = re.compile(r"^[0-9a-fA-F-]{8,64}$")
 BACKENDS = {"auhal", "cpal"}
 SETUP_STEPS = {
+    "none",
     "device_resolution",
     "audio_unit_creation",
     "audio_unit_new",
@@ -117,8 +121,8 @@ def new_cohort(install_id, version):
         "fallback_count": 0,
         "both_backends_failed_count": 0,
         "attempted_sessions": 0,
-        "zero_ready_sessions": 0,
-        "session_ready_histogram": Counter(),
+        "recent_session_ready_counts": deque(maxlen=RECENT_ATTEMPTED_SESSION_WINDOW),
+        "last_attempted_session_at": "",
         "first_event_at": "",
         "last_event_at": "",
     }
@@ -150,14 +154,14 @@ def touch_cohort(cohort, timestamp):
         cohort["last_event_at"] = timestamp
 
 
-def finish_session(session, cohorts, install_id):
+def finish_session(session, cohorts, install_id, finished_at):
     if not session or not session["attempted"]:
         return
     cohort = cohort_for(cohorts, install_id, session["version"])
     cohort["attempted_sessions"] += 1
-    cohort["session_ready_histogram"][session["ready_count"]] += 1
-    if session["ready_count"] == 0:
-        cohort["zero_ready_sessions"] += 1
+    cohort["recent_session_ready_counts"].append(session["ready_count"])
+    if finished_at and finished_at > cohort["last_attempted_session_at"]:
+        cohort["last_attempted_session_at"] = finished_at
 
 
 def scan_install(path, install_id, cohorts):
@@ -180,7 +184,7 @@ def scan_install(path, install_id, cohorts):
             touch_cohort(cohort, timestamp)
 
             if event.get("summary") == "startup_baseline":
-                finish_session(session, cohorts, install_id)
+                finish_session(session, cohorts, install_id, timestamp)
                 session = {
                     "version": version,
                     "attempted": False,
@@ -191,16 +195,25 @@ def scan_install(path, install_id, cohorts):
             code = event_code(event)
             data = event_data(event)
             if code == "audio.capture_started":
-                if session is not None and session["version"] == version:
+                if (
+                    data.get("owner_kind") == CAPTURE_HEALTH_OWNER_KIND
+                    and session is not None
+                    and session["version"] == version
+                ):
                     session["attempted"] = True
                 continue
             if code == "audio.capture_ready":
+                if data.get("owner_kind") != CAPTURE_HEALTH_OWNER_KIND:
+                    continue
                 startup_ms = numeric_startup(event)
                 if startup_ms is not None:
                     cohort["startup_samples"].append(startup_ms)
                     cohort["startup_sample_total"] += 1
                 if session is not None and session["version"] == version:
-                    session["ready_count"] += 1
+                    session["ready_count"] = min(
+                        session["ready_count"] + 1,
+                        MAX_READY_RECORDINGS_PER_SESSION,
+                    )
                 continue
             if code == "audio.capture_backend_timeout":
                 key = (
@@ -223,6 +236,8 @@ def scan_install(path, install_id, cohorts):
 
 def serialize_cohort(cohort):
     samples = list(cohort["startup_samples"])
+    recent_session_ready_counts = list(cohort["recent_session_ready_counts"])
+    session_ready_histogram = Counter(recent_session_ready_counts)
     timeout_rows = [
         {
             "backend": backend,
@@ -248,11 +263,24 @@ def serialize_cohort(cohort):
         "fallback_count": cohort["fallback_count"],
         "both_backends_failed_count": cohort["both_backends_failed_count"],
         "attempted_sessions": cohort["attempted_sessions"],
-        "zero_ready_sessions": cohort["zero_ready_sessions"],
+        "evaluated_attempted_sessions": len(recent_session_ready_counts),
+        "attempted_sessions_truncated": (
+            cohort["attempted_sessions"] > len(recent_session_ready_counts)
+        ),
+        "last_attempted_session_at": cohort["last_attempted_session_at"],
+        "zero_ready_sessions": sum(
+            ready_count == 0 for ready_count in recent_session_ready_counts
+        ),
         "ready_recordings_per_session": [
-            {"ready_recordings": ready_count, "sessions": session_count}
+            {
+                "ready_recordings": ready_count,
+                "ready_recordings_capped": (
+                    ready_count == MAX_READY_RECORDINGS_PER_SESSION
+                ),
+                "sessions": session_count,
+            }
             for ready_count, session_count in sorted(
-                cohort["session_ready_histogram"].items()
+                session_ready_histogram.items()
             )
         ],
     }
@@ -266,18 +294,42 @@ def regression_alerts(cohort_rows):
             continue
         by_install.setdefault(row["install_id"], []).append(row)
 
-        if row["zero_ready_sessions"] >= REPEATED_ZERO_READY_SESSIONS:
+    for install_id, rows in by_install.items():
+        attempted_rows = [
+            row
+            for row in rows
+            if row["evaluated_attempted_sessions"] > 0
+            and row["last_attempted_session_at"]
+        ]
+        if attempted_rows:
+            latest_attempted = max(
+                attempted_rows,
+                key=lambda row: (
+                    row["last_attempted_session_at"],
+                    row["last_event_at"],
+                    row["app_version"],
+                ),
+            )
+        else:
+            latest_attempted = None
+        if (
+            latest_attempted is not None
+            and latest_attempted["zero_ready_sessions"]
+            >= REPEATED_ZERO_READY_SESSIONS
+        ):
             alerts.append(
                 {
                     "kind": "repeated_zero_ready_sessions",
-                    "install_id": row["install_id"],
-                    "app_version": row["app_version"],
-                    "zero_ready_sessions": row["zero_ready_sessions"],
-                    "attempted_sessions": row["attempted_sessions"],
+                    "install_id": latest_attempted["install_id"],
+                    "app_version": latest_attempted["app_version"],
+                    "zero_ready_sessions": latest_attempted["zero_ready_sessions"],
+                    "evaluated_attempted_sessions": latest_attempted[
+                        "evaluated_attempted_sessions"
+                    ],
+                    "attempted_sessions": latest_attempted["attempted_sessions"],
                 }
             )
 
-    for install_id, rows in by_install.items():
         eligible = [
             row
             for row in rows
@@ -287,7 +339,11 @@ def regression_alerts(cohort_rows):
         eligible.sort(key=lambda row: row["last_event_at"])
         if len(eligible) < 2:
             continue
-        baseline, candidate = eligible[-2:]
+        candidate = eligible[-1]
+        baseline = min(
+            eligible[:-1],
+            key=lambda row: (row["startup_p50_ms"], row["last_event_at"]),
+        )
         baseline_p50 = baseline["startup_p50_ms"]
         candidate_p50 = candidate["startup_p50_ms"]
         if baseline_p50 > 0 and candidate_p50 > baseline_p50 * STARTUP_REGRESSION_RATIO:
@@ -346,6 +402,11 @@ def build_report(root):
             "minimum_comparison_samples": MIN_COMPARISON_SAMPLES,
             "startup_p50_regression_ratio": STARTUP_REGRESSION_RATIO,
             "repeated_zero_ready_sessions": REPEATED_ZERO_READY_SESSIONS,
+            "recent_attempted_session_window": RECENT_ATTEMPTED_SESSION_WINDOW,
+            "maximum_ready_recordings_per_session": (
+                MAX_READY_RECORDINGS_PER_SESSION
+            ),
+            "capture_health_owner_kind": CAPTURE_HEALTH_OWNER_KIND,
             "maximum_startup_samples_per_cohort": MAX_STARTUP_SAMPLES,
             "maximum_versions_per_install": MAX_VERSIONS_PER_INSTALL,
         },

--- a/tests/test_capture_regression_watch.py
+++ b/tests/test_capture_regression_watch.py
@@ -58,7 +58,11 @@ class CaptureRegressionWatchTests(unittest.TestCase):
                 "audio readiness accepted",
                 f"2026-08-{prefix}T00:00:{index:02d}Z",
                 version=version,
-                data={"event_code": "audio.capture_ready", "startup_ms": value},
+                data={
+                    "event_code": "audio.capture_ready",
+                    "owner_kind": "dictation",
+                    "startup_ms": value,
+                },
             )
             for index, value in enumerate(startup_values)
         ]
@@ -122,6 +126,20 @@ class CaptureRegressionWatchTests(unittest.TestCase):
         self.assertEqual(alert["baseline_p50_ms"], 200)
         self.assertEqual(alert["candidate_p50_ms"], 540)
 
+    def test_persistent_p50_regression_uses_best_retained_earlier_baseline(self) -> None:
+        events = self.ready_events("1.0.0", "01", [200] * 5)
+        events += self.ready_events("1.1.0", "02", [500] * 5)
+        events += self.ready_events("1.2.0", "03", [520] * 5)
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        alert = report["alerts"][0]
+        self.assertEqual(alert["kind"], "startup_p50_regression")
+        self.assertEqual(alert["baseline_version"], "1.0.0")
+        self.assertEqual(alert["candidate_version"], "1.2.0")
+        self.assertEqual(alert["ratio"], 2.6)
+
     def test_small_or_cross_install_cohorts_never_form_a_regression(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             self.write_install(
@@ -150,6 +168,7 @@ class CaptureRegressionWatchTests(unittest.TestCase):
                         "audio initialization accepted",
                         f"2026-08-{day}T00:00:01Z",
                         version=version,
+                        data={"owner_kind": "dictation"},
                     ),
                 ]
             )
@@ -162,9 +181,106 @@ class CaptureRegressionWatchTests(unittest.TestCase):
         self.assertEqual(cohort["zero_ready_sessions"], 2)
         self.assertEqual(
             cohort["ready_recordings_per_session"],
-            [{"ready_recordings": 0, "sessions": 2}],
+            [
+                {
+                    "ready_recordings": 0,
+                    "ready_recordings_capped": False,
+                    "sessions": 2,
+                }
+            ],
         )
         self.assertEqual(report["alerts"][0]["kind"], "repeated_zero_ready_sessions")
+
+    def test_recent_healthy_sessions_clear_zero_ready_alert(self) -> None:
+        version = "1.2.3"
+        events = []
+        for day in range(1, 8):
+            events.append(
+                event(
+                    "startup_baseline",
+                    f"2026-08-{day:02d}T00:00:00Z",
+                    version=version,
+                )
+            )
+            events.append(
+                event(
+                    "audio initialization accepted",
+                    f"2026-08-{day:02d}T00:00:01Z",
+                    version=version,
+                    data={"owner_kind": "dictation"},
+                )
+            )
+            if day >= 3:
+                events.append(
+                    event(
+                        "audio readiness accepted",
+                        f"2026-08-{day:02d}T00:00:02Z",
+                        version=version,
+                        data={
+                            "event_code": "audio.capture_ready",
+                            "owner_kind": "dictation",
+                            "startup_ms": 200,
+                        },
+                    )
+                )
+        events.append(
+            event("startup_baseline", "2026-08-08T00:00:00Z", version=version)
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohort = report["cohorts"][0]
+        self.assertEqual(cohort["attempted_sessions"], 7)
+        self.assertEqual(cohort["evaluated_attempted_sessions"], 5)
+        self.assertTrue(cohort["attempted_sessions_truncated"])
+        self.assertEqual(cohort["zero_ready_sessions"], 0)
+        self.assertEqual(report["alerts"], [])
+        self.assertEqual(report["status"], "healthy")
+
+    def test_healthy_attempt_on_new_version_supersedes_stale_zero_ready_cohort(self) -> None:
+        events = [
+            event("startup_baseline", "2026-08-01T00:00:00Z", version="1.0.0"),
+            event(
+                "audio initialization accepted",
+                "2026-08-01T00:00:01Z",
+                version="1.0.0",
+                data={"owner_kind": "dictation"},
+            ),
+            event("startup_baseline", "2026-08-02T00:00:00Z", version="1.0.0"),
+            event(
+                "audio initialization accepted",
+                "2026-08-02T00:00:01Z",
+                version="1.0.0",
+                data={"owner_kind": "dictation"},
+            ),
+            event("startup_baseline", "2026-08-03T00:00:00Z", version="1.1.0"),
+            event(
+                "audio initialization accepted",
+                "2026-08-03T00:00:01Z",
+                version="1.1.0",
+                data={"owner_kind": "dictation"},
+            ),
+            event(
+                "audio readiness accepted",
+                "2026-08-03T00:00:02Z",
+                version="1.1.0",
+                data={
+                    "event_code": "audio.capture_ready",
+                    "owner_kind": "dictation",
+                    "startup_ms": 200,
+                },
+            ),
+            event("startup_baseline", "2026-08-04T00:00:00Z", version="1.1.0"),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohorts = {row["app_version"]: row for row in report["cohorts"]}
+        self.assertEqual(cohorts["1.0.0"]["zero_ready_sessions"], 2)
+        self.assertEqual(cohorts["1.1.0"]["zero_ready_sessions"], 0)
+        self.assertEqual(report["alerts"], [])
 
     def test_idle_and_still_open_sessions_are_not_zero_ready(self) -> None:
         version = "1.2.3"
@@ -176,6 +292,7 @@ class CaptureRegressionWatchTests(unittest.TestCase):
                 "audio initialization accepted",
                 "2026-08-02T00:00:01Z",
                 version=version,
+                data={"owner_kind": "dictation"},
             ),
         ]
         with tempfile.TemporaryDirectory() as root:
@@ -194,7 +311,7 @@ class CaptureRegressionWatchTests(unittest.TestCase):
             event(
                 "audio readiness accepted",
                 f"2026-08-01T00:00:0{index}Z",
-                data={"startup_ms": 100},
+                data={"owner_kind": "dictation", "startup_ms": 100},
             )
             for index in range(5)
         ]
@@ -209,26 +326,119 @@ class CaptureRegressionWatchTests(unittest.TestCase):
         self.assertEqual(report["alerts"], [])
 
     def test_untrusted_labels_are_collapsed_and_malformed_lines_are_counted(self) -> None:
-        item = event(
-            "capture backend exceeded its active initialization budget",
-            "2026-08-01T00:00:00Z",
-            version="1.2.3",
-            data={
-                "backend": "private-device-name",
-                "last_setup_step": "unsafe\nstep",
-            },
-        )
+        items = [
+            event(
+                "capture backend exceeded its active initialization budget",
+                "2026-08-01T00:00:00Z",
+                version="1.2.3",
+                data={
+                    "backend": "private-device-name",
+                    "last_setup_step": "unsafe\nstep",
+                },
+            ),
+            event(
+                "capture backend exceeded its active initialization budget",
+                "2026-08-01T00:00:01Z",
+                version="1.2.3",
+                data={"backend": "cpal", "last_setup_step": "none"},
+            ),
+        ]
         with tempfile.TemporaryDirectory() as root:
-            self.write_install(root, "12345678-abcd", [item])
+            self.write_install(root, "12345678-abcd", items)
             path = Path(root) / "12345678-abcd" / "events.jsonl"
             with path.open("a", encoding="utf-8") as handle:
                 handle.write("{broken\n")
             report = watch.build_report(root)
 
         self.assertEqual(report["malformed_lines"], 1)
-        timeout = report["cohorts"][0]["capture_backend_timeouts"][0]
-        self.assertEqual(timeout["backend"], "unknown")
-        self.assertEqual(timeout["last_setup_step"], "unknown")
+        timeouts = report["cohorts"][0]["capture_backend_timeouts"]
+        self.assertIn(
+            {"backend": "unknown", "last_setup_step": "unknown", "count": 1},
+            timeouts,
+        )
+        self.assertIn(
+            {"backend": "cpal", "last_setup_step": "none", "count": 1},
+            timeouts,
+        )
+
+    def test_transform_capture_events_do_not_enter_dictation_health_cohorts(self) -> None:
+        events = self.ready_events("1.0.0", "01", [200] * 5)
+        events += [
+            event("startup_baseline", "2026-08-02T00:00:00Z", version="1.1.0"),
+            event(
+                "audio initialization accepted",
+                "2026-08-02T00:00:01Z",
+                version="1.1.0",
+                data={"owner_kind": "transform"},
+            ),
+        ]
+        events += [
+            event(
+                "audio readiness accepted",
+                f"2026-08-02T00:00:{index + 2:02d}Z",
+                version="1.1.0",
+                data={
+                    "event_code": "audio.capture_ready",
+                    "owner_kind": "transform",
+                    "startup_ms": 10_000,
+                },
+            )
+            for index in range(5)
+        ]
+        events.append(
+            event("startup_baseline", "2026-08-03T00:00:00Z", version="1.1.0")
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohorts = {row["app_version"]: row for row in report["cohorts"]}
+        self.assertEqual(cohorts["1.0.0"]["startup_sample_count"], 5)
+        self.assertEqual(cohorts["1.1.0"]["startup_sample_count"], 0)
+        self.assertEqual(cohorts["1.1.0"]["attempted_sessions"], 0)
+        self.assertEqual(report["alerts"], [])
+
+    def test_ready_recording_histogram_has_a_bounded_tail_bucket(self) -> None:
+        version = "1.2.3"
+        events = [
+            event("startup_baseline", "2026-08-01T00:00:00Z", version=version),
+            event(
+                "audio initialization accepted",
+                "2026-08-01T00:00:01Z",
+                version=version,
+                data={"owner_kind": "dictation"},
+            ),
+        ]
+        events += [
+            event(
+                "audio readiness accepted",
+                f"2026-08-01T00:{index // 60:02d}:{index % 60:02d}Z",
+                version=version,
+                data={
+                    "event_code": "audio.capture_ready",
+                    "owner_kind": "dictation",
+                    "startup_ms": 100,
+                },
+            )
+            for index in range(100)
+        ]
+        events.append(
+            event("startup_baseline", "2026-08-02T00:00:00Z", version=version)
+        )
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        self.assertEqual(
+            report["cohorts"][0]["ready_recordings_per_session"],
+            [
+                {
+                    "ready_recordings": watch.MAX_READY_RECORDINGS_PER_SESSION,
+                    "ready_recordings_capped": True,
+                    "sessions": 1,
+                }
+            ],
+        )
 
     def test_version_cohort_cardinality_is_bounded(self) -> None:
         events = [
@@ -236,7 +446,7 @@ class CaptureRegressionWatchTests(unittest.TestCase):
                 "audio readiness accepted",
                 f"2026-08-01T00:{index:02d}:00Z",
                 version=f"1.0.{index}",
-                data={"startup_ms": index},
+                data={"owner_kind": "dictation", "startup_ms": index},
             )
             for index in range(watch.MAX_VERSIONS_PER_INSTALL + 3)
         ]


### PR DESCRIPTION
## Summary
- evaluate zero-ready alerts over the latest five completed dictation attempts and supersede stale version cohorts
- anchor newest-version p50 checks to the best retained earlier eligible cohort so persistent regressions remain visible
- cap ready-count histogram buckets, preserve the explicit `none` setup step, and exclude transform captures from dictation health

## Test plan
- [x] `python3 -m unittest tests/test_capture_regression_watch.py tests/test_log_receiver.py`
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1`
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test`
- [x] native app smoke: N/A — scheduled stdlib receiver aggregation only; no app runtime or UI behavior changed
- [x] Murmur Bench: N/A — receiver-side diagnostic aggregation cannot affect recognition latency, accuracy, delivered text, or app memory

Closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved capture-health monitoring to distinguish completed dictation attempts from idle, transform-only, or unfinished sessions.
  - Reduced false alerts by comparing startup performance with the strongest eligible historical baseline.
  - Alerts now recognize recovery after recent healthy sessions and account for newer software versions.
  - Improved reporting for timeouts, fallback failures, and ready-recording outcomes.

- **Documentation**
  - Updated capture monitoring documentation to describe the refined alerting, sampling, and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->