### PR TITLE
fix: fail open on unavailable updater policy (#558)

### DIFF
--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -180,7 +180,7 @@ describe('useAutoUpdater presentation state', () => {
     expect(mocks.flogError).not.toHaveBeenCalled();
   });
 
-  it('fails closed when update availability is known but policy cannot be verified', async () => {
+  it('offers a verified update as optional when policy cannot be verified', async () => {
     mocks.check.mockResolvedValue({
       available: true,
       version: '0.24.2',
@@ -192,11 +192,18 @@ describe('useAutoUpdater presentation state', () => {
     await act(async () => current.checkForUpdate());
 
     expect(current.updateStatus).toMatchObject({
-      phase: 'error',
-      stage: 'check',
-      message: expect.stringContaining('verify the update policy'),
+      phase: 'available',
+      version: '0.24.2',
+      isForced: false,
     });
-    expect(localStorage.getItem('updater-last-check')).toBeNull();
+    expect(current.isUpdateDialogOpen).toBe(true);
+    expect(localStorage.getItem('updater-last-check')).not.toBeNull();
+    expect(mocks.flogWarn).toHaveBeenCalledWith(
+      'updater',
+      'could not verify update policy',
+      { error: 'Update manifest was not an object.' },
+    );
+    expect(mocks.flogError).not.toHaveBeenCalled();
   });
 
   it('uses an absent policy from the native response without a webview fetch', async () => {

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -181,6 +181,8 @@ describe('useAutoUpdater presentation state', () => {
   });
 
   it('offers a verified update as optional when policy cannot be verified', async () => {
+    mocks.getVersion.mockRejectedValue(new Error('installed version unavailable'));
+    mocks.getVersion.mockClear();
     mocks.check.mockResolvedValue({
       available: true,
       version: '0.24.2',
@@ -197,6 +199,7 @@ describe('useAutoUpdater presentation state', () => {
       isForced: false,
     });
     expect(current.isUpdateDialogOpen).toBe(true);
+    expect(mocks.getVersion).not.toHaveBeenCalled();
     expect(localStorage.getItem('updater-last-check')).not.toBeNull();
     expect(mocks.flogWarn).toHaveBeenCalledWith(
       'updater',
@@ -207,6 +210,8 @@ describe('useAutoUpdater presentation state', () => {
   });
 
   it('uses an absent policy from the native response without a webview fetch', async () => {
+    mocks.getVersion.mockRejectedValue(new Error('installed version unavailable'));
+    mocks.getVersion.mockClear();
     mocks.check.mockResolvedValue({
       available: true,
       version: '0.24.2',
@@ -218,6 +223,7 @@ describe('useAutoUpdater presentation state', () => {
     await act(async () => current.checkForUpdate());
 
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(mocks.getVersion).not.toHaveBeenCalled();
     expect(current.updateStatus).toMatchObject({
       phase: 'available',
       version: '0.24.2',

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -28,8 +28,6 @@ import { getUpdateInstallEnvironment } from '../updaterEnvironment';
 
 const APP_TRANSLOCATION_MESSAGE =
   'macOS opened Murmur from a read-only security location. Quit Murmur, then use Finder to move or reinstall it in Applications before reopening it and trying the update again.';
-const UPDATE_POLICY_UNAVAILABLE_MESSAGE =
-  'Could not verify the update policy. Check your connection and try again.';
 
 type UpdaterOperation = 'idle' | 'checking' | 'installing';
 
@@ -158,18 +156,10 @@ export function useAutoUpdater(
         flog.warn('updater', 'could not verify update policy', {
           error: policy.message,
         });
-        if (shouldPresentManualResult()) {
-          setIsUpdateDialogOpen(false);
-          setUpdateStatus({
-            phase: 'error',
-            stage: 'check',
-            message: UPDATE_POLICY_UNAVAILABLE_MESSAGE,
-            isForced: false,
-          });
-        }
-        return;
       }
       setLastCheckTimestamp(Date.now());
+      // A secondary policy read may fail to force an update; it must never
+      // fail to offer a verified update.
       const isForced =
         policy.status === 'present' &&
         isBelowMinVersion(currentVersion, policy.minVersion);

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -150,19 +150,20 @@ export function useAutoUpdater(
 
       // Tauri exposes the exact native response as rawJson, so policy parsing
       // does not need a second cross-origin request from the webview.
-      const currentVersion = await getVersion();
       const policy = parseMinVersionPolicy(update.rawJson);
       if (policy.status === 'unavailable') {
         flog.warn('updater', 'could not verify update policy', {
           error: policy.message,
         });
       }
-      setLastCheckTimestamp(Date.now());
       // A secondary policy read may fail to force an update; it must never
       // fail to offer a verified update.
-      const isForced =
-        policy.status === 'present' &&
-        isBelowMinVersion(currentVersion, policy.minVersion);
+      let isForced = false;
+      if (policy.status === 'present') {
+        const currentVersion = await getVersion();
+        isForced = isBelowMinVersion(currentVersion, policy.minVersion);
+      }
+      setLastCheckTimestamp(Date.now());
 
       // If not forced and user previously skipped this version, suppress
       if (!isForced && getSkippedVersion() === update.version) {

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -51,7 +51,8 @@ than the release. The legacy bridge manifest intentionally omits this policy.
 
 ### Normal Updates
 
-When a new version is available and the current version is above `min_version`:
+When a new version is available and the current version is above a verified
+`min_version` (or no verifiable minimum policy is available):
 
 1. **Available** — Background discovery is passive: the main Record/File row
    shows an update pill and the menu-bar action changes to the available
@@ -106,9 +107,11 @@ or failed installation as an update-check failure.
 
 The updater manifest policy parser also distinguishes an intentionally absent
 `min_version` from unavailable or malformed native metadata. Once update
-availability is known, Murmur refuses to present it as optional unless the
-policy was verified. A policy failure is retryable as an update-check error and
-does not advance the successful-check timestamp.
+availability is known, an unavailable or malformed policy is logged as a
+warning and the signed update is still offered as optional (`isForced: false`).
+Only a verifiably present policy can force an update, and the successful-check
+timestamp advances because native update availability was verified. A secondary
+policy read may fail to force an update; it must never fail to offer one.
 
 ### Background Notifications
 

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -51,8 +51,8 @@ than the release. The legacy bridge manifest intentionally omits this policy.
 
 ### Normal Updates
 
-When a new version is available and the current version is above a verified
-`min_version` (or no verifiable minimum policy is available):
+When a new version is available and the current version is at or above a
+verified `min_version` (or no verifiable minimum policy is available):
 
 1. **Available** — Background discovery is passive: the main Record/File row
    shows an update pill and the menu-bar action changes to the available
@@ -106,12 +106,14 @@ the Settings page and homepage indicator do not describe a completed download
 or failed installation as an update-check failure.
 
 The updater manifest policy parser also distinguishes an intentionally absent
-`min_version` from unavailable or malformed native metadata. Once update
-availability is known, an unavailable or malformed policy is logged as a
-warning and the signed update is still offered as optional (`isForced: false`).
-Only a verifiably present policy can force an update, and the successful-check
-timestamp advances because native update availability was verified. A secondary
-policy read may fail to force an update; it must never fail to offer one.
+`min_version` from unavailable or structurally malformed native metadata. Once
+update availability is known, an absent policy leaves the signed update
+optional. Unavailable or structurally malformed metadata is logged as a warning
+and the signed update is still offered as optional (`isForced: false`). Only a
+present string policy can enter forced-update enforcement. If that policy's
+`min_version`, or the installed version, is unparseable, the existing
+`isBelowMinVersion` fail-safe forces the update. A secondary policy read may
+fail to force an update; it must never fail to offer one.
 
 ### Background Notifications
 


### PR DESCRIPTION
## Summary

Closes #558.

When native updater availability is verified but `min_version` policy metadata is unavailable or malformed, Murmur now logs the policy warning and offers the update as optional (`isForced: false`) instead of vetoing it as a check error. Forced enforcement remains limited to a verifiably present policy, including the existing fail-safe behavior for unparseable versions.

## Acceptance criteria

- [x] Policy `unavailable` + valid update reaches `phase: 'available'`, `isForced: false`, and logs a warning without an error state.
- [x] Policy `present` above the installed version remains forced.
- [x] Policy `absent` remains optional and unchanged.
- [x] `isBelowMinVersion` fail-safe behavior remains unchanged.
- [x] Documentation and code comment state the fail-open policy rule.

## Validation

- `cd app && npx tsc --noEmit` — passed
- `cd app && npm test` — passed (87 files, 751 tests)

Murmur Bench: N/A — updater-only change, no benchmarked paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-updates can now remain available as optional updates when policy verification is unavailable or malformed.
  * Policy-check failures no longer incorrectly produce an error state or block verified updates.
  * The last policy-check timestamp is recorded consistently, with warnings logged for verification issues.

* **Documentation**
  * Updated auto-updater guidance to clarify minimum-version checks and optional update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->