### PR TITLE
CI: smoke capture worker to first PCM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       rust: ${{ steps.filter.outputs.rust }}
       github: ${{ steps.filter.outputs.github }}
+      capture: ${{ steps.filter.outputs.capture }}
     steps:
       - uses: actions/checkout@v4
 
@@ -63,6 +64,13 @@ jobs:
               - 'tests/test_capture_agent_matrix.py'
               - 'tests/test_capture_worker_smoke.py'
               - 'tests/test_log_receiver.py'
+            capture:
+              - 'app/src-tauri/sidecars/capture/**'
+              - 'app/src-tauri/crates/capture-helper-protocol/**'
+              - 'app/src-tauri/src/audio*.rs'
+              - 'scripts/smoke_test_capture_worker.py'
+              - 'tests/test_capture_worker_smoke.py'
+              - '.github/workflows/ci.yml'
 
       - name: Validate workflow policy
         run: |
@@ -241,6 +249,38 @@ jobs:
           LD_LIBRARY_PATH="$CUDA_DRIVER_STUB_DIR:${LD_LIBRARY_PATH:-}" \
             cargo test --lib -- --test-threads=1
 
+  capture-worker-smoke:
+    needs: changes
+    if: "${{ needs.changes.outputs.capture == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}"
+    runs-on: [self-hosted, macOS, ARM64, murmur-audio]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Build capture worker
+        run: >-
+          cd app/src-tauri &&
+          MURMUR_CAPTURE_ROLE=worker
+          CARGO_TARGET_DIR=target/capture-worker-smoke
+          cargo build -p murmur-capture-helper
+
+      - name: Run native capture worker to first PCM
+        env:
+          MURMUR_CAPTURE_DEVICE_UID: ${{ vars.MURMUR_CAPTURE_DEVICE_UID }}
+        run: |
+          if [ -z "$MURMUR_CAPTURE_DEVICE_UID" ]; then
+            echo "ERROR: configure repository variable MURMUR_CAPTURE_DEVICE_UID with the stable runner input UID"
+            exit 1
+          fi
+          python3 scripts/smoke_test_capture_worker.py \
+            --worker app/src-tauri/target/capture-worker-smoke/debug/murmur-capture-helper \
+            --device-id "$MURMUR_CAPTURE_DEVICE_UID" \
+            --first-pcm-seconds 2 \
+            --timeout-seconds 8
+
   dependency-audit:
     runs-on: ubuntu-latest
     steps:
@@ -270,7 +310,7 @@ jobs:
           npm audit --audit-level=high
 
   ci-pass:
-    needs: [changes, typecheck, visual-regression, rust-macos, linux]
+    needs: [changes, typecheck, visual-regression, rust-macos, linux, capture-worker-smoke]
     # Keep this guard aligned with `changes`; otherwise the sentinel would turn
     # an intentionally skipped release-bump run into a failure.
     if: "${{ always() && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: bump version')) }}"
@@ -287,7 +327,8 @@ jobs:
             "${{ needs.typecheck.result }}" \
             "${{ needs.visual-regression.result }}" \
             "${{ needs.rust-macos.result }}" \
-            "${{ needs.linux.result }}"; do
+            "${{ needs.linux.result }}" \
+            "${{ needs.capture-worker-smoke.result }}"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "required CI job failed or was cancelled: $result"
               exit 1

--- a/scripts/smoke_test_capture_worker.py
+++ b/scripts/smoke_test_capture_worker.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""Exercise the final signed capture worker's production-v3 startup protocol."""
+"""Exercise the capture worker's production-v3 startup protocol."""
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
 import secrets
 import selectors
+import signal
 import struct
 import subprocess
 import time
@@ -19,10 +21,38 @@ MAGIC = b"MRMR"
 PROTOCOL_VERSION = 3
 HEADER_BYTES = 36
 MAX_CONTROL_BYTES = 16 * 1024
