### PR TITLE
fix(query): unblock dictation during answer generation, follow Spaces

### DIFF
--- a/app/src-tauri/src/commands/benchmark.rs
+++ b/app/src-tauri/src/commands/benchmark.rs
@@ -76,6 +76,9 @@ pub async fn run_benchmark(
         if state.app_state.transform_status().blocks_recording() {
             return Err("Wait for the transform to finish before benchmarking".to_string());
         }
+        // Deliberately the strict predicate, not `blocks_capture`: a query in
+        // `Running` still has a CLI child competing for CPU, which would skew
+        // the latency numbers this harness exists to measure.
         if state.query.status().blocks_pipeline() {
             return Err("Wait for the voice query to finish before benchmarking".to_string());
         }

--- a/app/src-tauri/src/commands/corpus.rs
+++ b/app/src-tauri/src/commands/corpus.rs
@@ -542,6 +542,9 @@ pub async fn start_corpus_recording(
         if state.benchmark.is_running() {
             return Err("Finish the current benchmark first".to_string());
         }
+        // Strict predicate on purpose (see `benchmark.rs`): corpus audio is
+        // reference material, so it must not be recorded while a query's CLI
+        // child is loading the machine.
         if state.query.status().blocks_pipeline() {
             return Err("Finish the current voice query first".to_string());
         }

--- a/app/src-tauri/src/commands/microphone_preview.rs
+++ b/app/src-tauri/src/commands/microphone_preview.rs
@@ -105,8 +105,11 @@ pub async fn start_microphone_preview(
         {
             return Err("Finish the current transform before testing the microphone".to_string());
         }
-        if state.query.status().blocks_pipeline() {
-            return Err("Finish the current voice query before testing the microphone".to_string());
+        if state.query.status().blocks_capture() {
+            return Err(
+                "Finish the current voice query's recording before testing the microphone"
+                    .to_string(),
+            );
         }
         if state.benchmark.is_running() {
             return Err("Finish the current benchmark before testing the microphone".to_string());

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -1098,9 +1098,9 @@ pub async fn process_audio(
             tracing::warn!(target: "pipeline", "process_audio: blocked — transform in progress");
             return Err("Cannot process audio while a transform is in progress.".to_string());
         }
-        if state.query.status().blocks_pipeline() {
-            tracing::warn!(target: "pipeline", "process_audio: blocked — voice query in progress");
-            return Err("Cannot process audio while a voice query is in progress.".to_string());
+        if state.query.status().blocks_capture() {
+            tracing::warn!(target: "pipeline", "process_audio: blocked — voice query is capturing");
+            return Err("Cannot process audio while a voice query is listening.".to_string());
         }
         // Mutual exclusion with the local-LLM transform runtime: only one heavy
         // inference runtime may be resident. Refuse while a transform is active.
@@ -2585,8 +2585,8 @@ pub async fn start_native_recording(
                 "state": "idle"
             }));
         }
-        if state.query.status().blocks_pipeline() {
-            tracing::warn!(target: "pipeline", "start_native_recording: blocked — voice query in progress");
+        if state.query.status().blocks_capture() {
+            tracing::warn!(target: "pipeline", "start_native_recording: blocked — voice query is capturing");
             return Ok(serde_json::json!({
                 "type": "busy_querying",
                 "state": "idle"
@@ -3239,9 +3239,10 @@ pub async fn transcribe_file(
         if state.app_state.transform_status().blocks_recording() {
             return Err("Wait for the transform to finish before transcribing a file.".to_string());
         }
-        if state.query.status().blocks_pipeline() {
+        if state.query.status().blocks_capture() {
             return Err(
-                "Wait for the voice query to finish before transcribing a file.".to_string(),
+                "Wait for the voice query to finish listening before transcribing a file."
+                    .to_string(),
             );
         }
         if dictation.status != DictationStatus::Idle {

--- a/app/src-tauri/src/query_flow.rs
+++ b/app/src-tauri/src/query_flow.rs
@@ -54,11 +54,29 @@ impl QueryStatus {
         }
     }
 
-    pub(crate) fn blocks_pipeline(self) -> bool {
+    /// True while the query owns the microphone or the shared ASR backend.
+    ///
+    /// `finish_query_capture` stops and joins the query's audio owner before it
+    /// transitions to `Transcribing`, and ASR completes before `Running`, so a
+    /// query that has reached `Running` holds only its CLI child. Capture-only
+    /// work (dictation, file transcription, microphone preview) is therefore
+    /// free to start once the answer is being generated — which is the long
+    /// phase of a query and used to lock the user out of dictation entirely.
+    pub(crate) fn blocks_capture(self) -> bool {
         matches!(
             self,
-            Self::Connecting | Self::Listening | Self::Transcribing | Self::Running
+            Self::Connecting | Self::Listening | Self::Transcribing
         )
+    }
+
+    /// True for every non-terminal state, `Running` included.
+    ///
+    /// Stricter than [`Self::blocks_capture`]: the CLI child competes for CPU
+    /// and may itself be a heavy inference runtime. Latency-sensitive work
+    /// (benchmarks, corpus capture) and the local-LLM transform runtime stay
+    /// mutually exclusive with it, so they keep using this predicate.
+    pub(crate) fn blocks_pipeline(self) -> bool {
+        self.blocks_capture() || matches!(self, Self::Running)
     }
 
     fn accepts_new_pass(self) -> bool {
@@ -1000,6 +1018,29 @@ mod tests {
         };
         let valid = validate_command(valid).expect("printf must be executable");
         assert_eq!(valid.arguments, vec!["%s"]);
+    }
+
+    #[test]
+    fn running_frees_capture_but_still_blocks_heavy_runtimes() {
+        // Capture-only work may start once the answer is generating: the audio
+        // owner is stopped and joined before `Transcribing`, and ASR finishes
+        // before `Running`.
+        assert!(!QueryStatus::Running.blocks_capture());
+        assert!(QueryStatus::Running.blocks_pipeline());
+
+        for status in [
+            QueryStatus::Connecting,
+            QueryStatus::Listening,
+            QueryStatus::Transcribing,
+        ] {
+            assert!(status.blocks_capture(), "{status:?} owns mic or ASR");
+            assert!(status.blocks_pipeline(), "{status:?} must stay strict");
+        }
+
+        for status in [QueryStatus::Idle, QueryStatus::Ready, QueryStatus::Failed] {
+            assert!(!status.blocks_capture(), "{status:?} is terminal");
+            assert!(!status.blocks_pipeline(), "{status:?} is terminal");
+        }
     }
 
     #[test]

--- a/app/src-tauri/src/transform_flow.rs
+++ b/app/src-tauri/src/transform_flow.rs
@@ -1747,6 +1747,9 @@ pub(crate) async fn start_transform_capture(
         } else if state.transform_runtime.is_transform_busy() {
             tracing::info!(target: "transform", transform_pass_id, error_code = "runtime_busy", "start_transform_capture ignored");
             Err("runtime_busy")
+        // Strict predicate on purpose: the transform holds the local-LLM
+        // sidecar, and only one heavy inference runtime may be resident. A
+        // query in `Running` may itself be driving an LLM.
         } else if state.query.status().blocks_pipeline() {
             tracing::info!(target: "transform", transform_pass_id, error_code = "query_busy", "start_transform_capture ignored");
             Err("query_busy")

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -71,7 +71,8 @@
         "resizable": false,
         "visible": false,
         "focus": false,
-        "shadow": true
+        "shadow": true,
+        "visibleOnAllWorkspaces": true
       },
       {
         "label": "query-review",
@@ -86,7 +87,8 @@
         "resizable": false,
         "visible": false,
         "focus": false,
-        "shadow": true
+        "shadow": true,
+        "visibleOnAllWorkspaces": true
       }
     ],
     "macOSPrivateApi": true,

--- a/app/src/lib/hooks/useRecordingState.test.tsx
+++ b/app/src/lib/hooks/useRecordingState.test.tsx
@@ -92,6 +92,26 @@ describe('useRecordingState transition ordering', () => {
     expect(current.status).toBe('idle');
   });
 
+  it('surfaces a reason for every busy refusal instead of failing silently', async () => {
+    const refusals = [
+      'busy_benchmarking',
+      'busy_transcribing_file',
+      'busy_meeting',
+      'busy_querying',
+      'busy_transforming',
+      'busy_recording_corpus',
+    ];
+
+    for (const type of refusals) {
+      mocks.startRecording.mockResolvedValueOnce({ type, state: 'idle' });
+
+      await act(async () => current.handleStart());
+
+      expect(current.status).toBe('idle');
+      expect(current.error, `${type} must explain itself`).not.toBe('');
+    }
+  });
+
   it('does not let a start response overwrite an earlier readiness event', async () => {
     mocks.startRecording.mockImplementationOnce(async () => {
       mocks.listeners.get('recording-status-changed')?.({ payload: 'starting' });

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -232,6 +232,11 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
           else if (res.type === 'busy_benchmarking') setError('Wait for the benchmark to finish.');
           else if (res.type === 'busy_transcribing_file') setError('Wait for the file transcription to finish.');
           else if (res.type === 'busy_meeting') setError('Stop the meeting capture before starting dictation.');
+          // Without these three the press is a silent no-op: Rust refuses the
+          // start but nothing tells the user why.
+          else if (res.type === 'busy_querying') setError('Finish speaking your voice query before starting dictation.');
+          else if (res.type === 'busy_transforming') setError('Wait for the transform to finish.');
+          else if (res.type === 'busy_recording_corpus') setError('Finish the corpus recording before starting dictation.');
           else if (res.type === 'audio_recovering') {
             setError('Microphone cleanup is still in progress. Try again when Murmur is ready.');
           }

--- a/docs/features/voice-query.md
+++ b/docs/features/voice-query.md
@@ -16,9 +16,15 @@ Issue [#538](https://github.com/georgenijo/murmur-app/issues/538). Voice Query i
 
 The shared `rdev` listener owns a third detector for the query shortcut (`alt_r`, `ctrl_l`, or `shift_r`). It uses the same double-tap timing as toggle dictation but has no spoken-keyword path. A query and selected-text transform cannot use the same physical key.
 
-Each accepted press allocates a monotonic `query_pass_id`. Capture, ASR, process ownership, streamed chunks, completion, Copy, Escape, and cancellation carry that exact ID. Stale continuations no-op. Query capture is mutually exclusive with dictation, file transcription, Performance Lab, corpus capture, and selected-text transform.
+Each accepted press allocates a monotonic `query_pass_id`. Capture, ASR, process ownership, streamed chunks, completion, Copy, Escape, and cancellation carry that exact ID. Stale continuations no-op.
+
+Exclusivity is scoped to what a query actually holds, and the two predicates in `query_flow.rs` are deliberately different. While the query owns the microphone or the shared ASR backend (`connecting`, `listening`, `transcribing`), `blocks_capture` refuses dictation, file transcription, and the Settings microphone test. Once the query reaches `running` it holds only its CLI child — capture stopped and joined before `transcribing`, ASR finished before `running` — so dictation is free to start again during answer generation, which is the longest phase. The stricter `blocks_pipeline` additionally covers `running` and continues to exclude Performance Lab, corpus capture, and selected-text transform, because the child competes for CPU and may itself be a heavy inference runtime. Dictation refused during capture reports `busy_querying` rather than failing silently.
+
+Dictation and a query answer both finish on the clipboard, and neither defers to the other: an answer that completes after a dictation lands overwrites it, matching the more recent user action.
 
 The state sequence is `connecting → listening → transcribing → running → ready|failed`. A single tap stops capture after the double-tap start. Escape and Cancel are valid throughout. The completed answer is copied to the clipboard and remains selectable in the popover; Copy repeats that action. It is never pasted automatically.
+
+Like the notch overlay, the answer popover is configured `visibleOnAllWorkspaces` so it joins every Space instead of staying pinned to the one it was created on. Its position still derives from the main window's monitor, so on a multi-display setup it follows that display rather than the active one.
 
 ## Process and output bounds
 


### PR DESCRIPTION
Two UX defects George hit using Voice Query (#538) in v0.31.2.

## 1. Dictation was blocked for the whole query

`blocks_pipeline` covered `running`, so double-tap dictation was refused from the moment a query started until its answer landed. But `finish_query_capture` stops and joins the audio owner *before* `transcribing`, and ASR completes before `running` — a query in `running` holds only its CLI child, leaving the mic and the shared Whisper backend free. `running` is also the longest phase, so the shortcut was effectively dead for the entire wait.

Rather than loosen the guard everywhere, the predicate is split:

| Predicate | States | Gates |
|---|---|---|
| `blocks_capture` | connecting, listening, transcribing | dictation, file transcription, microphone test |
| `blocks_pipeline` | + running | Performance Lab, corpus capture, selected-text transform |

The strict sites keep `blocks_pipeline` deliberately — the CLI child competes for CPU (which would skew the very latency the bench harness measures) and may itself be a heavy inference runtime, which the local-LLM transform must stay exclusive with. Each strict call site now carries a comment saying so.

## 2. The refusal was silent

`start_native_recording` returns six `busy_*` types; the frontend had messages for three. Pressing the hotkey during a query did nothing and explained nothing. Added the missing `busy_querying`, plus `busy_transforming` and `busy_recording_corpus`, which had the identical defect.

## 3. The popover didn't follow across Spaces

`query-review` lacked the `visibleOnAllWorkspaces` the notch overlay already sets, so it stayed pinned to the Space it was created on. Added to both the query and transform popovers.

Position still derives from the main window's monitor, so multi-display placement is unchanged — now documented as a known limitation rather than silently altered.

## Clipboard interaction

Dictation and a query answer both finish on the clipboard and neither defers to the other: an answer completing after a dictation overwrites it, matching the more recent user action. Documented in `voice-query.md` rather than arbitrated in code.

## Verification

Run on the trusted macbook against this branch's base (`84c2880b`):

| Check | Result |
|---|---|
| `cargo test -- --test-threads=1` | 862 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | 0 warnings |
| `cargo fmt --all -- --check` | clean |
| `npm test` | 740 passed / 84 files |
| `npx tsc --noEmit` | clean |

New coverage: `running_frees_capture_but_still_blocks_heavy_runtimes` pins the two predicates apart; a frontend test asserts every `busy_*` refusal explains itself (confirmed failing before the fix).

**Not verified end-to-end.** Whether the popover actually follows Spaces is macOS window-server behavior no test covers, and nobody has held a live query and hit double-shift. Both need a native smoke test before merge.

**Murmur Bench: N/A** — guard predicates, window config, comments, and UI strings only. No VAD, backend, model-runtime, or transcript-transform path is touched, and the benchmark entry point keeps its original predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording and microphone workflows can now continue while a voice query is generating an answer.
  * Query and transform review windows remain visible across workspaces.
  * Recording attempts now show clear error messages when another operation is actively using the microphone or processing resources.

* **Bug Fixes**
  * Improved handling of recording refusals, ensuring the recording state returns to idle.
  * Clarified voice-query busy-state behavior and related user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->