### PR TITLE
fix: retain capture health diagnostics after idle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (115 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (116 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -95,7 +95,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 116 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Microphone startup health now retains a bounded, content-free local history
+  independently of general event traffic, so idle system telemetry no longer
+  resets the five-recording signal and the Performance tab no longer polls the
+  full event history every two seconds (#514).
+
 ## [0.30.1] - 2026-08-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (115 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (116 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -99,7 +99,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 116 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -595,6 +595,7 @@ fn handle_start(
 
     tracing::info!(
         target: "audio",
+        event_code = "audio.capture_started",
         owner = request.owner.telemetry_id(),
         owner_kind = request.owner.kind(),
         origin = request.origin.as_str(),

--- a/app/src-tauri/src/capture_health.rs
+++ b/app/src-tauri/src/capture_health.rs
@@ -1,0 +1,518 @@
+use crate::telemetry::AppEvent;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+const CAPTURE_HEALTH_SCHEMA_VERSION: u32 = 1;
+const CAPTURE_HEALTH_FILE: &str = "capture-health-v1.json";
+const MAX_CAPTURE_OBSERVATIONS: usize = 20;
+const FALLBACK_CORRELATION_WINDOW_MS: i64 = 35_000;
+const START_SUMMARY: &str = "audio initialization accepted";
+const READY_SUMMARY: &str = "audio readiness accepted";
+const FALLBACK_SUMMARY: &str =
+    "capture backend failed before retained audio; trying bounded fallback";
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum CaptureBackendV1 {
+    Auhal,
+    Cpal,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CaptureHealthObservationV1 {
+    pub(crate) startup_ms: u64,
+    pub(crate) used_fallback: bool,
+    pub(crate) fallback_from_backend: Option<CaptureBackendV1>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CaptureHealthHistoryV1 {
+    pub(crate) schema_version: u32,
+    pub(crate) observations: Vec<CaptureHealthObservationV1>,
+}
+
+impl Default for CaptureHealthHistoryV1 {
+    fn default() -> Self {
+        Self {
+            schema_version: CAPTURE_HEALTH_SCHEMA_VERSION,
+            observations: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PendingFallback {
+    at_ms: i64,
+    from_backend: Option<CaptureBackendV1>,
+}
+
+#[derive(Default)]
+struct CaptureHealthAccumulator {
+    observations: VecDeque<CaptureHealthObservationV1>,
+    pending_fallbacks: HashMap<u64, PendingFallback>,
+}
+
+impl CaptureHealthAccumulator {
+    fn from_history(history: CaptureHealthHistoryV1) -> Self {
+        let observations = history
+            .observations
+            .into_iter()
+            .rev()
+            .take(MAX_CAPTURE_OBSERVATIONS)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        Self {
+            observations,
+            pending_fallbacks: HashMap::new(),
+        }
+    }
+
+    fn history(&self) -> CaptureHealthHistoryV1 {
+        CaptureHealthHistoryV1 {
+            schema_version: CAPTURE_HEALTH_SCHEMA_VERSION,
+            observations: self.observations.iter().cloned().collect(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.observations.clear();
+        self.pending_fallbacks.clear();
+    }
+
+    fn observe(&mut self, event: &AppEvent) -> bool {
+        let Some(owner) = numeric_field(event, "owner") else {
+            return false;
+        };
+
+        if is_start(event) {
+            self.pending_fallbacks.remove(&owner);
+            return false;
+        }
+        if is_fallback(event) {
+            if let Some(at_ms) = observed_at_ms(event) {
+                self.pending_fallbacks.insert(
+                    owner,
+                    PendingFallback {
+                        at_ms,
+                        from_backend: backend_field(event, "from_backend"),
+                    },
+                );
+            }
+            return false;
+        }
+        if is_capture_failed(event) {
+            self.pending_fallbacks.remove(&owner);
+            return false;
+        }
+        if !is_ready(event) || string_field(event, "owner_kind") != Some("dictation") {
+            return false;
+        }
+
+        let Some(startup_ms) = numeric_field(event, "startup_ms") else {
+            return false;
+        };
+        let Some(ready_at_ms) = observed_at_ms(event) else {
+            return false;
+        };
+        let fallback = self
+            .pending_fallbacks
+            .get(&owner)
+            .filter(|pending| {
+                ready_at_ms >= pending.at_ms
+                    && ready_at_ms - pending.at_ms <= FALLBACK_CORRELATION_WINDOW_MS
+            })
+            .copied();
+
+        self.pending_fallbacks.remove(&owner);
+        if self.observations.len() >= MAX_CAPTURE_OBSERVATIONS {
+            self.observations.pop_front();
+        }
+        self.observations.push_back(CaptureHealthObservationV1 {
+            startup_ms,
+            used_fallback: fallback.is_some(),
+            fallback_from_backend: fallback.and_then(|pending| pending.from_backend),
+        });
+        true
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct CaptureHealthDiagnostics {
+    inner: Arc<Mutex<CaptureHealthInner>>,
+}
+
+#[derive(Default)]
+struct CaptureHealthInner {
+    accumulator: CaptureHealthAccumulator,
+    file_path: Option<PathBuf>,
+    writer_running: bool,
+}
+
+impl CaptureHealthDiagnostics {
+    pub(crate) fn initialize(
+        &self,
+        diagnostics_root: PathBuf,
+        event_log_paths: &[PathBuf],
+    ) -> Result<(), String> {
+        fs::create_dir_all(&diagnostics_root).map_err(|_| storage_error())?;
+        let file_path = diagnostics_root.join(CAPTURE_HEALTH_FILE);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner.file_path = Some(file_path.clone());
+
+        if file_path.exists() {
+            inner.accumulator = CaptureHealthAccumulator::from_history(load_history(&file_path)?);
+            return Ok(());
+        }
+
+        let mut migrated = CaptureHealthAccumulator::default();
+        for path in event_log_paths {
+            replay_event_log(path, &mut migrated);
+        }
+        let history = migrated.history();
+        save_history(&file_path, &history)?;
+        inner.accumulator = migrated;
+        Ok(())
+    }
+
+    pub(crate) fn observe(&self, event: &AppEvent) {
+        let should_persist = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if inner.accumulator.observe(event)
+                && inner.file_path.is_some()
+                && !inner.writer_running
+            {
+                inner.writer_running = true;
+                true
+            } else {
+                false
+            }
+        };
+        if should_persist {
+            #[cfg(test)]
+            self.persist_current();
+            #[cfg(not(test))]
+            {
+                let diagnostics = self.clone();
+                if std::thread::Builder::new()
+                    .name("capture-health-writer".to_string())
+                    .spawn(move || diagnostics.persist_current())
+                    .is_err()
+                {
+                    self.inner
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .writer_running = false;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn history(&self) -> CaptureHealthHistoryV1 {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .accumulator
+            .history()
+    }
+
+    pub(crate) fn clear(&self) -> Result<(), String> {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        inner.accumulator.clear();
+        if let Some(path) = &inner.file_path {
+            save_history(path, &inner.accumulator.history())?;
+        }
+        Ok(())
+    }
+
+    fn persist_current(&self) {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(path) = &inner.file_path {
+            let _ = save_history(path, &inner.accumulator.history());
+        }
+        inner.writer_running = false;
+    }
+}
+
+#[tauri::command]
+pub(crate) fn get_capture_health_history(
+    state: tauri::State<'_, crate::State>,
+) -> CaptureHealthHistoryV1 {
+    state.capture_health.history()
+}
+
+fn event_code(event: &AppEvent) -> Option<&str> {
+    string_field(event, "event_code")
+}
+
+fn string_field<'a>(event: &'a AppEvent, key: &str) -> Option<&'a str> {
+    event.data.get(key)?.as_str()
+}
+
+fn numeric_field(event: &AppEvent, key: &str) -> Option<u64> {
+    event.data.get(key)?.as_u64()
+}
+
+fn backend_field(event: &AppEvent, key: &str) -> Option<CaptureBackendV1> {
+    match string_field(event, key) {
+        Some("auhal") => Some(CaptureBackendV1::Auhal),
+        Some("cpal") => Some(CaptureBackendV1::Cpal),
+        _ => None,
+    }
+}
+
+fn observed_at_ms(event: &AppEvent) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(&event.timestamp)
+        .ok()
+        .map(|timestamp| timestamp.timestamp_millis())
+}
+
+fn is_start(event: &AppEvent) -> bool {
+    event_code(event) == Some("audio.capture_started") || event.summary == START_SUMMARY
+}
+
+fn is_ready(event: &AppEvent) -> bool {
+    event_code(event) == Some("audio.capture_ready") || event.summary == READY_SUMMARY
+}
+
+fn is_fallback(event: &AppEvent) -> bool {
+    event_code(event) == Some("audio.fallback_started") || event.summary == FALLBACK_SUMMARY
+}
+
+fn is_capture_failed(event: &AppEvent) -> bool {
+    event_code(event) == Some("audio.capture_failed")
+}
+
+fn load_history(path: &Path) -> Result<CaptureHealthHistoryV1, String> {
+    let bytes = fs::read(path).map_err(|_| storage_error())?;
+    let history: CaptureHealthHistoryV1 = serde_json::from_slice(&bytes).map_err(|_| {
+        quarantine_corrupt_file(path);
+        storage_error()
+    })?;
+    if history.schema_version != CAPTURE_HEALTH_SCHEMA_VERSION {
+        return Err("The capture-health diagnostics schema is unsupported.".to_string());
+    }
+    Ok(history)
+}
+
+fn save_history(path: &Path, history: &CaptureHealthHistoryV1) -> Result<(), String> {
+    let bytes = serde_json::to_vec(history).map_err(|_| storage_error())?;
+    let temp_path = path.with_extension("json.tmp");
+    let write_result = (|| {
+        let mut file = fs::File::create(&temp_path).map_err(|_| storage_error())?;
+        file.write_all(&bytes).map_err(|_| storage_error())?;
+        file.sync_all().map_err(|_| storage_error())?;
+        fs::rename(&temp_path, path).map_err(|_| storage_error())
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    write_result
+}
+
+fn replay_event_log(path: &Path, accumulator: &mut CaptureHealthAccumulator) {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return;
+    };
+    for line in contents.lines() {
+        if let Ok(event) = serde_json::from_str::<AppEvent>(line) {
+            accumulator.observe(&event);
+        }
+    }
+}
+
+fn quarantine_corrupt_file(path: &Path) {
+    let suffix = chrono::Utc::now().timestamp();
+    let quarantine = path.with_extension(format!("json.corrupt-{suffix}"));
+    let _ = fs::rename(path, quarantine);
+}
+
+fn storage_error() -> String {
+    "The local capture-health diagnostics store is unavailable.".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(at_ms: i64, summary: &str, data: serde_json::Value) -> AppEvent {
+        AppEvent {
+            timestamp: chrono::DateTime::from_timestamp_millis(at_ms)
+                .unwrap()
+                .to_rfc3339(),
+            stream: "audio".to_string(),
+            level: "info".to_string(),
+            summary: summary.to_string(),
+            data,
+        }
+    }
+
+    fn start(at_ms: i64, owner: u64, kind: &str) -> AppEvent {
+        event(
+            at_ms,
+            START_SUMMARY,
+            serde_json::json!({
+                "event_code": "audio.capture_started",
+                "owner": owner,
+                "owner_kind": kind,
+            }),
+        )
+    }
+
+    fn fallback(at_ms: i64, owner: u64, backend: &str) -> AppEvent {
+        event(
+            at_ms,
+            FALLBACK_SUMMARY,
+            serde_json::json!({
+                "event_code": "audio.fallback_started",
+                "owner": owner,
+                "from_backend": backend,
+                "device_label": "SENTINEL DEVICE",
+                "device_uid": "SENTINEL UID",
+                "transcript": "SENTINEL CONTENT",
+            }),
+        )
+    }
+
+    fn ready(at_ms: i64, owner: u64, startup_ms: u64, kind: &str) -> AppEvent {
+        event(
+            at_ms,
+            READY_SUMMARY,
+            serde_json::json!({
+                "event_code": "audio.capture_ready",
+                "owner": owner,
+                "owner_kind": kind,
+                "startup_ms": startup_ms,
+            }),
+        )
+    }
+
+    #[test]
+    fn finalizes_only_successful_dictation_observations() {
+        let mut accumulator = CaptureHealthAccumulator::default();
+        accumulator.observe(&start(0, 1, "transform"));
+        accumulator.observe(&fallback(100, 1, "auhal"));
+        accumulator.observe(&ready(200, 1, 100, "transform"));
+        accumulator.observe(&start(300, 2, "dictation"));
+        accumulator.observe(&ready(500, 2, 200, "dictation"));
+
+        assert_eq!(
+            accumulator.history().observations,
+            vec![CaptureHealthObservationV1 {
+                startup_ms: 200,
+                used_fallback: false,
+                fallback_from_backend: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn owner_collision_start_and_stale_window_cannot_invent_fallback() {
+        let mut accumulator = CaptureHealthAccumulator::default();
+        accumulator.observe(&fallback(0, 7, "auhal"));
+        accumulator.observe(&start(1_000, 7, "transform"));
+        accumulator.observe(&ready(2_000, 7, 1_000, "dictation"));
+        accumulator.observe(&fallback(3_000, 8, "auhal"));
+        accumulator.observe(&ready(38_001, 8, 1_000, "dictation"));
+
+        assert_eq!(accumulator.history().observations.len(), 2);
+        assert!(accumulator
+            .history()
+            .observations
+            .iter()
+            .all(|observation| !observation.used_fallback));
+    }
+
+    #[test]
+    fn unknown_backend_still_records_recovered_fallback_without_its_label() {
+        let mut accumulator = CaptureHealthAccumulator::default();
+        accumulator.observe(&fallback(0, 9, "private-device-label"));
+        accumulator.observe(&ready(1_000, 9, 1_000, "dictation"));
+
+        let observation = &accumulator.history().observations[0];
+        assert!(observation.used_fallback);
+        assert_eq!(observation.fallback_from_backend, None);
+    }
+
+    #[test]
+    fn keeps_only_the_newest_bounded_observations() {
+        let mut accumulator = CaptureHealthAccumulator::default();
+        for owner in 0..(MAX_CAPTURE_OBSERVATIONS as u64 + 5) {
+            accumulator.observe(&ready(owner as i64, owner, owner, "dictation"));
+        }
+
+        let history = accumulator.history();
+        assert_eq!(history.observations.len(), MAX_CAPTURE_OBSERVATIONS);
+        assert_eq!(history.observations.first().unwrap().startup_ms, 5);
+    }
+
+    #[test]
+    fn migration_persists_only_content_free_finalized_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let event_log = temp.path().join("events.jsonl");
+        let events = [
+            start(0, 9, "dictation"),
+            fallback(1_000, 9, "auhal"),
+            ready(2_000, 9, 2_000, "dictation"),
+        ];
+        let jsonl = events
+            .iter()
+            .map(|event| serde_json::to_string(event).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&event_log, jsonl).unwrap();
+
+        let diagnostics = CaptureHealthDiagnostics::default();
+        let root = temp.path().join("diagnostics");
+        diagnostics.initialize(root.clone(), &[event_log]).unwrap();
+
+        let history = diagnostics.history();
+        assert_eq!(history.observations.len(), 1);
+        assert_eq!(
+            history.observations[0].fallback_from_backend,
+            Some(CaptureBackendV1::Auhal)
+        );
+        assert!(history.observations[0].used_fallback);
+        let persisted = fs::read_to_string(root.join(CAPTURE_HEALTH_FILE)).unwrap();
+        assert!(!persisted.contains("SENTINEL"));
+        assert!(!persisted.contains("owner"));
+        assert!(!persisted.contains("timestamp"));
+    }
+
+    #[test]
+    fn persisted_history_survives_restart_and_clear() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let first = CaptureHealthDiagnostics::default();
+        first.initialize(root.clone(), &[]).unwrap();
+        first.observe(&ready(2_000, 1, 240, "dictation"));
+
+        let restarted = CaptureHealthDiagnostics::default();
+        restarted.initialize(root.clone(), &[]).unwrap();
+        assert_eq!(restarted.history().observations.len(), 1);
+
+        restarted.clear().unwrap();
+        let cleared = CaptureHealthDiagnostics::default();
+        cleared.initialize(root, &[]).unwrap();
+        assert!(cleared.history().observations.is_empty());
+    }
+}

--- a/app/src-tauri/src/commands/performance.rs
+++ b/app/src-tauri/src/commands/performance.rs
@@ -58,7 +58,8 @@ pub fn get_performance_resource_window(
 
 #[tauri::command]
 pub fn clear_performance_diagnostics(state: tauri::State<'_, State>) -> Result<(), String> {
-    state.performance.clear()
+    state.performance.clear()?;
+    state.capture_health.clear()
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -3501,6 +3501,7 @@ mod tests {
                 corpus: crate::commands::corpus::CorpusRecorderState::default(),
                 knowledge: crate::knowledge_store::KnowledgeStore::default(),
                 correct_and_teach: crate::correct_and_teach::CorrectAndTeachState::default(),
+                capture_health: crate::capture_health::CaptureHealthDiagnostics::default(),
                 performance: performance.clone(),
                 transform_diagnostics: crate::transform_diagnostics::TransformDiagnostics::default(
                 ),
@@ -3590,6 +3591,7 @@ mod tests {
                 corpus: crate::commands::corpus::CorpusRecorderState::default(),
                 knowledge: crate::knowledge_store::KnowledgeStore::default(),
                 correct_and_teach: crate::correct_and_teach::CorrectAndTeachState::default(),
+                capture_health: crate::capture_health::CaptureHealthDiagnostics::default(),
                 performance: crate::performance_metrics::PerformanceMetrics::default(),
                 transform_diagnostics: crate::transform_diagnostics::TransformDiagnostics::default(
                 ),

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod audio_lifecycle;
 // stable external API.
 pub mod benchmark;
 pub mod capture_agent_probe;
+mod capture_health;
 pub mod capture_helper_probe;
 mod cleanup;
 mod cli_command;
@@ -125,6 +126,7 @@ pub(crate) struct State {
     pub(crate) corpus: commands::corpus::CorpusRecorderState,
     pub(crate) knowledge: knowledge_store::KnowledgeStore,
     pub(crate) correct_and_teach: correct_and_teach::CorrectAndTeachState,
+    pub(crate) capture_health: capture_health::CaptureHealthDiagnostics,
     pub(crate) performance: performance_metrics::PerformanceMetrics,
     pub(crate) transform_diagnostics: transform_diagnostics::TransformDiagnostics,
     /// Cached overlay screen geometry
@@ -247,6 +249,7 @@ pub fn run() {
             corpus: commands::corpus::CorpusRecorderState::default(),
             knowledge: knowledge_store::KnowledgeStore::default(),
             correct_and_teach: correct_and_teach::CorrectAndTeachState::default(),
+            capture_health: capture_health::CaptureHealthDiagnostics::default(),
             performance: performance_metrics::PerformanceMetrics::default(),
             transform_diagnostics: transform_diagnostics::TransformDiagnostics::default(),
             notch_info: Mutex::new(None),
@@ -326,6 +329,7 @@ pub fn run() {
             commands::logging::get_log_contents,
             commands::logging::clear_logs,
             commands::logging::log_frontend,
+            capture_health::get_capture_health_history,
             commands::performance::list_performance_runs,
             commands::performance::get_performance_run,
             commands::performance::get_performance_resource_window,
@@ -394,6 +398,18 @@ pub fn run() {
             }
 
             let performance_root = app.path().app_data_dir()?.join("diagnostics");
+            if let Err(error) = app
+                .state::<State>()
+                .capture_health
+                .initialize(performance_root.clone(), &telemetry::event_jsonl_paths())
+            {
+                tracing::warn!(
+                    target: "system",
+                    diagnostics_available = false,
+                    "capture-health diagnostics store unavailable: {}",
+                    error
+                );
+            }
             if let Err(error) = app
                 .state::<State>()
                 .performance

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 const REFACTOR_TEST_IDENTIFIER: &str = "com.localdictation.refactor-test";
 const BENCH_IDENTIFIER: &str = "com.localdictation.bench";
@@ -175,6 +175,11 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for TauriEmitterLayer 
             data,
         };
 
+        self.app_handle
+            .state::<crate::State>()
+            .capture_health
+            .observe(&app_event);
+
         // Push to ring buffer
         {
             let mut buf = self.buffer.lock().unwrap_or_else(|p| p.into_inner());
@@ -207,6 +212,7 @@ pub(crate) fn canonical_event_code(value: &str) -> Option<&'static str> {
         "keyboard.listener_silent" => Some("keyboard.listener_silent"),
         "keyboard.listener_failed" => Some("keyboard.listener_failed"),
         "audio.capture_backend_timeout" => Some("audio.capture_backend_timeout"),
+        "audio.capture_started" => Some("audio.capture_started"),
         "audio.fallback_started" => Some("audio.fallback_started"),
         "audio.capture_ready" => Some("audio.capture_ready"),
         "audio.capture_failed" => Some("audio.capture_failed"),
@@ -403,6 +409,13 @@ fn jsonl_path() -> Option<std::path::PathBuf> {
         "events.jsonl"
     };
     Some(logs_dir()?.join(name))
+}
+
+pub(crate) fn event_jsonl_paths() -> Vec<PathBuf> {
+    let Some(current) = jsonl_path() else {
+        return Vec::new();
+    };
+    vec![current.with_extension("jsonl.1"), current]
 }
 
 /// Read the last `n` AppEvent entries from the JSONL file to seed the ring buffer.

--- a/app/src/lib/captureHealth.test.ts
+++ b/app/src/lib/captureHealth.test.ts
@@ -1,50 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import type { AppEvent } from './events';
 import {
   CAPTURE_HEALTH_WINDOW,
   deriveCaptureHealth,
+  parseCaptureHealthHistory,
   SLOW_CAPTURE_STARTUP_MS,
+  type CaptureHealthObservationV1,
 } from './captureHealth';
 
-function event(
-  seconds: number,
-  summary: string,
-  data: Record<string, unknown>,
-): AppEvent {
+function observation(
+  startupMs: number,
+  fallbackFromBackend: CaptureHealthObservationV1['fallbackFromBackend'] = null,
+): CaptureHealthObservationV1 {
   return {
-    timestamp: new Date(Date.UTC(2026, 7, 7, 12, 0, seconds)).toISOString(),
-    stream: 'audio',
-    level: 'info',
-    summary,
-    data,
+    startupMs,
+    usedFallback: fallbackFromBackend !== null,
+    fallbackFromBackend,
   };
-}
-
-function ready(seconds: number, owner: number, startupMs: number): AppEvent {
-  return event(seconds, 'audio readiness accepted', {
-    event_code: 'audio.capture_ready',
-    owner,
-    owner_kind: 'dictation',
-    startup_ms: startupMs,
-  });
-}
-
-function fallback(seconds: number, owner: number, fromBackend = 'auhal'): AppEvent {
-  return event(seconds, 'capture backend failed before retained audio; trying bounded fallback', {
-    event_code: 'audio.fallback_started',
-    owner,
-    from_backend: fromBackend,
-    to_backend: 'cpal',
-  });
 }
 
 describe('deriveCaptureHealth', () => {
   it('requires five successful dictation captures before judging health', () => {
     const health = deriveCaptureHealth([
-      ready(1, 1, 180),
-      ready(2, 2, 220),
-      ready(3, 3, 240),
-      ready(4, 4, 260),
+      observation(180),
+      observation(220),
+      observation(240),
+      observation(260),
     ]);
 
     expect(health.status).toBe('insufficientData');
@@ -54,12 +34,11 @@ describe('deriveCaptureHealth', () => {
 
   it('reports a healthy rolling median and occasional fallback honestly', () => {
     const health = deriveCaptureHealth([
-      ready(1, 1, 180),
-      ready(2, 2, 220),
-      fallback(3, 3),
-      ready(4, 3, 320),
-      ready(5, 4, 240),
-      ready(6, 5, 260),
+      observation(180),
+      observation(220),
+      observation(320, 'auhal'),
+      observation(240),
+      observation(260),
     ]);
 
     expect(health.status).toBe('healthy');
@@ -68,27 +47,38 @@ describe('deriveCaptureHealth', () => {
     expect(health.chronicFallback).toBe(false);
   });
 
-  it('flags five consecutive recovered fallbacks and names the failed backend', () => {
-    const events: AppEvent[] = [];
-    for (let owner = 1; owner <= CAPTURE_HEALTH_WINDOW; owner += 1) {
-      events.push(fallback(owner * 2, owner));
-      events.push(ready(owner * 2 + 1, owner, 700 + owner));
-    }
+  it('preserves the verified five-of-five recovered-fallback threshold', () => {
+    const health = deriveCaptureHealth(
+      Array.from({ length: CAPTURE_HEALTH_WINDOW }, (_, index) => observation(700 + index, 'auhal')),
+    );
 
-    const health = deriveCaptureHealth(events);
     expect(health.status).toBe('degraded');
     expect(health.chronicFallback).toBe(true);
     expect(health.slowStartup).toBe(false);
     expect(health.degradedBackend).toBe('auhal');
   });
 
+  it('does not call four of five fallbacks chronic', () => {
+    const health = deriveCaptureHealth([
+      observation(700, 'auhal'),
+      observation(701, 'auhal'),
+      observation(702, 'auhal'),
+      observation(703, 'auhal'),
+      observation(200),
+    ]);
+
+    expect(health.status).toBe('healthy');
+    expect(health.fallbackCount).toBe(4);
+    expect(health.chronicFallback).toBe(false);
+  });
+
   it('flags a slow rolling median without inventing a degraded backend', () => {
     const health = deriveCaptureHealth([
-      ready(1, 1, SLOW_CAPTURE_STARTUP_MS - 1),
-      ready(2, 2, SLOW_CAPTURE_STARTUP_MS),
-      ready(3, 3, 2_500),
-      ready(4, 4, 2_800),
-      ready(5, 5, 3_100),
+      observation(SLOW_CAPTURE_STARTUP_MS - 1),
+      observation(SLOW_CAPTURE_STARTUP_MS),
+      observation(2_500),
+      observation(2_800),
+      observation(3_100),
     ]);
 
     expect(health.status).toBe('degraded');
@@ -96,36 +86,32 @@ describe('deriveCaptureHealth', () => {
     expect(health.chronicFallback).toBe(false);
     expect(health.degradedBackend).toBeNull();
   });
+});
 
-  it('does not correlate a stale fallback across a fresh owner start', () => {
-    const health = deriveCaptureHealth([
-      fallback(1, 1),
-      event(2, 'audio initialization accepted', { owner: 1 }),
-      ready(3, 1, 200),
-      ready(4, 2, 210),
-      ready(5, 3, 220),
-      ready(6, 4, 230),
-      ready(7, 5, 240),
-    ]);
+describe('parseCaptureHealthHistory', () => {
+  it('accepts only the versioned content-free observation shape', () => {
+    expect(parseCaptureHealthHistory({
+      schemaVersion: 1,
+      observations: [{ startupMs: 240, usedFallback: true, fallbackFromBackend: 'cpal' }],
+    }).observations).toHaveLength(1);
 
-    expect(health.status).toBe('healthy');
-    expect(health.fallbackCount).toBe(0);
-  });
+    expect(() => parseCaptureHealthHistory({
+      schemaVersion: 1,
+      observations: [{ startupMs: 240, usedFallback: true, fallbackFromBackend: 'device label' }],
+    })).toThrow(/unsupported capture-health schema/i);
+    expect(() => parseCaptureHealthHistory({
+      schemaVersion: 1,
+      observations: [{
+        startupMs: 240,
+        usedFallback: false,
+        fallbackFromBackend: null,
+        deviceUid: 'private',
+      }],
+    })).toThrow(/unsupported capture-health schema/i);
 
-  it('accepts exact historical summaries when stable event codes are absent', () => {
-    const events: AppEvent[] = [];
-    for (let owner = 1; owner <= CAPTURE_HEALTH_WINDOW; owner += 1) {
-      events.push(event(owner * 2, 'capture backend failed before retained audio; trying bounded fallback', {
-        owner,
-        from_backend: 'auhal',
-      }));
-      events.push(event(owner * 2 + 1, 'audio readiness accepted', {
-        owner,
-        owner_kind: 'dictation',
-        startup_ms: 650,
-      }));
-    }
-
-    expect(deriveCaptureHealth(events).chronicFallback).toBe(true);
+    expect(() => parseCaptureHealthHistory({
+      schemaVersion: 1,
+      observations: [{ startupMs: 240, usedFallback: false, fallbackFromBackend: 'auhal' }],
+    })).toThrow(/unsupported capture-health schema/i);
   });
 });

--- a/app/src/lib/captureHealth.ts
+++ b/app/src/lib/captureHealth.ts
@@ -1,14 +1,18 @@
-import type { AppEvent } from './events';
-
 export const CAPTURE_HEALTH_WINDOW = 5;
 export const SLOW_CAPTURE_STARTUP_MS = 2_000;
 
-const FALLBACK_CORRELATION_WINDOW_MS = 35_000;
-const READY_SUMMARY = 'audio readiness accepted';
-const FALLBACK_SUMMARY = 'capture backend failed before retained audio; trying bounded fallback';
-const START_SUMMARY = 'audio initialization accepted';
-
 export type CaptureBackendName = 'auhal' | 'cpal';
+
+export interface CaptureHealthObservationV1 {
+  startupMs: number;
+  usedFallback: boolean;
+  fallbackFromBackend: CaptureBackendName | null;
+}
+
+export interface CaptureHealthHistoryV1 {
+  schemaVersion: 1;
+  observations: CaptureHealthObservationV1[];
+}
 
 export interface CaptureHealth {
   status: 'insufficientData' | 'healthy' | 'degraded';
@@ -21,45 +25,43 @@ export interface CaptureHealth {
   degradedBackend: CaptureBackendName | null;
 }
 
-interface PendingFallback {
-  atMs: number;
-  fromBackend: CaptureBackendName | null;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-interface CaptureObservation {
-  startupMs: number;
-  fallback: PendingFallback | null;
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
-function eventCode(event: AppEvent): string | null {
-  return typeof event.data.event_code === 'string' ? event.data.event_code : null;
+function isCaptureBackend(value: unknown): value is CaptureBackendName {
+  return value === 'auhal' || value === 'cpal';
 }
 
-function numericField(event: AppEvent, key: string): number | null {
-  const value = event.data[key];
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+function isObservation(value: unknown): value is CaptureHealthObservationV1 {
+  return isRecord(value)
+    && Object.keys(value).length === 3
+    && hasOwn(value, 'startupMs')
+    && hasOwn(value, 'usedFallback')
+    && hasOwn(value, 'fallbackFromBackend')
+    && typeof value.startupMs === 'number'
+    && Number.isFinite(value.startupMs)
+    && value.startupMs >= 0
+    && typeof value.usedFallback === 'boolean'
+    && (value.usedFallback || value.fallbackFromBackend === null)
+    && (value.fallbackFromBackend === null || isCaptureBackend(value.fallbackFromBackend));
 }
 
-function backendField(event: AppEvent, key: string): CaptureBackendName | null {
-  const value = event.data[key];
-  return value === 'auhal' || value === 'cpal' ? value : null;
-}
-
-function observedAtMs(event: AppEvent): number | null {
-  const value = Date.parse(event.timestamp);
-  return Number.isFinite(value) ? value : null;
-}
-
-function isReady(event: AppEvent): boolean {
-  return eventCode(event) === 'audio.capture_ready' || event.summary === READY_SUMMARY;
-}
-
-function isFallback(event: AppEvent): boolean {
-  return eventCode(event) === 'audio.fallback_started' || event.summary === FALLBACK_SUMMARY;
-}
-
-function isCaptureFailed(event: AppEvent): boolean {
-  return eventCode(event) === 'audio.capture_failed';
+export function parseCaptureHealthHistory(value: unknown): CaptureHealthHistoryV1 {
+  if (!isRecord(value)
+    || Object.keys(value).length !== 2
+    || !hasOwn(value, 'schemaVersion')
+    || !hasOwn(value, 'observations')
+    || value.schemaVersion !== 1
+    || !Array.isArray(value.observations)
+    || !value.observations.every(isObservation)) {
+    throw new Error('Murmur returned an unsupported capture-health schema.');
+  }
+  return value as unknown as CaptureHealthHistoryV1;
 }
 
 function median(values: number[]): number {
@@ -70,61 +72,20 @@ function median(values: number[]): number {
     : (sorted[midpoint - 1] + sorted[midpoint]) / 2;
 }
 
-export function deriveCaptureHealth(events: AppEvent[]): CaptureHealth {
-  const pendingFallbacks = new Map<number, PendingFallback>();
-  const observations: CaptureObservation[] = [];
-
-  for (const event of events) {
-    const owner = numericField(event, 'owner');
-    if (owner === null) continue;
-
-    if (event.summary === START_SUMMARY) {
-      pendingFallbacks.delete(owner);
-      continue;
-    }
-    if (isFallback(event)) {
-      const atMs = observedAtMs(event);
-      if (atMs !== null) {
-        pendingFallbacks.set(owner, {
-          atMs,
-          fromBackend: backendField(event, 'from_backend'),
-        });
-      }
-      continue;
-    }
-    if (isCaptureFailed(event)) {
-      pendingFallbacks.delete(owner);
-      continue;
-    }
-    if (!isReady(event) || event.data.owner_kind !== 'dictation') continue;
-
-    const startupMs = numericField(event, 'startup_ms');
-    const readyAtMs = observedAtMs(event);
-    if (startupMs === null || startupMs < 0 || readyAtMs === null) continue;
-
-    const pending = pendingFallbacks.get(owner) ?? null;
-    const fallback = pending
-      && readyAtMs >= pending.atMs
-      && readyAtMs - pending.atMs <= FALLBACK_CORRELATION_WINDOW_MS
-      ? pending
-      : null;
-    observations.push({ startupMs, fallback });
-    pendingFallbacks.delete(owner);
-  }
-
+export function deriveCaptureHealth(observations: CaptureHealthObservationV1[]): CaptureHealth {
   const recent = observations.slice(-CAPTURE_HEALTH_WINDOW);
   const sampleCount = recent.length;
   const medianStartupMs = sampleCount > 0
     ? median(recent.map(observation => observation.startupMs))
     : null;
-  const fallbacks = recent.filter(observation => observation.fallback !== null);
+  const fallbacks = recent.filter(observation => observation.usedFallback);
   const fallbackCount = fallbacks.length;
   const enoughData = sampleCount === CAPTURE_HEALTH_WINDOW;
   const chronicFallback = enoughData && fallbackCount === CAPTURE_HEALTH_WINDOW;
   const slowStartup = enoughData
     && medianStartupMs !== null
     && medianStartupMs >= SLOW_CAPTURE_STARTUP_MS;
-  const degradedBackends = fallbacks.map(observation => observation.fallback?.fromBackend ?? null);
+  const degradedBackends = fallbacks.map(observation => observation.fallbackFromBackend);
   const degradedBackend = chronicFallback
     && degradedBackends[0] !== null
     && degradedBackends.every(backend => backend === degradedBackends[0])

--- a/app/src/lib/hooks/usePerformanceHealth.test.tsx
+++ b/app/src/lib/hooks/usePerformanceHealth.test.tsx
@@ -1,0 +1,64 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(async (command: string) => {
+    if (command === 'get_status') return { state: 'idle' };
+    if (command === 'transform_status') return 'idle';
+    if (command === 'get_capture_health_history') {
+      return {
+        schemaVersion: 1,
+        observations: Array.from({ length: 5 }, () => ({
+          startupMs: 240,
+          usedFallback: false,
+          fallbackFromBackend: null,
+        })),
+      };
+    }
+    throw new Error(`Unexpected command: ${command}`);
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+
+import { usePerformanceHealth } from './usePerformanceHealth';
+
+function Probe({ enabled }: { enabled: boolean }) {
+  const health = usePerformanceHealth(enabled);
+  return <output>{health.capture.status}</output>;
+}
+
+describe('usePerformanceHealth capture hydration', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    mocks.invoke.mockClear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('polls bounded capture history without requesting general event history', async () => {
+    await act(async () => {
+      root.render(<Probe enabled />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith('get_capture_health_history');
+    expect(mocks.invoke).not.toHaveBeenCalledWith('get_event_history');
+    expect(container.textContent).toBe('healthy');
+  });
+
+  it('does no diagnostic work while disabled', async () => {
+    await act(async () => root.render(<Probe enabled={false} />));
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/hooks/usePerformanceHealth.ts
+++ b/app/src/lib/hooks/usePerformanceHealth.ts
@@ -1,8 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
 import { useCallback, useEffect, useState } from 'react';
 import { getStatus } from '../dictation';
-import { deriveCaptureHealth, type CaptureHealth } from '../captureHealth';
-import type { AppEvent } from '../events';
+import {
+  deriveCaptureHealth,
+  parseCaptureHealthHistory,
+  type CaptureHealth,
+} from '../captureHealth';
 import {
   getModelRuntimeStatus,
   type ModelRuntimeSnapshot,
@@ -55,11 +58,12 @@ export function usePerformanceHealth(enabled: boolean): PerformanceHealth & { re
     if (!enabled) return;
     void (async () => {
       try {
-        const [status, transformStatus, events] = await Promise.all([
+        const [status, transformStatus, captureHistoryValue] = await Promise.all([
           getStatus(),
           invoke<unknown>('transform_status'),
-          invoke<AppEvent[]>('get_event_history'),
+          invoke<unknown>('get_capture_health_history'),
         ]);
+        const captureHistory = parseCaptureHealthHistory(captureHistoryValue);
         const modelName = typeof status.model === 'string' ? status.model : null;
         const runtime = modelName ? await getModelRuntimeStatus(modelName) : null;
         setHealth({
@@ -69,7 +73,7 @@ export function usePerformanceHealth(enabled: boolean): PerformanceHealth & { re
           dictationStatus: isDictationStatus(status.state) ? status.state : null,
           transformStatus: isTransformStatus(transformStatus) ? transformStatus : null,
           runtime,
-          capture: deriveCaptureHealth(events),
+          capture: deriveCaptureHealth(captureHistory.observations),
         });
       } catch (reason) {
         setHealth(current => ({

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ deliberately escaped process group. See the
 
 | Module | Purpose |
 |--------|---------|
-| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 115 registered commands, setup, tray, run loop |
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 116 registered commands, setup, tray, run loop |
 | `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
 | `audio.rs` | CPAL 0.18 capture worker, stable device-ID selection, typed error/phase telemetry, first-buffer readiness, mono mix, 16kHz resample, `audio-level` emission |
 | `audio_lifecycle.rs` | App-lifetime single-owner supervisor; async start, generation cancellation, deadlines, generation-gated publication, and strict worker ownership through exit |
@@ -350,7 +350,7 @@ Two rules keep the multi-window state coherent:
 
 ## Tauri Commands
 
-115 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
+116 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
 
 ## Events
 

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -135,6 +135,12 @@ backend, and accelerator identity. Accelerator identity is not utilization.
 `Accelerator utilization` is explicitly unavailable because Murmur has no
 production whole-device GPU or ANE percentage.
 
+Microphone startup health reads a separate versioned history containing at most
+20 finalized dictation observations. Each record has only startup duration, a
+fallback boolean, and an optional allowlisted backend enum. It survives app restarts and is
+not evicted by the general event ring; the five-recording verdict remains
+insufficient until five successful captures exist.
+
 **Scoped resources** keep each measurement in its typed scope:
 
 - Host CPU is whole-host utilization normalized to 0–100%.
@@ -232,7 +238,8 @@ The frontend event buffer is managed by the `useEventStore` hook:
 | `list_performance_runs` | Returns at most 200 newest typed performance runs |
 | `get_performance_run` | Returns one typed run by opaque `run_id` |
 | `get_performance_resource_window` | Returns the bounded typed resource window |
-| `clear_performance_diagnostics` | Clears only local Performance runs and samples |
+| `get_capture_health_history` | Returns the bounded, content-free V1 capture-startup observation history |
+| `clear_performance_diagnostics` | Clears local Performance runs, samples, and capture-startup observations |
 | `list_transform_attempts` | Lists bounded, content-free transform attempts |
 | `arm_next_transform_diagnostic_capture` | Arms one local exact-content capture for up to 10 minutes |
 | `get_transform_diagnostic_capture_status` | Reads the in-memory one-shot arm state |

--- a/docs/features/performance-diagnostics.md
+++ b/docs/features/performance-diagnostics.md
@@ -154,17 +154,26 @@ start.
 ## Capture startup health
 
 The Performance tab also derives a read-only, on-device microphone startup
-signal from the existing bounded event history. It considers the five newest
-successful dictation `audio.capture_ready` events and correlates a preceding
-`audio.fallback_started` only for the same owner within the bounded capture
-contract. It reports degraded health when all five captures required fallback
-or their median `startup_ms` is at least two seconds.
+signal from a dedicated rolling history of the 20 newest successful dictation
+captures. Rust correlates `audio.fallback_started` with `audio.capture_ready`
+only for the same owner within the bounded capture contract, then persists only
+the finalized startup duration, whether fallback occurred, and an optional
+stable backend enum. Persistence runs off the capture-ready path. The frontend
+polls this small typed history instead of the general 500-event telemetry ring.
+Idle heartbeats and system chatter therefore cannot evict capture health
+evidence. On first upgrade, Murmur reconstructs safe finalized observations
+once from the current and rotated structured event logs.
+
+The signal considers the five newest observations. It reports degraded health
+when all five captures required fallback or their median `startup_ms` is at
+least two seconds.
 
 This judgment does not change backend order, retry budgets, or any capture-path
-behavior. It accepts only the stable `auhal` and `cpal` backend labels and exact
-event codes (plus exact historical summaries); it never reads device labels,
-UIDs, transcript content, or free-form errors. Fewer than five successful
+behavior. The persistent record accepts only the stable `auhal` and `cpal`
+backend enums; it contains no timestamps, capture-owner IDs, device labels,
+device UIDs, transcript content, or free-form errors. Fewer than five successful
 captures is reported as insufficient data rather than healthy or degraded.
+Clearing Performance diagnostics also clears these retained observations.
 
 ## UI navigation latency
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Tauri Commands Reference
 
-The 115 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
+The 116 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
 Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
 
@@ -176,7 +176,8 @@ frontend.
 | `list_performance_runs` | `limit: Option<u32>` | `Result<PerformanceRunListV1, String>` | Completed runs, newest first (cap 200). |
 | `get_performance_run` | `run_id: String` | `Result<Option<PerformanceRunV1>, String>` | One run with stage timings, warm state, RSS deltas, and transform follow-ups. |
 | `get_performance_resource_window` | — | `Result<Vec<ResourceSampleV1>, String>` | The rolling CPU/memory sample window (cap 600). |
-| `clear_performance_diagnostics` | — | `Result<(), String>` | Deletes local run history and samples; emits `performance-diagnostics-cleared`. |
+| `get_capture_health_history` | — | `CaptureHealthHistoryV1` | The 20 newest finalized dictation startup observations. Each contains only `startupMs`, `usedFallback`, and an optional allowlisted fallback backend enum. |
+| `clear_performance_diagnostics` | — | `Result<(), String>` | Deletes local run history, samples, and capture-startup observations; emits `performance-diagnostics-cleared`. |
 | `show_diagnostics_window` | `tab: String` | `Result<(), String>` | Shows and focuses the persistent Diagnostics window, selecting one of its exact allowlisted tabs. |
 
 ## Logging (`commands/logging.rs`)

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -143,7 +143,9 @@ The structured event buffer: hydrates from `get_event_history`, streams live `ap
 Run history and resource samples. Hydrates from `list_performance_runs` / `get_performance_resource_window`, then merges live `performance-run-completed` and `performance-resource-sample` events (the exported `mergeRuns` / `mergeResourceSamples` are pure and unit-tested), and resets on `performance-diagnostics-cleared`. Gated by an `enabled` flag so a hidden tab does no work.
 
 ### `usePerformanceHealth`
-Summary health of the diagnostics store (availability, counts) with an explicit `refresh`.
+Live pipeline/model state plus capture-startup health with an explicit `refresh`.
+Its two-second refresh reads the dedicated bounded `get_capture_health_history`
+payload rather than polling the general event history.
 
 ### `useResourceMonitor`
 CPU/memory polling with a rolling 60-reading buffer. Only polls while the panel is expanded.

--- a/tests/test_reference_docs.py
+++ b/tests/test_reference_docs.py
@@ -28,7 +28,7 @@ def copy_reference_fixture(root: Path) -> None:
 
 class ReferenceDocsTests(unittest.TestCase):
     def test_repository_reference_docs_match_registered_commands(self) -> None:
-        self.assertEqual(validate_reference_docs(), 115)
+        self.assertEqual(validate_reference_docs(), 116)
 
     def test_missing_command_row_fails_even_when_prose_count_is_current(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -54,7 +54,7 @@ class ReferenceDocsTests(unittest.TestCase):
             architecture = root / "docs/ARCHITECTURE.md"
             architecture.write_text(
                 architecture.read_text().replace(
-                    "115 registered commands", "112 registered commands", 1
+                    "116 registered commands", "112 registered commands", 1
                 )
             )
 


### PR DESCRIPTION
## Summary

- persist a versioned, bounded 20-observation capture-health history outside the general telemetry ring
- retain only allowlisted startup/fallback evidence (no labels, UIDs, owner IDs, timestamps, or content) and migrate existing rotated/current event logs once
- poll the bounded capture-health command instead of the full event history every two seconds while preserving the existing 5/5 fallback threshold and insufficient-data fail-safe
- clear capture-health evidence with performance diagnostics and document the new command/storage contract

## Validation

- `cargo check`
- `cargo fmt --check`
- `cargo test capture_health -- --test-threads=1` (6/6)
- `cargo test -- --test-threads=1` (775 unit tests pass; timing-sensitive `capture_helper_spike` had one unrelated handshake timeout under the full run, then passed isolated 12/12)
- `npx tsc --noEmit`
- `npm test` (78 files, 699 tests)
- `python3 scripts/validate_reference_docs.py` (116/116)
- native debug bundle built; expected updater signing-key error occurred after `.app`, `.dmg`, and updater archive were produced
- native smoke: exact rebuilt app rendered retained degraded capture health after idle; Refresh remained stable
- privacy inspection: persisted file held 19 bounded observations and only `startupMs`, `usedFallback`, and `fallbackFromBackend`

Murmur Bench: N/A — diagnostics-only bounded storage/query change; it does not affect recognition, transcript delivery, model runtime, transforms, benchmarked execution paths, memory-sensitive dependencies, or synchronous capture readiness (persistence is dispatched off the capture-ready path).

Closes #514