### PR TITLE
fix: add updater check failure recovery (#559)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-autostart": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-notification": "^2",
+        "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-process": "^2",
         "@tauri-apps/plugin-updater": "^2",
         "react": "^18.3.1",
@@ -1571,6 +1572,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -1869,6 +1924,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
+      "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-process": {

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-autostart": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-notification": "^2",
+    "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "react": "^18.3.1",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -691,6 +691,7 @@ function App() {
         <UpdateModal
           status={isUpdateDialogOpen ? updateStatus : { phase: 'idle' }}
           onDownload={startDownload}
+          onRetryCheck={() => void checkForUpdate()}
           onSkip={skipVersion}
           onDismiss={dismissUpdate}
         />

--- a/app/src/components/UpdateModal.test.tsx
+++ b/app/src/components/UpdateModal.test.tsx
@@ -1,7 +1,16 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { UpdateModal } from './UpdateModal';
+
+const mocks = vi.hoisted(() => ({
+  exit: vi.fn(),
+  openUrl: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-process', () => ({ exit: mocks.exit }));
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: mocks.openUrl }));
+
+import { LATEST_RELEASES_URL, UpdateModal } from './UpdateModal';
 
 describe('UpdateModal', () => {
   let container: HTMLDivElement;
@@ -26,6 +35,7 @@ describe('UpdateModal', () => {
         <UpdateModal
           status={{ phase: 'preparing', version: '0.24.3' }}
           onDownload={onDownload}
+          onRetryCheck={vi.fn()}
           onSkip={vi.fn()}
           onDismiss={onDismiss}
         />,
@@ -40,5 +50,56 @@ describe('UpdateModal', () => {
     });
     expect(onDownload).not.toHaveBeenCalled();
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('offers release-page recovery and retries the check after a check failure', async () => {
+    const onRetryCheck = vi.fn();
+    await act(async () => {
+      root.render(
+        <UpdateModal
+          status={{ phase: 'error', stage: 'check', message: 'offline', isForced: false }}
+          onDownload={vi.fn()}
+          onRetryCheck={onRetryCheck}
+          onSkip={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      );
+    });
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    expect(buttons.map((button) => button.textContent)).toContain('Retry');
+    expect(buttons.map((button) => button.textContent)).toContain('Download latest version');
+
+    await act(async () => buttons.find((button) => button.textContent === 'Retry')?.click());
+    expect(onRetryCheck).toHaveBeenCalledOnce();
+
+    await act(async () => buttons.find((button) => button.textContent === 'Download latest version')?.click());
+    expect(mocks.openUrl).toHaveBeenCalledWith(LATEST_RELEASES_URL);
+  });
+
+  it.each([
+    ['idle', { phase: 'idle' }],
+    ['checking', { phase: 'checking' }],
+    ['up-to-date', { phase: 'up-to-date' }],
+    ['available', { phase: 'available', version: '0.24.3', notes: '', isForced: false }],
+    ['downloading', { phase: 'downloading', version: '0.24.3', progress: 50 }],
+    ['ready', { phase: 'ready', version: '0.24.3' }],
+    ['install error', { phase: 'error', stage: 'install', message: 'disk full', isForced: false }],
+  ] as const)('does not show release-page recovery in %s state', async (_name, status) => {
+    await act(async () => {
+      root.render(
+        <UpdateModal
+          // The union is narrowed by the component at runtime; these fixtures
+          // intentionally cover every non-check-error state.
+          status={status}
+          onDownload={vi.fn()}
+          onRetryCheck={vi.fn()}
+          onSkip={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).not.toContain('Download latest version');
   });
 });

--- a/app/src/components/UpdateModal.tsx
+++ b/app/src/components/UpdateModal.tsx
@@ -1,16 +1,22 @@
 import { exit } from '@tauri-apps/plugin-process';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import Markdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import type { UpdateStatus } from '../lib/updater';
 
+// Replace with an owned stable redirect (for example, murmur.georgenijo.com/download)
+// once one is publicly available.
+export const LATEST_RELEASES_URL = 'https://github.com/georgenijo/murmur-app/releases/latest';
+
 interface UpdateModalProps {
   status: UpdateStatus;
   onDownload: () => void;
+  onRetryCheck: () => void;
   onSkip: () => void;
   onDismiss: () => void;
 }
 
-export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateModalProps) {
+export function UpdateModal({ status, onDownload, onRetryCheck, onSkip, onDismiss }: UpdateModalProps) {
   if (
     status.phase !== 'available' &&
     status.phase !== 'preparing' &&
@@ -26,6 +32,7 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
   const isDownloading = status.phase === 'downloading';
   const isReady = status.phase === 'ready';
   const isError = status.phase === 'error';
+  const isCheckError = isError && status.stage === 'check';
   const requiresReinstall = isError && status.recovery === 'reinstall';
   const isBusy = isPreparing || isDownloading || isReady;
 
@@ -133,10 +140,20 @@ export function UpdateModal({ status, onDownload, onSkip, onDismiss }: UpdateMod
           <div className="flex flex-col gap-2">
             {(status.phase === 'available' || (isError && !requiresReinstall)) && (
               <button
-                onClick={onDownload}
+                onClick={isCheckError ? onRetryCheck : onDownload}
                 className="w-full py-2 px-4 bg-primary hover:bg-primary-dim text-on-primary text-sm font-medium rounded-lg transition-colors"
               >
                 {isError ? 'Retry' : 'Update Now'}
+              </button>
+            )}
+
+            {isCheckError && (
+              <button
+                type="button"
+                onClick={() => void openUrl(LATEST_RELEASES_URL)}
+                className="w-full rounded-lg border border-outline-variant/20 bg-surface-container-lowest px-4 py-2 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
+              >
+                Download latest version
               </button>
             )}
 

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -129,7 +129,7 @@ describe('useAutoUpdater presentation state', () => {
     );
   });
 
-  it('keeps a failed manual check inline instead of opening a broken retry modal', async () => {
+  it('opens a recovery modal after a failed manual check', async () => {
     mocks.check.mockRejectedValue(new Error('offline'));
 
     await act(async () => current.checkForUpdate());
@@ -139,7 +139,7 @@ describe('useAutoUpdater presentation state', () => {
       stage: 'check',
       message: 'Error: offline',
     });
-    expect(current.isUpdateDialogOpen).toBe(false);
+    expect(current.isUpdateDialogOpen).toBe(true);
     expect(mocks.check).toHaveBeenCalledTimes(2);
     expect(mocks.flogError).toHaveBeenCalledWith(
       'updater',

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -209,7 +209,7 @@ export function useAutoUpdater(
         error: String(err),
       });
       if (shouldPresentManualResult()) {
-        setIsUpdateDialogOpen(false);
+        setIsUpdateDialogOpen(true);
         setUpdateStatus({
           phase: 'error',
           stage: 'check',

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -92,7 +92,12 @@ When the current version is below the `min_version` field from the release manif
 
 ### Error State
 
-If the download or install fails, the modal shows a red error banner with the error message and a "Retry" button. For forced updates in error state, the "Quit" button remains available.
+If the update check fails, the modal shows a red error banner with the error
+message, a "Retry" button that runs the check again, and a secondary
+"Download latest version" button that opens the latest GitHub release page.
+This recovery button appears only for `stage: 'check'` errors; it is absent from
+all normal states and from download/install errors. For forced updates in error
+state, the "Quit" button remains available.
 
 Before downloading, Murmur asks the Rust host whether the current executable is
 running under macOS Gatekeeper's `AppTranslocation` path. A translocated app is


### PR DESCRIPTION
Closes #559

Stacked on #558 (base: `issue/558-updater-policy-fail-open`; merge #567 first).

## Acceptance checklist
- [x] Check-failure modal shows Retry wired to `checkForUpdate`
- [x] Check-failure modal shows Download latest version and opens GitHub releases
- [x] Recovery button is absent from idle, checking, available, downloading, ready, up-to-date, and install-error states
- [x] Existing #558 fail-open updater policy behavior preserved
- [x] `cd app && npx tsc --noEmit` passes
- [x] `cd app && npm test` passes (759 tests)

Murmur Bench: N/A — updater-only change, no benchmarked paths