### PR TITLE
fix(query): forward USER and LOGNAME to the configured CLI

### DIFF
--- a/app/src-tauri/src/managed_child.rs
+++ b/app/src-tauri/src/managed_child.rs
@@ -78,7 +78,11 @@ impl ManagedChild {
     ///
     /// The child receives only the small environment needed by common CLI
     /// shims and credential stores. Arbitrary parent variables (including API
-    /// keys) are deliberately not forwarded.
+    /// keys) are deliberately not forwarded. `USER`/`LOGNAME` carry no secret
+    /// (the username is already visible in `HOME`) and are required on macOS:
+    /// Claude Code derives its Keychain credential account name from `USER`
+    /// and resolves to a nonexistent "unknown" account without it, reporting
+    /// "Not logged in" even when the user is signed in.
     pub fn spawn_user_cli(
         executable: &Path,
         arguments: &[String],
@@ -91,7 +95,9 @@ impl ManagedChild {
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .env_clear();
-        for key in ["HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"] {
+        for key in [
+            "HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "USER", "LOGNAME",
+        ] {
             if let Some(value) = std::env::var_os(key) {
                 command.env(key, value);
             }
@@ -306,7 +312,9 @@ mod tests {
         child
             .wait_for_exit(Instant::now() + Duration::from_secs(1))
             .expect("env must exit cleanly");
-        let allowed = ["HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"];
+        let allowed = [
+            "HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "USER", "LOGNAME",
+        ];
         for line in output.lines() {
             let key = line.split_once('=').map(|(key, _)| key).unwrap_or(line);
             assert!(

--- a/docs/features/voice-query.md
+++ b/docs/features/voice-query.md
@@ -7,7 +7,7 @@ Issue [#538](https://github.com/georgenijo/murmur-app/issues/538). Voice Query i
 - Microphone capture and transcription stay in Murmur's existing local ASR runtime.
 - Murmur starts the exact absolute executable path directly. It never invokes a shell, builds a command string, expands variables, or interprets the transcript.
 - Fixed arguments remain separate argv elements. The recognized question is appended as exactly one final argv element.
-- The child receives a cleared environment with only `HOME`, `PATH`, `TMPDIR`, `LANG`, `LC_ALL`, and `LC_CTYPE` forwarded when present. Arbitrary parent secrets are not inherited.
+- The child receives a cleared environment with only `HOME`, `PATH`, `TMPDIR`, `LANG`, `LC_ALL`, `LC_CTYPE`, `USER`, and `LOGNAME` forwarded when present. Arbitrary parent secrets are not inherited. `USER` is required on macOS: Claude Code derives its Keychain credential account name from it and reports "Not logged in" without it.
 - The configured CLI is outside Murmur's local-only trust boundary. It may send the question or answer to cloud services according to its own configuration; Settings states this before the user opts in. Murmur cannot verify or prevent that egress.
 - No executable is selected by default and the shortcut is disabled by default.
 - Question and answer content never enters structured telemetry, dictation history, usage statistics, transcript/audio file output, or broadcast state events. Answer chunks are targeted only to the `query-review` webview; full answer retrieval is requester-gated to that window.


### PR DESCRIPTION
## Problem

Voice Query always failed with the CLI's own "Not logged in · Please run /login" message even when the user was signed in to Claude Code. Claude Code derives its macOS Keychain credential account name from `USER` and falls back to a nonexistent `unknown` account when the variable is absent — and `spawn_user_cli`'s cleared environment did not forward it. (Each failed attempt also left an empty `acct="unknown"` Keychain item behind, which poisoned service-name-only credential lookups by other local tools.)

Verified empirically in a GUI session on the affected machine:
- exact allowlisted env → `loggedIn: false`
- same env + `USER` only → `loggedIn: true`

Linux was unaffected (file-based `~/.claude/.credentials.json`, no account-named Keychain lookup), which is why the allowlist originally looked sufficient.

## Fix

Add `USER` and `LOGNAME` to the forwarded-variable allowlist in `ManagedChild::spawn_user_cli`. Neither carries a secret — the username is already visible in the forwarded `HOME` path. Updated the env-allowlist test and the feature doc.

## Tests

- `managed_child` suite: 5/5 pass on macOS (aarch64), including the updated `user_cli_environment_contains_only_explicit_allowlist`
- `query_flow` suite: 4/4 pass

Murmur Bench: N/A — changes only the spawn environment of the user-configured query CLI; no recognition, transform, or delivery path is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for voice queries by preserving the current user identity when launching voice-related processes.
  * Maintained environment isolation by forwarding only approved environment variables.

* **Documentation**
  * Updated voice query documentation to reflect the expanded environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->