### PR TITLE
ci: harden workflow policy matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'app/src-tauri/Cargo.lock'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rustfmt.toml'
             github:
               - '.github/**'
               - 'scripts/validate_workflow_policy.py'
@@ -242,6 +243,7 @@ jobs:
             cargo test --lib -- --test-threads=1
 
   dependency-audit:
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: bump version') }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/validate_workflow_policy.py
+++ b/scripts/validate_workflow_policy.py
@@ -36,9 +36,9 @@ SEMVER = re.compile(
 
 def job_block(workflow: str, job: str) -> str:
     match = re.search(
-        rf"^  {re.escape(job)}:\n(?P<body>(?:^(?:    .*|\s*)\n?)*)",
+        rf"^  {re.escape(job)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
         workflow,
-        re.MULTILINE,
+        re.MULTILINE | re.DOTALL,
     )
     if not match:
         raise AssertionError(f"missing job: {job}")
@@ -134,15 +134,27 @@ def tag_action(existing_sha: Optional[str], source_sha: str) -> str:
 def validate_ci(ci: str) -> int:
     assert "push:\n    branches: [main]" in ci
     assert "\n  pull_request:" in ci
-    assert scalar(job_block(ci, "changes"), "if") == CI_GUARD
+    changes = job_block(ci, "changes")
+    rust_macos = job_block(ci, "rust-macos")
+    dependency_audit = job_block(ci, "dependency-audit")
+    ci_pass = job_block(ci, "ci-pass")
+    assert scalar(changes, "if") == CI_GUARD
     for job in ("typecheck", "visual-regression", "rust-macos", "linux"):
         assert scalar(job_block(ci, job), "needs") == "changes"
-    assert scalar(job_block(ci, "ci-pass"), "needs") == (
+    assert scalar(dependency_audit, "if") == CI_GUARD
+    assert scalar(ci_pass, "needs") == (
         "[changes, typecheck, visual-regression, rust-macos, linux]"
     )
-    assert scalar(job_block(ci, "ci-pass"), "if") == CI_PASS_GUARD
-    ci_pass_step = named_step_block(ci, "Check CI result", 6)
+    assert scalar(ci_pass, "if") == CI_PASS_GUARD
+    ci_pass_step = named_step_block(ci_pass, "Check CI result", 6)
     assert "${{ needs.visual-regression.result }}" in ci_pass_step
+    rust_filter = re.search(
+        r"^            rust:\n(?P<paths>(?:^              - .+\n)+)",
+        changes,
+        re.MULTILINE,
+    )
+    assert rust_filter, "missing rust paths filter"
+    assert "'rustfmt.toml'" in rust_filter.group("paths")
     assert "scripts/validate_workflow_policy.py" in ci
     assert "'scripts/validate_reference_docs.py'" in ci
     assert "python3 scripts/validate_reference_docs.py" in ci
@@ -156,14 +168,14 @@ def validate_ci(ci: str) -> int:
     assert "tests/test_workflow_policy.py" in ci
     assert "tests/test_capture_agent_matrix.py" in ci
     capture_build = named_step_block(
-        ci, "Build capture isolation helpers and stub local-LLM externalBin", 6
+        rust_macos, "Build capture isolation helpers and stub local-LLM externalBin", 6
     )
-    rust_install = named_step_block(ci, "Install Rust", 6)
+    rust_install = named_step_block(rust_macos, "Install Rust", 6)
     assert "uses: dtolnay/rust-toolchain@1.96.0" in rust_install
     assert "components: clippy, rustfmt" in rust_install
-    rust_format = named_step_block(ci, "Check Rust formatting", 6)
+    rust_format = named_step_block(rust_macos, "Check Rust formatting", 6)
     assert "cargo fmt --all -- --check" in rust_format
-    rust_lint = named_step_block(ci, "Lint Rust", 6)
+    rust_lint = named_step_block(rust_macos, "Lint Rust", 6)
     assert "cargo clippy --all-targets -- -D warnings" in rust_lint
     assert "swiftc -warnings-as-errors" in capture_build
     assert "sidecars/capture-agent/main.swift" in capture_build
@@ -172,14 +184,17 @@ def validate_ci(ci: str) -> int:
     assert "CARGO_TARGET_DIR=target/capture-worker-build" in capture_build
     assert "target/capture-worker-build/debug/murmur-capture-helper" in capture_build
     assert "binaries/murmur-capture-worker-aarch64-apple-darwin" in capture_build
-    capture_tests = named_step_block(ci, "Run capture worker unit tests", 6)
+    capture_tests = named_step_block(rust_macos, "Run capture worker unit tests", 6)
     assert "cargo test -p murmur-capture-helper" in capture_tests
-    job_block(ci, "dependency-audit")
-    rust_audit = named_step_block(ci, "Audit Rust dependencies (advisory)", 6)
+    rust_audit = named_step_block(
+        dependency_audit, "Audit Rust dependencies (advisory)", 6
+    )
     assert "continue-on-error: true" in rust_audit
     assert "cargo install cargo-audit --locked --version 0.22.2" in rust_audit
     assert "cargo audit" in rust_audit
-    npm_audit = named_step_block(ci, "Audit npm dependencies (advisory)", 6)
+    npm_audit = named_step_block(
+        dependency_audit, "Audit npm dependencies (advisory)", 6
+    )
     assert "continue-on-error: true" in npm_audit
     assert "npm audit --audit-level=high" in npm_audit
     llm_target = "binaries/murmur-llm-sidecar-aarch64-apple-darwin"

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -18,6 +18,23 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class WorkflowPolicyMutationTests(unittest.TestCase):
+    def test_ci_rust_filter_includes_root_rustfmt_config(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        without_rust_path = workflow.replace("              - 'rustfmt.toml'\n", "", 1)
+        moved_to_github = without_rust_path.replace(
+            "            github:\n",
+            "            github:\n              - 'rustfmt.toml'\n",
+            1,
+        )
+        for name, mutated in (
+            ("removed", without_rust_path),
+            ("moved to another filter", moved_to_github),
+        ):
+            with self.subTest(mutation=name):
+                self.assertNotEqual(workflow, mutated)
+                with self.assertRaises(AssertionError):
+                    validate_ci(mutated)
+
     def test_ci_runs_reference_doc_drift_check(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()
         for marker in (
@@ -57,6 +74,31 @@ class WorkflowPolicyMutationTests(unittest.TestCase):
                 self.assertNotEqual(workflow, mutated)
                 with self.assertRaises(AssertionError):
                     validate_ci(mutated)
+
+    def test_dependency_audit_skips_release_bump_pushes(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        guard = (
+            "  dependency-audit:\n"
+            "    if: \"${{ github.event_name != 'push' || "
+            "!startsWith(github.event.head_commit.message, "
+            "'chore: bump version') }}\"\n"
+        )
+        mutated = workflow.replace(guard, "  dependency-audit:\n", 1)
+        self.assertNotEqual(workflow, mutated)
+        with self.assertRaises(AssertionError):
+            validate_ci(mutated)
+
+    def test_ci_step_policy_is_independent_of_job_order(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        dependency_start = workflow.index("  dependency-audit:\n")
+        dependency_end = workflow.index("  ci-pass:\n")
+        dependency_block = workflow[dependency_start:dependency_end]
+        reordered = workflow[:dependency_start] + workflow[dependency_end:]
+        reordered = reordered.replace(
+            "  rust-macos:\n", dependency_block + "  rust-macos:\n", 1
+        )
+
+        validate_ci(reordered)
 
     def test_ci_runs_capture_worker_unit_tests(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()


### PR DESCRIPTION
## Summary
- include the root Rust formatting config in the Rust CI path filter
- skip advisory dependency audits on release bump pushes, matching the main CI guard
- scope workflow step validation to explicit jobs and cover job reordering with mutation tests

## Test plan
- [x] `cargo check`
- [x] `cargo test -- --test-threads=1`
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `python3 -m unittest discover -s tests`
- [x] workflow policy validator and mutation tests
- [x] Native app smoke: N/A — CI policy and test-only change; no user-visible or native runtime behavior
- [x] Murmur Bench: N/A — CI policy and test-only change; no recognition, delivered-text, latency, or memory behavior

Closes #513