### PR TITLE
fix: normalize release-note comparison symmetrically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,13 +488,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.resolve.outputs.tag }}
         run: |
-          RELEASE_NOTES=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --json body --jq .body)
-          jq -e --arg notes "$RELEASE_NOTES" '.notes == $notes' \
-            remote-manifests/latest-v2.json >/dev/null || {
-            echo "ERROR: draft release notes differ from the updater manifest"
-            exit 1
-          }
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > draft-release-notes.md
+          python3 scripts/release_artifacts.py verify-notes \
+            --manifest remote-manifests/latest-v2.json \
+            --release-notes draft-release-notes.md
 
       - name: Publish release
         if: needs.resolve.outputs.publish == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Release promotion now compares draft and updater-manifest notes with the same
+  deterministic whitespace normalization, avoiding formatting-only failures
+  while still rejecting edited content (#512).
+
 ## [0.30.1] - 2026-08-09
 
 ### Fixed

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -133,8 +133,9 @@ requests into **New Features** (`enhancement`), **Bug Fixes** (`bug`), and
 **Other Changes** categories.
 
 Immediately before publication, promotion compares the draft release body with
-the remotely downloaded updater manifest and fails if they differ. Published
-updater assets are immutable: do not edit a published release body
+the remotely downloaded updater manifest after symmetrically normalizing line
+endings and outer whitespace, and fails if any remaining content differs.
+Published updater assets are immutable: do not edit a published release body
 independently. A correction that must reach both the public release and the
 in-app dialogs requires a patch release.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -73,7 +73,9 @@ version below that threshold must update or quit. Policy changes receive the
 same code review and trusted-main provenance as the release itself.
 
 Immediately before publication, the workflow requires the draft release body
-to match the remotely downloaded updater manifest notes. Once published,
+to match the remotely downloaded updater manifest notes after applying the same
+line-ending normalization and outer-whitespace trim to both. All remaining
+content must match exactly; the check is not fuzzy. Once published,
 updater assets are immutable; do not edit the release body independently. Ship
 a patch release when corrected notes must appear both on GitHub and in Murmur.
 

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -409,6 +409,10 @@ def validate_release(
     return result
 
 
+def _normalize_release_notes(value: str) -> str:
+    return value.replace("\r\n", "\n").replace("\r", "\n").strip()
+
+
 def write_updater_manifests(
     validated_path: Path,
     tag: str,
@@ -428,7 +432,9 @@ def write_updater_manifests(
         raise ArtifactError("bridge updater URL and signature are required")
     if not release_notes_path.is_file():
         raise ArtifactError("release notes file is required")
-    release_notes = release_notes_path.read_text(encoding="utf-8").strip()
+    release_notes = _normalize_release_notes(
+        release_notes_path.read_text(encoding="utf-8")
+    )
     if not release_notes:
         raise ArtifactError("release notes must not be empty")
 
@@ -497,6 +503,30 @@ def write_updater_manifests(
     return modern_path, legacy_path
 
 
+def verify_release_notes_match(
+    manifest_path: Path, release_notes_path: Path
+) -> None:
+    if not manifest_path.is_file():
+        raise ArtifactError("updater manifest is required")
+    if not release_notes_path.is_file():
+        raise ArtifactError("release notes file is required")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ArtifactError("updater manifest is not valid JSON") from exc
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("notes"), str):
+        raise ArtifactError("updater manifest notes must be a string")
+
+    manifest_notes = _normalize_release_notes(manifest["notes"])
+    release_notes = _normalize_release_notes(
+        release_notes_path.read_text(encoding="utf-8")
+    )
+    if not manifest_notes or not release_notes:
+        raise ArtifactError("release notes must not be empty")
+    if manifest_notes != release_notes:
+        raise ArtifactError("draft release notes differ from the updater manifest")
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -563,6 +593,10 @@ def _parser() -> argparse.ArgumentParser:
     manifests.add_argument("--release-notes", type=Path, required=True)
     manifests.add_argument("--min-version")
     manifests.add_argument("--output-dir", type=Path, required=True)
+
+    verify_notes = subparsers.add_parser("verify-notes")
+    verify_notes.add_argument("--manifest", type=Path, required=True)
+    verify_notes.add_argument("--release-notes", type=Path, required=True)
     return parser
 
 
@@ -678,7 +712,7 @@ def main() -> None:
                 f"validated immutable release artifacts for {payload['commit_sha']} "
                 f"(run {payload['workflow_run_id']})"
             )
-        else:
+        elif args.command == "manifests":
             modern, legacy = write_updater_manifests(
                 args.validated,
                 args.tag,
@@ -690,6 +724,9 @@ def main() -> None:
                 args.min_version,
             )
             print(f"wrote updater manifests: {modern}, {legacy}")
+        else:
+            verify_release_notes_match(args.manifest, args.release_notes)
+            print("verified draft release notes match the updater manifest")
     except ArtifactError as exc:
         raise SystemExit(f"ERROR: {exc}") from exc
 

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -512,7 +512,6 @@ def validate_promotion_policy(workflow: str) -> int:
     assert "updater policy must contain exactly one null or string min_version" in workflow
     assert '--min-version "$MIN_VERSION"' in workflow
     assert "published updater policy differs from the trusted source policy" in workflow
-    assert "draft release notes differ from the updater manifest" in workflow
     assert workflow.index("scripts/release_artifacts.py validate") < workflow.index(
         "Create automatic release tag"
     )
@@ -533,6 +532,15 @@ def validate_promotion_policy(workflow: str) -> int:
     assert workflow.index("Verify release metadata matches updater manifest") < workflow.index(
         "Publish release"
     )
+    metadata_check = named_step_block(
+        workflow, "Verify release metadata matches updater manifest", 6
+    )
+    assert "scripts/release_artifacts.py verify-notes" in metadata_check
+    assert "--json body --jq .body > draft-release-notes.md" in metadata_check
+    assert "--manifest remote-manifests/latest-v2.json" in metadata_check
+    assert "--release-notes draft-release-notes.md" in metadata_check
+    assert "RELEASE_NOTES=$(" not in metadata_check
+    assert ".notes == $notes" not in metadata_check
     rehearsal = named_step_block(
         workflow, "Report non-publishing promotion rehearsal", 6
     )

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -25,6 +25,7 @@ from scripts.release_artifacts import (
     ArtifactError,
     create_provenance,
     validate_release,
+    verify_release_notes_match,
     write_updater_manifests,
 )
 
@@ -111,6 +112,44 @@ class ReleaseArtifactTests(unittest.TestCase):
                 release_notes_path,
                 self.root / "manifests",
             )
+
+    def test_publish_check_normalizes_crlf_and_outer_whitespace_symmetrically(self) -> None:
+        manifest_path = self.root / "latest-v2.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "notes": (
+                        "## New Features\n\n"
+                        "- Added post-update release notes."
+                    )
+                }
+            ),
+            encoding="utf-8",
+        )
+        draft_path = self.root / "draft-release-notes.md"
+        draft_path.write_bytes(
+            b" \r\n## New Features\r\n\r\n"
+            b"- Added post-update release notes.   \r\n\t"
+        )
+
+        verify_release_notes_match(manifest_path, draft_path)
+
+    def test_publish_check_rejects_release_note_content_changes(self) -> None:
+        manifest_path = self.root / "latest-v2.json"
+        manifest_path.write_text(
+            json.dumps({"notes": "## Bug Fixes\n\n- Fixed the release gate."}),
+            encoding="utf-8",
+        )
+        draft_path = self.root / "draft-release-notes.md"
+        draft_path.write_text(
+            "## Bug Fixes\n\n- Edited after manifest generation.\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            ArtifactError, "draft release notes differ from the updater manifest"
+        ):
+            verify_release_notes_match(manifest_path, draft_path)
 
     def test_manifest_generation_includes_valid_minimum_version_on_modern_channel(self) -> None:
         validated_path = self.root / "validated.json"

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -172,6 +172,20 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             tag_action("b" * 40, source)
 
