### PR TITLE
feat: add post-release OTA canary gate (#560)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (147 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (148 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -95,7 +95,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 147 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 148 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (147 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (148 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -100,7 +100,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 147 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 148 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/app/src-tauri/src/commands/updater.rs
+++ b/app/src-tauri/src/commands/updater.rs
@@ -10,6 +10,7 @@ pub struct UpdateInstallEnvironment {
 }
 
 const CANARY_ENV: &str = "MURMUR_UPDATER_CANARY";
+const CANARY_DRY_RUN_ENV: &str = "MURMUR_UPDATER_CANARY_DRY_RUN";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,6 +24,7 @@ pub struct UpdaterCanaryRequest {
 pub struct UpdaterCanaryState {
     pub path: Option<String>,
     pub result: Option<serde_json::Value>,
+    pub dry_run: bool,
 }
 
 fn canary_path_from_env<F>(get: F) -> Option<String>
@@ -36,6 +38,20 @@ where
 
 fn canary_path() -> Option<String> {
     canary_path_from_env(|key| std::env::var_os(key))
+}
+
+fn canary_dry_run_from_env<F>(get: F) -> bool
+where
+    F: FnOnce(&str) -> Option<std::ffi::OsString>,
+{
+    get(CANARY_DRY_RUN_ENV)
+        .map(|value| {
+            matches!(
+                value.to_string_lossy().as_ref(),
+                "1" | "true" | "TRUE" | "True"
+            )
+        })
+        .unwrap_or(false)
 }
 
 fn read_canary_result(path: &Path) -> Option<serde_json::Value> {
@@ -80,7 +96,11 @@ pub fn updater_canary(request: UpdaterCanaryRequest) -> Result<UpdaterCanaryStat
     let result = path
         .as_deref()
         .and_then(|path| read_canary_result(Path::new(path)));
-    Ok(UpdaterCanaryState { path, result })
+    Ok(UpdaterCanaryState {
+        path,
+        result,
+        dry_run: canary_dry_run_from_env(|key| std::env::var_os(key)),
+    })
 }
 
 fn is_app_translocated(path: &Path) -> bool {
@@ -132,5 +152,12 @@ mod tests {
             canary_path_from_env(|_| Some(std::ffi::OsString::new())),
             None
         );
+    }
+
+    #[test]
+    fn canary_dry_run_is_false_without_explicit_marker() {
+        assert!(!canary_dry_run_from_env(|_| None));
+        assert!(!canary_dry_run_from_env(|_| Some("0".into())));
+        assert!(canary_dry_run_from_env(|_| Some("1".into())));
     }
 }

--- a/app/src-tauri/src/commands/updater.rs
+++ b/app/src-tauri/src/commands/updater.rs
@@ -1,11 +1,86 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
+use std::fs;
 use std::path::Path;
 
 #[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateInstallEnvironment {
     app_translocated: bool,
+}
+
+const CANARY_ENV: &str = "MURMUR_UPDATER_CANARY";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdaterCanaryRequest {
+    pub action: String,
+    pub result: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdaterCanaryState {
+    pub path: Option<String>,
+    pub result: Option<serde_json::Value>,
+}
+
+fn canary_path_from_env<F>(get: F) -> Option<String>
+where
+    F: FnOnce(&str) -> Option<std::ffi::OsString>,
+{
+    get(CANARY_ENV)
+        .filter(|path| !path.is_empty())
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+fn canary_path() -> Option<String> {
+    canary_path_from_env(|key| std::env::var_os(key))
+}
+
+fn read_canary_result(path: &Path) -> Option<serde_json::Value> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok())
+}
+
+fn write_canary_result(path: &Path, result: &serde_json::Value) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Canary result path has no parent directory".to_string())?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("Could not create canary result directory: {error}"))?;
+    let temporary = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(result)
+        .map_err(|error| format!("Could not encode canary result: {error}"))?;
+    fs::write(&temporary, bytes)
+        .map_err(|error| format!("Could not write canary result: {error}"))?;
+    fs::rename(&temporary, path)
+        .map_err(|error| format!("Could not publish canary result: {error}"))
+}
+
+/// Read or atomically update the opt-in OTA canary result file.
+///
+/// The environment variable is intentionally read by Rust: WebKit has no
+/// ambient process environment, and an absent variable returns an inert state.
+#[tauri::command]
+pub fn updater_canary(request: UpdaterCanaryRequest) -> Result<UpdaterCanaryState, String> {
+    let path = canary_path();
+    if request.action == "write" {
+        let path = path
+            .as_deref()
+            .ok_or_else(|| "Updater canary is not enabled".to_string())?;
+        let result = request
+            .result
+            .ok_or_else(|| "Canary write requires a result".to_string())?;
+        write_canary_result(Path::new(path), &result)?;
+    } else if request.action != "read" {
+        return Err(format!("Unknown updater canary action: {}", request.action));
+    }
+    let result = path
+        .as_deref()
+        .and_then(|path| read_canary_result(Path::new(path)));
+    Ok(UpdaterCanaryState { path, result })
 }
 
 fn is_app_translocated(path: &Path) -> bool {
@@ -44,5 +119,18 @@ mod tests {
     fn does_not_match_similar_component_names() {
         let path = Path::new("/tmp/MyAppTranslocation/Murmur.app/Contents/MacOS/ui");
         assert!(!is_app_translocated(path));
+    }
+
+    #[test]
+    fn canary_path_is_inert_when_environment_variable_is_absent() {
+        assert_eq!(canary_path_from_env(|_| None), None);
+    }
+
+    #[test]
+    fn canary_path_ignores_empty_environment_variable() {
+        assert_eq!(
+            canary_path_from_env(|_| Some(std::ffi::OsString::new())),
+            None
+        );
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -410,6 +410,7 @@ pub fn run() {
             commands::tray::update_tray_icon,
             commands::tray::set_tray_update_available,
             commands::updater::get_update_install_environment,
+            commands::updater::updater_canary,
             commands::overlay::show_overlay,
             commands::overlay::hide_overlay,
             commands::overlay::set_overlay_expanded,

--- a/app/src-tauri/src/log_shipper.rs
+++ b/app/src-tauri/src/log_shipper.rs
@@ -451,6 +451,10 @@ async fn tick(client: &reqwest::Client, endpoint: &str, device: &DeviceInfo) {
 }
 
 pub fn start(app_handle: &tauri::AppHandle) {
+    if std::env::var_os("MURMUR_UPDATER_CANARY").is_some() {
+        tracing::info!(target: "system", "log shipper disabled: updater canary run");
+        return;
+    }
     if crate::telemetry::is_internal_bundle(app_handle) {
         tracing::info!(target: "system", "log shipper disabled: internal bundle");
         return;

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   check: vi.fn(),
+  invoke: vi.fn(),
   getVersion: vi.fn(),
   relaunch: vi.fn(),
   isPermissionGranted: vi.fn(),
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@tauri-apps/plugin-updater', () => ({ check: mocks.check }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
 vi.mock('@tauri-apps/api/app', () => ({ getVersion: mocks.getVersion }));
 vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: mocks.relaunch }));
 vi.mock('@tauri-apps/plugin-notification', () => ({
@@ -57,6 +59,7 @@ describe('useAutoUpdater presentation state', () => {
     mocks.listen.mockResolvedValue(vi.fn());
     mocks.isPermissionGranted.mockResolvedValue(true);
     mocks.getUpdateInstallEnvironment.mockResolvedValue({ appTranslocated: false });
+    mocks.invoke.mockResolvedValue({ path: null, result: null });
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -127,6 +130,19 @@ describe('useAutoUpdater presentation state', () => {
       'no update available',
       { event_code: 'updater.check_current' },
     );
+  });
+
+  it('leaves the canary path inert when the launch marker is absent', async () => {
+    await act(async () => root.unmount());
+    automaticChecksEnabled = true;
+    root = createRoot(container);
+    mocks.check.mockResolvedValue({ available: false });
+    await act(async () => root.render(<Harness />));
+
+    expect(mocks.invoke).toHaveBeenCalledWith('updater_canary', { action: 'read' });
+    expect(mocks.check).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalledWith('updater_canary', expect.objectContaining({ action: 'write' }));
   });
 
   it('opens a recovery modal after a failed manual check', async () => {
@@ -345,8 +361,8 @@ describe('useAutoUpdater presentation state', () => {
     mocks.getUpdateInstallEnvironment.mockReturnValue(environment);
 
     await act(async () => current.checkForUpdate());
-    let first!: Promise<void>;
-    let second!: Promise<void>;
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
     await act(async () => {
       first = current.startDownload();
       second = current.startDownload();
@@ -382,8 +398,8 @@ describe('useAutoUpdater presentation state', () => {
         resolveCheck = resolve;
       })
     );
-    let pendingCheck!: Promise<void>;
-    let install!: Promise<void>;
+    let pendingCheck!: Promise<unknown>;
+    let install!: Promise<unknown>;
     await act(async () => {
       pendingCheck = current.checkForUpdate();
       install = current.startDownload();
@@ -413,7 +429,7 @@ describe('useAutoUpdater presentation state', () => {
     mocks.getUpdateInstallEnvironment.mockReturnValue(environment);
 
     await act(async () => current.checkForUpdate());
-    let install!: Promise<void>;
+    let install!: Promise<unknown>;
     await act(async () => {
       install = current.startDownload();
       await Promise.resolve();
@@ -459,7 +475,7 @@ describe('useAutoUpdater presentation state', () => {
         resolveEnvironment = resolve;
       }),
     );
-    let install!: Promise<void>;
+    let install!: Promise<unknown>;
     await act(async () => {
       install = current.startDownload();
       await Promise.resolve();

--- a/app/src/lib/hooks/useAutoUpdater.test.tsx
+++ b/app/src/lib/hooks/useAutoUpdater.test.tsx
@@ -145,6 +145,149 @@ describe('useAutoUpdater presentation state', () => {
     expect(mocks.invoke).not.toHaveBeenCalledWith('updater_canary', expect.objectContaining({ action: 'write' }));
   });
 
+  async function launchCanary(state: { path: string; result: unknown; dryRun: boolean }) {
+    await act(async () => root.unmount());
+    automaticChecksEnabled = true;
+    mocks.invoke.mockImplementation(async (_command: string, request: { action: string; result?: unknown }) => (
+      request.action === 'read' ? state : { ...state, result: request.result }
+    ));
+    root = createRoot(container);
+    await act(async () => root.render(<Harness />));
+    await act(async () => Promise.resolve());
+  }
+
+  function canaryWrites() {
+    return mocks.invoke.mock.calls
+      .filter(([, request]) => request?.action === 'write')
+      .map(([, request]) => request.result);
+  }
+
+  it('canary bypasses a skipped matching version and uses the real install path', async () => {
+    localStorage.setItem('skipped-update-version', '0.23.0');
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: {},
+      downloadAndInstall,
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: false });
+
+    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).toHaveBeenCalledOnce();
+  });
+
+  it('canary dry-run launches discovery and policy but never downloads or relaunches', async () => {
+    const downloadAndInstall = vi.fn();
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: {},
+      downloadAndInstall,
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: true });
+
+    expect(downloadAndInstall).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    const writes = canaryWrites();
+    expect(writes[writes.length - 1]).toMatchObject({ status: 'dry-run', dryRun: true });
+  });
+
+  it('records production stages as pending until install evidence is available', async () => {
+    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: {},
+      downloadAndInstall,
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: false });
+
+    const writes = canaryWrites();
+    expect(writes[0]).toMatchObject({ status: 'pending', stages: {
+      download: 'pending', signatureVerify: 'pending', install: 'pending', relaunch: 'pending',
+    } });
+    expect(writes[1]).toMatchObject({ status: 'pending', stages: {
+      download: 'passed', signatureVerify: 'passed', install: 'passed', relaunch: 'pending',
+    } });
+  });
+
+  it('records policy failure without fabricating production stages', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: undefined,
+      downloadAndInstall: vi.fn(),
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: false });
+
+    const writes = canaryWrites();
+    expect(writes[writes.length - 1]).toMatchObject({ status: 'failed', stages: {
+      discover: 'passed', policy: 'failed', download: 'pending', signatureVerify: 'pending', install: 'pending', relaunch: 'pending',
+    } });
+  });
+
+  it('records a canary download failure at the download stage', async () => {
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: {},
+      downloadAndInstall: vi.fn().mockRejectedValue(new Error('disk full')),
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: false });
+
+    const writes = canaryWrites();
+    expect(writes[writes.length - 1]).toMatchObject({ status: 'failed', stages: {
+      download: 'failed', signatureVerify: 'pending', install: 'pending', relaunch: 'pending',
+    } });
+  });
+
+  it('records a canary relaunch failure after install evidence', async () => {
+    mocks.relaunch.mockRejectedValueOnce(new Error('relaunch refused'));
+    mocks.check.mockResolvedValue({
+      available: true,
+      version: '0.23.0',
+      body: '',
+      rawJson: {},
+      downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await launchCanary({ path: '/tmp/canary.json', result: null, dryRun: false });
+
+    const writes = canaryWrites();
+    expect(writes[writes.length - 1]).toMatchObject({ status: 'failed', stages: {
+      download: 'passed', signatureVerify: 'passed', install: 'passed', relaunch: 'failed',
+    } });
+  });
+
+  it('recovers a pending canary only after the installed version matches', async () => {
+    const previous = {
+      schemaVersion: 1 as const,
+      status: 'pending' as const,
+      checkedVersion: '0.22.1',
+      offeredVersion: '0.23.0',
+      forced: false,
+      dryRun: false,
+      stages: { discover: 'passed' as const, policy: 'passed' as const, download: 'passed' as const, signatureVerify: 'passed' as const, install: 'passed' as const, relaunch: 'pending' as const },
+      error: null,
+    };
+    mocks.getVersion.mockResolvedValue('0.23.0');
+    await launchCanary({ path: '/tmp/canary.json', result: previous, dryRun: false });
+    const writes = canaryWrites();
+    expect(writes[writes.length - 1]).toMatchObject({ status: 'passed', stages: { relaunch: 'passed' } });
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
   it('opens a recovery modal after a failed manual check', async () => {
     mocks.check.mockRejectedValue(new Error('offline'));
 

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
@@ -30,6 +31,38 @@ const APP_TRANSLOCATION_MESSAGE =
   'macOS opened Murmur from a read-only security location. Quit Murmur, then use Finder to move or reinstall it in Applications before reopening it and trying the update again.';
 
 type UpdaterOperation = 'idle' | 'checking' | 'installing';
+type CanaryStage = 'pending' | 'passed' | 'failed';
+
+export interface UpdaterCanaryResult {
+  schemaVersion: 1;
+  status: 'pending' | 'passed' | 'failed';
+  checkedVersion: string;
+  offeredVersion: string | null;
+  forced: boolean;
+  stages: {
+    discover: CanaryStage;
+    policy: CanaryStage;
+    download: CanaryStage;
+    signatureVerify: CanaryStage;
+    install: CanaryStage;
+    relaunch: CanaryStage;
+  };
+  error: string | null;
+}
+
+interface UpdaterCanaryState {
+  path: string | null;
+  result: UpdaterCanaryResult | null;
+}
+
+type CheckOutcome =
+  | { kind: 'available'; version: string; forced: boolean; policyVerified: boolean }
+  | { kind: 'current'; version: string }
+  | { kind: 'failed'; version: string; stage: 'discover' | 'policy'; message: string };
+
+type InstallOutcome =
+  | { kind: 'installed'; version: string }
+  | { kind: 'failed'; version: string; message: string };
 
 const UPDATE_CHECK_ATTEMPTS = 2;
 
@@ -43,7 +76,7 @@ export interface UseAutoUpdaterReturn {
   isUpdateDialogOpen: boolean;
   checkForUpdate: () => Promise<void>;
   showAvailableUpdate: () => void;
-  startDownload: () => Promise<void>;
+  startDownload: () => Promise<InstallOutcome | undefined>;
   skipVersion: () => void;
   dismissUpdate: () => void;
   dismissCompletedUpdate: () => void;
@@ -63,6 +96,7 @@ export function useAutoUpdater(
   const pendingCheckRef = useRef<Promise<void> | null>(null);
   const isForcedRef = useRef(false);
   const manualPresentationRequestedRef = useRef(false);
+  const automaticStartupRef = useRef(false);
 
   // The updater process replaces the app before relaunching, so the release
   // payload is recovered from localStorage and shown only after the installed
@@ -90,17 +124,19 @@ export function useAutoUpdater(
     };
   }, []);
 
-  const performCheck = useCallback(async (opts: { isBackground: boolean }) => {
+  const performCheck = useCallback(async (opts: { isBackground: boolean }): Promise<CheckOutcome> => {
     if (operationRef.current === 'installing') {
       flog.info('updater', 'check ignored while install owns updater');
-      return;
+      return { kind: 'failed', version: 'unknown', stage: 'discover', message: 'Updater is installing.' };
     }
     if (!opts.isBackground) {
       clearSkippedVersion();
       manualPresentationRequestedRef.current = true;
       setUpdateStatus({ phase: 'checking' });
     }
-    if (operationRef.current === 'checking') return;
+    if (operationRef.current === 'checking') {
+      return { kind: 'failed', version: 'unknown', stage: 'discover', message: 'Updater check already in progress.' };
+    }
     operationRef.current = 'checking';
     let settleCheck!: () => void;
     pendingCheckRef.current = new Promise<void>((resolve) => {
@@ -143,7 +179,7 @@ export function useAutoUpdater(
           // Reset back to idle after a brief display
           setTimeout(() => setUpdateStatus(s => s.phase === 'up-to-date' ? { phase: 'idle' } : s), 3000);
         }
-        return;
+        return { kind: 'current', version: await getVersion() };
       }
 
       flog.info('updater', 'update available', { version: update.version });
@@ -171,7 +207,7 @@ export function useAutoUpdater(
         if (shouldPresentManualResult()) {
           setUpdateStatus({ phase: 'idle' });
         }
-        return;
+        return { kind: 'current', version: currentVersion };
       }
 
       const wasAlreadyAvailable = updateRef.current?.version === update.version;
@@ -203,6 +239,12 @@ export function useAutoUpdater(
           flog.warn('updater', 'notification failed', { error: String(err) });
         }
       }
+      return {
+        kind: 'available',
+        version: update.version,
+        forced: isForced,
+        policyVerified: policy.status !== 'unavailable',
+      };
     } catch (err) {
       flog.error('updater', 'check failed', {
         event_code: 'updater.check_failed',
@@ -218,6 +260,7 @@ export function useAutoUpdater(
         });
       }
       // Background errors are silent
+      return { kind: 'failed', version: 'unknown', stage: 'discover', message: String(err) };
     } finally {
       if (operationRef.current === 'checking') {
         operationRef.current = 'idle';
@@ -227,55 +270,6 @@ export function useAutoUpdater(
       manualPresentationRequestedRef.current = false;
     }
   }, []);
-
-  // On mount: always check on launch. A short, inert timer only asks whether
-  // the six-hour network interval is due; native wake events and foreground
-  // activation use the same gate so hidden/sleeping webviews do not strand the
-  // update indicator.
-  // Skip entirely in dev — a dev build auto-updating to a prod release would
-  // download+relaunch into /Applications, making `tauri dev` impossible.
-  useEffect(() => {
-    if (!automaticChecksEnabled) {
-      flog.info('updater', 'dev build — skipping automatic update check');
-      return;
-    }
-
-    performCheck({ isBackground: true });
-
-    const checkIfDue = () => {
-      if (isDueForCheck()) {
-        performCheck({ isBackground: true });
-      }
-    };
-    const interval = setInterval(checkIfDue, CHECK_TIMER_TICK_MS);
-    const onFocus = () => checkIfDue();
-    const onVisibilityChange = () => {
-      if (!document.hidden) checkIfDue();
-    };
-    window.addEventListener('focus', onFocus);
-    document.addEventListener('visibilitychange', onVisibilityChange);
-
-    let disposed = false;
-    let unlistenWake: (() => void) | undefined;
-    listen<unknown>('updater-background-check-requested', checkIfDue)
-      .then((unlisten) => {
-        if (disposed) unlisten();
-        else unlistenWake = unlisten;
-      })
-      .catch((err) => {
-        flog.warn('updater', 'could not listen for native wake checks', {
-          error: String(err),
-        });
-      });
-
-    return () => {
-      disposed = true;
-      clearInterval(interval);
-      window.removeEventListener('focus', onFocus);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-      unlistenWake?.();
-    };
-  }, [automaticChecksEnabled, performCheck]);
 
   const checkForUpdate = useCallback(async () => {
     await performCheck({ isBackground: false });
@@ -290,7 +284,7 @@ export function useAutoUpdater(
     }
   }, [updateStatus]);
 
-  const startDownload = useCallback(async () => {
+  const startDownload = useCallback(async (): Promise<InstallOutcome | undefined> => {
     if (operationRef.current === 'checking') {
       flog.info('updater', 'install waiting for in-flight update check');
       await pendingCheckRef.current;
@@ -299,10 +293,10 @@ export function useAutoUpdater(
       flog.info('updater', 'install ignored because updater is already busy', {
         operation: operationRef.current,
       });
-      return;
+      return undefined;
     }
     const update = updateRef.current;
-    if (!update) return;
+    if (!update) return undefined;
 
     const version =
       updateStatus.phase === 'available' ? updateStatus.version
@@ -324,7 +318,7 @@ export function useAutoUpdater(
           recovery: 'reinstall',
         });
         operationRef.current = 'idle';
-        return;
+        return { kind: 'failed', version, message: APP_TRANSLOCATION_MESSAGE };
       }
 
       setUpdateStatus({ phase: 'downloading', version, progress: 0 });
@@ -362,6 +356,7 @@ export function useAutoUpdater(
       });
       clearSkippedVersion();
       await relaunch();
+      return { kind: 'installed', version };
     } catch (err) {
       operationRef.current = 'idle';
       flog.error('updater', 'download/install failed', {
@@ -374,8 +369,163 @@ export function useAutoUpdater(
         message: String(err),
         isForced: isForcedRef.current,
       });
+      return { kind: 'failed', version, message: String(err) };
     }
   }, [updateStatus]);
+
+  const writeCanary = useCallback(async (result: UpdaterCanaryResult) => {
+    await invoke<UpdaterCanaryState>('updater_canary', { action: 'write', result });
+  }, []);
+
+  const runCanary = useCallback(async (previous: UpdaterCanaryResult | null) => {
+    const checkedVersion = await getVersion();
+    // A pending result with the offered version means this is the post-install
+    // launch. The running version is the final assertion of the OTA.
+    if (previous?.status === 'pending' && previous.offeredVersion === checkedVersion) {
+      await writeCanary({
+        ...previous,
+        status: 'passed',
+        stages: { ...previous.stages, relaunch: 'passed' },
+        error: null,
+      });
+      return;
+    }
+
+    const outcome = await performCheck({ isBackground: true });
+    if (outcome.kind !== 'available') {
+      await writeCanary({
+        schemaVersion: 1,
+        status: 'failed',
+        checkedVersion,
+        offeredVersion: null,
+        forced: false,
+        stages: {
+          discover: outcome.kind === 'current' ? 'passed' : 'failed',
+          policy: outcome.kind === 'current' ? 'passed' : outcome.stage === 'policy' ? 'failed' : 'pending',
+          download: 'pending',
+          signatureVerify: 'pending',
+          install: 'pending',
+          relaunch: 'pending',
+        },
+        error: outcome.kind === 'current'
+          ? 'No update was available for the canary run.'
+          : outcome.message,
+      });
+      return;
+    }
+
+    if (!outcome.policyVerified) {
+      await writeCanary({
+        schemaVersion: 1,
+        status: 'failed',
+        checkedVersion,
+        offeredVersion: outcome.version,
+        forced: outcome.forced,
+        stages: {
+          discover: 'passed',
+          policy: 'failed',
+          download: 'pending',
+          signatureVerify: 'pending',
+          install: 'pending',
+          relaunch: 'pending',
+        },
+        error: 'Update policy could not be parsed from the native updater response.',
+      });
+      return;
+    }
+
+    await writeCanary({
+      schemaVersion: 1,
+      status: 'pending',
+      checkedVersion,
+      offeredVersion: outcome.version,
+      forced: outcome.forced,
+      stages: {
+        discover: 'passed',
+        policy: 'passed',
+        // downloadAndInstall owns all three production operations; these are
+        // marked ready before the call so the file survives relaunch.
+        download: 'passed',
+        signatureVerify: 'passed',
+        install: 'passed',
+        relaunch: 'pending',
+      },
+      error: null,
+    });
+
+    const install = await startDownload();
+    if (!install || install.kind === 'installed') return;
+    await writeCanary({
+      schemaVersion: 1,
+      status: 'failed',
+      checkedVersion,
+      offeredVersion: outcome.version,
+      forced: outcome.forced,
+      stages: {
+        discover: 'passed',
+        policy: 'passed',
+        download: 'failed',
+        signatureVerify: 'failed',
+        install: 'failed',
+        relaunch: 'pending',
+      },
+      error: install.message,
+    });
+  }, [performCheck, startDownload, writeCanary]);
+
+  // On mount, inspect the opt-in canary marker before the normal launch check.
+  // An absent marker falls straight through to the existing updater behavior.
+  useEffect(() => {
+    if (!automaticChecksEnabled) {
+      flog.info('updater', 'dev build — skipping automatic update check');
+      return;
+    }
+    if (automaticStartupRef.current) return;
+    automaticStartupRef.current = true;
+
+    let disposed = false;
+    const start = async () => {
+      try {
+        const canary = await invoke<UpdaterCanaryState>('updater_canary', { action: 'read' });
+        if (disposed) return;
+        if (canary.path) await runCanary(canary.result);
+        else await performCheck({ isBackground: true });
+      } catch (error) {
+        flog.warn('updater', 'could not inspect updater canary state', { error: String(error) });
+        if (!disposed) await performCheck({ isBackground: true });
+      }
+    };
+    start();
+
+    const checkIfDue = () => {
+      if (isDueForCheck()) performCheck({ isBackground: true });
+    };
+    const interval = setInterval(checkIfDue, CHECK_TIMER_TICK_MS);
+    const onFocus = () => checkIfDue();
+    const onVisibilityChange = () => {
+      if (!document.hidden) checkIfDue();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    let unlistenWake: (() => void) | undefined;
+    listen<unknown>('updater-background-check-requested', checkIfDue)
+      .then((unlisten) => {
+        if (disposed) unlisten();
+        else unlistenWake = unlisten;
+      })
+      .catch((err) => {
+        flog.warn('updater', 'could not listen for native wake checks', { error: String(err) });
+      });
+
+    return () => {
+      disposed = true;
+      clearInterval(interval);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      unlistenWake?.();
+    };
+  }, [automaticChecksEnabled, performCheck, runCanary]);
 
   const skipVersion = useCallback(() => {
     if (updateStatus.phase === 'available') {

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -201,8 +201,9 @@ export function useAutoUpdater(
       // A secondary policy read may fail to force an update; it must never
       // fail to offer a verified update.
       let isForced = false;
+      let currentVersion: string = 'unknown';
       if (policy.status === 'present') {
-        const currentVersion = await getVersion();
+        currentVersion = await getVersion();
         isForced = isBelowMinVersion(currentVersion, policy.minVersion);
       }
       setLastCheckTimestamp(Date.now());

--- a/app/src/lib/hooks/useAutoUpdater.ts
+++ b/app/src/lib/hooks/useAutoUpdater.ts
@@ -35,10 +35,11 @@ type CanaryStage = 'pending' | 'passed' | 'failed';
 
 export interface UpdaterCanaryResult {
   schemaVersion: 1;
-  status: 'pending' | 'passed' | 'failed';
+  status: 'pending' | 'passed' | 'failed' | 'dry-run';
   checkedVersion: string;
   offeredVersion: string | null;
   forced: boolean;
+  dryRun: boolean;
   stages: {
     discover: CanaryStage;
     policy: CanaryStage;
@@ -53,6 +54,7 @@ export interface UpdaterCanaryResult {
 interface UpdaterCanaryState {
   path: string | null;
   result: UpdaterCanaryResult | null;
+  dryRun: boolean;
 }
 
 type CheckOutcome =
@@ -62,7 +64,11 @@ type CheckOutcome =
 
 type InstallOutcome =
   | { kind: 'installed'; version: string }
-  | { kind: 'failed'; version: string; message: string };
+  | { kind: 'failed'; version: string; stage: 'download' | 'install' | 'relaunch'; message: string };
+
+interface InstallLifecycle {
+  onInstalled?: () => Promise<void>;
+}
 
 const UPDATE_CHECK_ATTEMPTS = 2;
 
@@ -76,7 +82,7 @@ export interface UseAutoUpdaterReturn {
   isUpdateDialogOpen: boolean;
   checkForUpdate: () => Promise<void>;
   showAvailableUpdate: () => void;
-  startDownload: () => Promise<InstallOutcome | undefined>;
+  startDownload: (lifecycle?: InstallLifecycle) => Promise<InstallOutcome | undefined>;
   skipVersion: () => void;
   dismissUpdate: () => void;
   dismissCompletedUpdate: () => void;
@@ -124,7 +130,7 @@ export function useAutoUpdater(
     };
   }, []);
 
-  const performCheck = useCallback(async (opts: { isBackground: boolean }): Promise<CheckOutcome> => {
+  const performCheck = useCallback(async (opts: { isBackground: boolean; canary?: boolean }): Promise<CheckOutcome> => {
     if (operationRef.current === 'installing') {
       flog.info('updater', 'check ignored while install owns updater');
       return { kind: 'failed', version: 'unknown', stage: 'discover', message: 'Updater is installing.' };
@@ -202,7 +208,7 @@ export function useAutoUpdater(
       setLastCheckTimestamp(Date.now());
 
       // If not forced and user previously skipped this version, suppress
-      if (!isForced && getSkippedVersion() === update.version) {
+      if (!opts.canary && !isForced && getSkippedVersion() === update.version) {
         flog.info('updater', 'user skipped this version', { version: update.version });
         if (shouldPresentManualResult()) {
           setUpdateStatus({ phase: 'idle' });
@@ -222,7 +228,7 @@ export function useAutoUpdater(
       setIsUpdateDialogOpen(isForced || shouldPresentManualResult());
 
       // Background check: fire macOS notification
-      if (opts.isBackground && !wasAlreadyAvailable) {
+      if (opts.isBackground && !opts.canary && !wasAlreadyAvailable) {
         try {
           let permGranted = await isPermissionGranted();
           if (!permGranted) {
@@ -284,7 +290,7 @@ export function useAutoUpdater(
     }
   }, [updateStatus]);
 
-  const startDownload = useCallback(async (): Promise<InstallOutcome | undefined> => {
+  const startDownload = useCallback(async (lifecycle?: InstallLifecycle): Promise<InstallOutcome | undefined> => {
     if (operationRef.current === 'checking') {
       flog.info('updater', 'install waiting for in-flight update check');
       await pendingCheckRef.current;
@@ -301,6 +307,8 @@ export function useAutoUpdater(
     const version =
       updateStatus.phase === 'available' ? updateStatus.version
       : updateRef.current?.version ?? 'unknown';
+    let downloadFinished = false;
+    let relaunchStarted = false;
     operationRef.current = 'installing';
     setUpdateStatus({ phase: 'preparing', version });
 
@@ -318,7 +326,7 @@ export function useAutoUpdater(
           recovery: 'reinstall',
         });
         operationRef.current = 'idle';
-        return { kind: 'failed', version, message: APP_TRANSLOCATION_MESSAGE };
+        return { kind: 'failed', version, stage: 'install', message: APP_TRANSLOCATION_MESSAGE };
       }
 
       setUpdateStatus({ phase: 'downloading', version, progress: 0 });
@@ -327,7 +335,6 @@ export function useAutoUpdater(
 
       let totalContentLength = 0;
       let totalDownloaded = 0;
-
       await update.downloadAndInstall((event) => {
         switch (event.event) {
           case 'Started':
@@ -346,6 +353,7 @@ export function useAutoUpdater(
             break;
           case 'Finished':
             flog.info('updater', 'download finished');
+            downloadFinished = true;
             break;
         }
       });
@@ -355,6 +363,8 @@ export function useAutoUpdater(
         event_code: 'updater.install_ready',
       });
       clearSkippedVersion();
+      await lifecycle?.onInstalled?.();
+      relaunchStarted = true;
       await relaunch();
       return { kind: 'installed', version };
     } catch (err) {
@@ -369,7 +379,12 @@ export function useAutoUpdater(
         message: String(err),
         isForced: isForcedRef.current,
       });
-      return { kind: 'failed', version, message: String(err) };
+      return {
+        kind: 'failed',
+        version,
+        stage: relaunchStarted ? 'relaunch' : downloadFinished ? 'install' : 'download',
+        message: String(err),
+      };
     }
   }, [updateStatus]);
 
@@ -377,11 +392,11 @@ export function useAutoUpdater(
     await invoke<UpdaterCanaryState>('updater_canary', { action: 'write', result });
   }, []);
 
-  const runCanary = useCallback(async (previous: UpdaterCanaryResult | null) => {
+  const runCanary = useCallback(async (previous: UpdaterCanaryResult | null, dryRun: boolean) => {
     const checkedVersion = await getVersion();
     // A pending result with the offered version means this is the post-install
     // launch. The running version is the final assertion of the OTA.
-    if (previous?.status === 'pending' && previous.offeredVersion === checkedVersion) {
+    if (!dryRun && previous?.status === 'pending' && previous.offeredVersion === checkedVersion) {
       await writeCanary({
         ...previous,
         status: 'passed',
@@ -391,7 +406,51 @@ export function useAutoUpdater(
       return;
     }
 
-    const outcome = await performCheck({ isBackground: true });
+    const outcome = await performCheck({ isBackground: true, canary: true });
+    if (outcome.kind === 'available' && !outcome.policyVerified) {
+      await writeCanary({
+        schemaVersion: 1,
+        status: 'failed',
+        checkedVersion,
+        offeredVersion: outcome.version,
+        forced: outcome.forced,
+        dryRun,
+        stages: {
+          discover: 'passed',
+          policy: 'failed',
+          download: 'pending',
+          signatureVerify: 'pending',
+          install: 'pending',
+          relaunch: 'pending',
+        },
+        error: 'Update policy could not be parsed from the native updater response.',
+      });
+      return;
+    }
+
+    if (dryRun) {
+      await writeCanary({
+        schemaVersion: 1,
+        status: outcome.kind === 'available' ? 'dry-run' : 'failed',
+        checkedVersion,
+        offeredVersion: outcome.kind === 'available' ? outcome.version : null,
+        forced: outcome.kind === 'available' ? outcome.forced : false,
+        dryRun: true,
+        stages: {
+          discover: outcome.kind === 'failed' && outcome.stage === 'discover' ? 'failed' : 'passed',
+          policy: outcome.kind === 'failed' && outcome.stage === 'policy' ? 'failed' : 'passed',
+          download: 'pending',
+          signatureVerify: 'pending',
+          install: 'pending',
+          relaunch: 'pending',
+        },
+        error: outcome.kind === 'available' ? null : outcome.kind === 'current'
+          ? 'No update was available for the canary dry run.'
+          : outcome.message,
+      });
+      return;
+    }
+
     if (outcome.kind !== 'available') {
       await writeCanary({
         schemaVersion: 1,
@@ -399,6 +458,7 @@ export function useAutoUpdater(
         checkedVersion,
         offeredVersion: null,
         forced: false,
+        dryRun: false,
         stages: {
           discover: outcome.kind === 'current' ? 'passed' : 'failed',
           policy: outcome.kind === 'current' ? 'passed' : outcome.stage === 'policy' ? 'failed' : 'pending',
@@ -414,46 +474,43 @@ export function useAutoUpdater(
       return;
     }
 
-    if (!outcome.policyVerified) {
-      await writeCanary({
-        schemaVersion: 1,
-        status: 'failed',
-        checkedVersion,
-        offeredVersion: outcome.version,
-        forced: outcome.forced,
-        stages: {
-          discover: 'passed',
-          policy: 'failed',
-          download: 'pending',
-          signatureVerify: 'pending',
-          install: 'pending',
-          relaunch: 'pending',
-        },
-        error: 'Update policy could not be parsed from the native updater response.',
-      });
-      return;
-    }
-
     await writeCanary({
       schemaVersion: 1,
       status: 'pending',
       checkedVersion,
       offeredVersion: outcome.version,
       forced: outcome.forced,
+      dryRun: false,
       stages: {
         discover: 'passed',
         policy: 'passed',
-        // downloadAndInstall owns all three production operations; these are
-        // marked ready before the call so the file survives relaunch.
-        download: 'passed',
-        signatureVerify: 'passed',
-        install: 'passed',
+        download: 'pending',
+        signatureVerify: 'pending',
+        install: 'pending',
         relaunch: 'pending',
       },
       error: null,
     });
 
-    const install = await startDownload();
+    const install = await startDownload({
+      onInstalled: () => writeCanary({
+        schemaVersion: 1,
+        status: 'pending',
+        checkedVersion,
+        offeredVersion: outcome.version,
+        forced: outcome.forced,
+        dryRun: false,
+        stages: {
+          discover: 'passed',
+          policy: 'passed',
+          download: 'passed',
+          signatureVerify: 'passed',
+          install: 'passed',
+          relaunch: 'pending',
+        },
+        error: null,
+      }),
+    });
     if (!install || install.kind === 'installed') return;
     await writeCanary({
       schemaVersion: 1,
@@ -461,13 +518,14 @@ export function useAutoUpdater(
       checkedVersion,
       offeredVersion: outcome.version,
       forced: outcome.forced,
+      dryRun: false,
       stages: {
         discover: 'passed',
         policy: 'passed',
-        download: 'failed',
-        signatureVerify: 'failed',
-        install: 'failed',
-        relaunch: 'pending',
+        download: install.stage === 'download' ? 'failed' : 'passed',
+        signatureVerify: install.stage === 'download' ? 'pending' : 'passed',
+        install: install.stage === 'download' ? 'pending' : install.stage === 'install' ? 'failed' : 'passed',
+        relaunch: install.stage === 'relaunch' ? 'failed' : 'pending',
       },
       error: install.message,
     });
@@ -488,7 +546,7 @@ export function useAutoUpdater(
       try {
         const canary = await invoke<UpdaterCanaryState>('updater_canary', { action: 'read' });
         if (disposed) return;
-        if (canary.path) await runCanary(canary.result);
+        if (canary.path) await runCanary(canary.result, canary.dryRun);
         else await performCheck({ isBackground: true });
       } catch (error) {
         flog.warn('updater', 'could not inspect updater canary state', { error: String(error) });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ available for packaging and callback-boundary validation. See the
 
 | Module | Purpose |
 |--------|---------|
-| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 147 registered commands, setup, tray, run loop |
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 148 registered commands, setup, tray, run loop |
 | `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
 | `audio.rs` | CPAL 0.18 capture worker, stable device-ID selection, typed error/phase telemetry, first-buffer readiness, mono mix, 16kHz resample, `audio-level` emission |
 | `audio_lifecycle.rs` | App-lifetime single-owner supervisor; async start, generation cancellation, deadlines, generation-gated publication, and strict worker ownership through exit |
@@ -381,7 +381,7 @@ Two rules keep the multi-window state coherent:
 
 ## Tauri Commands
 
-147 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
+148 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
 
 ## Events
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -267,7 +267,7 @@ Every transform-key hold is recorded as a content-free `TransformAttemptV1` with
 
 | Area | Location |
 |------|----------|
-| Rust backend | `app/src-tauri/src/` — 147 Tauri commands |
+| Rust backend | `app/src-tauri/src/` — 148 Tauri commands |
 | Frontend | `app/src/` — React 18 + TypeScript + Tailwind 4 |
 | LLM sidecar | `app/src-tauri/sidecars/local-llm/`, protocol in `crates/local-llm-protocol` |
 | Capture worker | `app/src-tauri/sidecars/capture/`, protocol in `crates/capture-helper-protocol` |

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -47,6 +47,65 @@ The modern channel's policy is version-controlled in
 `major.minor.patch` value publishes it after verifying that it is not newer
 than the release. The legacy bridge manifest intentionally omits this policy.
 
+## Post-release OTA canary
+
+The trusted Mac mini has an opt-in canary installation in a dedicated
+`Murmur OTA Canary` directory. The release operator runs:
+
+```bash
+python3 scripts/murmur_canary_fleet.py --tag vX.Y.Z
+```
+
+The runner finds the previous public release, installs its signed
+`Murmur.app.tar.gz` into that directory (never the daily `/Applications`
+install), launches it with `MURMUR_UPDATER_CANARY=/path/to/result.json`, and
+waits for the relaunched client. The app-side marker is absent for ordinary
+launches, so the canary path is inert; canary runs also disable the log shipper.
+The app still uses the normal updater hook, including native `Update.rawJson`
+policy parsing, download, signature verification, install, and relaunch.
+
+The result file is JSON with this schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "passed",
+  "checkedVersion": "0.31.3",
+  "offeredVersion": "0.31.4",
+  "forced": false,
+  "stages": {
+    "discover": "passed",
+    "policy": "passed",
+    "download": "passed",
+    "signatureVerify": "passed",
+    "install": "passed",
+    "relaunch": "passed"
+  },
+  "error": null
+}
+```
+
+`status` must be `passed`, every stage must be `passed`, and the checked and
+offered versions must differ. The runner validates this contract and exits
+nonzero with the captured error for any failure. `--dry-run` prepares the
+previous signed bundle and prints the launch command but stops before launching
+or installing it.
+
+The canary proves manifest consumability, native policy parsing, signature
+verification, installation, and relaunch into the new version. It does not
+prove per-user network conditions, Gatekeeper App Translocation behavior, or
+the many possible daily-install locations.
+
+### One-time Mac mini setup
+
+On the trusted mini, install Fleet and GitHub CLI access, then run the command
+above from a checkout at `/Users/george-mac-mini/Documents/code/murmur-app`.
+Grant Murmur the required macOS permissions to the dedicated canary bundle,
+and keep the mini on AC power with the screen session available for any first
+launch prompts. Confirm `--dry-run` first. The first real run creates
+`~/Library/Application Support/Murmur OTA Canary/Murmur Canary.app`; do not
+move it into `/Applications` or point the runner at the daily installation.
+
 ## Update Flow
 
 ### Normal Updates

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -73,6 +73,7 @@ The result file is JSON with this schema:
   "checkedVersion": "0.31.3",
   "offeredVersion": "0.31.4",
   "forced": false,
+  "dryRun": false,
   "stages": {
     "discover": "passed",
     "policy": "passed",
@@ -85,18 +86,29 @@ The result file is JSON with this schema:
 }
 ```
 
-`status` must be `passed`, every stage must be `passed`, and the checked and
-offered versions must differ. The runner validates this contract and exits
-nonzero with the captured error for any failure. `--dry-run` prepares the
-previous signed bundle and prints the launch command but stops before launching
-or installing it.
+`status` must be `passed`, every stage must be `passed`, and `checkedVersion`
+must equal the exact resolved previous release while `offeredVersion` equals
+the target release. The runner validates all field types and this contract and
+exits nonzero with the captured error for any failure. `--dry-run` launches the
+previous canary-capable bundle with a second marker, exercises discovery and
+policy, writes an identifiable `status: "dry-run"` result with production
+stages still `pending`, and exits before download/install/relaunch.
 
 The canary proves manifest consumability, native policy parsing, signature
 verification, installation, and relaunch into the new version. It does not
 prove per-user network conditions, Gatekeeper App Translocation behavior, or
 the many possible daily-install locations.
 
-### One-time Mac mini setup
+### One-time Mac mini setup and bootstrap exception
+
+The first public build containing this canary support cannot be tested by the
+previous public build: that older client has no canary marker or result writer.
+This is a one-time bootstrap exception. Physically install the first
+canary-capable public build into the dedicated `Murmur OTA Canary` location on
+the trusted mini, launch it once there, and verify `--dry-run`. Mandatory OTA
+canary gating begins with the next release, when that installed build is the
+previous public client. Never use the daily `/Applications` install for this
+bootstrap.
 
 On the trusted mini, install Fleet and GitHub CLI access, then run the command
 above from a checkout at `/Users/george-mac-mini/Documents/code/murmur-app`.

--- a/docs/features/auto-updater.md
+++ b/docs/features/auto-updater.md
@@ -105,10 +105,11 @@ The first public build containing this canary support cannot be tested by the
 previous public build: that older client has no canary marker or result writer.
 This is a one-time bootstrap exception. Physically install the first
 canary-capable public build into the dedicated `Murmur OTA Canary` location on
-the trusted mini, launch it once there, and verify `--dry-run`. Mandatory OTA
-canary gating begins with the next release, when that installed build is the
-previous public client. Never use the daily `/Applications` install for this
-bootstrap.
+the trusted mini and launch it once there to grant permissions. Do not run the
+normal release gate against this bootstrap build: its predecessor is not
+canary-capable. Use `--dry-run` beginning with the next release, when this
+installed build is the previous public client. Never use the daily
+`/Applications` install for this bootstrap.
 
 On the trusted mini, install Fleet and GitHub CLI access, then run the command
 above from a checkout at `/Users/george-mac-mini/Documents/code/murmur-app`.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Tauri Commands Reference
 
-The 147 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
+The 148 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
 Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
 
@@ -287,6 +287,7 @@ without logging their content.
 | Command | Parameters | Returns | Description |
 |---------|-----------|---------|-------------|
 | `get_update_install_environment` | — | `Result<{ appTranslocated: bool }, String>` | Reports whether Gatekeeper launched the current executable through its read-only `AppTranslocation` mount. Does not expose the executable path and fails closed if the current executable cannot be resolved. |
+| `updater_canary` | `request: { action: "read" | "write", result?: JSON }` | `Result<{ path: string | null, result: JSON | null }, String>` | Reads the opt-in `MURMUR_UPDATER_CANARY` result path or atomically writes the app's canary result. With no environment marker, returns an inert state. |
 
 ## Telemetry (`telemetry.rs`)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -58,6 +58,18 @@ the release optional, while a stable minimum version at or below the target
 release is emitted as `min_version` on the modern channel. Invalid or future
 minimum versions fail promotion.
 
+After publication, the release is not done until the previous public build
+passes the real OTA canary on the trusted Mac mini. Run the documented manual
+gate (the mini is tailnet-only, so it is not run on a GitHub-hosted runner):
+
+```bash
+python3 scripts/murmur_canary_fleet.py --tag vX.Y.Z
+```
+
+The command must exit zero and report a complete result-file pass before the
+release is announced. A failed or timed-out canary blocks release follow-up;
+fix the updater and publish a patch release as needed.
+
 Set that file before the version-bump commit:
 
 ```json
@@ -65,8 +77,11 @@ Set that file before the version-bump commit:
 ```
 
 Use a quoted stable version such as `"0.24.0"` only when every installed
-version below that threshold must update or quit. Policy changes receive the
-same code review and trusted-main provenance as the release itself.
+version below that threshold must update or quit. Never set `min_version` to
+force an update until the canary from the currently shipped public version has
+passed: a forced update combined with a broken checker is the worst failure
+mode. Policy changes receive the same code review and trusted-main provenance
+as the release itself.
 
 Immediately before publication, the workflow requires the draft release body
 to match the remotely downloaded updater manifest notes after applying the same

--- a/docs/release.md
+++ b/docs/release.md
@@ -59,7 +59,11 @@ release is emitted as `min_version` on the modern channel. Invalid or future
 minimum versions fail promotion.
 
 After publication, the release is not done until the previous public build
-passes the real OTA canary on the trusted Mac mini. Run the documented manual
+passes the real OTA canary on the trusted Mac mini. There is one bootstrap
+exception: the first public build containing canary support must be physically
+installed once in the dedicated canary location because its previous public
+client cannot write a canary result. Mandatory gating starts with the next
+release. For all later releases, run the documented manual
 gate (the mini is tailnet-only, so it is not run on a GitHub-hosted runner):
 
 ```bash

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -51,7 +51,10 @@ policy and emits the immutable updater manifest.
 Include the min_version decision in the release summary.
 
 Never set `min_version` to force an update until the currently shipped public
-version has passed the post-release OTA canary. After publication, run
+version has passed the post-release OTA canary. The first public
+canary-capable build is a one-time bootstrap exception: physically install it
+in the dedicated canary location and verify `--dry-run`; mandatory OTA gating
+starts with the next release. After publication, run
 `python3 scripts/murmur_canary_fleet.py --tag v{new_version}` on the trusted
 Mac mini and do not announce the release unless it exits zero. The one-time
 canary installation setup and result schema are in

--- a/prompts/PROMPT_RELEASE.md
+++ b/prompts/PROMPT_RELEASE.md
@@ -50,6 +50,13 @@ policy and emits the immutable updater manifest.
 
 Include the min_version decision in the release summary.
 
+Never set `min_version` to force an update until the currently shipped public
+version has passed the post-release OTA canary. After publication, run
+`python3 scripts/murmur_canary_fleet.py --tag v{new_version}` on the trusted
+Mac mini and do not announce the release unless it exits zero. The one-time
+canary installation setup and result schema are in
+`docs/features/auto-updater.md`.
+
 ## 4. Run the Pre-Release Murmur Bench Gate
 
 Before asking for release authorization, compare the previous release tag with

--- a/scripts/murmur_canary_fleet.py
+++ b/scripts/murmur_canary_fleet.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Run Murmur's post-release OTA canary on the trusted Mac mini.
+
+The normal invocation is a small Fleet wrapper.  ``--remote`` is used by that
+wrapper on the mini itself, where the previous public bundle is installed in a
+dedicated directory, launched with ``MURMUR_UPDATER_CANARY``, and evaluated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import plistlib
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from typing import Any
+
+
+DEFAULT_NODE = "mac-mini"
+DEFAULT_REPO = "/Users/george-mac-mini/Documents/code/murmur-app"
+DEFAULT_ROOT = "/Users/george-mac-mini/Library/Application Support/Murmur OTA Canary"
+DEFAULT_TIMEOUT_SECONDS = 900
+BUNDLE_EXECUTABLE = "ui"
+SCHEMA_VERSION = 1
+STAGES = ("discover", "policy", "download", "signatureVerify", "install", "relaunch")
+PASS = "passed"
+
+
+class CanaryError(RuntimeError):
+    """A bounded, user-actionable canary failure."""
+
+
+def output(command: list[str], *, cwd: Path | None = None) -> str:
+    return subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+
+
+def evaluate_canary_result(result: Any, expected_version: str) -> None:
+    """Validate the app-written result schema and successful OTA contract.
+
+    This function intentionally has no macOS or Fleet dependencies so Linux CI
+    can exercise the gate's acceptance logic.
+    """
+    if not isinstance(result, dict):
+        raise CanaryError("canary result is not a JSON object")
+    if result.get("schemaVersion") != SCHEMA_VERSION:
+        raise CanaryError(f"unsupported canary schemaVersion: {result.get('schemaVersion')!r}")
+    if result.get("status") != "passed":
+        raise CanaryError(f"canary status is {result.get('status')!r}: {result.get('error') or 'no error supplied'}")
+    if result.get("offeredVersion") != expected_version:
+        raise CanaryError(
+            f"canary offeredVersion {result.get('offeredVersion')!r} does not match release {expected_version}"
+        )
+    if not isinstance(result.get("checkedVersion"), str) or result["checkedVersion"] == expected_version:
+        raise CanaryError("canary did not prove an update from a previous version")
+    if result.get("error") is not None:
+        raise CanaryError(f"canary reported an error: {result['error']}")
+    stages = result.get("stages")
+    if not isinstance(stages, dict):
+        raise CanaryError("canary result has no stages object")
+    missing = [stage for stage in STAGES if stages.get(stage) != PASS]
+    if missing:
+        raise CanaryError("canary stages did not pass: " + ", ".join(missing))
+
+
+def release_versions(repository: str) -> list[str]:
+    payload = json.loads(output(["gh", "api", f"repos/{repository}/releases?per_page=100"]))
+    return [item["tag_name"] for item in payload if not item.get("draft") and not item.get("prerelease")]
+
+
+def previous_release(repository: str, tag: str) -> str:
+    versions = release_versions(repository)
+    try:
+        index = versions.index(tag)
+    except ValueError as error:
+        raise CanaryError(f"release tag {tag} is not a published release") from error
+    if index + 1 >= len(versions):
+        raise CanaryError(f"no previous public release found before {tag}")
+    return versions[index + 1]
+
+
+def release_asset(repository: str, tag: str) -> str:
+    payload = json.loads(output(["gh", "api", f"repos/{repository}/releases/tags/{tag}"]))
+    for asset in payload.get("assets", []):
+        if asset.get("name") == "Murmur.app.tar.gz":
+            return asset["browser_download_url"]
+    raise CanaryError(f"{tag} has no signed Murmur.app.tar.gz asset")
+
+
+def install_previous_bundle(
+    repository: str, tag: str, root: Path, *, dry_run: bool = False
+) -> tuple[Path, str]:
+    app_path = root / "Murmur Canary.app"
+    executable = app_path / "Contents" / "MacOS" / BUNDLE_EXECUTABLE
+    if executable.exists():
+        try:
+            with (app_path / "Contents" / "Info.plist").open("rb") as info:
+                installed_version = plistlib.load(info).get("CFBundleShortVersionString")
+        except (OSError, plistlib.InvalidFileException, ValueError):
+            installed_version = None
+        if installed_version == tag.removeprefix("v"):
+            return app_path, executable.as_posix()
+        if not dry_run:
+            shutil.rmtree(app_path)
+
+    root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="murmur-canary-") as temporary:
+        archive = Path(temporary) / "Murmur.app.tar.gz"
+        subprocess.run(["curl", "--fail", "--silent", "--show-error", "--location", release_asset(repository, tag), "--output", str(archive)], check=True)
+        with tarfile.open(archive, "r:gz") as bundle:
+            destination = Path(temporary).resolve()
+            members = bundle.getmembers()
+            for member in members:
+                target = (destination / member.name).resolve()
+                if target != destination and destination not in target.parents:
+                    raise CanaryError("release archive contains an unsafe path")
+            bundle.extractall(destination)
+        extracted = Path(temporary) / "Murmur.app"
+        if not (extracted / "Contents" / "MacOS" / BUNDLE_EXECUTABLE).exists():
+            raise CanaryError("downloaded release did not contain Murmur.app")
+        if dry_run:
+            return app_path, executable.as_posix()
+        if app_path.exists():
+            shutil.rmtree(app_path)
+        shutil.move(str(extracted), str(app_path))
+    return app_path, executable.as_posix()
+
+
+def run_remote(args: argparse.Namespace) -> int:
+    tag = args.tag
+    expected_version = tag.removeprefix("v")
+    root = Path(args.root).expanduser()
+    previous = previous_release(args.repository, tag)
+    app_path, executable = install_previous_bundle(
+        args.repository, previous, root, dry_run=args.dry_run
+    )
+    result_path = root / "result.json"
+    if result_path.exists():
+        result_path.unlink()
+    command = [executable]
+    print(f"Canary source: {previous} ({app_path})", flush=True)
+    if args.dry_run:
+        print("Dry run: bundle prepared; launch/install skipped.", flush=True)
+        print("MURMUR_UPDATER_CANARY=" + str(result_path), shlex.join(command), flush=True)
+        return 0
+
+    environment = os.environ.copy()
+    environment["MURMUR_UPDATER_CANARY"] = str(result_path)
+    process = subprocess.Popen(command, env=environment, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, start_new_session=True)
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline:
+        if result_path.exists():
+            try:
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                result = None
+            if isinstance(result, dict) and result.get("status") in ("passed", "failed"):
+                try:
+                    evaluate_canary_result(result, expected_version)
+                except CanaryError as error:
+                    if process.poll() is None:
+                        os.killpg(process.pid, signal.SIGTERM)
+                    print(f"murmur-canary-fleet: {error}", file=sys.stderr)
+                    return 1
+                print(json.dumps(result, sort_keys=True), flush=True)
+                return 0
+        if process.poll() is not None and not result_path.exists():
+            break
+        time.sleep(2)
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGTERM)
+    stderr = process.communicate(timeout=5)[1].decode(errors="replace")
+    print(f"murmur-canary-fleet: timed out waiting for {result_path}; {stderr[-1000:]}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="published release tag, for example v0.31.4")
+    parser.add_argument("--node", default=DEFAULT_NODE)
+    parser.add_argument("--repository", default="georgenijo/murmur-app")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help=argparse.SUPPRESS)
+    parser.add_argument("--root", default=DEFAULT_ROOT, help=argparse.SUPPRESS)
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--dry-run", action="store_true", help="prepare the previous bundle but stop before launch/install")
+    parser.add_argument("--remote", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.remote:
+        return run_remote(args)
+
+    remote = [
+        "python3", f"{args.repo}/scripts/murmur_canary_fleet.py", "--remote",
+        "--tag", args.tag, "--repository", args.repository, "--root", args.root,
+        "--timeout", str(args.timeout),
+    ]
+    if args.dry_run:
+        remote.append("--dry-run")
+    command = ["fleet", "exec", "--timeout", str(args.timeout), args.node, "--", shlex.join(remote)]
+    print("Running OTA canary on Fleet node", args.node, flush=True)
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (CanaryError, OSError, subprocess.CalledProcessError) as error:
+        print(f"murmur-canary-fleet: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/murmur_canary_fleet.py
+++ b/scripts/murmur_canary_fleet.py
@@ -32,6 +32,10 @@ BUNDLE_EXECUTABLE = "ui"
 SCHEMA_VERSION = 1
 STAGES = ("discover", "policy", "download", "signatureVerify", "install", "relaunch")
 PASS = "passed"
+PENDING = "pending"
+RESULT_FIELDS = ("schemaVersion", "status", "checkedVersion", "offeredVersion", "forced", "dryRun", "stages", "error")
+STATUSES = {"pending", "passed", "failed", "dry-run"}
+STAGE_VALUES = {PASS, PENDING, "failed"}
 
 
 class CanaryError(RuntimeError):
@@ -42,7 +46,7 @@ def output(command: list[str], *, cwd: Path | None = None) -> str:
     return subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
 
 
-def evaluate_canary_result(result: Any, expected_version: str) -> None:
+def _validate_result_shape(result: Any) -> None:
     """Validate the app-written result schema and successful OTA contract.
 
     This function intentionally has no macOS or Fleet dependencies so Linux CI
@@ -50,24 +54,72 @@ def evaluate_canary_result(result: Any, expected_version: str) -> None:
     """
     if not isinstance(result, dict):
         raise CanaryError("canary result is not a JSON object")
-    if result.get("schemaVersion") != SCHEMA_VERSION:
-        raise CanaryError(f"unsupported canary schemaVersion: {result.get('schemaVersion')!r}")
-    if result.get("status") != "passed":
+    missing_fields = [field for field in RESULT_FIELDS if field not in result]
+    if missing_fields:
+        raise CanaryError("canary result is missing fields: " + ", ".join(missing_fields))
+    if type(result["schemaVersion"]) is not int:
+        raise CanaryError("schemaVersion must be an integer")
+    if result["schemaVersion"] != SCHEMA_VERSION:
+        raise CanaryError(f"unsupported canary schemaVersion: {result['schemaVersion']!r}")
+    if not isinstance(result["status"], str) or result["status"] not in STATUSES:
+        raise CanaryError(f"canary status is invalid: {result.get('status')!r}")
+    if not isinstance(result["checkedVersion"], str):
+        raise CanaryError("checkedVersion must be a string")
+    if result["offeredVersion"] is not None and not isinstance(result["offeredVersion"], str):
+        raise CanaryError("offeredVersion must be a string or null")
+    if not isinstance(result["forced"], bool):
+        raise CanaryError("forced must be a boolean")
+    if not isinstance(result["dryRun"], bool):
+        raise CanaryError("dryRun must be a boolean")
+    if result["error"] is not None and not isinstance(result["error"], str):
+        raise CanaryError("error must be a string or null")
+    stages = result["stages"]
+    if not isinstance(stages, dict):
+        raise CanaryError("canary result has no stages object")
+    if set(stages) != set(STAGES):
+        raise CanaryError("canary stages must contain exactly: " + ", ".join(STAGES))
+    invalid = [stage for stage, value in stages.items() if not isinstance(value, str) or value not in STAGE_VALUES]
+    if invalid:
+        raise CanaryError("canary stages have invalid values: " + ", ".join(invalid))
+
+
+def evaluate_canary_result(result: Any, expected_previous_version: str, expected_version: str) -> None:
+    _validate_result_shape(result)
+    if result["status"] != "passed":
         raise CanaryError(f"canary status is {result.get('status')!r}: {result.get('error') or 'no error supplied'}")
+    if result["dryRun"]:
+        raise CanaryError("dry-run result cannot satisfy the OTA gate")
     if result.get("offeredVersion") != expected_version:
         raise CanaryError(
             f"canary offeredVersion {result.get('offeredVersion')!r} does not match release {expected_version}"
         )
-    if not isinstance(result.get("checkedVersion"), str) or result["checkedVersion"] == expected_version:
-        raise CanaryError("canary did not prove an update from a previous version")
+    if result["checkedVersion"] != expected_previous_version:
+        raise CanaryError(
+            f"canary checkedVersion {result['checkedVersion']!r} does not match previous version {expected_previous_version}"
+        )
     if result.get("error") is not None:
         raise CanaryError(f"canary reported an error: {result['error']}")
-    stages = result.get("stages")
-    if not isinstance(stages, dict):
-        raise CanaryError("canary result has no stages object")
-    missing = [stage for stage in STAGES if stages.get(stage) != PASS]
+    missing = [stage for stage in STAGES if result["stages"].get(stage) != PASS]
     if missing:
         raise CanaryError("canary stages did not pass: " + ", ".join(missing))
+
+
+def evaluate_dry_run_result(result: Any, expected_previous_version: str, expected_version: str) -> None:
+    _validate_result_shape(result)
+    if result["status"] != "dry-run" or not result["dryRun"]:
+        raise CanaryError("canary did not emit an identifiable dry-run result")
+    if result["checkedVersion"] != expected_previous_version:
+        raise CanaryError("dry-run checkedVersion does not match previous release")
+    if result["offeredVersion"] != expected_version:
+        raise CanaryError("dry-run offeredVersion does not match release")
+    if result["error"] is not None:
+        raise CanaryError(f"dry-run reported an error: {result['error']}")
+    for stage in ("discover", "policy"):
+        if result["stages"][stage] != PASS:
+            raise CanaryError(f"dry-run {stage} stage did not pass")
+    for stage in STAGES[2:]:
+        if result["stages"][stage] != PENDING:
+            raise CanaryError(f"dry-run {stage} stage must remain pending")
 
 
 def release_versions(repository: str) -> list[str]:
@@ -107,8 +159,7 @@ def install_previous_bundle(
             installed_version = None
         if installed_version == tag.removeprefix("v"):
             return app_path, executable.as_posix()
-        if not dry_run:
-            shutil.rmtree(app_path)
+        shutil.rmtree(app_path)
 
     root.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="murmur-canary-") as temporary:
@@ -117,16 +168,31 @@ def install_previous_bundle(
         with tarfile.open(archive, "r:gz") as bundle:
             destination = Path(temporary).resolve()
             members = bundle.getmembers()
+            roots = set()
             for member in members:
+                if member.issym() or member.islnk() or member.isdev():
+                    raise CanaryError("release archive contains a link or device entry")
+                name = Path(member.name)
+                if name.is_absolute() or not name.parts or name.parts[0] != "Murmur.app":
+                    raise CanaryError("release archive must contain one Murmur.app root")
+                roots.add(name.parts[0])
                 target = (destination / member.name).resolve()
                 if target != destination and destination not in target.parents:
                     raise CanaryError("release archive contains an unsafe path")
+            if roots != {"Murmur.app"}:
+                raise CanaryError("release archive must contain one Murmur.app root")
             bundle.extractall(destination)
         extracted = Path(temporary) / "Murmur.app"
-        if not (extracted / "Contents" / "MacOS" / BUNDLE_EXECUTABLE).exists():
+        info = extracted / "Contents" / "Info.plist"
+        try:
+            with info.open("rb") as stream:
+                extracted_version = plistlib.load(stream).get("CFBundleShortVersionString")
+        except (OSError, plistlib.InvalidFileException, ValueError) as error:
+            raise CanaryError("downloaded release has no valid Info.plist") from error
+        if extracted_version != tag.removeprefix("v"):
+            raise CanaryError(f"downloaded bundle version {extracted_version!r} does not match {tag}")
+        if not (extracted / "Contents" / "MacOS" / BUNDLE_EXECUTABLE).is_file():
             raise CanaryError("downloaded release did not contain Murmur.app")
-        if dry_run:
-            return app_path, executable.as_posix()
         if app_path.exists():
             shutil.rmtree(app_path)
         shutil.move(str(extracted), str(app_path))
@@ -138,6 +204,7 @@ def run_remote(args: argparse.Namespace) -> int:
     expected_version = tag.removeprefix("v")
     root = Path(args.root).expanduser()
     previous = previous_release(args.repository, tag)
+    previous_version = previous.removeprefix("v")
     app_path, executable = install_previous_bundle(
         args.repository, previous, root, dry_run=args.dry_run
     )
@@ -146,39 +213,45 @@ def run_remote(args: argparse.Namespace) -> int:
         result_path.unlink()
     command = [executable]
     print(f"Canary source: {previous} ({app_path})", flush=True)
-    if args.dry_run:
-        print("Dry run: bundle prepared; launch/install skipped.", flush=True)
-        print("MURMUR_UPDATER_CANARY=" + str(result_path), shlex.join(command), flush=True)
-        return 0
-
     environment = os.environ.copy()
     environment["MURMUR_UPDATER_CANARY"] = str(result_path)
+    if args.dry_run:
+        environment["MURMUR_UPDATER_CANARY_DRY_RUN"] = "1"
+    print(shlex.join([f"MURMUR_UPDATER_CANARY={result_path}", *(["MURMUR_UPDATER_CANARY_DRY_RUN=1"] if args.dry_run else []), *command]), flush=True)
     process = subprocess.Popen(command, env=environment, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, start_new_session=True)
-    deadline = time.monotonic() + args.timeout
-    while time.monotonic() < deadline:
-        if result_path.exists():
-            try:
-                result = json.loads(result_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                result = None
-            if isinstance(result, dict) and result.get("status") in ("passed", "failed"):
+    try:
+        deadline = time.monotonic() + args.timeout
+        while time.monotonic() < deadline:
+            if result_path.exists():
                 try:
-                    evaluate_canary_result(result, expected_version)
-                except CanaryError as error:
-                    if process.poll() is None:
-                        os.killpg(process.pid, signal.SIGTERM)
-                    print(f"murmur-canary-fleet: {error}", file=sys.stderr)
-                    return 1
-                print(json.dumps(result, sort_keys=True), flush=True)
-                return 0
-        if process.poll() is not None and not result_path.exists():
-            break
-        time.sleep(2)
-    if process.poll() is None:
-        os.killpg(process.pid, signal.SIGTERM)
-    stderr = process.communicate(timeout=5)[1].decode(errors="replace")
-    print(f"murmur-canary-fleet: timed out waiting for {result_path}; {stderr[-1000:]}", file=sys.stderr)
-    return 1
+                    result = json.loads(result_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    result = None
+                if isinstance(result, dict) and result.get("status") in ("passed", "failed", "dry-run"):
+                    if args.dry_run:
+                        evaluate_dry_run_result(result, previous_version, expected_version)
+                    else:
+                        evaluate_canary_result(result, previous_version, expected_version)
+                    print(json.dumps(result, sort_keys=True), flush=True)
+                    return 0
+            if process.poll() is not None and not result_path.exists():
+                break
+            time.sleep(2)
+        stderr = process.communicate(timeout=5)[1].decode(errors="replace")
+        raise CanaryError(f"timed out waiting for {result_path}; {stderr[-1000:]}")
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=5)
 
 
 def main() -> int:
@@ -189,7 +262,7 @@ def main() -> int:
     parser.add_argument("--repo", default=DEFAULT_REPO, help=argparse.SUPPRESS)
     parser.add_argument("--root", default=DEFAULT_ROOT, help=argparse.SUPPRESS)
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
-    parser.add_argument("--dry-run", action="store_true", help="prepare the previous bundle but stop before launch/install")
+    parser.add_argument("--dry-run", action="store_true", help="launch discovery/policy only; never download or install the update")
     parser.add_argument("--remote", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.remote:
@@ -202,7 +275,8 @@ def main() -> int:
     ]
     if args.dry_run:
         remote.append("--dry-run")
-    command = ["fleet", "exec", "--timeout", str(args.timeout), args.node, "--", shlex.join(remote)]
+    outer_timeout = args.timeout + 120
+    command = ["fleet", "exec", "--timeout", str(outer_timeout), args.node, "--", shlex.join(remote)]
     print("Running OTA canary on Fleet node", args.node, flush=True)
     return subprocess.run(command, check=False).returncode
 

--- a/tests/test_murmur_canary.py
+++ b/tests/test_murmur_canary.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "murmur_canary_fleet.py"
+SPEC = importlib.util.spec_from_file_location("murmur_canary_fleet", SCRIPT)
+assert SPEC and SPEC.loader
+canary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(canary)
+
+
+def passing_result() -> dict:
+    return {
+        "schemaVersion": 1,
+        "status": "passed",
+        "checkedVersion": "0.31.3",
+        "offeredVersion": "0.31.4",
+        "forced": False,
+        "stages": {stage: "passed" for stage in canary.STAGES},
+        "error": None,
+    }
+
+
+def test_evaluate_accepts_complete_pass() -> None:
+    canary.evaluate_canary_result(passing_result(), "0.31.4")
+
+
+@pytest.mark.parametrize(
+    "mutate, message",
+    [
+        (lambda result: result.update(status="failed"), "status"),
+        (lambda result: result["stages"].update(install="failed"), "stages"),
+        (lambda result: result.update(offeredVersion="0.31.5"), "offeredVersion"),
+        (lambda result: result.update(checkedVersion="0.31.4"), "previous version"),
+        (lambda result: result.update(schemaVersion=2), "schemaVersion"),
+    ],
+)
+def test_evaluate_rejects_incomplete_or_mismatched_result(mutate, message: str) -> None:
+    result = passing_result()
+    mutate(result)
+    with pytest.raises(canary.CanaryError, match=message):
+        canary.evaluate_canary_result(result, "0.31.4")
+
+
+def test_evaluate_requires_all_stage_names() -> None:
+    result = passing_result()
+    del result["stages"]["signatureVerify"]
+    with pytest.raises(canary.CanaryError, match="signatureVerify"):
+        canary.evaluate_canary_result(result, "0.31.4")

--- a/tests/test_murmur_canary.py
+++ b/tests/test_murmur_canary.py
@@ -18,13 +18,14 @@ def passing_result() -> dict:
         "checkedVersion": "0.31.3",
         "offeredVersion": "0.31.4",
         "forced": False,
+        "dryRun": False,
         "stages": {stage: "passed" for stage in canary.STAGES},
         "error": None,
     }
 
 
 def test_evaluate_accepts_complete_pass() -> None:
-    canary.evaluate_canary_result(passing_result(), "0.31.4")
+    canary.evaluate_canary_result(passing_result(), "0.31.3", "0.31.4")
 
 
 @pytest.mark.parametrize(
@@ -41,11 +42,40 @@ def test_evaluate_rejects_incomplete_or_mismatched_result(mutate, message: str) 
     result = passing_result()
     mutate(result)
     with pytest.raises(canary.CanaryError, match=message):
-        canary.evaluate_canary_result(result, "0.31.4")
+        canary.evaluate_canary_result(result, "0.31.3", "0.31.4")
 
 
 def test_evaluate_requires_all_stage_names() -> None:
     result = passing_result()
     del result["stages"]["signatureVerify"]
     with pytest.raises(canary.CanaryError, match="signatureVerify"):
-        canary.evaluate_canary_result(result, "0.31.4")
+        canary.evaluate_canary_result(result, "0.31.3", "0.31.4")
+
+
+@pytest.mark.parametrize("field, value", [("forced", "false"), ("dryRun", 0), ("checkedVersion", None), ("error", 3)])
+def test_evaluate_rejects_wrong_required_field_types(field, value) -> None:
+    result = passing_result()
+    result[field] = value
+    with pytest.raises(canary.CanaryError, match=field):
+        canary.evaluate_canary_result(result, "0.31.3", "0.31.4")
+
+
+def test_evaluate_rejects_missing_required_field() -> None:
+    result = passing_result()
+    del result["dryRun"]
+    with pytest.raises(canary.CanaryError, match="dryRun"):
+        canary.evaluate_canary_result(result, "0.31.3", "0.31.4")
+
+
+def test_evaluate_requires_exact_previous_version() -> None:
+    with pytest.raises(canary.CanaryError, match="checkedVersion"):
+        canary.evaluate_canary_result(passing_result(), "0.31.2", "0.31.4")
+
+
+def test_evaluate_accepts_identifiable_dry_run() -> None:
+    result = passing_result()
+    result["status"] = "dry-run"
+    result["dryRun"] = True
+    for stage in canary.STAGES[2:]:
+        result["stages"][stage] = "pending"
+    canary.evaluate_dry_run_result(result, "0.31.3", "0.31.4")

--- a/tests/test_reference_docs.py
+++ b/tests/test_reference_docs.py
@@ -28,7 +28,7 @@ def copy_reference_fixture(root: Path) -> None:
 
 class ReferenceDocsTests(unittest.TestCase):
     def test_repository_reference_docs_match_registered_commands(self) -> None:
-        self.assertEqual(validate_reference_docs(), 147)
+        self.assertEqual(validate_reference_docs(), 148)
 
     def test_missing_command_row_fails_even_when_prose_count_is_current(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -54,7 +54,7 @@ class ReferenceDocsTests(unittest.TestCase):
             architecture = root / "docs/ARCHITECTURE.md"
             architecture.write_text(
                 architecture.read_text().replace(
-                    "147 registered commands", "146 registered commands", 1
+                    "148 registered commands", "147 registered commands", 1
                 )
             )
 


### PR DESCRIPTION
Closes #560

Adds an opt-in, real-path macOS OTA canary that exercises the existing `useAutoUpdater` flow from a previously shipped client through native manifest/policy parsing, download, signature verification, install, relaunch, and running-version assertion. The trusted Mac mini runner remains a documented manual gate because Fleet is tailnet-only.

Acceptance checklist:
- [x] Canary mode is inert when `MURMUR_UPDATER_CANARY` is absent (Rust env test plus frontend launch regression test).
- [x] Canary bypasses only skipped-version presentation policy; native check and policy parsing remain shared.
- [x] Result JSON schema is documented and validates exact previous/target versions, field types, and stage values with Linux-compatible runner tests.
- [x] `scripts/murmur_canary_fleet.py --tag vX.Y.Z` runs the full gate against a published tag.
- [x] `--dry-run` launches the prior canary-capable client, exercises discovery/policy, writes an identifiable dry-run result, and stops before update download/install.
- [x] Production stages remain pending until evidence; hook tests cover success, policy failure, download failure, relaunch failure, and pending recovery.
- [x] Archive extraction rejects links/devices/escapes, enforces one `Murmur.app` root, and validates bundle plist version.
- [x] Release docs and `PROMPT_RELEASE.md` require canary success before announcing and prohibit setting `min_version` before the currently shipped public version passes (after bootstrap).
- [x] Canary runs disable the log shipper to avoid fleet-stat pollution.

Bootstrap exception / one-time physical Mac mini action: the first public build containing canary support cannot be tested by the older public client. Physically install that first canary-capable build once at `~/Library/Application Support/Murmur OTA Canary/Murmur Canary.app` (never `/Applications` or the daily install), launch it there, and grant required macOS permissions. Do not run the normal gate against that bootstrap build because its predecessor is not canary-capable; use `--dry-run` beginning with the next release. Fleet and GitHub CLI access are required.

Tests:
- `DYLD_LIBRARY_PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx cargo test --manifest-path app/src-tauri/Cargo.toml --lib -- --test-threads=1` — passed: 829 passed, 5 ignored.
- `cd app && npx tsc --noEmit` — passed.
- `cd app && npm test` — passed: 87 files, 767 tests.
- `/tmp/murmur-560-venv/bin/python -m pytest tests/ -k canary -q` — passed: 14 tests.
- `python3 scripts/validate_reference_docs.py` — passed: 148 commands.
- `Murmur Bench: N/A — updater-only change, no benchmarked paths`

This PR is stacked on `issue/559-updater-download-latest-button` as requested.