+MAX_PCM_SAMPLES = 16 * 1024
+MIN_PCM_FRAMES = 3
+
+SETUP_STEPS = {
+    "auhal": (
+        "deviceResolution",
+        "audioUnitNew",
+        "enableInputIo",
+        "disableOutputIo",
+        "setCurrentDevice",
+        "formatConfiguration",
+        "callbackInstallation",
+        "streamStart",
+    ),
+    "cpal": (
+        "deviceResolution",
+        "defaultConfig",
+        "streamBuild",
+        "streamStart",
+    ),
+}
 
 
 class SmokeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class PcmFrame:
+    sequence: int
+    sample_rate: int
+    sample_count: int
 
 
 def encode_control_frame(
@@ -53,9 +83,7 @@ def _read_exact(stream: BinaryIO, length: int, deadline: float) -> bytes:
     try:
         while len(chunks) < length:
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise SmokeError("capture worker response timed out")
-            if not selector.select(remaining):
+            if remaining <= 0 or not selector.select(remaining):
                 raise SmokeError("capture worker response timed out")
             chunk = os.read(stream.fileno(), length - len(chunks))
             if not chunk:
@@ -66,9 +94,16 @@ def _read_exact(stream: BinaryIO, length: int, deadline: float) -> bytes:
     return bytes(chunks)
 
 
-def read_control_frame(
+def _discard_exact(stream: BinaryIO, length: int, deadline: float) -> None:
+    remaining = length
+    while remaining:
+        chunk = _read_exact(stream, min(remaining, 4096), deadline)
+        remaining -= len(chunk)
+
+
+def read_production_frame(
     stream: BinaryIO, capture_id: int, nonce: bytes, deadline: float
-) -> dict[str, object]:
+) -> dict[str, object] | PcmFrame:
     header = _read_exact(stream, HEADER_BYTES, deadline)
     magic, version, kind, reserved, length, actual_capture_id, actual_nonce = (
         struct.unpack("<4sHBBIQ16s", header)
@@ -76,37 +111,99 @@ def read_control_frame(
     if (
         magic != MAGIC
         or version != PROTOCOL_VERSION
-        or kind != 0
         or reserved != 0
         or actual_capture_id != capture_id
         or actual_nonce != nonce
-        or length > MAX_CONTROL_BYTES
     ):
         raise SmokeError("capture worker returned an invalid protocol header")
-    payload = _read_exact(stream, length, deadline)
-    try:
-        message = json.loads(payload)
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise SmokeError("capture worker returned invalid control JSON") from error
-    if not isinstance(message, dict):
-        raise SmokeError("capture worker returned a non-object control message")
-    return message
+
+    if kind == 0:
+        if length > MAX_CONTROL_BYTES:
+            raise SmokeError("capture worker returned an oversized control frame")
+        payload = _read_exact(stream, length, deadline)
+        try:
+            message = json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise SmokeError("capture worker returned invalid control JSON") from error
+        if not isinstance(message, dict):
+            raise SmokeError("capture worker returned a non-object control message")
+        return message
+
+    if kind != 1 or not 16 <= length <= 16 + MAX_PCM_SAMPLES * 4:
+        raise SmokeError("capture worker returned an invalid PCM frame header")
+    metadata = _read_exact(stream, 16, deadline)
+    sequence, sample_rate, sample_count = struct.unpack("<QII", metadata)
+    if (
+        sample_count == 0
+        or sample_count > MAX_PCM_SAMPLES
+        or length != 16 + sample_count * 4
+    ):
+        raise SmokeError("capture worker returned a malformed PCM frame")
+    # Consume but never decode, print, persist, or upload PCM content.
+    _discard_exact(stream, sample_count * 4, deadline)
+    return PcmFrame(sequence, sample_rate, sample_count)
+
+
+def read_control_frame(
+    stream: BinaryIO, capture_id: int, nonce: bytes, deadline: float
+) -> dict[str, object]:
+    frame = read_production_frame(stream, capture_id, nonce, deadline)
+    if not isinstance(frame, dict):
+        raise SmokeError("capture worker returned PCM where control was required")
+    return frame
 
 
 def terminate_worker(process: subprocess.Popen[bytes]) -> None:
     if process.poll() is not None:
         return
-    process.terminate()
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        if process.poll() is not None:
+            return
+        process.terminate()
+    except PermissionError:
+        process.terminate()
     try:
         process.wait(timeout=2)
     except subprocess.TimeoutExpired:
-        process.kill()
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            if process.poll() is None:
+                process.kill()
+        except PermissionError:
+            process.kill()
         process.wait(timeout=2)
 
 
-def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
-    if not worker.is_file() or not os.access(worker, os.X_OK):
-        raise SmokeError("capture worker is missing or not executable")
+def _write_control(
+    process: subprocess.Popen[bytes],
+    capture_id: int,
+    nonce: bytes,
+    message: dict[str, object],
+) -> None:
+    if process.stdin is None:
+        raise SmokeError("capture worker protocol input is unavailable")
+    process.stdin.write(encode_control_frame(capture_id, nonce, message))
+    process.stdin.flush()
+
+
+def _expect_control(
+    stream: BinaryIO,
+    capture_id: int,
+    nonce: bytes,
+    deadline: float,
+    expected: dict[str, object],
+) -> None:
+    actual = read_control_frame(stream, capture_id, nonce, deadline)
+    if actual.get("type") == "failure":
+        raise SmokeError(f"capture worker failed: {actual}")
+    if actual != expected:
+        raise SmokeError(f"expected control message {expected}, received {actual}")
+
+
+def _start_worker(worker: Path) -> tuple[subprocess.Popen[bytes], int, bytes]:
     capture_id = secrets.randbits(63) or 1
     nonce = os.urandom(16)
     process = subprocess.Popen(
@@ -114,34 +211,41 @@ def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=True,
     )
-    try:
-        if process.stdin is None or process.stdout is None:
-            raise SmokeError("capture worker protocol pipes are unavailable")
-        deadline = time.monotonic() + timeout_seconds
-        process.stdin.write(
-            encode_control_frame(capture_id, nonce, {"type": "hello"})
-        )
-        process.stdin.flush()
-        hello = read_control_frame(process.stdout, capture_id, nonce, deadline)
-        if hello != {"type": "helloAck"}:
-            raise SmokeError("capture worker did not acknowledge protocol hello")
+    return process, capture_id, nonce
 
-        process.stdin.write(
-            encode_control_frame(
-                capture_id,
-                nonce,
-                {"type": "start", "deviceId": None, "backend": "auhal"},
-            )
+
+def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
+    """Keep the hardware-free stream-open smoke used by release builders."""
+    if not worker.is_file() or not os.access(worker, os.X_OK):
+        raise SmokeError("capture worker is missing or not executable")
+    process, capture_id, nonce = _start_worker(worker)
+    try:
+        if process.stdout is None:
+            raise SmokeError("capture worker protocol output is unavailable")
+        deadline = time.monotonic() + timeout_seconds
+        _write_control(process, capture_id, nonce, {"type": "hello"})
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            deadline,
+            {"type": "helloAck"},
         )
-        process.stdin.flush()
-        phase = read_control_frame(process.stdout, capture_id, nonce, deadline)
-        if phase != {
-            "type": "phase",
-            "phase": "streamOpen",
-            "backend": "auhal",
-        }:
-            raise SmokeError("capture worker did not enter the stream-open phase")
+        _write_control(
+            process,
+            capture_id,
+            nonce,
+            {"type": "start", "deviceId": None, "backend": "auhal"},
+        )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            deadline,
+            {"type": "phase", "phase": "streamOpen", "backend": "auhal"},
+        )
     finally:
         terminate_worker(process)
         for stream in (process.stdin, process.stdout, process.stderr):
@@ -149,16 +253,223 @@ def smoke_test(worker: Path, timeout_seconds: float = 5.0) -> None:
                 stream.close()
 
 
+def _smoke_backend_to_first_pcm(
+    worker: Path,
+    device_id: str,
+    backend: str,
+    timeout_seconds: float,
+    first_pcm_seconds: float,
+) -> float:
+    process, capture_id, nonce = _start_worker(worker)
+    try:
+        if process.stdout is None:
+            raise SmokeError("capture worker protocol output is unavailable")
+        hard_deadline = time.monotonic() + timeout_seconds
+        _write_control(process, capture_id, nonce, {"type": "hello"})
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            hard_deadline,
+            {"type": "helloAck"},
+        )
+
+        started_at = time.monotonic()
+        first_pcm_deadline = min(hard_deadline, started_at + first_pcm_seconds)
+        _write_control(
+            process,
+            capture_id,
+            nonce,
+            {"type": "start", "deviceId": device_id, "backend": backend},
+        )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            first_pcm_deadline,
+            {"type": "phase", "phase": "streamOpen", "backend": backend},
+        )
+        for step in SETUP_STEPS[backend]:
+            for transition in ("entered", "completed"):
+                _expect_control(
+                    process.stdout,
+                    capture_id,
+                    nonce,
+                    first_pcm_deadline,
+                    {
+                        "type": "setupStep",
+                        "backend": backend,
+                        "step": step,
+                        "transition": transition,
+                    },
+                )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            first_pcm_deadline,
+            {
+                "type": "setupStep",
+                "backend": backend,
+                "step": "awaitingFirstCallback",
+                "transition": "entered",
+            },
+        )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            first_pcm_deadline,
+            {
+                "type": "phase",
+                "phase": "awaitingFirstCallback",
+                "backend": backend,
+            },
+        )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            first_pcm_deadline,
+            {
+                "type": "setupStep",
+                "backend": backend,
+                "step": "awaitingFirstCallback",
+                "transition": "completed",
+            },
+        )
+        _expect_control(
+            process.stdout,
+            capture_id,
+            nonce,
+            first_pcm_deadline,
+            {"type": "phase", "phase": "active", "backend": backend},
+        )
+
+        pcm_frames = 0
+        pcm_samples = 0
+        expected_sequence = 0
+        first_pcm_elapsed = 0.0
+        while pcm_frames < MIN_PCM_FRAMES:
+            deadline = first_pcm_deadline if pcm_frames == 0 else hard_deadline
+            frame = read_production_frame(
+                process.stdout, capture_id, nonce, deadline
+            )
+            if isinstance(frame, dict):
+                if frame.get("type") == "failure":
+                    raise SmokeError(f"capture worker failed: {frame}")
+                raise SmokeError(f"expected PCM frame, received {frame}")
+            if frame.sequence != expected_sequence:
+                raise SmokeError(
+                    f"expected PCM sequence {expected_sequence}, received {frame.sequence}"
+                )
+            if frame.sample_rate <= 0:
+                raise SmokeError("capture worker returned an invalid PCM sample rate")
+            if pcm_frames == 0:
+                first_pcm_elapsed = time.monotonic() - started_at
+                if first_pcm_elapsed >= first_pcm_seconds:
+                    raise SmokeError(
+                        f"{backend} first PCM took {first_pcm_elapsed:.3f}s "
+                        f"(limit {first_pcm_seconds:.3f}s)"
+                    )
+            pcm_frames += 1
+            pcm_samples += frame.sample_count
+            expected_sequence += 1
+
+        _write_control(process, capture_id, nonce, {"type": "stop"})
+        while True:
+            frame = read_production_frame(
+                process.stdout, capture_id, nonce, hard_deadline
+            )
+            if isinstance(frame, PcmFrame):
+                if frame.sequence != expected_sequence:
+                    raise SmokeError(
+                        f"expected PCM sequence {expected_sequence}, received {frame.sequence}"
+                    )
+                expected_sequence += 1
+                pcm_samples += frame.sample_count
+                continue
+            if frame.get("type") == "failure":
+                raise SmokeError(f"capture worker failed while stopping: {frame}")
+            if frame.get("type") != "stopped":
+                raise SmokeError(f"expected stopped response, received {frame}")
+            retained = frame.get("retainedSamples")
+            if not isinstance(retained, int) or retained < pcm_samples:
+                raise SmokeError("capture worker reported an invalid retained sample count")
+            break
+
+        remaining = hard_deadline - time.monotonic()
+        if remaining <= 0:
+            raise SmokeError("capture worker hard timeout expired before clean exit")
+        try:
+            return_code = process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired as error:
+            raise SmokeError("capture worker did not exit after stopped") from error
+        if return_code != 0:
+            raise SmokeError(f"capture worker exited with status {return_code}")
+        return first_pcm_elapsed
+    finally:
+        terminate_worker(process)
+        for stream in (process.stdin, process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+
+
+def smoke_test_to_first_pcm(
+    worker: Path,
+    device_id: str,
+    timeout_seconds: float = 8.0,
+    first_pcm_seconds: float = 2.0,
+) -> dict[str, float]:
+    if not worker.is_file() or not os.access(worker, os.X_OK):
+        raise SmokeError("capture worker is missing or not executable")
+    if not device_id.strip():
+        raise SmokeError("an explicit capture device UID is required")
+    if timeout_seconds <= 0 or first_pcm_seconds <= 0:
+        raise SmokeError("timeouts must be positive")
+    return {
+        backend: _smoke_backend_to_first_pcm(
+            worker,
+            device_id,
+            backend,
+            timeout_seconds,
+            first_pcm_seconds,
+        )
+        for backend in ("auhal", "cpal")
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--worker", required=True, type=Path)
-    parser.add_argument("--timeout-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--device-id",
+        help="run the deep AUHAL+CPAL smoke against this explicit Core Audio UID",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=8.0)
+    parser.add_argument("--first-pcm-seconds", type=float, default=2.0)
     arguments = parser.parse_args()
     try:
-        smoke_test(arguments.worker, arguments.timeout_seconds)
+        if arguments.device_id:
+            timings = smoke_test_to_first_pcm(
+                arguments.worker,
+                arguments.device_id,
+                arguments.timeout_seconds,
+                arguments.first_pcm_seconds,
+            )
+        else:
+            smoke_test(arguments.worker, arguments.timeout_seconds)
+            timings = None
     except SmokeError as error:
         raise SystemExit(f"ERROR: {error}") from error
-    print("signed capture worker production-v3 startup smoke passed")
+    if timings is None:
+        print("signed capture worker production-v3 startup smoke passed")
+    else:
+        summary = ", ".join(
+            f"{backend} first_pcm={elapsed:.3f}s"
+            for backend, elapsed in timings.items()
+        )
+        print(f"capture worker first-PCM smoke passed: {summary}")
     return 0
 
 

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -135,10 +135,17 @@ def validate_ci(ci: str) -> int:
     assert "push:\n    branches: [main]" in ci
     assert "\n  pull_request:" in ci
     assert scalar(job_block(ci, "changes"), "if") == CI_GUARD
-    for job in ("typecheck", "visual-regression", "rust-macos", "linux"):
+    for job in (
+        "typecheck",
+        "visual-regression",
+        "rust-macos",
+        "linux",
+        "capture-worker-smoke",
+    ):
         assert scalar(job_block(ci, job), "needs") == "changes"
     assert scalar(job_block(ci, "ci-pass"), "needs") == (
-        "[changes, typecheck, visual-regression, rust-macos, linux]"
+        "[changes, typecheck, visual-regression, rust-macos, linux, "
+        "capture-worker-smoke]"
     )
     assert scalar(job_block(ci, "ci-pass"), "if") == CI_PASS_GUARD
     ci_pass_step = named_step_block(ci, "Check CI result", 6)
@@ -155,6 +162,13 @@ def validate_ci(ci: str) -> int:
     assert "tests/test_release_version.py" in ci
     assert "tests/test_workflow_policy.py" in ci
     assert "tests/test_capture_agent_matrix.py" in ci
+    assert "capture: ${{ steps.filter.outputs.capture }}" in ci
+    for capture_path in (
+        "'app/src-tauri/sidecars/capture/**'",
+        "'app/src-tauri/crates/capture-helper-protocol/**'",
+        "'app/src-tauri/src/audio*.rs'",
+    ):
+        assert capture_path in ci
     capture_build = named_step_block(
         ci, "Build capture isolation helpers and stub local-LLM externalBin", 6
     )
@@ -174,6 +188,26 @@ def validate_ci(ci: str) -> int:
     assert "binaries/murmur-capture-worker-aarch64-apple-darwin" in capture_build
     capture_tests = named_step_block(ci, "Run capture worker unit tests", 6)
     assert "cargo test -p murmur-capture-helper" in capture_tests
+    capture_smoke = job_block(ci, "capture-worker-smoke")
+    assert scalar(capture_smoke, "runs-on") == (
+        "[self-hosted, macOS, ARM64, murmur-audio]"
+    )
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in scalar(
+        capture_smoke, "if"
+    )
+    assert "timeout-minutes: 10" in capture_smoke
+    capture_worker_build = named_step_block(ci, "Build capture worker", 6)
+    assert "MURMUR_CAPTURE_ROLE=worker" in capture_worker_build
+    native_capture_smoke = named_step_block(
+        ci, "Run native capture worker to first PCM", 6
+    )
+    assert "scripts/smoke_test_capture_worker.py" in native_capture_smoke
+    assert "MURMUR_CAPTURE_DEVICE_UID: ${{ vars.MURMUR_CAPTURE_DEVICE_UID }}" in (
+        native_capture_smoke
+    )
+    assert '--device-id "$MURMUR_CAPTURE_DEVICE_UID"' in native_capture_smoke
+    assert "--first-pcm-seconds 2 \\" in native_capture_smoke
+    assert "${{ needs.capture-worker-smoke.result }}" in ci_pass_step
     job_block(ci, "dependency-audit")
     rust_audit = named_step_block(ci, "Audit Rust dependencies (advisory)", 6)
     assert "continue-on-error: true" in rust_audit

--- a/tests/test_capture_worker_smoke.py
+++ b/tests/test_capture_worker_smoke.py
@@ -10,13 +10,73 @@ import unittest
 
 from scripts.smoke_test_capture_worker import (
     encode_control_frame,
+    PcmFrame,
     read_control_frame,
+    read_production_frame,
     SmokeError,
     smoke_test,
+    smoke_test_to_first_pcm,
+)
+
+
+FAKE_DEEP_WORKER = textwrap.dedent(
+    """\
+    #!/usr/bin/env python3
+    import json
+    import struct
+    import sys
+
+    capture_id = int(sys.argv[2])
+    nonce = bytes.fromhex(sys.argv[3])
+
+    def read_frame():
+        header = sys.stdin.buffer.read(36)
+        magic, version, kind, reserved, length, actual_id, actual_nonce = struct.unpack("<4sHBBIQ16s", header)
+        assert (magic, version, kind, reserved, actual_id, actual_nonce) == (b"MRMR", 3, 0, 0, capture_id, nonce)
+        return json.loads(sys.stdin.buffer.read(length))
+
+    def write_control(message):
+        body = json.dumps(message, separators=(",", ":")).encode()
+        sys.stdout.buffer.write(struct.pack("<4sHBBIQ16s", b"MRMR", 3, 0, 0, len(body), capture_id, nonce) + body)
+        sys.stdout.buffer.flush()
+
+    def write_pcm(sequence):
+        body = struct.pack("<QIIf", sequence, 48000, 1, 0.25)
+        sys.stdout.buffer.write(struct.pack("<4sHBBIQ16s", b"MRMR", 3, 1, 0, len(body), capture_id, nonce) + body)
+        sys.stdout.buffer.flush()
+
+    assert read_frame() == {"type": "hello"}
+    write_control({"type": "helloAck"})
+    start = read_frame()
+    backend = start["backend"]
+    assert start == {"type": "start", "deviceId": "fixture-device-uid", "backend": backend}
+    steps = {
+        "auhal": ["deviceResolution", "audioUnitNew", "enableInputIo", "disableOutputIo", "setCurrentDevice", "formatConfiguration", "callbackInstallation", "streamStart"],
+        "cpal": ["deviceResolution", "defaultConfig", "streamBuild", "streamStart"],
+    }[backend]
+    write_control({"type": "phase", "phase": "streamOpen", "backend": backend})
+    for step in steps:
+        for transition in ("entered", "completed"):
+            write_control({"type": "setupStep", "backend": backend, "step": step, "transition": transition})
+    write_control({"type": "setupStep", "backend": backend, "step": "awaitingFirstCallback", "transition": "entered"})
+    write_control({"type": "phase", "phase": "awaitingFirstCallback", "backend": backend})
+    write_control({"type": "setupStep", "backend": backend, "step": "awaitingFirstCallback", "transition": "completed"})
+    write_control({"type": "phase", "phase": "active", "backend": backend})
+    for sequence in range(3):
+        write_pcm(sequence)
+    assert read_frame() == {"type": "stop"}
+    write_control({"type": "stopped", "retainedSamples": 3})
+    """
 )
 
 
 class CaptureWorkerSmokeTests(unittest.TestCase):
+    def _worker(self, directory: str, contents: str) -> Path:
+        worker = Path(directory) / "fake-worker"
+        worker.write_text(contents, encoding="utf-8")
+        worker.chmod(worker.stat().st_mode | stat.S_IXUSR)
+        return worker
+
     def test_control_frame_round_trip(self) -> None:
         capture_id = 42
         nonce = bytes(range(16))
@@ -34,6 +94,38 @@ class CaptureWorkerSmokeTests(unittest.TestCase):
                 {"type": "helloAck"},
             )
 
+    def test_pcm_frame_is_counted_without_exposing_content(self) -> None:
+        capture_id = 42
+        nonce = bytes(range(16))
+        body = b"".join(
+            (
+                (7).to_bytes(8, "little"),
+                (48_000).to_bytes(4, "little"),
+                (2).to_bytes(4, "little"),
+                b"private!",
+            )
+        )
+        header = (
+            b"MRMR"
+            + (3).to_bytes(2, "little")
+            + bytes((1, 0))
+            + len(body).to_bytes(4, "little")
+            + capture_id.to_bytes(8, "little")
+            + nonce
+        )
+        read_fd, write_fd = os.pipe()
+        try:
+            os.write(write_fd, header + body)
+        finally:
+            os.close(write_fd)
+        with os.fdopen(read_fd, "rb", buffering=0) as stream:
+            self.assertEqual(
+                read_production_frame(
+                    stream, capture_id, nonce, time.monotonic() + 1
+                ),
+                PcmFrame(sequence=7, sample_rate=48_000, sample_count=2),
+            )
+
     def test_invalid_capture_identity_fails_closed(self) -> None:
         nonce = bytes(range(16))
         encoded = encode_control_frame(41, nonce, {"type": "helloAck"})
@@ -46,12 +138,11 @@ class CaptureWorkerSmokeTests(unittest.TestCase):
             with self.assertRaisesRegex(SmokeError, "invalid protocol header"):
                 read_control_frame(stream, 42, nonce, time.monotonic() + 1)
 
-    def test_smoke_exercises_hello_and_start(self) -> None:
+    def test_protocol_only_smoke_exercises_hello_and_start(self) -> None:
         fake_worker = textwrap.dedent(
             """\
             #!/usr/bin/env python3
             import json
-            import os
             import struct
             import sys
 
@@ -77,10 +168,48 @@ class CaptureWorkerSmokeTests(unittest.TestCase):
             """
         )
         with tempfile.TemporaryDirectory() as directory:
-            worker = Path(directory) / "fake-worker"
-            worker.write_text(fake_worker, encoding="utf-8")
-            worker.chmod(worker.stat().st_mode | stat.S_IXUSR)
-            smoke_test(worker, timeout_seconds=2)
+            smoke_test(self._worker(directory, fake_worker), timeout_seconds=2)
+
+    def test_deep_smoke_exercises_both_backends_to_three_pcm_frames(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            timings = smoke_test_to_first_pcm(
+                self._worker(directory, FAKE_DEEP_WORKER),
+                "fixture-device-uid",
+                timeout_seconds=2,
+                first_pcm_seconds=1,
+            )
+        self.assertEqual(set(timings), {"auhal", "cpal"})
+        self.assertTrue(all(0 <= timing < 1 for timing in timings.values()))
+
+    def test_deep_smoke_rejects_out_of_order_setup_steps(self) -> None:
+        out_of_order = FAKE_DEEP_WORKER.replace(
+            '["deviceResolution", "defaultConfig", "streamBuild", "streamStart"]',
+            '["defaultConfig", "deviceResolution", "streamBuild", "streamStart"]',
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(SmokeError, "expected control message"):
+                smoke_test_to_first_pcm(
+                    self._worker(directory, out_of_order),
+                    "fixture-device-uid",
+                    timeout_seconds=2,
+                    first_pcm_seconds=1,
+                )
+
+    def test_deep_smoke_hard_times_out_and_kills_worker(self) -> None:
+        hanging = FAKE_DEEP_WORKER.replace(
+            'write_control({"type": "phase", "phase": "streamOpen", "backend": backend})',
+            'import time; time.sleep(60)',
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            started = time.monotonic()
+            with self.assertRaisesRegex(SmokeError, "timed out"):
+                smoke_test_to_first_pcm(
+                    self._worker(directory, hanging),
+                    "fixture-device-uid",
+                    timeout_seconds=0.2,
+                    first_pcm_seconds=0.1,
+                )
+            self.assertLess(time.monotonic() - started, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -92,6 +92,41 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate_ci(mutated)
 
+    def test_native_capture_smoke_requires_labeled_runner_and_device_uid(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        for old, new in (
+            (
+                "runs-on: [self-hosted, macOS, ARM64, murmur-audio]",
+                "runs-on: macos-latest",
+            ),
+            (
+                "MURMUR_CAPTURE_DEVICE_UID: ${{ vars.MURMUR_CAPTURE_DEVICE_UID }}",
+                "MURMUR_CAPTURE_DEVICE_UID: ''",
+            ),
+            ('--device-id "$MURMUR_CAPTURE_DEVICE_UID"', "--device-id default"),
+            ("--first-pcm-seconds 2", "--first-pcm-seconds 20"),
+        ):
+            with self.subTest(policy=old):
+                mutated = workflow.replace(old, new, 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_ci(mutated)
+
+    def test_native_capture_smoke_covers_capture_paths_and_ci_sentinel(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        for marker in (
+            "      capture: ${{ steps.filter.outputs.capture }}\n",
+            "              - 'app/src-tauri/sidecars/capture/**'\n",
+            "              - 'app/src-tauri/crates/capture-helper-protocol/**'\n",
+            "              - 'app/src-tauri/src/audio*.rs'\n",
+            '            "${{ needs.capture-worker-smoke.result }}"; do\n',
+        ):
+            with self.subTest(marker=marker.strip()):
+                mutated = workflow.replace(marker, "", 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_ci(mutated)
+
     def test_automatic_promotion_requires_workflow_run_trigger(self) -> None:
         workflow = (ROOT / ".github/workflows/release.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
## Summary
- extend the production-v3 worker smoke with explicit-device AUHAL and CPAL runs through first PCM, three PCM frames, and graceful stop
- assert exact native setup-step ordering, a two-second first-PCM bound, frame sequencing, and hard process-group termination without decoding or exporting PCM
- gate capture-path changes on a labeled self-hosted Apple Silicon macOS audio runner and protect the workflow contract with mutation tests

## Test plan
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1`
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test -- --run` (697 tests)
- [x] Python workflow/smoke/policy suite (123 tests)
- [x] real capture-worker protocol-only smoke
- [ ] native AUHAL + CPAL first-PCM smoke — awaiting runner prerequisites below
- [x] Murmur Bench: N/A — this PR changes only CI/smoke infrastructure and does not change recognition, delivered text, model runtime, VAD, or production capture behavior

## Runner prerequisite receipt

As of 2026-08-11, the repository reports zero registered self-hosted runners and has no `MURMUR_CAPTURE_DEVICE_UID` repository variable. The current Mac mini exposes no audio input in `system_profiler`, has no BlackHole installation, and the worker fails closed with `noInputDevice` / `retainedSamples: 0` for an explicit unavailable UID.

To make this check green, register the Mac with the standard `self-hosted`, `macOS`, and `ARM64` labels plus `murmur-audio`; install/configure a stable virtual input; and set `MURMUR_CAPTURE_DEVICE_UID` to its Core Audio UID. The job then verifies both AUHAL and CPAL against that exact input without retaining or uploading PCM content.

Closes #448