+    def test_publish_check_requires_shared_release_note_normalization(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        for marker in (
+            "scripts/release_artifacts.py verify-notes",
+            "--json body --jq .body > draft-release-notes.md",
+            "--manifest remote-manifests/latest-v2.json",
+            "--release-notes draft-release-notes.md",
+        ):
+            with self.subTest(marker=marker):
+                mutated = workflow.replace(marker, "echo skipped", 1)
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_promotion_policy(mutated)
+
     def test_tag_workflow_rejects_cuda_cache_save_action(self) -> None:
         workflow = (ROOT / ".github/workflows/release.yml").read_text()
         mutated = workflow.replace(


### PR DESCRIPTION
## Summary
- normalize draft and updater-manifest release notes through the same deterministic CRLF/CR-to-LF and outer-whitespace path
- preserve fail-closed exact equality for all remaining release-note content
- cover CRLF/trailing-space equivalence, content drift rejection, and promotion workflow policy

## Test plan
- [x] `cd app/src-tauri && cargo check`
- [x] `cd app/src-tauri && cargo test -- --test-threads=1`
- [x] `cd app && npx tsc --noEmit`
- [x] `cd app && npm test` (697 passed; one unrelated focus timing flake passed on targeted and full reruns)
- [x] release/workflow Python validation (120 passed)
- [x] Rust formatting and clippy
- [x] frontend visual regression suite (19 passed; one unrelated readiness timing flake passed on targeted and full reruns)
- [x] native app smoke: N/A — release automation only; no app behavior or UI changed
- [x] Murmur Bench: N/A — release metadata verification cannot affect recognition latency, accuracy, delivered text, or memory

Closes #512
