### PR TITLE
fix: recover performance diagnostics store failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (158 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (160 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -95,7 +95,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 158 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 160 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Start here for orientation:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System structure: module map, data flows, windows, threads, design decisions
 - **[docs/FEATURES.md](docs/FEATURES.md)** — What ships, breadth-first, with links into each feature doc
-- **[docs/reference/](docs/reference/)** — `commands.md` (158 Tauri commands), `events.md`, `hooks.md`, `settings.md`
+- **[docs/reference/](docs/reference/)** — `commands.md` (160 Tauri commands), `events.md`, `hooks.md`, `settings.md`
 
 Read these before working on a feature:
 
@@ -100,7 +100,7 @@ Read these before working on a feature:
 
 | File | Purpose |
 |------|---------|
-| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 158 registered commands, setup, tray, `run()` |
+| `lib.rs` | App wiring: mod declarations, `State`, `MutexExt`, 160 registered commands, setup, tray, `run()` |
 | `commands/mod.rs` | Re-exports command sub-modules |
 | `commands/integrations.rs` | Local availability probes for optional companion apps |
 | `commands/recording.rs` | `IdleGuard`, dictation pipeline, file transcription, vocab scan, IDE context commands |

--- a/app/src-tauri/src/commands/performance.rs
+++ b/app/src-tauri/src/commands/performance.rs
@@ -1,4 +1,6 @@
-use crate::performance_metrics::{PerformanceRunListV1, PerformanceRunV1, ResourceSampleV1};
+use crate::performance_metrics::{
+    PerformanceRunListV1, PerformanceRunV1, PerformanceStoreHealthV1, ResourceSampleV1,
+};
 use crate::State;
 use tauri::{Emitter, Manager};
 
@@ -10,6 +12,19 @@ const DIAGNOSTICS_TABS: [&str; 6] = [
     "reports",
     "transforms",
 ];
+
+const DIAGNOSTICS_WINDOW_LABELS: [&str; 2] = ["main", "diagnostics"];
+
+fn require_diagnostics_window(label: &str) -> Result<(), String> {
+    if DIAGNOSTICS_WINDOW_LABELS.contains(&label) {
+        Ok(())
+    } else {
+        Err(
+            "Diagnostics store health is only available in an authorized Diagnostics view."
+                .to_string(),
+        )
+    }
+}
 
 #[tauri::command]
 pub fn show_diagnostics_window(app: tauri::AppHandle, tab: String) -> Result<(), String> {
@@ -57,6 +72,25 @@ pub fn get_performance_resource_window(
 }
 
 #[tauri::command]
+pub fn get_performance_store_health(
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, State>,
+) -> Result<PerformanceStoreHealthV1, String> {
+    require_diagnostics_window(window.label())?;
+    Ok(state.performance.health())
+}
+
+#[tauri::command]
+pub fn recover_performance_store(
+    window: tauri::WebviewWindow,
+    allow_reinitialize: bool,
+    state: tauri::State<'_, State>,
+) -> Result<PerformanceStoreHealthV1, String> {
+    require_diagnostics_window(window.label())?;
+    state.performance.recover(allow_reinitialize)
+}
+
+#[tauri::command]
 pub fn clear_performance_diagnostics(state: tauri::State<'_, State>) -> Result<(), String> {
     state.performance.clear()?;
     state.capture_health.clear()
@@ -64,7 +98,7 @@ pub fn clear_performance_diagnostics(state: tauri::State<'_, State>) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::DIAGNOSTICS_TABS;
+    use super::{require_diagnostics_window, DIAGNOSTICS_TABS, DIAGNOSTICS_WINDOW_LABELS};
 
     #[test]
     fn pop_out_tab_allowlist_covers_every_diagnostics_view() {
@@ -79,5 +113,18 @@ mod tests {
                 "transforms"
             ]
         );
+    }
+
+    #[test]
+    fn performance_store_health_is_strictly_scoped_to_diagnostics_surfaces() {
+        for label in DIAGNOSTICS_WINDOW_LABELS {
+            assert!(require_diagnostics_window(label).is_ok());
+        }
+        for label in ["overlay", "transform-review", "log-viewer", "", "main-copy"] {
+            assert!(
+                require_diagnostics_window(label).is_err(),
+                "unexpected Diagnostics store access for {label:?}"
+            );
+        }
     }
 }

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -4,15 +4,16 @@ use crate::dictation_telemetry::{DictationErrorCode, DictationTerminalOutcome};
 use crate::model_runtime::{self, PreparationReason};
 use crate::performance_metrics::{
     AcceleratorV1, ContentFreeInputSummaryV1, ModelWarmStateV1, PerformanceRunGuard,
-    PerformanceStageV1, RunCorrelationV1, RunOutcomeV1, RuntimeBackendV1, RuntimeIdentityV1,
-    RuntimeRoleV1, StableRunErrorV1, StageOutcomeV1, StageTimingV1,
+    PerformanceStageV1, PerformanceStoreError, RunCorrelationV1, RunOutcomeV1, RuntimeBackendV1,
+    RuntimeIdentityV1, RuntimeRoleV1, StableRunErrorV1, StageOutcomeV1, StageTimingV1,
 };
 use crate::state::{AppState, DictationStatus};
 use crate::transcriber;
 use crate::{audio, audio_decode, injector, keyboard, vad};
 use crate::{MutexExt, State};
+use std::collections::HashMap;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{Emitter, Manager};
 
 /// Max number of code identifiers fed to Whisper as an initial prompt. Whisper
@@ -762,6 +763,456 @@ fn runtime_identity(model_name: &str, warm_state: ModelWarmStateV1) -> Vec<Runti
     runtime_identity_for_role(model_name, warm_state, RuntimeRoleV1::Transcription)
 }
 
+fn emit_performance_store_begin_failure(recording_id: u64, error: &PerformanceStoreError) {
+    tracing::warn!(
+        target: "system",
+        event_code = "performance.store_operation_failed",
+        operation = error.operation.as_str(),
+        error_class = error.class.as_str(),
+        attempts = u64::from(error.attempts),
+        recording_id,
+        "performance diagnostics store operation failed"
+    );
+}
+
+#[derive(Clone)]
+struct DictationPerformanceCompletion {
+    outcome: RunOutcomeV1,
+    stages: Vec<StageTimingV1>,
+    input: Option<ContentFreeInputSummaryV1>,
+    runtimes: Option<Vec<RuntimeIdentityV1>>,
+}
+
+enum DictationPerformanceBeginState {
+    Beginning {
+        completion: Option<DictationPerformanceCompletion>,
+        latest_stage: Option<PerformanceStageV1>,
+    },
+    Ready,
+    Completing(DictationPerformanceCompletion),
+}
+
+struct DictationPerformanceBeginResolution {
+    completion: Option<DictationPerformanceCompletion>,
+    latest_stage: Option<PerformanceStageV1>,
+}
+
+#[derive(Default)]
+struct DictationPerformanceBeginCoordinator {
+    entries: Mutex<HashMap<u64, DictationPerformanceBeginState>>,
+}
+
+enum DictationPerformanceCompletionAction {
+    Persist(DictationPerformanceCompletion),
+    Deferred,
+    AlreadyCompleting,
+}
+
+impl DictationPerformanceBeginCoordinator {
+    fn register(&self, recording_id: u64) {
+        self.entries.lock_or_recover().insert(
+            recording_id,
+            DictationPerformanceBeginState::Beginning {
+                completion: None,
+                latest_stage: None,
+            },
+        );
+    }
+
+    fn abort(&self, recording_id: u64) {
+        self.entries.lock_or_recover().remove(&recording_id);
+    }
+
+    fn request_completion(
+        &self,
+        recording_id: u64,
+        completion: DictationPerformanceCompletion,
+    ) -> DictationPerformanceCompletionAction {
+        let mut entries = self.entries.lock_or_recover();
+        match entries.get_mut(&recording_id) {
+            Some(DictationPerformanceBeginState::Beginning {
+                completion: pending,
+                ..
+            }) => {
+                if pending.is_none() {
+                    *pending = Some(completion);
+                    DictationPerformanceCompletionAction::Deferred
+                } else {
+                    DictationPerformanceCompletionAction::AlreadyCompleting
+                }
+            }
+            Some(DictationPerformanceBeginState::Ready) => {
+                entries.insert(
+                    recording_id,
+                    DictationPerformanceBeginState::Completing(completion.clone()),
+                );
+                DictationPerformanceCompletionAction::Persist(completion)
+            }
+            Some(DictationPerformanceBeginState::Completing(_)) => {
+                DictationPerformanceCompletionAction::AlreadyCompleting
+            }
+            None => {
+                entries.insert(
+                    recording_id,
+                    DictationPerformanceBeginState::Completing(completion.clone()),
+                );
+                DictationPerformanceCompletionAction::Persist(completion)
+            }
+        }
+    }
+
+    fn resolve_begin(
+        &self,
+        recording_id: u64,
+        succeeded: bool,
+    ) -> Option<DictationPerformanceBeginResolution> {
+        let mut entries = self.entries.lock_or_recover();
+        let (completion, latest_stage) = match entries.get_mut(&recording_id) {
+            Some(DictationPerformanceBeginState::Beginning {
+                completion,
+                latest_stage,
+            }) => (completion.take(), latest_stage.take()),
+            Some(
+                DictationPerformanceBeginState::Ready
+                | DictationPerformanceBeginState::Completing(_),
+            )
+            | None => return None,
+        };
+        if succeeded {
+            if let Some(completion) = &completion {
+                entries.insert(
+                    recording_id,
+                    DictationPerformanceBeginState::Completing(completion.clone()),
+                );
+            } else {
+                entries.insert(recording_id, DictationPerformanceBeginState::Ready);
+            }
+            Some(DictationPerformanceBeginResolution {
+                completion,
+                latest_stage,
+            })
+        } else {
+            entries.remove(&recording_id);
+            None
+        }
+    }
+
+    fn finish_completion(&self, recording_id: u64) {
+        let mut entries = self.entries.lock_or_recover();
+        let should_remove = match entries.get(&recording_id) {
+            Some(DictationPerformanceBeginState::Completing(claimed)) => {
+                // Keep the claimed payload alive until persistence succeeds;
+                // observing it here also makes that ownership explicit.
+                let _ = &claimed.outcome;
+                true
+            }
+            _ => false,
+        };
+        if should_remove {
+            entries.remove(&recording_id);
+        }
+    }
+
+    fn defer_stage(&self, recording_id: u64, stage: PerformanceStageV1) -> bool {
+        let mut entries = self.entries.lock_or_recover();
+        match entries.get_mut(&recording_id) {
+            Some(DictationPerformanceBeginState::Beginning { latest_stage, .. }) => {
+                *latest_stage = Some(stage);
+                true
+            }
+            Some(DictationPerformanceBeginState::Completing(_)) => true,
+            Some(DictationPerformanceBeginState::Ready) => false,
+            None => false,
+        }
+    }
+
+    #[cfg(test)]
+    fn completion_is_claimed(&self, recording_id: u64) -> bool {
+        matches!(
+            self.entries.lock_or_recover().get(&recording_id),
+            Some(DictationPerformanceBeginState::Completing(_))
+        )
+    }
+
+    #[cfg(test)]
+    fn claimed_outcome(&self, recording_id: u64) -> Option<RunOutcomeV1> {
+        match self.entries.lock_or_recover().get(&recording_id) {
+            Some(DictationPerformanceBeginState::Completing(claimed)) => {
+                Some(claimed.outcome.clone())
+            }
+            _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    fn begin_is_pending(&self, recording_id: u64) -> bool {
+        self.entries.lock_or_recover().contains_key(&recording_id)
+    }
+}
+
+struct DictationPerformanceBeginRegistration<'a> {
+    coordinator: &'a DictationPerformanceBeginCoordinator,
+    recording_id: u64,
+    armed: bool,
+}
+
+impl<'a> DictationPerformanceBeginRegistration<'a> {
+    fn new(coordinator: &'a DictationPerformanceBeginCoordinator, recording_id: u64) -> Self {
+        Self {
+            coordinator,
+            recording_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DictationPerformanceBeginRegistration<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.coordinator.abort(self.recording_id);
+        }
+    }
+}
+
+fn dictation_performance_begins() -> &'static DictationPerformanceBeginCoordinator {
+    static COORDINATOR: OnceLock<DictationPerformanceBeginCoordinator> = OnceLock::new();
+    COORDINATOR.get_or_init(DictationPerformanceBeginCoordinator::default)
+}
+
+fn persist_dictation_performance_completion(
+    performance: &crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    completion: DictationPerformanceCompletion,
+) -> Result<(), String> {
+    performance
+        .complete(
+            &RunCorrelationV1::Dictation { recording_id },
+            completion.outcome,
+            completion.stages,
+            completion.input,
+            completion.runtimes,
+        )
+        .map(|_| ())
+}
+
+fn flush_dictation_performance_begin(
+    coordinator: &DictationPerformanceBeginCoordinator,
+    performance: &crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    resolution: DictationPerformanceBeginResolution,
+) {
+    if let Some(stage) = resolution.latest_stage {
+        let _ = performance.set_current_stage(&RunCorrelationV1::Dictation { recording_id }, stage);
+    }
+    if let Some(completion) = resolution.completion {
+        if persist_dictation_performance_completion(performance, recording_id, completion).is_ok() {
+            coordinator.finish_completion(recording_id);
+        }
+    }
+}
+
+fn spawn_dictation_performance_completion(
+    performance: crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    completion: DictationPerformanceCompletion,
+) {
+    drop(tauri::async_runtime::spawn_blocking(move || {
+        if persist_dictation_performance_completion(&performance, recording_id, completion).is_ok()
+        {
+            dictation_performance_begins().finish_completion(recording_id);
+        }
+    }));
+}
+
+fn complete_dictation_performance(
+    performance: &crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    outcome: RunOutcomeV1,
+    stages: Vec<StageTimingV1>,
+    input: Option<ContentFreeInputSummaryV1>,
+    runtimes: Option<Vec<RuntimeIdentityV1>>,
+) {
+    let completion = DictationPerformanceCompletion {
+        outcome,
+        stages,
+        input,
+        runtimes,
+    };
+    match dictation_performance_begins().request_completion(recording_id, completion) {
+        DictationPerformanceCompletionAction::Persist(completion) => {
+            spawn_dictation_performance_completion(performance.clone(), recording_id, completion);
+        }
+        DictationPerformanceCompletionAction::Deferred
+        | DictationPerformanceCompletionAction::AlreadyCompleting => {}
+    }
+}
+
+fn spawn_native_dictation_performance_begin(
+    performance: crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    runtimes: Vec<RuntimeIdentityV1>,
+    started_at_ms: i64,
+) {
+    drop(tauri::async_runtime::spawn_blocking(move || {
+        let coordinator = dictation_performance_begins();
+        let mut registration =
+            DictationPerformanceBeginRegistration::new(coordinator, recording_id);
+        let result =
+            performance.begin_dictation_diagnosed_at(recording_id, runtimes, started_at_ms);
+        let succeeded = result.is_ok();
+        if let Err(error) = &result {
+            emit_performance_store_begin_failure(recording_id, error);
+        }
+        if let Some(resolution) = coordinator.resolve_begin(recording_id, succeeded) {
+            flush_dictation_performance_begin(coordinator, &performance, recording_id, resolution);
+        }
+        registration.disarm();
+    }));
+}
+
+struct NativeDictationPerformanceGuard {
+    performance: crate::performance_metrics::PerformanceMetrics,
+    recording_id: u64,
+    current_stage: PerformanceStageV1,
+    buffered_stages: Vec<StageTimingV1>,
+    finished: bool,
+}
+
+impl NativeDictationPerformanceGuard {
+    fn new(
+        performance: crate::performance_metrics::PerformanceMetrics,
+        recording_id: u64,
+        stage: PerformanceStageV1,
+    ) -> Self {
+        let guard = Self {
+            performance,
+            recording_id,
+            current_stage: stage,
+            buffered_stages: Vec::new(),
+            finished: false,
+        };
+        guard.track_current_stage();
+        guard
+    }
+
+    fn track_current_stage(&self) {
+        // While begin is pending, the coordinator flushes the latest stage as
+        // soon as the row exists. Once begin is Ready, final/Drop completion
+        // carries the authoritative stage data. Native recognition must never
+        // wait on an interim diagnostics write.
+        let _ = dictation_performance_begins().defer_stage(self.recording_id, self.current_stage);
+    }
+
+    fn enter(&mut self, stage: PerformanceStageV1) {
+        self.current_stage = stage;
+        self.track_current_stage();
+    }
+
+    fn record(&mut self, timing: StageTimingV1) {
+        self.current_stage = timing.stage;
+        if let Some(existing) = self
+            .buffered_stages
+            .iter_mut()
+            .find(|stage| stage.stage == timing.stage)
+        {
+            *existing = timing.clone();
+        } else {
+            self.buffered_stages.push(timing.clone());
+        }
+        self.track_current_stage();
+    }
+
+    fn finish(
+        mut self,
+        outcome: RunOutcomeV1,
+        mut stages: Vec<StageTimingV1>,
+        input: Option<ContentFreeInputSummaryV1>,
+        runtimes: Option<Vec<RuntimeIdentityV1>>,
+    ) {
+        for timing in std::mem::take(&mut self.buffered_stages) {
+            if !stages.iter().any(|stage| stage.stage == timing.stage) {
+                stages.push(timing);
+            }
+        }
+        self.finished = true;
+        complete_dictation_performance(
+            &self.performance,
+            self.recording_id,
+            outcome,
+            stages,
+            input,
+            runtimes,
+        );
+    }
+}
+
+impl Drop for NativeDictationPerformanceGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        complete_dictation_performance(
+            &self.performance,
+            self.recording_id,
+            RunOutcomeV1::Failed {
+                stage: self.current_stage,
+                error_code: StableRunErrorV1::InternalEarlyExit,
+            },
+            std::mem::take(&mut self.buffered_stages),
+            None,
+            None,
+        );
+    }
+}
+
+trait DictationPerformanceStageRecorder {
+    fn enter(&mut self, stage: PerformanceStageV1);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeStartContextAction {
+    Activate,
+    FlushLifecycleTerminal { install_context: bool },
+    Superseded,
+}
+
+fn native_start_context_action(
+    is_current_generation: bool,
+    status: DictationStatus,
+) -> NativeStartContextAction {
+    if !is_current_generation {
+        return NativeStartContextAction::Superseded;
+    }
+    match status {
+        DictationStatus::Starting => NativeStartContextAction::Activate,
+        DictationStatus::Recovering => NativeStartContextAction::FlushLifecycleTerminal {
+            install_context: true,
+        },
+        DictationStatus::Idle => NativeStartContextAction::FlushLifecycleTerminal {
+            install_context: false,
+        },
+        DictationStatus::Recording | DictationStatus::Processing => {
+            NativeStartContextAction::Superseded
+        }
+    }
+}
+
+impl DictationPerformanceStageRecorder for PerformanceRunGuard {
+    fn enter(&mut self, stage: PerformanceStageV1) {
+        PerformanceRunGuard::enter(self, stage);
+    }
+}
+
+impl DictationPerformanceStageRecorder for NativeDictationPerformanceGuard {
+    fn enter(&mut self, stage: PerformanceStageV1) {
+        NativeDictationPerformanceGuard::enter(self, stage);
+    }
+}
+
 pub(crate) fn runtime_identity_for_role(
     model_name: &str,
     warm_state: ModelWarmStateV1,
@@ -929,7 +1380,7 @@ async fn run_transcription_pipeline(
     app_handle: &tauri::AppHandle,
     app_state: &AppState,
     recording_id: u64,
-    performance_guard: &mut PerformanceRunGuard,
+    performance_guard: &mut impl DictationPerformanceStageRecorder,
     context: Arc<DictationContextSnapshot>,
 ) -> Result<PipelineResult, String> {
     // Guard resets status to Idle on any return path (error or success),
@@ -1427,16 +1878,11 @@ pub async fn process_audio(
     let _ = app_handle.emit("recording-status-changed", "processing");
     let app_identity = crate::frontmost::frontmost_app_identity();
     let context = resolve_live_context(&state.app_state, &state.knowledge, &app_identity);
-    if let Err(error) = state.performance.begin_dictation(
+    if let Err(error) = state.performance.begin_dictation_diagnosed(
         rid,
         runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown),
     ) {
-        tracing::warn!(
-            target: "system",
-            recording_id = rid,
-            "performance run start failed: {}",
-            error
-        );
+        emit_performance_store_begin_failure(rid, &error);
     }
     let mut performance_guard = state.performance.guard(
         RunCorrelationV1::Dictation { recording_id: rid },
@@ -2677,8 +3123,9 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 reason,
                 AudioCancelReason::HardDeadline | AudioCancelReason::RuntimeFailure
             ) {
-                let _ = state.performance.complete(
-                    &RunCorrelationV1::Dictation { recording_id },
+                complete_dictation_performance(
+                    &state.performance,
+                    recording_id,
                     RunOutcomeV1::Cancelled {
                         stage: PerformanceStageV1::CaptureFinalization,
                     },
@@ -2748,8 +3195,9 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 DictationErrorCode::from_audio_failure(kind),
             );
             state.app_state.clear_active_context(recording_id);
-            let _ = state.performance.complete(
-                &RunCorrelationV1::Dictation { recording_id },
+            complete_dictation_performance(
+                &state.performance,
+                recording_id,
                 RunOutcomeV1::Failed {
                     stage: PerformanceStageV1::CaptureFinalization,
                     error_code: StableRunErrorV1::AudioCaptureFailed,
@@ -2787,8 +3235,9 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                     DictationTerminalOutcome::Superseded,
                     DictationErrorCode::StaleOwner,
                 );
-                let _ = state.performance.complete(
-                    &RunCorrelationV1::Dictation { recording_id },
+                complete_dictation_performance(
+                    &state.performance,
+                    recording_id,
                     RunOutcomeV1::Failed {
                         stage: PerformanceStageV1::CaptureFinalization,
                         error_code: StableRunErrorV1::AudioCaptureFailed,
@@ -2820,8 +3269,9 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                     DictationErrorCode::RuntimeFailure,
                 );
                 state.app_state.clear_active_context(recording_id);
-                let _ = state.performance.complete(
-                    &RunCorrelationV1::Dictation { recording_id },
+                complete_dictation_performance(
+                    &state.performance,
+                    recording_id,
                     RunOutcomeV1::Failed {
                         stage: PerformanceStageV1::CaptureFinalization,
                         error_code: StableRunErrorV1::AudioCaptureFailed,
@@ -2857,6 +3307,17 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 recording_id,
                 DictationTerminalOutcome::PipelineFailure,
                 DictationErrorCode::RuntimeFailure,
+            );
+            complete_dictation_performance(
+                &state.performance,
+                recording_id,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::CaptureFinalization,
+                    error_code: StableRunErrorV1::AudioCaptureFailed,
+                },
+                Vec::new(),
+                None,
+                None,
             );
             dictation.status = DictationStatus::Idle;
             state.app_state.clear_active_context(recording_id);
@@ -3052,6 +3513,7 @@ pub async fn start_native_recording(
             }
         }
     };
+    let performance_started_at_ms = chrono::Utc::now().timestamp_millis();
     let origin = match origin.as_deref() {
         Some("hold") => "hold",
         _ => "toggle",
@@ -3072,9 +3534,14 @@ pub async fn start_native_recording(
         serde_json::json!({ "recordingId": rid }),
     );
     let _ = app_handle.emit("recording-status-changed", "starting");
+    // Reserve the generation before the worker is allowed to emit lifecycle
+    // events. Terminal persistence can now wait for the asynchronous begin
+    // without holding capture ownership or the recording transition.
+    dictation_performance_begins().register(rid);
     if let Err(error) =
         audio_lifecycle::start_dictation_recording(app_handle.clone(), device_name, rid, origin)
     {
+        dictation_performance_begins().abort(rid);
         tracing::error!(target: "audio", "start_native_recording: audio failed: {}", error);
         state.app_state.clear_active_context(rid);
         let mut dictation = state.app_state.dictation.lock_or_recover();
@@ -3082,16 +3549,6 @@ pub async fn start_native_recording(
             dictation.status = DictationStatus::Idle;
         }
         let _ = app_handle.emit("recording-status-changed", "idle");
-        let _ = state.performance.complete(
-            &RunCorrelationV1::Dictation { recording_id: rid },
-            RunOutcomeV1::Failed {
-                stage: PerformanceStageV1::CaptureFinalization,
-                error_code: StableRunErrorV1::AudioCaptureFailed,
-            },
-            Vec::new(),
-            None,
-            None,
-        );
         return match error {
             AudioStartError::AlreadyStarting => Ok(serde_json::json!({
                 "type": "already_starting",
@@ -3116,11 +3573,54 @@ pub async fn start_native_recording(
         app_identity.bundle_id.as_deref(),
     );
     let context = resolve_live_context(&state.app_state, &state.knowledge, &app_identity);
-    {
+    let context_action = {
         let dictation = state.app_state.dictation.lock_or_recover();
-        if state.app_state.recording_id.load(Ordering::SeqCst) != rid
-            || dictation.status != DictationStatus::Starting
-        {
+        let action = native_start_context_action(
+            state.app_state.recording_id.load(Ordering::SeqCst) == rid,
+            dictation.status,
+        );
+        if matches!(
+            action,
+            NativeStartContextAction::Activate
+                | NativeStartContextAction::FlushLifecycleTerminal {
+                    install_context: true
+                }
+        ) {
+            state
+                .app_state
+                .set_active_context(rid, Arc::clone(&context));
+        }
+        (action, dictation.status)
+    };
+    match context_action {
+        (NativeStartContextAction::Activate, _) => {}
+        (NativeStartContextAction::FlushLifecycleTerminal { .. }, status) => {
+            let runtimes =
+                runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown);
+            tracing::info!(
+                target: "pipeline",
+                recording_id = rid,
+                ?status,
+                "flushing reserved diagnostics after audio lifecycle terminal"
+            );
+            drop(_transition);
+            spawn_native_dictation_performance_begin(
+                state.performance.clone(),
+                rid,
+                runtimes,
+                performance_started_at_ms,
+            );
+            return Ok(serde_json::json!({
+                "type": "audio_recovering",
+                "state": match status {
+                    DictationStatus::Idle => "idle",
+                    DictationStatus::Recovering => "recovering",
+                    _ => unreachable!("lifecycle flush only follows idle or recovering"),
+                }
+            }));
+        }
+        (NativeStartContextAction::Superseded, status) => {
+            dictation_performance_begins().abort(rid);
             state.app_state.dictation_telemetry.emit_terminal(
                 rid,
                 DictationTerminalOutcome::Superseded,
@@ -3129,12 +3629,12 @@ pub async fn start_native_recording(
             tracing::warn!(
                 target: "pipeline",
                 recording_id = rid,
-                status = ?dictation.status,
+                ?status,
                 "dictation context discarded after audio initialization ended"
             );
             return Ok(serde_json::json!({
                 "type": "audio_recovering",
-                "state": match dictation.status {
+                "state": match status {
                     DictationStatus::Idle => "idle",
                     DictationStatus::Starting => "starting",
                     DictationStatus::Recording => "recording",
@@ -3143,20 +3643,6 @@ pub async fn start_native_recording(
                 }
             }));
         }
-        if let Err(error) = state.performance.begin_dictation(
-            rid,
-            runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown),
-        ) {
-            tracing::warn!(
-                target: "system",
-                recording_id = rid,
-                "performance run start failed: {}",
-                error
-            );
-        }
-        state
-            .app_state
-            .set_active_context(rid, Arc::clone(&context));
     }
     tracing::info!(
         target: "pipeline",
@@ -3177,6 +3663,16 @@ pub async fn start_native_recording(
         app_handle.clone(),
         context.transcription.model_name.clone(),
         rid,
+    );
+    let runtimes = runtime_identity(&context.transcription.model_name, ModelWarmStateV1::Unknown);
+    // Ownership is fully installed before diagnostics begin. Release the
+    // transition first so Recording, stop, and cancel never wait for SQLite.
+    drop(_transition);
+    spawn_native_dictation_performance_begin(
+        state.performance.clone(),
+        rid,
+        runtimes,
+        performance_started_at_ms,
     );
 
     Ok(serde_json::json!({
@@ -3268,10 +3764,6 @@ async fn stop_native_recording_for(
             "state": "recovering"
         }));
     }
-    let mut performance_guard = state.performance.guard(
-        RunCorrelationV1::Dictation { recording_id: rid },
-        PerformanceStageV1::CaptureFinalization,
-    );
     let context = match state.app_state.active_context(rid) {
         Some(context) => context,
         None => {
@@ -3286,6 +3778,18 @@ async fn stop_native_recording_for(
             }
             keyboard::set_processing(false);
             let _ = app_handle.emit("recording-status-changed", "idle");
+            drop(transition);
+            complete_dictation_performance(
+                &state.performance,
+                rid,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::CaptureFinalization,
+                    error_code: StableRunErrorV1::InternalEarlyExit,
+                },
+                Vec::new(),
+                None,
+                None,
+            );
             return Err(format!("Missing dictation context for recording {rid}"));
         }
     };
@@ -3325,9 +3829,25 @@ async fn stop_native_recording_for(
             if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
                 let _ = app_handle.emit("recording-status-changed", "idle");
             }
+            complete_dictation_performance(
+                &state.performance,
+                rid,
+                RunOutcomeV1::Failed {
+                    stage: PerformanceStageV1::CaptureFinalization,
+                    error_code: StableRunErrorV1::AudioCaptureFailed,
+                },
+                Vec::new(),
+                None,
+                None,
+            );
             e
         })?
     };
+    let mut performance_guard = NativeDictationPerformanceGuard::new(
+        state.performance.clone(),
+        rid,
+        PerformanceStageV1::CaptureFinalization,
+    );
     tracing::info!(
         target: "pipeline",
         event_code = "pipeline.dictation_stop_handoff",
@@ -3355,7 +3875,7 @@ async fn stop_native_recording_for(
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
-        let _ = performance_guard.finish(
+        performance_guard.finish(
             RunOutcomeV1::NoSpeech,
             vec![StageTimingV1::measured(
                 PerformanceStageV1::TotalProcessing,
@@ -3388,7 +3908,7 @@ async fn stop_native_recording_for(
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
             let _ = app_handle.emit("recording-status-changed", "idle");
         }
-        let _ = performance_guard.finish(
+        performance_guard.finish(
             RunOutcomeV1::NoSpeech,
             vec![StageTimingV1::measured(
                 PerformanceStageV1::TotalProcessing,
@@ -3509,7 +4029,7 @@ async fn stop_native_recording_for(
         PipelineTerminal::Cancelled(stage) => RunOutcomeV1::Cancelled { stage },
     };
     let warm_state = timings.warm_state.unwrap_or(ModelWarmStateV1::Unknown);
-    let _ = performance_guard.finish(
+    performance_guard.finish(
         outcome,
         pipeline_stages(&timings, total_ms),
         Some(ContentFreeInputSummaryV1::audio_with_output(
@@ -3615,8 +4135,14 @@ pub async fn cancel_native_recording(
         serde_json::json!({ "recordingId": rid }),
     );
 
-    let _ = state.performance.complete(
-        &RunCorrelationV1::Dictation { recording_id: rid },
+    // Keep the transition fence through the old generation's unscoped UI
+    // events so a newer start cannot publish `starting` and then be reset by
+    // this cancellation's trailing `idle`. Diagnostics completion is already
+    // asynchronous, so releasing immediately before it never waits on SQLite.
+    drop(transition);
+    complete_dictation_performance(
+        &state.performance,
+        rid,
         RunOutcomeV1::Cancelled {
             stage: PerformanceStageV1::InferenceDecode,
         },
@@ -4014,6 +4540,280 @@ mod tests {
     use std::path::PathBuf;
     use tauri::Listener;
 
+    fn failed_capture_completion() -> DictationPerformanceCompletion {
+        DictationPerformanceCompletion {
+            outcome: RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::CaptureFinalization,
+                error_code: StableRunErrorV1::AudioCaptureFailed,
+            },
+            stages: Vec::new(),
+            input: None,
+            runtimes: None,
+        }
+    }
+
+    fn wait_for_completed_runs(
+        performance: &crate::performance_metrics::PerformanceMetrics,
+        expected: usize,
+    ) -> Vec<crate::performance_metrics::PerformanceRunV1> {
+        for _ in 0..100 {
+            let runs = performance.list(10).expect("list completed runs").runs;
+            if runs.len() == expected {
+                return runs;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        panic!("timed out waiting for {expected} completed diagnostics runs");
+    }
+
+    #[test]
+    fn terminal_before_diagnostics_begin_is_deferred_and_keeps_first_outcome() {
+        let coordinator = DictationPerformanceBeginCoordinator::default();
+        let recording_id = 536_001;
+        coordinator.register(recording_id);
+
+        assert!(matches!(
+            coordinator.request_completion(recording_id, failed_capture_completion()),
+            DictationPerformanceCompletionAction::Deferred
+        ));
+        assert!(matches!(
+            coordinator.request_completion(
+                recording_id,
+                DictationPerformanceCompletion {
+                    outcome: RunOutcomeV1::Cancelled {
+                        stage: PerformanceStageV1::CaptureFinalization,
+                    },
+                    stages: Vec::new(),
+                    input: None,
+                    runtimes: None,
+                },
+            ),
+            DictationPerformanceCompletionAction::AlreadyCompleting
+        ));
+
+        let resolution = coordinator
+            .resolve_begin(recording_id, true)
+            .expect("the first terminal waits for begin");
+        let pending = resolution.completion.expect("queued terminal outcome");
+        assert!(matches!(
+            pending.outcome,
+            RunOutcomeV1::Failed {
+                error_code: StableRunErrorV1::AudioCaptureFailed,
+                ..
+            }
+        ));
+        assert!(coordinator.begin_is_pending(recording_id));
+        coordinator.finish_completion(recording_id);
+        assert!(!coordinator.begin_is_pending(recording_id));
+    }
+
+    #[test]
+    fn failed_capture_queued_before_begin_persists_once_after_begin() {
+        assert_eq!(
+            native_start_context_action(true, DictationStatus::Idle),
+            NativeStartContextAction::FlushLifecycleTerminal {
+                install_context: false,
+            },
+            "current-generation Idle must flush, not abort, its reserved begin"
+        );
+        assert_eq!(
+            native_start_context_action(true, DictationStatus::Recovering),
+            NativeStartContextAction::FlushLifecycleTerminal {
+                install_context: true,
+            },
+            "Recovering keeps context for an interrupted transcription"
+        );
+        let root = tempfile::tempdir().expect("temporary diagnostics root");
+        let performance = crate::performance_metrics::PerformanceMetrics::default();
+        performance
+            .initialize(root.path().to_path_buf(), None)
+            .expect("initialize performance diagnostics");
+        let recording_id = 536_002;
+        let coordinator = DictationPerformanceBeginCoordinator::default();
+        coordinator.register(recording_id);
+        assert!(matches!(
+            coordinator.request_completion(recording_id, failed_capture_completion()),
+            DictationPerformanceCompletionAction::Deferred
+        ));
+
+        performance
+            .begin_dictation(recording_id, Vec::new())
+            .expect("begin delayed diagnostics row");
+        let resolution = coordinator
+            .resolve_begin(recording_id, true)
+            .expect("queued terminal outcome");
+        let pending = resolution.completion.expect("queued terminal completion");
+        persist_dictation_performance_completion(&performance, recording_id, pending)
+            .expect("persist queued terminal");
+        coordinator.finish_completion(recording_id);
+
+        let runs = wait_for_completed_runs(&performance, 1);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(
+            runs[0].outcome,
+            RunOutcomeV1::Failed {
+                stage: PerformanceStageV1::CaptureFinalization,
+                error_code: StableRunErrorV1::AudioCaptureFailed,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_after_diagnostics_begin_can_persist_immediately() {
+        let coordinator = DictationPerformanceBeginCoordinator::default();
+        let recording_id = 536_003;
+        coordinator.register(recording_id);
+        assert!(coordinator.resolve_begin(recording_id, true).is_some());
+        assert!(coordinator.begin_is_pending(recording_id));
+        let claimed =
+            match coordinator.request_completion(recording_id, failed_capture_completion()) {
+                DictationPerformanceCompletionAction::Persist(completion) => completion,
+                _ => panic!("Ready must claim the first terminal for persistence"),
+            };
+        assert!(coordinator.completion_is_claimed(recording_id));
+        let unavailable = crate::performance_metrics::PerformanceMetrics::default();
+        assert!(
+            persist_dictation_performance_completion(&unavailable, recording_id, claimed).is_err(),
+            "the failure seam must exercise a real rejected persistence attempt"
+        );
+        assert!(matches!(
+            coordinator.request_completion(
+                recording_id,
+                DictationPerformanceCompletion {
+                    outcome: RunOutcomeV1::Cancelled {
+                        stage: PerformanceStageV1::CaptureFinalization,
+                    },
+                    stages: Vec::new(),
+                    input: None,
+                    runtimes: None,
+                }
+            ),
+            DictationPerformanceCompletionAction::AlreadyCompleting
+        ));
+        // A failed persistence attempt deliberately leaves the exact first
+        // completion claimed; only a successful persist removes the entry.
+        assert!(coordinator.completion_is_claimed(recording_id));
+        assert!(matches!(
+            coordinator.claimed_outcome(recording_id),
+            Some(RunOutcomeV1::Failed {
+                error_code: StableRunErrorV1::AudioCaptureFailed,
+                ..
+            })
+        ));
+        coordinator.finish_completion(recording_id);
+        assert!(!coordinator.begin_is_pending(recording_id));
+    }
+
+    #[test]
+    fn deferred_native_guard_retains_capture_finalization_timing() {
+        let root = tempfile::tempdir().expect("temporary diagnostics root");
+        let performance = crate::performance_metrics::PerformanceMetrics::default();
+        performance
+            .initialize(root.path().to_path_buf(), None)
+            .expect("initialize performance diagnostics");
+        let recording_id = 536_004;
+        let coordinator = dictation_performance_begins();
+        coordinator.register(recording_id);
+
+        let mut guard = NativeDictationPerformanceGuard::new(
+            performance.clone(),
+            recording_id,
+            PerformanceStageV1::CaptureFinalization,
+        );
+        guard.record(StageTimingV1::measured(
+            PerformanceStageV1::CaptureFinalization,
+            37,
+        ));
+        guard.finish(
+            RunOutcomeV1::NoSpeech,
+            vec![StageTimingV1::measured(
+                PerformanceStageV1::TotalProcessing,
+                41,
+            )],
+            Some(ContentFreeInputSummaryV1::audio(100)),
+            None,
+        );
+
+        performance
+            .begin_dictation(recording_id, Vec::new())
+            .expect("begin delayed diagnostics row");
+        let resolution = coordinator
+            .resolve_begin(recording_id, true)
+            .expect("native terminal waits for begin");
+        flush_dictation_performance_begin(coordinator, &performance, recording_id, resolution);
+
+        let runs = performance.list(10).expect("list completed runs").runs;
+        let capture = runs[0]
+            .stages
+            .iter()
+            .find(|stage| stage.stage == PerformanceStageV1::CaptureFinalization)
+            .expect("capture finalization stage");
+        assert_eq!(
+            capture.duration_ms,
+            crate::performance_metrics::MeasurementV1::measured(37)
+        );
+    }
+
+    #[test]
+    fn begin_registration_cleans_up_if_worker_unwinds() {
+        let coordinator = DictationPerformanceBeginCoordinator::default();
+        let recording_id = 536_005;
+        coordinator.register(recording_id);
+
+        let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _registration =
+                DictationPerformanceBeginRegistration::new(&coordinator, recording_id);
+            panic!("forced begin worker unwind");
+        }));
+
+        assert!(unwind.is_err());
+        assert!(!coordinator.begin_is_pending(recording_id));
+        assert!(matches!(
+            coordinator.request_completion(recording_id, failed_capture_completion()),
+            DictationPerformanceCompletionAction::Persist(_)
+        ));
+    }
+
+    #[test]
+    fn delayed_begin_flushes_latest_stage_and_preserves_request_timestamp() {
+        let root = tempfile::tempdir().expect("temporary diagnostics root");
+        let performance = crate::performance_metrics::PerformanceMetrics::default();
+        performance
+            .initialize(root.path().to_path_buf(), None)
+            .expect("initialize performance diagnostics");
+        let coordinator = DictationPerformanceBeginCoordinator::default();
+        let recording_id = 536_006;
+        let requested_at_ms = 1_725_000_000_123_i64;
+        coordinator.register(recording_id);
+        assert!(coordinator.defer_stage(recording_id, PerformanceStageV1::Vad));
+
+        let active = performance
+            .begin_dictation_diagnosed_at(recording_id, Vec::new(), requested_at_ms)
+            .expect("begin delayed diagnostics row");
+        assert_eq!(active.started_at_ms, requested_at_ms);
+        let resolution = coordinator
+            .resolve_begin(recording_id, true)
+            .expect("successful delayed begin");
+        assert_eq!(resolution.latest_stage, Some(PerformanceStageV1::Vad));
+        flush_dictation_performance_begin(&coordinator, &performance, recording_id, resolution);
+        drop(performance);
+
+        let restarted = crate::performance_metrics::PerformanceMetrics::default();
+        restarted
+            .initialize(root.path().to_path_buf(), None)
+            .expect("recover interrupted diagnostics row");
+        let runs = restarted.list(10).expect("list recovered run").runs;
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].started_at_ms, requested_at_ms);
+        assert!(matches!(
+            runs[0].outcome,
+            RunOutcomeV1::Interrupted {
+                stage: PerformanceStageV1::Vad,
+                ..
+            }
+        ));
+    }
+
     #[test]
     fn model_preparation_starts_at_accepted_start_and_stops_during_recovery() {
         assert!(status_allows_model_preparation(DictationStatus::Starting));
@@ -4138,7 +4938,7 @@ mod tests {
             vec!["audio-recovery-started", "recording-initialization-failed"],
             "the production bridge must preserve recovery-before-failure order"
         );
-        let runs = performance.list(10).expect("list completed runs").runs;
+        let runs = wait_for_completed_runs(&performance, 1);
         assert_eq!(
             runs.len(),
             1,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -366,6 +366,8 @@ pub fn run() {
             commands::performance::list_performance_runs,
             commands::performance::get_performance_run,
             commands::performance::get_performance_resource_window,
+            commands::performance::get_performance_store_health,
+            commands::performance::recover_performance_store,
             commands::performance::clear_performance_diagnostics,
             commands::performance::show_diagnostics_window,
             commands::transform_diagnostics::arm_next_transform_diagnostic_capture,

--- a/app/src-tauri/src/performance_metrics/mod.rs
+++ b/app/src-tauri/src/performance_metrics/mod.rs
@@ -3,21 +3,33 @@ mod types;
 
 pub use types::*;
 
-use repository::PerformanceRepository;
+pub(crate) use repository::PerformanceStoreError;
+use repository::{InitializationOutcome, PerformanceRepository};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tauri::Emitter;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct PerformanceMetrics {
     inner: Arc<Mutex<PerformanceMetricsInner>>,
+    operation_lock: Arc<Mutex<()>>,
+}
+
+impl Default for PerformanceMetrics {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PerformanceMetricsInner::default())),
+            operation_lock: Arc::new(Mutex::new(())),
+        }
+    }
 }
 
 #[derive(Default)]
 struct PerformanceMetricsInner {
     repository: Option<PerformanceRepository>,
+    root: Option<PathBuf>,
     app_handle: Option<tauri::AppHandle>,
-    initialization_error: Option<String>,
+    health: PerformanceStoreHealthV1,
 }
 
 impl PerformanceMetrics {
@@ -26,37 +38,125 @@ impl PerformanceMetrics {
         root: PathBuf,
         app_handle: Option<tauri::AppHandle>,
     ) -> Result<(), String> {
-        let result = PerformanceRepository::initialize(root);
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = PerformanceRepository::initialize(root.clone());
         let mut inner = self
             .inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         inner.app_handle = app_handle;
+        inner.root = Some(root);
         match result {
-            Ok(repository) => {
+            Ok((repository, outcome)) => {
                 inner.repository = Some(repository);
-                inner.initialization_error = None;
+                inner.health.status = PerformanceStoreStatusV1::Available;
+                inner.health.recommended_action = PerformanceStoreRecommendedActionV1::None;
+                if let InitializationOutcome::Reinitialized { at_ms } = outcome {
+                    inner.health.last_recovery = Some(PerformanceStoreRecoveryV1 {
+                        action: PerformanceStoreRecoveryActionV1::QuarantinedAndReinitialized,
+                        at_ms,
+                    });
+                }
                 Ok(())
             }
             Err(error) => {
                 inner.repository = None;
-                inner.initialization_error = Some(error.clone());
-                Err(error)
+                apply_failure(&mut inner, &error, None, false);
+                Err(error.to_string())
             }
         }
     }
 
-    fn repository(&self) -> Result<PerformanceRepository, String> {
+    fn repository(
+        &self,
+        operation: PerformanceStoreOperationV1,
+    ) -> Result<PerformanceRepository, PerformanceStoreError> {
         let inner = self
             .inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        inner.repository.clone().ok_or_else(|| {
-            inner
-                .initialization_error
-                .clone()
-                .unwrap_or_else(|| "The local diagnostics store is unavailable.".to_string())
-        })
+        inner
+            .repository
+            .clone()
+            .ok_or_else(|| PerformanceStoreError {
+                operation,
+                class: inner
+                    .health
+                    .last_failure
+                    .as_ref()
+                    .map(|failure| failure.error_class)
+                    .unwrap_or(PerformanceStoreErrorClassV1::Unavailable),
+                attempts: 1,
+            })
+    }
+
+    pub(crate) fn health(&self) -> PerformanceStoreHealthV1 {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .health
+            .clone()
+    }
+
+    pub(crate) fn recover(
+        &self,
+        allow_reinitialize: bool,
+    ) -> Result<PerformanceStoreHealthV1, String> {
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let root = {
+            let inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if inner.health.status == PerformanceStoreStatusV1::Available
+                && inner.repository.is_some()
+            {
+                return Ok(inner.health.clone());
+            }
+            inner.root.clone().ok_or_else(|| {
+                "The local diagnostics store has not been initialized.".to_string()
+            })?
+        };
+        let result = if allow_reinitialize {
+            PerformanceRepository::reinitialize(root)
+        } else {
+            PerformanceRepository::reopen(root)
+        };
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match result {
+            Ok((repository, outcome)) => {
+                inner.repository = Some(repository);
+                inner.health.status = PerformanceStoreStatusV1::Available;
+                inner.health.recommended_action = PerformanceStoreRecommendedActionV1::None;
+                if let InitializationOutcome::Reinitialized { at_ms } = outcome {
+                    inner.health.last_recovery = Some(PerformanceStoreRecoveryV1 {
+                        action: PerformanceStoreRecoveryActionV1::QuarantinedAndReinitialized,
+                        at_ms,
+                    });
+                }
+                Ok(inner.health.clone())
+            }
+            Err(error) => {
+                apply_failure(&mut inner, &error, None, false);
+                if allow_reinitialize {
+                    Err(error.to_string())
+                } else {
+                    // A failed safe probe is itself a valid health result. The
+                    // caller can now present the freshly classified recovery
+                    // action and require a separate confirmed reinitialize.
+                    Ok(inner.health.clone())
+                }
+            }
+        }
     }
 
     pub(crate) fn begin(
@@ -66,19 +166,89 @@ impl PerformanceMetrics {
         runtimes: Vec<RuntimeIdentityV1>,
         input: ContentFreeInputSummaryV1,
     ) -> Result<ActiveRunV1, String> {
-        self.repository()?.begin(kind, correlation, runtimes, input)
+        let started_at_ms = chrono::Utc::now().timestamp_millis();
+        self.begin_diagnosed(kind, correlation, runtimes, input, None, started_at_ms)
+            .map_err(|error| error.to_string())
     }
 
+    fn begin_diagnosed(
+        &self,
+        kind: PerformanceRunKindV1,
+        correlation: RunCorrelationV1,
+        runtimes: Vec<RuntimeIdentityV1>,
+        input: ContentFreeInputSummaryV1,
+        recording_id: Option<u64>,
+        started_at_ms: i64,
+    ) -> Result<ActiveRunV1, PerformanceStoreError> {
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Begin)
+            .and_then(|repository| {
+                repository.begin_at(kind, correlation, runtimes, input, started_at_ms)
+            });
+        if let Err(error) = &result {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            // The health banner's skipped-run counter is specifically the
+            // dictation reliability signal requested by #536. Other run kinds
+            // still update last_failure, but must not make the UI claim that a
+            // dictation continued after their diagnostics row was skipped.
+            apply_failure(&mut inner, error, recording_id, recording_id.is_some());
+        }
+        result
+    }
+
+    fn observe<T>(&self, result: Result<T, PerformanceStoreError>) -> Result<T, String> {
+        result.map_err(|error| {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            apply_failure(&mut inner, &error, None, false);
+            error.to_string()
+        })
+    }
+
+    #[cfg(test)]
     pub(crate) fn begin_dictation(
         &self,
         recording_id: u64,
         runtimes: Vec<RuntimeIdentityV1>,
     ) -> Result<ActiveRunV1, String> {
-        self.begin(
+        self.begin_dictation_diagnosed(recording_id, runtimes)
+            .map_err(|error| error.to_string())
+    }
+
+    pub(crate) fn begin_dictation_diagnosed(
+        &self,
+        recording_id: u64,
+        runtimes: Vec<RuntimeIdentityV1>,
+    ) -> Result<ActiveRunV1, PerformanceStoreError> {
+        self.begin_dictation_diagnosed_at(
+            recording_id,
+            runtimes,
+            chrono::Utc::now().timestamp_millis(),
+        )
+    }
+
+    pub(crate) fn begin_dictation_diagnosed_at(
+        &self,
+        recording_id: u64,
+        runtimes: Vec<RuntimeIdentityV1>,
+        started_at_ms: i64,
+    ) -> Result<ActiveRunV1, PerformanceStoreError> {
+        self.begin_diagnosed(
             PerformanceRunKindV1::Dictation,
             RunCorrelationV1::Dictation { recording_id },
             runtimes,
             ContentFreeInputSummaryV1::default(),
+            Some(recording_id),
+            started_at_ms,
         )
     }
 
@@ -130,9 +300,16 @@ impl PerformanceMetrics {
     pub(crate) fn update_active(
         &self,
         correlation: &RunCorrelationV1,
-        update: impl FnOnce(&mut ActiveRunV1),
+        update: impl FnOnce(&mut ActiveRunV1) + Clone,
     ) -> Result<bool, String> {
-        self.repository()?.update_active(correlation, update)
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Update)
+            .and_then(|repository| repository.update_active(correlation, update));
+        self.observe(result)
     }
 
     pub(crate) fn record_stage(
@@ -170,9 +347,18 @@ impl PerformanceMetrics {
         input: Option<ContentFreeInputSummaryV1>,
         runtimes: Option<Vec<RuntimeIdentityV1>>,
     ) -> Result<Option<PerformanceRunV1>, String> {
-        let run = self
-            .repository()?
-            .complete(correlation, outcome, stages, input, runtimes)?;
+        let run = {
+            let _operation_guard = self
+                .operation_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let result = self
+                .repository(PerformanceStoreOperationV1::Complete)
+                .and_then(|repository| {
+                    repository.complete(correlation, outcome, stages, input, runtimes)
+                });
+            self.observe(result)?
+        };
         if let Some(run) = &run {
             let app_handle = self
                 .inner
@@ -202,7 +388,16 @@ impl PerformanceMetrics {
     }
 
     pub(crate) fn insert_resource_sample(&self, sample: &ResourceSampleV1) -> Result<(), String> {
-        self.repository()?.insert_resource_sample(sample)?;
+        {
+            let _operation_guard = self
+                .operation_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let result = self
+                .repository(PerformanceStoreOperationV1::Write)
+                .and_then(|repository| repository.insert_resource_sample(sample));
+            self.observe(result)?;
+        }
         let app_handle = self
             .inner
             .lock()
@@ -220,29 +415,71 @@ impl PerformanceMetrics {
         transform_pass_id: u64,
         follow_up: TransformFollowUpV1,
     ) -> Result<Option<PerformanceRunV1>, String> {
-        self.repository()?.append_transform_follow_up(
-            &RunCorrelationV1::SelectedTextTransform { transform_pass_id },
-            follow_up,
-        )
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Write)
+            .and_then(|repository| {
+                repository.append_transform_follow_up(
+                    &RunCorrelationV1::SelectedTextTransform { transform_pass_id },
+                    follow_up,
+                )
+            });
+        self.observe(result)
     }
 
     pub(crate) fn list(&self, limit: u32) -> Result<PerformanceRunListV1, String> {
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Read)
+            .and_then(|repository| repository.list(limit));
         Ok(PerformanceRunListV1 {
             schema_version: PERFORMANCE_RUN_SCHEMA_VERSION,
-            runs: self.repository()?.list(limit)?,
+            runs: self.observe(result)?,
         })
     }
 
     pub(crate) fn get(&self, run_id: &str) -> Result<Option<PerformanceRunV1>, String> {
-        self.repository()?.get(run_id)
+        if run_id.len() != 32 || !run_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err("The performance run ID is invalid.".to_string());
+        }
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Read)
+            .and_then(|repository| repository.get(run_id));
+        self.observe(result)
     }
 
     pub(crate) fn resource_window(&self) -> Result<Vec<ResourceSampleV1>, String> {
-        self.repository()?.resource_window()
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Read)
+            .and_then(|repository| repository.resource_window());
+        self.observe(result)
     }
 
     pub(crate) fn clear(&self) -> Result<(), String> {
-        self.repository()?.clear()?;
+        {
+            let _operation_guard = self
+                .operation_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let result = self
+                .repository(PerformanceStoreOperationV1::Clear)
+                .and_then(|repository| repository.clear());
+            self.observe(result)?;
+        }
         let app_handle = self
             .inner
             .lock()
@@ -257,7 +494,60 @@ impl PerformanceMetrics {
 
     #[cfg(test)]
     pub(crate) fn counts(&self) -> Result<(u64, u64, u64), String> {
-        self.repository()?.counts()
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let result = self
+            .repository(PerformanceStoreOperationV1::Read)
+            .and_then(|repository| repository.counts());
+        self.observe(result)
+    }
+}
+
+fn recommended_action(class: PerformanceStoreErrorClassV1) -> PerformanceStoreRecommendedActionV1 {
+    match class {
+        PerformanceStoreErrorClassV1::BusyLocked
+        | PerformanceStoreErrorClassV1::Io
+        | PerformanceStoreErrorClassV1::Unavailable => PerformanceStoreRecommendedActionV1::Retry,
+        PerformanceStoreErrorClassV1::StorageFull => PerformanceStoreRecommendedActionV1::FreeDisk,
+        PerformanceStoreErrorClassV1::ReadOnly => {
+            PerformanceStoreRecommendedActionV1::CheckPermissions
+        }
+        PerformanceStoreErrorClassV1::CorruptIntegrity
+        | PerformanceStoreErrorClassV1::InvalidRecord => {
+            PerformanceStoreRecommendedActionV1::ReinitializeStore
+        }
+        PerformanceStoreErrorClassV1::SchemaMigration => {
+            PerformanceStoreRecommendedActionV1::RestartApp
+        }
+    }
+}
+
+fn apply_failure(
+    inner: &mut PerformanceMetricsInner,
+    error: &PerformanceStoreError,
+    recording_id: Option<u64>,
+    skipped_run: bool,
+) {
+    if skipped_run {
+        inner.health.skipped_run_count = inner.health.skipped_run_count.saturating_add(1);
+    }
+    let retry_exhausted = error.retry_exhausted();
+    inner.health.last_failure = Some(PerformanceStoreFailureV1 {
+        operation: error.operation,
+        error_class: error.class,
+        attempt_count: error.attempts,
+        retry_exhausted,
+        at_ms: chrono::Utc::now().timestamp_millis(),
+        recording_id,
+    });
+    inner.health.recommended_action = recommended_action(error.class);
+    if error.class != PerformanceStoreErrorClassV1::BusyLocked {
+        inner.health.status = PerformanceStoreStatusV1::Unavailable;
+        inner.repository = None;
+    } else if inner.repository.is_some() {
+        inner.health.status = PerformanceStoreStatusV1::Available;
     }
 }
 
@@ -321,6 +611,9 @@ impl Drop for PerformanceRunGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     fn metrics() -> (tempfile::TempDir, PerformanceMetrics) {
         let temp = tempfile::tempdir().unwrap();
@@ -501,5 +794,174 @@ mod tests {
         ] {
             assert!(!json.contains(forbidden_key));
         }
+    }
+
+    #[test]
+    fn busy_begin_is_a_skipped_run_without_disabling_the_store() {
+        let (_temp, metrics) = metrics();
+        let repository = metrics
+            .repository(PerformanceStoreOperationV1::Read)
+            .unwrap();
+        let blocker = repository.test_connection().unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+
+        let file_error = metrics
+            .begin_file_transcription(66, Vec::new())
+            .unwrap_err();
+        assert!(file_error.contains("busy"));
+        assert_eq!(metrics.health().skipped_run_count, 0);
+
+        let error = metrics
+            .begin_dictation_diagnosed(77, Vec::new())
+            .unwrap_err();
+        assert_eq!(error.operation, PerformanceStoreOperationV1::Begin);
+        assert_eq!(error.class, PerformanceStoreErrorClassV1::BusyLocked);
+        assert_eq!(error.attempts, 3);
+        let health = metrics.health();
+        assert_eq!(health.status, PerformanceStoreStatusV1::Available);
+        assert_eq!(health.skipped_run_count, 1);
+        let failure = health.last_failure.unwrap();
+        assert_eq!(failure.recording_id, Some(77));
+        assert_eq!(failure.attempt_count, 3);
+        assert!(failure.retry_exhausted);
+        assert!(failure.at_ms >= 0);
+        assert_eq!(
+            health.recommended_action,
+            PerformanceStoreRecommendedActionV1::Retry
+        );
+
+        blocker.execute_batch("ROLLBACK;").unwrap();
+        metrics.begin_dictation_diagnosed(78, Vec::new()).unwrap();
+        assert_eq!(metrics.health().skipped_run_count, 1);
+    }
+
+    #[test]
+    fn invalid_run_id_does_not_change_store_health() {
+        let (_temp, metrics) = metrics();
+        let before = metrics.health();
+        assert!(metrics.get("not-a-run-id").is_err());
+        assert_eq!(metrics.health(), before);
+    }
+
+    #[test]
+    fn proven_invalid_record_becomes_unavailable_and_recovers_with_evidence() {
+        let (temp, metrics) = metrics();
+        let repository = metrics
+            .repository(PerformanceStoreOperationV1::Read)
+            .unwrap();
+        repository
+            .test_connection()
+            .unwrap()
+            .execute(
+                "INSERT INTO completed_runs(
+                    run_id, record_version, kind, correlation_kind, correlation_id,
+                    started_at_ms, finished_at_ms, outcome_code, payload_json
+                 ) VALUES ('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 1, 'dictation',
+                           'dictation', 1, 1, 2, 'success', 'not json')",
+                [],
+            )
+            .unwrap();
+
+        assert!(metrics.list(10).is_err());
+        let unavailable = metrics.health();
+        assert_eq!(unavailable.status, PerformanceStoreStatusV1::Unavailable);
+        assert_eq!(
+            unavailable.last_failure.unwrap().error_class,
+            PerformanceStoreErrorClassV1::InvalidRecord
+        );
+        assert_eq!(
+            unavailable.recommended_action,
+            PerformanceStoreRecommendedActionV1::ReinitializeStore
+        );
+
+        let still_unavailable = metrics.recover(false).unwrap();
+        assert_eq!(
+            still_unavailable.status,
+            PerformanceStoreStatusV1::Unavailable
+        );
+        assert_eq!(
+            still_unavailable.last_failure.unwrap().error_class,
+            PerformanceStoreErrorClassV1::InvalidRecord
+        );
+        assert!(!temp.path().join("diagnostics/quarantine").exists());
+
+        let recovered = metrics.recover(true).unwrap();
+        assert_eq!(recovered.status, PerformanceStoreStatusV1::Available);
+        assert_eq!(
+            recovered.last_recovery.unwrap().action,
+            PerformanceStoreRecoveryActionV1::QuarantinedAndReinitialized
+        );
+        let quarantine = temp.path().join("diagnostics/quarantine");
+        assert!(quarantine.exists());
+        assert!(!std::fs::read_dir(quarantine)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn recovery_is_a_no_op_while_store_is_available() {
+        let (temp, metrics) = metrics();
+        let before = metrics.health();
+        assert_eq!(metrics.recover(false).unwrap(), before);
+        assert_eq!(metrics.recover(true).unwrap(), before);
+        assert!(!temp.path().join("diagnostics/quarantine").exists());
+    }
+
+    #[test]
+    fn recovery_waits_for_an_in_flight_failure_and_cannot_be_cleared_by_it() {
+        let (temp, metrics) = metrics();
+        let (operation_started_tx, operation_started_rx) = mpsc::channel();
+        let (release_operation_tx, release_operation_rx) = mpsc::channel();
+        let ordinary = {
+            let metrics = metrics.clone();
+            thread::spawn(move || {
+                let _operation_guard = metrics
+                    .operation_lock
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                operation_started_tx.send(()).unwrap();
+                release_operation_rx.recv().unwrap();
+                let mut inner = metrics
+                    .inner
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                apply_failure(
+                    &mut inner,
+                    &PerformanceStoreError {
+                        operation: PerformanceStoreOperationV1::Read,
+                        class: PerformanceStoreErrorClassV1::InvalidRecord,
+                        attempts: 1,
+                    },
+                    None,
+                    false,
+                );
+            })
+        };
+        operation_started_rx.recv().unwrap();
+
+        let (recovery_finished_tx, recovery_finished_rx) = mpsc::channel();
+        let recovery = {
+            let metrics = metrics.clone();
+            thread::spawn(move || {
+                let result = metrics.recover(true);
+                recovery_finished_tx.send(result).unwrap();
+            })
+        };
+        assert!(recovery_finished_rx
+            .recv_timeout(Duration::from_millis(25))
+            .is_err());
+        release_operation_tx.send(()).unwrap();
+        ordinary.join().unwrap();
+        let recovered = recovery_finished_rx
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        recovery.join().unwrap();
+
+        assert_eq!(recovered.status, PerformanceStoreStatusV1::Available);
+        assert_eq!(metrics.health().status, PerformanceStoreStatusV1::Available);
+        assert!(!temp.path().join("diagnostics/quarantine").exists());
     }
 }

--- a/app/src-tauri/src/performance_metrics/repository.rs
+++ b/app/src-tauri/src/performance_metrics/repository.rs
@@ -1,58 +1,255 @@
 use super::types::*;
-use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use rusqlite::{params, Connection, ErrorCode, OptionalExtension, Transaction};
+use std::fmt;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 const DB_FILE: &str = "performance.sqlite3";
 const LATEST_DB_SCHEMA_VERSION: u32 = 2;
 const MAX_COMPLETED_RUNS: usize = 200;
 const MAX_RESOURCE_SAMPLES: usize = 600;
 const MAX_TRANSFORM_FOLLOW_UPS: usize = 8;
+const BUSY_TIMEOUT: Duration = Duration::from_millis(25);
+const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_millis(5), Duration::from_millis(15)];
+const MAX_OPERATION_ATTEMPTS: u8 = 3;
 
-#[derive(Clone)]
+pub(crate) type StoreResult<T> = Result<T, PerformanceStoreError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PerformanceStoreError {
+    pub(crate) operation: PerformanceStoreOperationV1,
+    pub(crate) class: PerformanceStoreErrorClassV1,
+    pub(crate) attempts: u8,
+}
+
+impl PerformanceStoreError {
+    fn new(operation: PerformanceStoreOperationV1, class: PerformanceStoreErrorClassV1) -> Self {
+        Self {
+            operation,
+            class,
+            attempts: 1,
+        }
+    }
+
+    fn for_operation(mut self, operation: PerformanceStoreOperationV1) -> Self {
+        self.operation = operation;
+        self
+    }
+
+    pub(crate) fn retry_exhausted(&self) -> bool {
+        self.class == PerformanceStoreErrorClassV1::BusyLocked
+            && self.attempts >= MAX_OPERATION_ATTEMPTS
+    }
+}
+
+impl fmt::Display for PerformanceStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self.class {
+            PerformanceStoreErrorClassV1::BusyLocked => {
+                "The local diagnostics database is busy. Dictation was not affected."
+            }
+            PerformanceStoreErrorClassV1::StorageFull => {
+                "The local diagnostics storage is full. Free disk space, then retry."
+            }
+            PerformanceStoreErrorClassV1::ReadOnly => {
+                "The local diagnostics storage is read-only. Check its permissions, then retry."
+            }
+            PerformanceStoreErrorClassV1::Io => {
+                "The local diagnostics storage could not be accessed. Retry after checking local storage."
+            }
+            PerformanceStoreErrorClassV1::CorruptIntegrity => {
+                "The local diagnostics database failed its integrity check."
+            }
+            PerformanceStoreErrorClassV1::SchemaMigration => {
+                "The local diagnostics database schema is not supported by this Murmur build."
+            }
+            PerformanceStoreErrorClassV1::InvalidRecord => {
+                "The local diagnostics database contains an invalid record."
+            }
+            PerformanceStoreErrorClassV1::Unavailable => {
+                "The local diagnostics store is unavailable."
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for PerformanceStoreError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InitializationOutcome {
+    Ready,
+    Reinitialized { at_ms: i64 },
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct PerformanceRepository {
+    root: PathBuf,
     db_path: PathBuf,
 }
 
 impl PerformanceRepository {
-    pub(crate) fn initialize(root: PathBuf) -> Result<Self, String> {
-        fs::create_dir_all(&root).map_err(|_| storage_error())?;
+    pub(crate) fn initialize(root: PathBuf) -> StoreResult<(Self, InitializationOutcome)> {
+        fs::create_dir_all(&root).map_err(storage_error)?;
         let repository = Self {
             db_path: root.join(DB_FILE),
+            root,
         };
-        let mut connection = repository.open()?;
-        migrate(&mut connection)?;
-        quick_check(&connection)?;
-        repository.recover_stale_runs(&mut connection)?;
-        Ok(repository)
+        let existed = repository.db_path.exists();
+        match repository.initialize_database() {
+            Ok(()) => Ok((repository, InitializationOutcome::Ready)),
+            Err(error)
+                if existed && error.class == PerformanceStoreErrorClassV1::CorruptIntegrity =>
+            {
+                repository.quarantine_database()?;
+                repository.initialize_database()?;
+                Ok((
+                    repository,
+                    InitializationOutcome::Reinitialized { at_ms: now_ms() },
+                ))
+            }
+            Err(error) => Err(error),
+        }
     }
 
-    fn open(&self) -> Result<Connection, String> {
+    /// Reopen and validate an existing store without ever quarantining it.
+    /// This is the safe first step of user-requested recovery.
+    pub(crate) fn reopen(root: PathBuf) -> StoreResult<(Self, InitializationOutcome)> {
+        fs::create_dir_all(&root).map_err(storage_error)?;
+        let repository = Self {
+            db_path: root.join(DB_FILE),
+            root,
+        };
+        repository.initialize_database()?;
+        Ok((repository, InitializationOutcome::Ready))
+    }
+
+    fn initialize_database(&self) -> StoreResult<()> {
+        (|| {
+            let mut connection = self.open()?;
+            migrate(&mut connection)?;
+            quick_check(&connection)?;
+            validate_records(&connection)?;
+            self.recover_stale_runs(&mut connection)
+        })()
+        .map_err(|error: PerformanceStoreError| {
+            error.for_operation(PerformanceStoreOperationV1::Initialize)
+        })
+    }
+
+    fn open(&self) -> StoreResult<Connection> {
         let connection = Connection::open(&self.db_path).map_err(db_error)?;
+        connection.busy_timeout(BUSY_TIMEOUT).map_err(db_error)?;
         connection
             .execute_batch(
                 "PRAGMA journal_mode=WAL;
                  PRAGMA synchronous=NORMAL;
-                 PRAGMA foreign_keys=ON;
-                 PRAGMA busy_timeout=2000;",
+                 PRAGMA foreign_keys=ON;",
             )
             .map_err(db_error)?;
         Ok(connection)
     }
 
+    pub(crate) fn reinitialize(root: PathBuf) -> StoreResult<(Self, InitializationOutcome)> {
+        let repository = Self {
+            db_path: root.join(DB_FILE),
+            root,
+        };
+        if !repository.db_path.exists() {
+            repository.initialize_database()?;
+            return Ok((repository, InitializationOutcome::Ready));
+        }
+        match repository.initialize_database() {
+            Ok(()) => return Ok((repository, InitializationOutcome::Ready)),
+            Err(error)
+                if matches!(
+                    error.class,
+                    PerformanceStoreErrorClassV1::CorruptIntegrity
+                        | PerformanceStoreErrorClassV1::InvalidRecord
+                ) => {}
+            Err(error) => return Err(error),
+        }
+        // Reinitialization is permitted only after this fresh validation proves
+        // physical corruption or an undecodable supported-version record.
+        repository.quarantine_database()?;
+        repository.initialize_database()?;
+        Ok((
+            repository,
+            InitializationOutcome::Reinitialized { at_ms: now_ms() },
+        ))
+    }
+
+    fn quarantine_database(&self) -> StoreResult<()> {
+        let quarantine = self.root.join("quarantine");
+        fs::create_dir_all(&quarantine).map_err(storage_error)?;
+        let stamp = now_ms();
+        for (index, source) in [
+            self.db_path.clone(),
+            sqlite_sidecar_path(&self.db_path, "-wal"),
+            sqlite_sidecar_path(&self.db_path, "-shm"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if !source.exists() {
+                continue;
+            }
+            let suffix = match index {
+                0 => "sqlite3",
+                1 => "sqlite3-wal",
+                _ => "sqlite3-shm",
+            };
+            let destination = unique_quarantine_path(&quarantine, stamp, suffix);
+            fs::rename(source, destination).map_err(storage_error)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(crate) fn begin(
         &self,
         kind: PerformanceRunKindV1,
         correlation: RunCorrelationV1,
         runtimes: Vec<RuntimeIdentityV1>,
         input: ContentFreeInputSummaryV1,
-    ) -> Result<ActiveRunV1, String> {
+    ) -> StoreResult<ActiveRunV1> {
+        self.begin_at(kind, correlation, runtimes, input, now_ms())
+    }
+
+    pub(crate) fn begin_at(
+        &self,
+        kind: PerformanceRunKindV1,
+        correlation: RunCorrelationV1,
+        runtimes: Vec<RuntimeIdentityV1>,
+        input: ContentFreeInputSummaryV1,
+        started_at_ms: i64,
+    ) -> StoreResult<ActiveRunV1> {
+        retry_operation(PerformanceStoreOperationV1::Begin, || {
+            self.begin_once(
+                kind,
+                correlation.clone(),
+                runtimes.clone(),
+                input.clone(),
+                started_at_ms,
+            )
+        })
+    }
+
+    fn begin_once(
+        &self,
+        kind: PerformanceRunKindV1,
+        correlation: RunCorrelationV1,
+        runtimes: Vec<RuntimeIdentityV1>,
+        input: ContentFreeInputSummaryV1,
+        started_at_ms: i64,
+    ) -> StoreResult<ActiveRunV1> {
         let mut connection = self.open()?;
         let transaction = connection.transaction().map_err(db_error)?;
         let run_id: String = transaction
             .query_row("SELECT lower(hex(randomblob(16)))", [], |row| row.get(0))
             .map_err(db_error)?;
-        let started_at_ms = now_ms();
         let clear_epoch = clear_epoch_tx(&transaction)?;
         let active = ActiveRunV1 {
             run_id,
@@ -75,8 +272,18 @@ impl PerformanceRepository {
     pub(crate) fn update_active(
         &self,
         correlation: &RunCorrelationV1,
+        update: impl FnOnce(&mut ActiveRunV1) + Clone,
+    ) -> StoreResult<bool> {
+        retry_operation(PerformanceStoreOperationV1::Update, || {
+            self.update_active_once(correlation, update.clone())
+        })
+    }
+
+    fn update_active_once(
+        &self,
+        correlation: &RunCorrelationV1,
         update: impl FnOnce(&mut ActiveRunV1),
-    ) -> Result<bool, String> {
+    ) -> StoreResult<bool> {
         let mut connection = self.open()?;
         let transaction = connection.transaction().map_err(db_error)?;
         let Some(mut active) = active_by_correlation_tx(&transaction, correlation)? else {
@@ -102,7 +309,26 @@ impl PerformanceRepository {
         stages: Vec<StageTimingV1>,
         input: Option<ContentFreeInputSummaryV1>,
         runtimes: Option<Vec<RuntimeIdentityV1>>,
-    ) -> Result<Option<PerformanceRunV1>, String> {
+    ) -> StoreResult<Option<PerformanceRunV1>> {
+        retry_operation(PerformanceStoreOperationV1::Complete, || {
+            self.complete_once(
+                correlation,
+                outcome.clone(),
+                stages.clone(),
+                input.clone(),
+                runtimes.clone(),
+            )
+        })
+    }
+
+    fn complete_once(
+        &self,
+        correlation: &RunCorrelationV1,
+        outcome: RunOutcomeV1,
+        stages: Vec<StageTimingV1>,
+        input: Option<ContentFreeInputSummaryV1>,
+        runtimes: Option<Vec<RuntimeIdentityV1>>,
+    ) -> StoreResult<Option<PerformanceRunV1>> {
         let mut connection = self.open()?;
         let transaction = connection.transaction().map_err(db_error)?;
         let Some(mut active) = active_by_correlation_tx(&transaction, correlation)? else {
@@ -183,7 +409,7 @@ impl PerformanceRepository {
         Ok(Some(run))
     }
 
-    pub(crate) fn insert_resource_sample(&self, sample: &ResourceSampleV1) -> Result<(), String> {
+    pub(crate) fn insert_resource_sample(&self, sample: &ResourceSampleV1) -> StoreResult<()> {
         let mut connection = self.open()?;
         let transaction = connection.transaction().map_err(db_error)?;
         let payload = serde_json::to_string(sample).map_err(|_| invalid_record())?;
@@ -207,7 +433,7 @@ impl PerformanceRepository {
         &self,
         correlation: &RunCorrelationV1,
         follow_up: TransformFollowUpV1,
-    ) -> Result<Option<PerformanceRunV1>, String> {
+    ) -> StoreResult<Option<PerformanceRunV1>> {
         if !matches!(correlation, RunCorrelationV1::SelectedTextTransform { .. }) {
             return Ok(None);
         }
@@ -255,7 +481,7 @@ impl PerformanceRepository {
         Ok(Some(run))
     }
 
-    pub(crate) fn list(&self, limit: u32) -> Result<Vec<PerformanceRunV1>, String> {
+    pub(crate) fn list(&self, limit: u32) -> StoreResult<Vec<PerformanceRunV1>> {
         let connection = self.open()?;
         let limit = limit.clamp(1, MAX_COMPLETED_RUNS as u32);
         let mut statement = connection
@@ -280,9 +506,12 @@ impl PerformanceRepository {
         Ok(runs)
     }
 
-    pub(crate) fn get(&self, run_id: &str) -> Result<Option<PerformanceRunV1>, String> {
+    pub(crate) fn get(&self, run_id: &str) -> StoreResult<Option<PerformanceRunV1>> {
         if !valid_run_id(run_id) {
-            return Err("The performance run ID is invalid.".to_string());
+            return Err(PerformanceStoreError::new(
+                PerformanceStoreOperationV1::Read,
+                PerformanceStoreErrorClassV1::InvalidRecord,
+            ));
         }
         let connection = self.open()?;
         let row = connection
@@ -296,7 +525,10 @@ impl PerformanceRepository {
         match row {
             None => Ok(None),
             Some((version, _)) if version != PERFORMANCE_RUN_SCHEMA_VERSION => {
-                Err("This performance run uses an unsupported record version.".to_string())
+                Err(PerformanceStoreError::new(
+                    PerformanceStoreOperationV1::Read,
+                    PerformanceStoreErrorClassV1::SchemaMigration,
+                ))
             }
             Some((_, payload)) => serde_json::from_str(&payload)
                 .map(Some)
@@ -304,12 +536,12 @@ impl PerformanceRepository {
         }
     }
 
-    pub(crate) fn resource_window(&self) -> Result<Vec<ResourceSampleV1>, String> {
+    pub(crate) fn resource_window(&self) -> StoreResult<Vec<ResourceSampleV1>> {
         let connection = self.open()?;
         resource_samples_tx(&connection, i64::MIN, i64::MAX)
     }
 
-    pub(crate) fn clear(&self) -> Result<(), String> {
+    pub(crate) fn clear(&self) -> StoreResult<()> {
         let mut connection = self.open()?;
         let transaction = connection.transaction().map_err(db_error)?;
         let next_epoch = clear_epoch_tx(&transaction)?.saturating_add(1);
@@ -332,7 +564,7 @@ impl PerformanceRepository {
     }
 
     #[cfg(test)]
-    pub(crate) fn counts(&self) -> Result<(u64, u64, u64), String> {
+    pub(crate) fn counts(&self) -> StoreResult<(u64, u64, u64)> {
         let connection = self.open()?;
         let active = count(&connection, "active_runs")?;
         let completed = count(&connection, "completed_runs")?;
@@ -340,7 +572,12 @@ impl PerformanceRepository {
         Ok((active, completed, samples))
     }
 
-    fn recover_stale_runs(&self, connection: &mut Connection) -> Result<(), String> {
+    #[cfg(test)]
+    pub(crate) fn test_connection(&self) -> StoreResult<Connection> {
+        self.open()
+    }
+
+    fn recover_stale_runs(&self, connection: &mut Connection) -> StoreResult<()> {
         let correlations = {
             let mut statement = connection
                 .prepare("SELECT payload_json FROM active_runs")
@@ -370,13 +607,14 @@ impl PerformanceRepository {
     }
 }
 
-fn migrate(connection: &mut Connection) -> Result<(), String> {
+fn migrate(connection: &mut Connection) -> StoreResult<()> {
     let current: u32 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .map_err(db_error)?;
     if current > LATEST_DB_SCHEMA_VERSION {
-        return Err(format!(
-            "The diagnostics database uses schema version {current}, which is newer than this Murmur build supports."
+        return Err(PerformanceStoreError::new(
+            PerformanceStoreOperationV1::Initialize,
+            PerformanceStoreErrorClassV1::SchemaMigration,
         ));
     }
     if current == 0 {
@@ -443,7 +681,7 @@ fn migrate(connection: &mut Connection) -> Result<(), String> {
     Ok(())
 }
 
-fn insert_active(transaction: &Transaction<'_>, active: &ActiveRunV1) -> Result<(), String> {
+fn insert_active(transaction: &Transaction<'_>, active: &ActiveRunV1) -> StoreResult<()> {
     let payload = serde_json::to_string(active).map_err(|_| invalid_record())?;
     let (correlation_kind, correlation_id) = active.correlation.storage_parts();
     transaction
@@ -469,7 +707,7 @@ fn insert_active(transaction: &Transaction<'_>, active: &ActiveRunV1) -> Result<
 fn active_by_correlation_tx(
     transaction: &Transaction<'_>,
     correlation: &RunCorrelationV1,
-) -> Result<Option<ActiveRunV1>, String> {
+) -> StoreResult<Option<ActiveRunV1>> {
     let (kind, id) = correlation.storage_parts();
     transaction
         .query_row(
@@ -484,7 +722,7 @@ fn active_by_correlation_tx(
         .transpose()
 }
 
-fn clear_epoch_tx(transaction: &Transaction<'_>) -> Result<u64, String> {
+fn clear_epoch_tx(transaction: &Transaction<'_>) -> StoreResult<u64> {
     transaction
         .query_row(
             "SELECT value FROM performance_meta WHERE key = 'clear_epoch'",
@@ -554,7 +792,7 @@ fn canonical_stages(measured: Vec<StageTimingV1>) -> Vec<StageTimingV1> {
         .collect()
 }
 
-fn prune_completed_tx(transaction: &Transaction<'_>) -> Result<(), String> {
+fn prune_completed_tx(transaction: &Transaction<'_>) -> StoreResult<()> {
     transaction
         .execute(
             "DELETE FROM completed_runs
@@ -568,7 +806,7 @@ fn prune_completed_tx(transaction: &Transaction<'_>) -> Result<(), String> {
     Ok(())
 }
 
-fn prune_resource_samples_tx(transaction: &Transaction<'_>) -> Result<(), String> {
+fn prune_resource_samples_tx(transaction: &Transaction<'_>) -> StoreResult<()> {
     transaction
         .execute(
             "DELETE FROM resource_samples
@@ -586,7 +824,7 @@ fn resource_summary_tx(
     kind: PerformanceRunKindV1,
     started_at_ms: i64,
     finished_at_ms: i64,
-) -> Result<ResourceSummaryV1, String> {
+) -> StoreResult<ResourceSummaryV1> {
     let samples = resource_samples_tx(transaction, started_at_ms, finished_at_ms)?;
     if samples.is_empty() {
         return Ok(ResourceSummaryV1::unavailable_for(kind));
@@ -652,7 +890,7 @@ fn resource_samples_tx(
     connection: &Connection,
     started_at_ms: i64,
     finished_at_ms: i64,
-) -> Result<Vec<ResourceSampleV1>, String> {
+) -> StoreResult<Vec<ResourceSampleV1>> {
     let mut statement = connection
         .prepare(
             "SELECT record_version, payload_json FROM resource_samples
@@ -725,29 +963,118 @@ fn valid_run_id(run_id: &str) -> bool {
     run_id.len() == 32 && run_id.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
-fn quick_check(connection: &Connection) -> Result<(), String> {
+fn retry_operation<T>(
+    operation: PerformanceStoreOperationV1,
+    mut attempt: impl FnMut() -> StoreResult<T>,
+) -> StoreResult<T> {
+    for attempt_index in 0..MAX_OPERATION_ATTEMPTS {
+        match attempt() {
+            Ok(value) => return Ok(value),
+            Err(error) if error.class == PerformanceStoreErrorClassV1::BusyLocked => {
+                let attempts = attempt_index.saturating_add(1);
+                if attempts >= MAX_OPERATION_ATTEMPTS {
+                    return Err(PerformanceStoreError {
+                        operation,
+                        class: PerformanceStoreErrorClassV1::BusyLocked,
+                        attempts,
+                    });
+                }
+                thread::sleep(RETRY_BACKOFFS[usize::from(attempt_index)]);
+            }
+            Err(error) => return Err(error.for_operation(operation)),
+        }
+    }
+    unreachable!("the bounded retry loop always returns")
+}
+
+fn unique_quarantine_path(root: &Path, stamp: i64, suffix: &str) -> PathBuf {
+    for sequence in 0_u16..=u16::MAX {
+        let candidate = root.join(format!("performance-{stamp}-{sequence}.{suffix}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    root.join(format!("performance-{stamp}.overflow.{suffix}"))
+}
+
+fn sqlite_sidecar_path(database: &Path, suffix: &str) -> PathBuf {
+    let mut path = database.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn quick_check(connection: &Connection) -> StoreResult<()> {
     let result: String = connection
         .pragma_query_value(None, "quick_check", |row| row.get(0))
         .map_err(db_error)?;
     if result == "ok" {
         Ok(())
     } else {
-        Err("The diagnostics database failed its integrity check.".to_string())
+        Err(PerformanceStoreError::new(
+            PerformanceStoreOperationV1::Initialize,
+            PerformanceStoreErrorClassV1::CorruptIntegrity,
+        ))
     }
+}
+
+fn validate_records(connection: &Connection) -> StoreResult<()> {
+    {
+        let mut active = connection
+            .prepare("SELECT payload_json FROM active_runs")
+            .map_err(db_error)?;
+        let active_rows = active
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(db_error)?;
+        for row in active_rows {
+            let payload = row.map_err(db_error)?;
+            serde_json::from_str::<ActiveRunV1>(&payload).map_err(|_| invalid_record())?;
+        }
+    }
+    {
+        let mut completed = connection
+            .prepare("SELECT record_version, payload_json FROM completed_runs")
+            .map_err(db_error)?;
+        let completed_rows = completed
+            .query_map([], |row| {
+                Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(db_error)?;
+        for row in completed_rows {
+            let (version, payload) = row.map_err(db_error)?;
+            if version == PERFORMANCE_RUN_SCHEMA_VERSION {
+                serde_json::from_str::<PerformanceRunV1>(&payload).map_err(|_| invalid_record())?;
+            }
+        }
+    }
+    {
+        let mut samples = connection
+            .prepare("SELECT record_version, payload_json FROM resource_samples")
+            .map_err(db_error)?;
+        let sample_rows = samples
+            .query_map([], |row| {
+                Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(db_error)?;
+        for row in sample_rows {
+            let (version, payload) = row.map_err(db_error)?;
+            if version == RESOURCE_SAMPLE_SCHEMA_VERSION {
+                serde_json::from_str::<ResourceSampleV1>(&payload).map_err(|_| invalid_record())?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
-fn to_i64(value: u64) -> Result<i64, String> {
-    value
-        .try_into()
-        .map_err(|_| "The diagnostics correlation ID is out of range.".to_string())
+fn to_i64(value: u64) -> StoreResult<i64> {
+    value.try_into().map_err(|_| invalid_record())
 }
 
 #[cfg(test)]
-fn count(connection: &Connection, table: &str) -> Result<u64, String> {
+fn count(connection: &Connection, table: &str) -> StoreResult<u64> {
     let sql = format!("SELECT COUNT(*) FROM {table}");
     connection
         .query_row(&sql, [], |row| row.get::<_, i64>(0))
@@ -763,26 +1090,66 @@ fn count(connection: &Connection, table: &str) -> Result<u64, String> {
         .map_err(db_error)
 }
 
-fn db_error(_error: rusqlite::Error) -> String {
-    "The local diagnostics database operation failed.".to_string()
+fn db_error(error: rusqlite::Error) -> PerformanceStoreError {
+    let class = match error {
+        rusqlite::Error::SqliteFailure(sqlite, _) => match sqlite.code {
+            ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked => {
+                PerformanceStoreErrorClassV1::BusyLocked
+            }
+            ErrorCode::DiskFull => PerformanceStoreErrorClassV1::StorageFull,
+            ErrorCode::ReadOnly
+            | ErrorCode::PermissionDenied
+            | ErrorCode::AuthorizationForStatementDenied => PerformanceStoreErrorClassV1::ReadOnly,
+            ErrorCode::DatabaseCorrupt | ErrorCode::NotADatabase => {
+                PerformanceStoreErrorClassV1::CorruptIntegrity
+            }
+            ErrorCode::SchemaChanged => PerformanceStoreErrorClassV1::SchemaMigration,
+            ErrorCode::SystemIoFailure
+            | ErrorCode::CannotOpen
+            | ErrorCode::FileLockingProtocolFailed
+            | ErrorCode::NoLargeFileSupport => PerformanceStoreErrorClassV1::Io,
+            _ => PerformanceStoreErrorClassV1::Io,
+        },
+        rusqlite::Error::InvalidColumnType(..)
+        | rusqlite::Error::FromSqlConversionFailure(..)
+        | rusqlite::Error::IntegralValueOutOfRange(..)
+        | rusqlite::Error::Utf8Error(..) => PerformanceStoreErrorClassV1::InvalidRecord,
+        rusqlite::Error::InvalidQuery
+        | rusqlite::Error::InvalidParameterName(..)
+        | rusqlite::Error::InvalidColumnName(..)
+        | rusqlite::Error::InvalidColumnIndex(..) => PerformanceStoreErrorClassV1::SchemaMigration,
+        _ => PerformanceStoreErrorClassV1::Io,
+    };
+    PerformanceStoreError::new(PerformanceStoreOperationV1::Read, class)
 }
 
-fn storage_error() -> String {
-    "The local diagnostics storage directory is unavailable.".to_string()
+fn storage_error(error: std::io::Error) -> PerformanceStoreError {
+    let class = match error.kind() {
+        std::io::ErrorKind::PermissionDenied => PerformanceStoreErrorClassV1::ReadOnly,
+        std::io::ErrorKind::StorageFull => PerformanceStoreErrorClassV1::StorageFull,
+        _ => PerformanceStoreErrorClassV1::Io,
+    };
+    PerformanceStoreError::new(PerformanceStoreOperationV1::Initialize, class)
 }
 
-fn invalid_record() -> String {
-    "The local diagnostics database contains an invalid record.".to_string()
+fn invalid_record() -> PerformanceStoreError {
+    PerformanceStoreError::new(
+        PerformanceStoreOperationV1::Read,
+        PerformanceStoreErrorClassV1::InvalidRecord,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::time::Instant;
 
     fn repository() -> (tempfile::TempDir, PerformanceRepository) {
         let temp = tempfile::tempdir().unwrap();
-        let repository =
-            PerformanceRepository::initialize(temp.path().join("diagnostics")).unwrap();
+        let repository = PerformanceRepository::initialize(temp.path().join("diagnostics"))
+            .unwrap()
+            .0;
         (temp, repository)
     }
 
@@ -1001,7 +1368,7 @@ mod tests {
     fn restart_closes_stale_run_and_allows_reused_session_correlation() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path().join("diagnostics");
-        let repository = PerformanceRepository::initialize(root.clone()).unwrap();
+        let repository = PerformanceRepository::initialize(root.clone()).unwrap().0;
         repository
             .begin(
                 PerformanceRunKindV1::Dictation,
@@ -1010,7 +1377,7 @@ mod tests {
                 ContentFreeInputSummaryV1::default(),
             )
             .unwrap();
-        let restarted = PerformanceRepository::initialize(root).unwrap();
+        let restarted = PerformanceRepository::initialize(root).unwrap().0;
         let interrupted = restarted.list(10).unwrap();
         assert_eq!(interrupted.len(), 1);
         assert!(matches!(
@@ -1063,7 +1430,7 @@ mod tests {
     fn v1_database_migrates_without_losing_completed_or_active_runs() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path().join("diagnostics");
-        let repository = PerformanceRepository::initialize(root.clone()).unwrap();
+        let repository = PerformanceRepository::initialize(root.clone()).unwrap().0;
         repository
             .begin(
                 PerformanceRunKindV1::Dictation,
@@ -1107,7 +1474,7 @@ mod tests {
         connection.pragma_update(None, "user_version", 1).unwrap();
         drop(connection);
 
-        let migrated = PerformanceRepository::initialize(root).unwrap();
+        let migrated = PerformanceRepository::initialize(root).unwrap().0;
         let connection = migrated.open().unwrap();
         let version: u32 = connection
             .pragma_query_value(None, "user_version", |row| row.get(0))
@@ -1175,5 +1542,247 @@ mod tests {
             run.resources.sidecar_process.rss_bytes.start,
             MeasurementV1::NotApplicable
         ));
+    }
+
+    #[test]
+    fn retry_policy_is_bounded_and_only_retries_busy_locked() {
+        let attempts = AtomicU8::new(0);
+        let started = Instant::now();
+        let error = retry_operation(PerformanceStoreOperationV1::Begin, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err::<(), _>(PerformanceStoreError::new(
+                PerformanceStoreOperationV1::Read,
+                PerformanceStoreErrorClassV1::BusyLocked,
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_OPERATION_ATTEMPTS);
+        assert_eq!(error.operation, PerformanceStoreOperationV1::Begin);
+        assert_eq!(error.attempts, MAX_OPERATION_ATTEMPTS);
+        assert!(error.retry_exhausted());
+        assert!(started.elapsed() < Duration::from_millis(500));
+
+        let attempts = AtomicU8::new(0);
+        let value = retry_operation(PerformanceStoreOperationV1::Update, || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt < MAX_OPERATION_ATTEMPTS {
+                Err(PerformanceStoreError::new(
+                    PerformanceStoreOperationV1::Read,
+                    PerformanceStoreErrorClassV1::BusyLocked,
+                ))
+            } else {
+                Ok(41)
+            }
+        })
+        .unwrap();
+        assert_eq!(value, 41);
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_OPERATION_ATTEMPTS);
+
+        let attempts = AtomicU8::new(0);
+        let error = retry_operation(PerformanceStoreOperationV1::Complete, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err::<(), _>(PerformanceStoreError::new(
+                PerformanceStoreOperationV1::Read,
+                PerformanceStoreErrorClassV1::Io,
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(error.class, PerformanceStoreErrorClassV1::Io);
+    }
+
+    #[test]
+    fn locked_writer_exhausts_quickly_and_a_later_begin_recovers() {
+        let (_temp, repository) = repository();
+        let blocker = repository.open().unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+        let started = Instant::now();
+        let error = repository
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(901),
+                Vec::new(),
+                ContentFreeInputSummaryV1::default(),
+            )
+            .unwrap_err();
+        assert_eq!(error.class, PerformanceStoreErrorClassV1::BusyLocked);
+        assert_eq!(error.attempts, MAX_OPERATION_ATTEMPTS);
+        assert!(started.elapsed() < Duration::from_millis(500));
+        blocker.execute_batch("ROLLBACK;").unwrap();
+        assert!(repository
+            .begin(
+                PerformanceRunKindV1::Dictation,
+                correlation(901),
+                Vec::new(),
+                ContentFreeInputSummaryV1::default(),
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn corrupt_database_is_quarantined_with_sidecars_and_reinitialized() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        fs::create_dir_all(&root).unwrap();
+        let db_path = root.join(DB_FILE);
+        fs::write(&db_path, b"not a sqlite database").unwrap();
+        fs::write(sqlite_sidecar_path(&db_path, "-wal"), b"wal evidence").unwrap();
+        fs::write(sqlite_sidecar_path(&db_path, "-shm"), b"shm evidence").unwrap();
+
+        let (repository, outcome) = PerformanceRepository::initialize(root.clone()).unwrap();
+        assert!(matches!(
+            outcome,
+            InitializationOutcome::Reinitialized { .. }
+        ));
+        assert_eq!(repository.counts().unwrap(), (0, 0, 0));
+        let quarantined = fs::read_dir(root.join("quarantine"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!quarantined.is_empty());
+        assert!(quarantined.len() <= 3);
+    }
+
+    #[test]
+    fn quarantine_preserves_database_wal_and_shm_as_separate_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        fs::create_dir_all(&root).unwrap();
+        let repository = PerformanceRepository {
+            db_path: root.join(DB_FILE),
+            root: root.clone(),
+        };
+        fs::write(&repository.db_path, b"database evidence").unwrap();
+        fs::write(
+            sqlite_sidecar_path(&repository.db_path, "-wal"),
+            b"wal evidence",
+        )
+        .unwrap();
+        fs::write(
+            sqlite_sidecar_path(&repository.db_path, "-shm"),
+            b"shm evidence",
+        )
+        .unwrap();
+
+        repository.quarantine_database().unwrap();
+        assert!(!repository.db_path.exists());
+        assert!(!sqlite_sidecar_path(&repository.db_path, "-wal").exists());
+        assert!(!sqlite_sidecar_path(&repository.db_path, "-shm").exists());
+        let mut evidence = fs::read_dir(root.join("quarantine"))
+            .unwrap()
+            .map(|entry| fs::read(entry.unwrap().path()).unwrap())
+            .collect::<Vec<_>>();
+        evidence.sort();
+        let mut expected = vec![
+            b"database evidence".to_vec(),
+            b"wal evidence".to_vec(),
+            b"shm evidence".to_vec(),
+        ];
+        expected.sort();
+        assert_eq!(evidence, expected);
+    }
+
+    #[test]
+    fn explicit_recovery_does_not_quarantine_a_healthy_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let (_repository, _) = PerformanceRepository::initialize(root.clone()).unwrap();
+        let (_repository, outcome) = PerformanceRepository::reinitialize(root.clone()).unwrap();
+        assert_eq!(outcome, InitializationOutcome::Ready);
+        assert!(!root.join("quarantine").exists());
+    }
+
+    #[test]
+    fn reopen_reports_corruption_without_quarantining() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(DB_FILE), b"not a sqlite database").unwrap();
+
+        let error = PerformanceRepository::reopen(root.clone()).unwrap_err();
+        assert_eq!(error.class, PerformanceStoreErrorClassV1::CorruptIntegrity);
+        assert!(root.join(DB_FILE).exists());
+        assert!(!root.join("quarantine").exists());
+    }
+
+    #[test]
+    fn invalid_supported_record_requires_explicit_evidence_based_reinitialization() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("diagnostics");
+        let (repository, _) = PerformanceRepository::initialize(root.clone()).unwrap();
+        repository
+            .open()
+            .unwrap()
+            .execute(
+                "INSERT INTO completed_runs(
+                    run_id, record_version, kind, correlation_kind, correlation_id,
+                    started_at_ms, finished_at_ms, outcome_code, payload_json
+                 ) VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1, 'dictation',
+                           'dictation', 1, 1, 2, 'success', 'not json')",
+                [],
+            )
+            .unwrap();
+        drop(repository);
+
+        let error = PerformanceRepository::initialize(root.clone()).unwrap_err();
+        assert_eq!(error.class, PerformanceStoreErrorClassV1::InvalidRecord);
+        assert!(!root.join("quarantine").exists());
+
+        let (recovered, outcome) = PerformanceRepository::reinitialize(root.clone()).unwrap();
+        assert!(matches!(
+            outcome,
+            InitializationOutcome::Reinitialized { .. }
+        ));
+        assert_eq!(recovered.counts().unwrap(), (0, 0, 0));
+        assert!(!fs::read_dir(root.join("quarantine"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sqlite_and_filesystem_failures_map_to_stable_safe_classes() {
+        let classified = |code| {
+            db_error(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(code),
+                Some("private SQL and /private/path".to_string()),
+            ))
+        };
+        assert_eq!(
+            classified(rusqlite::ffi::SQLITE_BUSY).class,
+            PerformanceStoreErrorClassV1::BusyLocked
+        );
+        assert_eq!(
+            classified(rusqlite::ffi::SQLITE_FULL).class,
+            PerformanceStoreErrorClassV1::StorageFull
+        );
+        let read_only = classified(rusqlite::ffi::SQLITE_READONLY);
+        assert_eq!(read_only.class, PerformanceStoreErrorClassV1::ReadOnly);
+        assert!(!read_only.to_string().contains("private"));
+        assert_eq!(
+            classified(rusqlite::ffi::SQLITE_IOERR).class,
+            PerformanceStoreErrorClassV1::Io
+        );
+        assert_eq!(
+            classified(rusqlite::ffi::SQLITE_CORRUPT).class,
+            PerformanceStoreErrorClassV1::CorruptIntegrity
+        );
+        assert_eq!(
+            classified(rusqlite::ffi::SQLITE_SCHEMA).class,
+            PerformanceStoreErrorClassV1::SchemaMigration
+        );
+        assert_eq!(
+            storage_error(std::io::Error::from(std::io::ErrorKind::StorageFull)).class,
+            PerformanceStoreErrorClassV1::StorageFull
+        );
+        assert_eq!(
+            storage_error(std::io::Error::from(std::io::ErrorKind::PermissionDenied)).class,
+            PerformanceStoreErrorClassV1::ReadOnly
+        );
+
+        let temp = tempfile::tempdir().unwrap();
+        let error = Connection::open(temp.path()).unwrap_err();
+        assert_eq!(db_error(error).class, PerformanceStoreErrorClassV1::Io);
     }
 }

--- a/app/src-tauri/src/performance_metrics/types.rs
+++ b/app/src-tauri/src/performance_metrics/types.rs
@@ -2,6 +2,130 @@ use serde::{Deserialize, Serialize};
 
 pub const PERFORMANCE_RUN_SCHEMA_VERSION: u32 = 1;
 pub const RESOURCE_SAMPLE_SCHEMA_VERSION: u32 = 1;
+pub const PERFORMANCE_STORE_HEALTH_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStoreErrorClassV1 {
+    BusyLocked,
+    StorageFull,
+    ReadOnly,
+    Io,
+    CorruptIntegrity,
+    SchemaMigration,
+    InvalidRecord,
+    Unavailable,
+}
+
+impl PerformanceStoreErrorClassV1 {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::BusyLocked => "busyLocked",
+            Self::StorageFull => "storageFull",
+            Self::ReadOnly => "readOnly",
+            Self::Io => "io",
+            Self::CorruptIntegrity => "corruptIntegrity",
+            Self::SchemaMigration => "schemaMigration",
+            Self::InvalidRecord => "invalidRecord",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStoreOperationV1 {
+    Initialize,
+    Begin,
+    Update,
+    Complete,
+    Read,
+    Write,
+    Clear,
+}
+
+impl PerformanceStoreOperationV1 {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Initialize => "initialize",
+            Self::Begin => "begin",
+            Self::Update => "update",
+            Self::Complete => "complete",
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Clear => "clear",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStoreStatusV1 {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStoreRecommendedActionV1 {
+    None,
+    Retry,
+    FreeDisk,
+    CheckPermissions,
+    ReinitializeStore,
+    RestartApp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PerformanceStoreRecoveryActionV1 {
+    QuarantinedAndReinitialized,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceStoreFailureV1 {
+    pub operation: PerformanceStoreOperationV1,
+    pub error_class: PerformanceStoreErrorClassV1,
+    pub attempt_count: u8,
+    pub retry_exhausted: bool,
+    pub at_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recording_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceStoreRecoveryV1 {
+    pub action: PerformanceStoreRecoveryActionV1,
+    pub at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceStoreHealthV1 {
+    pub schema_version: u32,
+    pub status: PerformanceStoreStatusV1,
+    pub skipped_run_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<PerformanceStoreFailureV1>,
+    pub recommended_action: PerformanceStoreRecommendedActionV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_recovery: Option<PerformanceStoreRecoveryV1>,
+}
+
+impl Default for PerformanceStoreHealthV1 {
+    fn default() -> Self {
+        Self {
+            schema_version: PERFORMANCE_STORE_HEALTH_SCHEMA_VERSION,
+            status: PerformanceStoreStatusV1::Unavailable,
+            skipped_run_count: 0,
+            last_failure: None,
+            recommended_action: PerformanceStoreRecommendedActionV1::Retry,
+            last_recovery: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -222,6 +222,7 @@ pub(crate) fn canonical_event_code(value: &str) -> Option<&'static str> {
         "pipeline.dictation_terminal" => Some("pipeline.dictation_terminal"),
         "pipeline.dictation_completed" => Some("pipeline.dictation_completed"),
         "pipeline.dictation_failed" => Some("pipeline.dictation_failed"),
+        "performance.store_operation_failed" => Some("performance.store_operation_failed"),
         "system.startup_baseline" => Some("system.startup_baseline"),
         "overlay.position_default" => Some("overlay.position_default"),
         "overlay.position_offset_applied" => Some("overlay.position_offset_applied"),
@@ -241,6 +242,39 @@ pub(crate) fn canonical_event_code(value: &str) -> Option<&'static str> {
         "updater.install_ready" => Some("updater.install_ready"),
         "updater.install_failed" => Some("updater.install_failed"),
         _ => None,
+    }
+}
+
+fn is_performance_store_event(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    data.get("event_code").and_then(serde_json::Value::as_str)
+        == Some("performance.store_operation_failed")
+}
+
+fn is_safe_performance_store_field(key: &str, value: &serde_json::Value) -> bool {
+    match key {
+        "event_code" => value.as_str() == Some("performance.store_operation_failed"),
+        "operation" => value.as_str().is_some_and(|value| {
+            matches!(
+                value,
+                "initialize" | "begin" | "update" | "complete" | "read" | "write" | "clear"
+            )
+        }),
+        "error_class" => value.as_str().is_some_and(|value| {
+            matches!(
+                value,
+                "busyLocked"
+                    | "storageFull"
+                    | "readOnly"
+                    | "io"
+                    | "corruptIntegrity"
+                    | "schemaMigration"
+                    | "invalidRecord"
+                    | "unavailable"
+            )
+        }),
+        "attempts" => value.as_u64().is_some_and(|value| (1..=3).contains(&value)),
+        "recording_id" => value.as_u64().is_some_and(|value| value > 0),
+        _ => false,
     }
 }
 
@@ -553,6 +587,13 @@ fn sanitize_event_data(stream: &str, data: &mut serde_json::Value, debug_build: 
     let Some(obj) = data.as_object_mut() else {
         return;
     };
+    if is_performance_store_event(obj) {
+        // Performance-store failures are shipped for fleet regression watches.
+        // Treat them as a dedicated schema even in debug builds so a future
+        // call site cannot add SQLite text, SQL, paths, or captured content.
+        obj.retain(|key, value| is_safe_performance_store_field(key, value));
+        return;
+    }
     if !debug_build && stream == "pipeline" {
         obj.retain(|key, value| {
             !value.is_string()
@@ -1132,6 +1173,74 @@ mod tests {
         assert!(data.get("event_code").is_none());
         assert!(data.get("outcome").is_none());
         assert!(data.get("error_code").is_none());
+    }
+
+    #[test]
+    fn performance_store_failure_schema_is_content_free_in_every_build() {
+        for debug_build in [true, false] {
+            let mut data = serde_json::json!({
+                "event_code": "performance.store_operation_failed",
+                "operation": "begin",
+                "error_class": "busyLocked",
+                "attempts": 3,
+                "recording_id": 35,
+                "error": "database is locked at /Users/private/diagnostics.sqlite3",
+                "sql": "INSERT INTO runs VALUES ('SENTINEL_TRANSCRIPT')",
+                "path": "/Users/private/diagnostics.sqlite3",
+                "content": "SENTINEL_TRANSCRIPT"
+            });
+
+            sanitize_event_data("system", &mut data, debug_build);
+
+            assert_eq!(data["event_code"], "performance.store_operation_failed");
+            assert_eq!(data["operation"], "begin");
+            assert_eq!(data["error_class"], "busyLocked");
+            assert_eq!(data["attempts"], 3);
+            assert_eq!(data["recording_id"], 35);
+            assert_eq!(data.as_object().unwrap().len(), 5);
+            let encoded = serde_json::to_string(&data).unwrap();
+            assert!(!encoded.contains("Users"));
+            assert!(!encoded.contains("INSERT"));
+            assert!(!encoded.contains("SENTINEL"));
+        }
+    }
+
+    #[test]
+    fn performance_store_failure_schema_rejects_unknown_strings_and_types() {
+        let mut data = serde_json::json!({
+            "event_code": "performance.store_operation_failed",
+            "operation": "SELECT private_path",
+            "error_class": "/Users/private",
+            "attempts": "three",
+            "recording_id": -1,
+        });
+
+        sanitize_event_data("system", &mut data, true);
+
+        assert_eq!(data["event_code"], "performance.store_operation_failed");
+        assert_eq!(data.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn performance_store_failure_schema_is_exact_even_on_the_wrong_stream() {
+        let mut data = serde_json::json!({
+            "event_code": "performance.store_operation_failed",
+            "operation": "begin",
+            "error_class": "busyLocked",
+            "attempts": 3,
+            "recording_id": 35,
+            "error": "database is locked at /Users/private/performance.sqlite3",
+            "content": "SENTINEL_TRANSCRIPT",
+        });
+
+        sanitize_event_data("pipeline", &mut data, true);
+
+        assert_eq!(data["event_code"], "performance.store_operation_failed");
+        assert_eq!(data["operation"], "begin");
+        assert_eq!(data["error_class"], "busyLocked");
+        assert_eq!(data["attempts"], 3);
+        assert_eq!(data["recording_id"], 35);
+        assert_eq!(data.as_object().unwrap().len(), 5);
     }
 
     #[test]

--- a/app/src/components/log-viewer/DiagnosticsWindowApp.test.tsx
+++ b/app/src/components/log-viewer/DiagnosticsWindowApp.test.tsx
@@ -7,8 +7,13 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => {}),
 }));
 
+const workspaceMock = vi.hoisted(() => vi.fn());
+
 vi.mock('./DiagnosticsWorkspace', () => ({
-  DiagnosticsWorkspace: () => <div>Diagnostics workspace</div>,
+  DiagnosticsWorkspace: (props: unknown) => {
+    workspaceMock(props);
+    return <div>Diagnostics workspace</div>;
+  },
   isDiagnosticsTab: () => true,
 }));
 
@@ -42,5 +47,11 @@ describe('DiagnosticsWindowApp native chrome', () => {
 
     expect(diagnosticsCapability.permissions).toContain('core:window:allow-start-dragging');
     expect(mainCapability.permissions).toContain('core:window:allow-start-dragging');
+  });
+
+  it('enables requester-gated diagnostics store health in this webview', () => {
+    expect(workspaceMock).toHaveBeenCalledWith(expect.objectContaining({
+      storeHealthEnabled: true,
+    }));
   });
 });

--- a/app/src/components/log-viewer/DiagnosticsWindowApp.tsx
+++ b/app/src/components/log-viewer/DiagnosticsWindowApp.tsx
@@ -31,7 +31,7 @@ export function DiagnosticsWindowApp() {
     <div className="flex h-screen min-h-0 flex-col overflow-hidden bg-background text-on-surface font-[-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,sans-serif]">
       <WindowHeader contextLabel="Diagnostics" />
       <main className="min-h-0 flex-1 overflow-hidden">
-        <DiagnosticsWorkspace requestedTab={requestedTab} />
+        <DiagnosticsWorkspace requestedTab={requestedTab} storeHealthEnabled />
       </main>
     </div>
   );

--- a/app/src/components/log-viewer/DiagnosticsWorkspace.test.tsx
+++ b/app/src/components/log-viewer/DiagnosticsWorkspace.test.tsx
@@ -12,6 +12,7 @@ const hookMocks = vi.hoisted(() => ({
   }>,
   useEventStore: vi.fn(),
   usePerformanceDiagnostics: vi.fn(),
+  usePerformanceStoreHealth: vi.fn(),
 }));
 
 vi.mock('../../lib/hooks/useEventStore', () => ({
@@ -63,6 +64,26 @@ vi.mock('../../lib/hooks/usePerformanceHealth', () => ({
   }),
 }));
 
+vi.mock('../../lib/hooks/usePerformanceStoreHealth', () => ({
+  usePerformanceStoreHealth: (enabled: boolean) => {
+    hookMocks.usePerformanceStoreHealth(enabled);
+    return ({
+      health: {
+        schemaVersion: 1,
+        status: 'available',
+        skippedRunCount: 0,
+        recommendedAction: 'none',
+      },
+      loading: false,
+      error: null,
+      recovering: false,
+      recoveryError: null,
+      refresh: vi.fn(),
+      recover: vi.fn(),
+    });
+  },
+}));
+
 vi.mock('../../lib/transformDiagnostics', () => ({
   listTransformAttempts: vi.fn(async () => []),
   listTransformCaptures: vi.fn(async () => []),
@@ -84,6 +105,7 @@ describe('DiagnosticsWorkspace shared diagnostics shell', () => {
     hookMocks.events = [];
     hookMocks.useEventStore.mockClear();
     hookMocks.usePerformanceDiagnostics.mockClear();
+    hookMocks.usePerformanceStoreHealth.mockClear();
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -151,6 +173,23 @@ describe('DiagnosticsWorkspace shared diagnostics shell', () => {
     ));
     expect(hookMocks.useEventStore).toHaveBeenLastCalledWith(false);
     expect(hookMocks.usePerformanceDiagnostics).toHaveBeenLastCalledWith(false);
+  });
+
+  it('enables store health only when an authorized host opts in', async () => {
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    await act(async () => (tabs[2] as HTMLButtonElement).click());
+    expect(hookMocks.usePerformanceStoreHealth).toHaveBeenLastCalledWith(false);
+    expect(container.textContent).not.toContain('Diagnostics storage');
+
+    await act(async () => root.render(
+      <DiagnosticsWorkspace
+        requestedTab="performance"
+        storeHealthEnabled
+        onPopOut={onPopOut}
+      />,
+    ));
+    expect(hookMocks.usePerformanceStoreHealth).toHaveBeenLastCalledWith(true);
+    expect(container.textContent).toContain('Diagnostics storage');
   });
 
   it('renders only the newest 100 rows while retaining the full filtered count', async () => {

--- a/app/src/components/log-viewer/DiagnosticsWorkspace.tsx
+++ b/app/src/components/log-viewer/DiagnosticsWorkspace.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useEventStore } from '../../lib/hooks/useEventStore';
 import { usePerformanceDiagnostics } from '../../lib/hooks/usePerformanceDiagnostics';
 import { usePerformanceHealth } from '../../lib/hooks/usePerformanceHealth';
+import { usePerformanceStoreHealth } from '../../lib/hooks/usePerformanceStoreHealth';
 import { StreamChips } from './StreamChips';
 import { LevelFilter } from './LevelFilter';
 import { EventRow } from './EventRow';
@@ -39,18 +40,24 @@ interface DiagnosticsWorkspaceProps {
   active?: boolean;
   requestedTab?: DiagnosticsTab;
   onPopOut?: (tab: DiagnosticsTab) => void;
+  /** Authorized `main` and `diagnostics` webviews may read or recover store health. */
+  storeHealthEnabled?: boolean;
 }
 
 export function DiagnosticsWorkspace({
   active = true,
   requestedTab,
   onPopOut,
+  storeHealthEnabled = false,
 }: DiagnosticsWorkspaceProps) {
   const { events, clear } = useEventStore(active);
   const [tab, setTab] = useState<DiagnosticsTab>(requestedTab ?? 'events');
   useUiLatencyDestination(active ? `settings.model.diagnostics.${tab}` : null);
   const performance = usePerformanceDiagnostics(active);
   const health = usePerformanceHealth(active && tab === 'performance');
+  const storeHealth = usePerformanceStoreHealth(
+    active && storeHealthEnabled && (tab === 'performance' || tab === 'runs'),
+  );
   const [activeStreams, setActiveStreams] = useState<Set<StreamName>>(
     () => new Set(['pipeline', 'audio', 'transform', 'query', 'system'])
   );
@@ -273,6 +280,7 @@ export function DiagnosticsWorkspace({
             loading={performance.resourcesLoading}
             error={performance.resourcesError}
             health={health}
+            store={storeHealthEnabled ? storeHealth : undefined}
             onRetry={() => {
               void performance.refreshResources();
               health.refresh();
@@ -307,6 +315,7 @@ export function DiagnosticsWorkspace({
             onRetry={performance.refreshRuns}
             onClear={performance.clear}
             onShowEvents={showCorrelatedEvents}
+            store={storeHealthEnabled ? storeHealth : undefined}
           />
         </div>
       )}

--- a/app/src/components/log-viewer/PerformanceStoreHealthBanner.test.tsx
+++ b/app/src/components/log-viewer/PerformanceStoreHealthBanner.test.tsx
@@ -1,0 +1,173 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PerformanceStoreHealthV1 } from '../../lib/performance';
+import { PerformanceStoreHealthBanner } from './PerformanceStoreHealthBanner';
+
+const AVAILABLE: PerformanceStoreHealthV1 = {
+  schemaVersion: 1,
+  status: 'available',
+  skippedRunCount: 0,
+  recommendedAction: 'none',
+};
+
+describe('PerformanceStoreHealthBanner', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onRefresh: ReturnType<typeof vi.fn<() => void>>;
+  let onRecover: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onRefresh = vi.fn<() => void>();
+    onRecover = vi.fn<() => void>();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function render(health: PerformanceStoreHealthV1 | null, overrides: {
+    loading?: boolean;
+    error?: string | null;
+    recovering?: boolean;
+    recoveryError?: string | null;
+  } = {}) {
+    await act(async () => {
+      root.render(
+        <PerformanceStoreHealthBanner
+          health={health}
+          loading={overrides.loading ?? false}
+          error={overrides.error ?? null}
+          recovering={overrides.recovering ?? false}
+          recoveryError={overrides.recoveryError ?? null}
+          onRefresh={onRefresh}
+          onRecover={onRecover}
+        />,
+      );
+    });
+  }
+
+  it('distinguishes a skipped run from an unavailable store', async () => {
+    await render({
+      ...AVAILABLE,
+      skippedRunCount: 1,
+      lastFailure: {
+        operation: 'begin',
+        errorClass: 'busyLocked',
+        attemptCount: 3,
+        retryExhausted: true,
+        atMs: 1_786_720_000_000,
+        recordingId: 35,
+      },
+    });
+    expect(container.textContent).toContain('1 diagnostics run was skipped');
+    expect(container.textContent).toContain('Dictation continued normally');
+    expect(container.textContent).toContain('store is available now');
+    expect(container.textContent).toContain('after 3 attempts');
+    expect(container.textContent).not.toContain('unavailable');
+
+    await render({
+      ...AVAILABLE,
+      status: 'unavailable',
+      recommendedAction: 'freeDisk',
+    });
+    expect(container.textContent).toContain('Diagnostics store unavailable');
+    expect(container.textContent).toContain('Free local disk space, then retry');
+    expect(container.textContent).toContain('new diagnostics are not being saved');
+  });
+
+  it('requires exact confirmation before quarantining and reinitializing', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await render({
+      ...AVAILABLE,
+      status: 'unavailable',
+      recommendedAction: 'reinitializeStore',
+    });
+
+    const button = Array.from(container.querySelectorAll('button'))
+      .find(candidate => candidate.textContent === 'Reinitialize Store…')!;
+    await act(async () => button.click());
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining(
+      'This removes Performance runs and resource samples only',
+    ));
+    expect(onRecover).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    await act(async () => button.click());
+    expect(onRecover).toHaveBeenCalledOnce();
+  });
+
+  it('does not report healthy when a later diagnostics write exhausted retries', async () => {
+    await render({
+      ...AVAILABLE,
+      lastFailure: {
+        operation: 'complete',
+        errorClass: 'busyLocked',
+        attemptCount: 3,
+        retryExhausted: true,
+        atMs: 1_786_720_000_000,
+      },
+    });
+    expect(container.textContent).toContain('Recent diagnostics data was not saved');
+    expect(container.textContent).toContain('latest run completion did not finish');
+    expect(container.textContent).toContain('after 3 attempts');
+    expect(container.textContent).not.toContain('New content-free performance runs');
+  });
+
+  it('keeps cumulative skipped runs separate from a newer unsaved write', async () => {
+    await render({
+      ...AVAILABLE,
+      skippedRunCount: 2,
+      lastFailure: {
+        operation: 'update',
+        errorClass: 'busyLocked',
+        attemptCount: 3,
+        retryExhausted: true,
+        atMs: 1_786_720_000_000,
+      },
+    });
+
+    expect(container.textContent).toContain('2 diagnostics runs were skipped');
+    expect(container.textContent).toContain('Recent diagnostics data was not saved');
+    expect(container.textContent).toContain('latest run update did not finish');
+    expect(container.textContent).not.toContain('run update was skipped');
+  });
+
+  it('shows bounded recovery evidence without exposing a path or raw error', async () => {
+    await render({
+      ...AVAILABLE,
+      lastRecovery: {
+        action: 'quarantinedAndReinitialized',
+        atMs: 1_786_720_000_000,
+      },
+    });
+    expect(container.textContent).toContain('Diagnostics store recovered');
+    expect(container.textContent).toContain('quarantined an unreadable diagnostics store');
+    expect(container.textContent).not.toContain('/');
+    expect(container.textContent).not.toContain('SQLITE');
+  });
+
+  it('offers refresh when health itself cannot be verified', async () => {
+    await render(null, {
+      error: 'Murmur could not verify the local diagnostics store.',
+    });
+    expect(container.textContent).toContain('Diagnostics health could not be verified');
+    const refresh = Array.from(container.querySelectorAll('button'))
+      .find(candidate => candidate.textContent === 'Refresh')!;
+    await act(async () => refresh.click());
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it('does not present a stale healthy snapshot after verification fails', async () => {
+    await render(AVAILABLE, {
+      error: 'Murmur could not verify the local diagnostics store.',
+    });
+    expect(container.textContent).toContain('Diagnostics health could not be verified');
+    expect(container.textContent).not.toContain('Diagnostics store available');
+  });
+});

--- a/app/src/components/log-viewer/PerformanceStoreHealthBanner.tsx
+++ b/app/src/components/log-viewer/PerformanceStoreHealthBanner.tsx
@@ -1,0 +1,199 @@
+import type {
+  PerformanceStoreErrorClassV1,
+  PerformanceStoreHealthV1,
+  PerformanceStoreOperationV1,
+} from '../../lib/performance';
+
+interface PerformanceStoreHealthBannerProps {
+  health: PerformanceStoreHealthV1 | null;
+  loading: boolean;
+  error: string | null;
+  recovering: boolean;
+  recoveryError: string | null;
+  onRefresh: () => void;
+  onRecover: () => void;
+}
+
+const ERROR_CLASS_LABELS: Record<PerformanceStoreErrorClassV1, string> = {
+  busyLocked: 'the local store stayed busy',
+  storageFull: 'local storage space was unavailable',
+  readOnly: 'the local store was read-only',
+  io: 'a local storage operation failed',
+  corruptIntegrity: 'the local store failed an integrity check',
+  schemaMigration: 'the local store schema could not be opened safely',
+  invalidRecord: 'an invalid diagnostics record was rejected',
+  unavailable: 'the local store was unavailable',
+};
+
+const OPERATION_LABELS: Record<PerformanceStoreOperationV1, string> = {
+  initialize: 'startup',
+  begin: 'run start',
+  update: 'run update',
+  complete: 'run completion',
+  read: 'read',
+  write: 'write',
+  clear: 'clear',
+};
+
+function unavailableGuidance(health: PerformanceStoreHealthV1): string {
+  switch (health.recommendedAction) {
+    case 'freeDisk':
+      return 'Free local disk space, then retry. Dictation remains available, but new diagnostics are not being saved.';
+    case 'checkPermissions':
+      return 'Check that Murmur can write to its Application Support data, then retry. Dictation remains available.';
+    case 'reinitializeStore':
+      return 'Reinitialize the diagnostics store to quarantine the unreadable copy and start a new one. Transcription history, settings, and logs are not changed.';
+    case 'restartApp':
+      return 'Quit and reopen Murmur to retry local diagnostics startup. Dictation remains available.';
+    case 'retry':
+      return 'Retry the local diagnostics store. Dictation remains available, but new diagnostics may be skipped.';
+    case 'none':
+      return 'Quit and reopen Murmur. Dictation remains available, but new diagnostics are not being saved.';
+  }
+}
+
+function shouldOfferRecovery(health: PerformanceStoreHealthV1): boolean {
+  return health.recommendedAction === 'retry'
+    || health.recommendedAction === 'freeDisk'
+    || health.recommendedAction === 'checkPermissions'
+    || health.recommendedAction === 'reinitializeStore';
+}
+
+function recoveryButtonLabel(health: PerformanceStoreHealthV1, recovering: boolean): string {
+  if (recovering) return 'Recovering…';
+  return health.recommendedAction === 'reinitializeStore'
+    ? 'Reinitialize Store…'
+    : 'Retry Store';
+}
+
+export function PerformanceStoreHealthBanner({
+  health,
+  loading,
+  error,
+  recovering,
+  recoveryError,
+  onRefresh,
+  onRecover,
+}: PerformanceStoreHealthBannerProps) {
+  if (loading && !health) {
+    return (
+      <div role="status" className="rounded-xl border border-outline-variant/15 bg-surface-container-low px-3 py-2">
+        <div className="text-xs font-medium text-on-surface">Checking diagnostics store…</div>
+      </div>
+    );
+  }
+
+  if (error || !health) {
+    return (
+      <div role="alert" className="rounded-xl border border-warning/20 bg-warning/10 px-3 py-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs font-semibold text-warning">Diagnostics health could not be verified</div>
+            <p className="mt-0.5 text-[11px] text-on-surface-variant">
+              Refresh to check the local diagnostics store. Dictation remains available.
+            </p>
+          </div>
+          <button type="button" onClick={onRefresh} className="shrink-0 text-xs font-semibold text-warning underline">
+            Refresh
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (health.status === 'unavailable') {
+    const recover = () => {
+      if (health.recommendedAction === 'reinitializeStore') {
+        const confirmed = window.confirm(
+          'Reinitialize the local diagnostics store?\n\n'
+          + 'Murmur will quarantine the unreadable diagnostics database and start a new one. '
+          + 'This removes Performance runs and resource samples only; transcription history, settings, logs, and benchmark reports are not changed.',
+        );
+        if (!confirmed) return;
+      }
+      onRecover();
+    };
+    return (
+      <div role="alert" className="rounded-xl border border-error/20 bg-error/10 px-3 py-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs font-semibold text-error">Diagnostics store unavailable</div>
+            <p className="mt-0.5 text-[11px] text-on-surface-variant">{unavailableGuidance(health)}</p>
+            {recoveryError && (
+              <p className="mt-1 text-[11px] font-medium text-error">
+                Diagnostics recovery did not complete. Dictation remains available.
+              </p>
+            )}
+          </div>
+          {shouldOfferRecovery(health) && (
+            <button
+              type="button"
+              disabled={recovering}
+              onClick={recover}
+              className="shrink-0 text-xs font-semibold text-error underline disabled:opacity-50"
+            >
+              {recoveryButtonLabel(health, recovering)}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (health.skippedRunCount > 0) {
+    const failure = health.lastFailure;
+    const latestWriteWasNotSaved = failure?.retryExhausted === true
+      && failure.operation !== 'begin';
+    return (
+      <div role="status" className="rounded-xl border border-warning/20 bg-warning/10 px-3 py-2">
+        <div className="text-xs font-semibold text-warning">
+          {health.skippedRunCount} diagnostics {health.skippedRunCount === 1 ? 'run was' : 'runs were'} skipped
+        </div>
+        <p className="mt-0.5 text-[11px] text-on-surface-variant">
+          Dictation continued normally, and the diagnostics store is available now.
+          {failure?.operation === 'begin' && ` The latest run start was skipped because ${ERROR_CLASS_LABELS[failure.errorClass]} after ${failure.attemptCount} ${failure.attemptCount === 1 ? 'attempt' : 'attempts'}.`}
+          {health.lastRecovery && ' Murmur also quarantined the unreadable diagnostics store and started a new one.'}
+        </p>
+        {latestWriteWasNotSaved && (
+          <p className="mt-1 text-[11px] text-on-surface-variant">
+            <span className="font-semibold text-warning">Recent diagnostics data was not saved.</span>
+            {' '}The latest {OPERATION_LABELS[failure.operation]} did not finish because {ERROR_CLASS_LABELS[failure.errorClass]} after {failure.attemptCount} {failure.attemptCount === 1 ? 'attempt' : 'attempts'}.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (health.lastFailure?.retryExhausted) {
+    const failure = health.lastFailure;
+    return (
+      <div role="status" className="rounded-xl border border-warning/20 bg-warning/10 px-3 py-2">
+        <div className="text-xs font-semibold text-warning">Recent diagnostics data was not saved</div>
+        <p className="mt-0.5 text-[11px] text-on-surface-variant">
+          Dictation continued normally, and the diagnostics store is available now. The latest {OPERATION_LABELS[failure.operation]} did not finish because {ERROR_CLASS_LABELS[failure.errorClass]} after {failure.attemptCount} {failure.attemptCount === 1 ? 'attempt' : 'attempts'}.
+          {health.lastRecovery && ' Murmur also quarantined the unreadable diagnostics store and started a new one.'}
+        </p>
+      </div>
+    );
+  }
+
+  if (health.lastRecovery) {
+    return (
+      <div role="status" className="rounded-xl border border-primary/20 bg-primary/10 px-3 py-2">
+        <div className="text-xs font-semibold text-on-surface">Diagnostics store recovered</div>
+        <p className="mt-0.5 text-[11px] text-on-surface">
+          Murmur quarantined an unreadable diagnostics store and started a new one. Dictation data, settings, and logs were not changed.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div role="status" className="rounded-xl border border-success/20 bg-success/10 px-3 py-2">
+      <div className="text-xs font-semibold text-success">Diagnostics store available</div>
+      <p className="mt-0.5 text-[11px] text-on-surface-variant">
+        New content-free performance runs and resource samples are being saved locally.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/log-viewer/PerformanceView.tsx
+++ b/app/src/components/log-viewer/PerformanceView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { MeasurementV1, ResourceSampleV1 } from '../../lib/performance';
 import type { PerformanceHealth } from '../../lib/hooks/usePerformanceHealth';
+import type { PerformanceStoreHealthState } from '../../lib/hooks/usePerformanceStoreHealth';
 import {
   formatBytes,
   formatMeasurement,
@@ -8,12 +9,14 @@ import {
   type FormattedMeasurement,
 } from '../../lib/performancePresentation';
 import { PerformanceChart, type ResourceChartSeries } from './PerformanceChart';
+import { PerformanceStoreHealthBanner } from './PerformanceStoreHealthBanner';
 
 interface PerformanceViewProps {
   samples: ResourceSampleV1[];
   loading: boolean;
   error: string | null;
   health: PerformanceHealth;
+  store?: PerformanceStoreHealthState;
   onRetry: () => void;
 }
 
@@ -176,6 +179,7 @@ export function PerformanceView({
   loading,
   error,
   health,
+  store,
   onRetry,
 }: PerformanceViewProps) {
   const [selectedIndex, setSelectedIndex] = useState(Math.max(samples.length - 1, 0));
@@ -223,6 +227,23 @@ export function PerformanceView({
 
   return (
     <div className="flex flex-col gap-5 p-4">
+      {store && (
+        <section aria-labelledby="diagnostics-store-health-heading">
+          <h2 id="diagnostics-store-health-heading" className="mb-2 text-sm font-semibold text-on-surface">
+            Diagnostics storage
+          </h2>
+          <PerformanceStoreHealthBanner
+            health={store.health}
+            loading={store.loading}
+            error={store.error}
+            recovering={store.recovering}
+            recoveryError={store.recoveryError}
+            onRefresh={() => void store.refresh()}
+            onRecover={() => void store.recover()}
+          />
+        </section>
+      )}
+
       <section aria-labelledby="runtime-health-heading">
         <div className="mb-2 flex items-end justify-between gap-3">
           <div>

--- a/app/src/components/log-viewer/RunsView.tsx
+++ b/app/src/components/log-viewer/RunsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { CorrelationFilter } from '../../lib/eventFilters';
+import type { PerformanceStoreHealthState } from '../../lib/hooks/usePerformanceStoreHealth';
 import {
   getPerformanceRun,
   type PerformanceRunKindV1,
@@ -17,6 +18,7 @@ import {
   runtimeSummary,
 } from '../../lib/performancePresentation';
 import { RunDetail } from './RunDetail';
+import { PerformanceStoreHealthBanner } from './PerformanceStoreHealthBanner';
 
 type OutcomeFilter =
   | 'all'
@@ -37,6 +39,7 @@ interface RunsViewProps {
   onRetry: () => void;
   onClear: () => Promise<void>;
   onShowEvents: (filter: CorrelationFilter) => void;
+  store?: PerformanceStoreHealthState;
 }
 
 function outcomeClasses(status: PerformanceRunV1['outcome']['status']): string {
@@ -57,6 +60,7 @@ export function RunsView({
   onRetry,
   onClear,
   onShowEvents,
+  store,
 }: RunsViewProps) {
   const [kind, setKind] = useState<'all' | PerformanceRunKindV1>('all');
   const [outcome, setOutcome] = useState<OutcomeFilter>('all');
@@ -128,6 +132,19 @@ export function RunsView({
 
   return (
     <div className="flex min-h-full flex-col p-4">
+      {store && (
+        <div className="mb-4">
+          <PerformanceStoreHealthBanner
+            health={store.health}
+            loading={store.loading}
+            error={store.error}
+            recovering={store.recovering}
+            recoveryError={store.recoveryError}
+            onRefresh={() => void store.refresh()}
+            onRecover={() => void store.recover()}
+          />
+        </div>
+      )}
       <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="text-sm font-semibold text-on-surface">Runs</h2>

--- a/app/src/components/settings/SettingsPanel.test.tsx
+++ b/app/src/components/settings/SettingsPanel.test.tsx
@@ -18,6 +18,7 @@ const coreMocks = vi.hoisted(() => ({
   notchPillDetectionError: false,
   invoke: vi.fn(),
 }));
+const diagnosticsWorkspaceMock = vi.hoisted(() => vi.fn());
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: coreMocks.invoke,
 }));
@@ -34,7 +35,12 @@ vi.mock('./AppOverridesEditor', () => ({ AppOverridesEditor: () => <div>App over
 vi.mock('./AppearanceSettings', () => ({ AppearanceSettings: () => <div>Appearance settings</div> }));
 vi.mock('./KnowledgeManager', () => ({ KnowledgeManager: () => <div>Knowledge manager</div> }));
 vi.mock('./PerformanceLab', () => ({ PerformanceLab: () => <div>Performance lab</div> }));
-vi.mock('../log-viewer/DiagnosticsWorkspace', () => ({ DiagnosticsWorkspace: () => <div>Diagnostics workspace</div> }));
+vi.mock('../log-viewer/DiagnosticsWorkspace', () => ({
+  DiagnosticsWorkspace: (props: unknown) => {
+    diagnosticsWorkspaceMock(props);
+    return <div>Diagnostics workspace</div>;
+  },
+}));
 vi.mock('./VocabularyAliasesEditor', () => ({ VocabularyAliasesEditor: () => <div>Vocabulary editor</div> }));
 vi.mock('./VoiceCommandsManager', () => ({ VoiceCommandsManager: () => <div>Voice commands editor</div> }));
 vi.mock('./TransformsManager', () => ({ TransformsManager: () => <div>Transforms manager</div> }));
@@ -57,6 +63,7 @@ vi.mock('../../lib/transformSettings', () => ({
 }));
 
 beforeEach(() => {
+  diagnosticsWorkspaceMock.mockClear();
   coreMocks.notchPillInstalled = false;
   coreMocks.notchPillDetectionError = false;
   coreMocks.invoke.mockReset();
@@ -293,6 +300,9 @@ describe('SettingsPanel information architecture', () => {
 
     await act(async () => summary.click());
     expect(container.textContent).toContain('Diagnostics workspace');
+    expect(diagnosticsWorkspaceMock).toHaveBeenCalledWith(expect.objectContaining({
+      storeHealthEnabled: true,
+    }));
   });
 
   it('searches across tabs and routes a result to its owning tab', async () => {

--- a/app/src/components/settings/SettingsPanel.tsx
+++ b/app/src/components/settings/SettingsPanel.tsx
@@ -1866,6 +1866,7 @@ export const SettingsPanel = memo(function SettingsPanel({
                 <div className="mt-3 h-[520px] min-h-0 overflow-hidden rounded-xl border border-outline-variant/25 bg-surface-container-lowest">
                   <DiagnosticsWorkspace
                     active
+                    storeHealthEnabled
                     onPopOut={(tab) => { void popOutDiagnostics(tab); }}
                   />
                 </div>

--- a/app/src/lib/hooks/usePerformanceStoreHealth.test.tsx
+++ b/app/src/lib/hooks/usePerformanceStoreHealth.test.tsx
@@ -1,0 +1,181 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PerformanceStoreHealthV1 } from '../performance';
+
+const AVAILABLE: PerformanceStoreHealthV1 = {
+  schemaVersion: 1,
+  status: 'available',
+  skippedRunCount: 0,
+  recommendedAction: 'none',
+};
+
+const mocks = vi.hoisted(() => ({
+  getHealth: vi.fn(),
+  recover: vi.fn(),
+}));
+
+vi.mock('../performance', async importOriginal => ({
+  ...(await importOriginal<typeof import('../performance')>()),
+  getPerformanceStoreHealth: mocks.getHealth,
+  recoverPerformanceStore: mocks.recover,
+}));
+
+import { usePerformanceStoreHealth } from './usePerformanceStoreHealth';
+
+function Probe({ enabled }: { enabled: boolean }) {
+  const store = usePerformanceStoreHealth(enabled);
+  return (
+    <div>
+      <output>{store.health?.status ?? 'unknown'}|{store.error}|{store.recoveryError}</output>
+      <button type="button" onClick={() => void store.recover()}>Recover</button>
+    </div>
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('usePerformanceStoreHealth', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.getHealth.mockReset().mockResolvedValue(AVAILABLE);
+    mocks.recover.mockReset().mockResolvedValue(AVAILABLE);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('does no store work while disabled', async () => {
+    await act(async () => root.render(<Probe enabled={false} />));
+    expect(mocks.getHealth).not.toHaveBeenCalled();
+    expect(mocks.recover).not.toHaveBeenCalled();
+  });
+
+  it('hydrates typed health and accepts the recovered snapshot as authoritative', async () => {
+    const recovered: PerformanceStoreHealthV1 = {
+      ...AVAILABLE,
+      lastRecovery: {
+        action: 'quarantinedAndReinitialized',
+        atMs: 1_786_720_000_000,
+      },
+    };
+    mocks.recover.mockResolvedValue(recovered);
+
+    await act(async () => {
+      root.render(<Probe enabled />);
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('available');
+
+    await act(async () => {
+      container.querySelector('button')?.click();
+      await Promise.resolve();
+    });
+    expect(mocks.recover).toHaveBeenCalledOnce();
+    expect(mocks.recover).toHaveBeenCalledWith(false);
+    expect(container.textContent).toContain('available');
+  });
+
+  it('passes explicit destructive intent only for reinitialization', async () => {
+    mocks.getHealth.mockResolvedValue({
+      ...AVAILABLE,
+      status: 'unavailable',
+      recommendedAction: 'reinitializeStore',
+    });
+
+    await act(async () => {
+      root.render(<Probe enabled />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container.querySelector('button')?.click();
+      await Promise.resolve();
+    });
+
+    expect(mocks.recover).toHaveBeenCalledWith(true);
+  });
+
+  it('does not let an older poll overwrite a completed recovery', async () => {
+    const poll = deferred<PerformanceStoreHealthV1>();
+    const recovered: PerformanceStoreHealthV1 = {
+      ...AVAILABLE,
+      lastRecovery: {
+        action: 'quarantinedAndReinitialized',
+        atMs: 1_786_720_000_000,
+      },
+    };
+    mocks.getHealth.mockReturnValueOnce(poll.promise);
+    mocks.recover.mockResolvedValue(recovered);
+
+    await act(async () => root.render(<Probe enabled />));
+    await act(async () => {
+      container.querySelector('button')?.click();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('available||');
+
+    await act(async () => {
+      poll.resolve({
+        ...AVAILABLE,
+        status: 'unavailable',
+        recommendedAction: 'retry',
+      });
+      await poll.promise;
+    });
+    expect(container.textContent).toContain('available||');
+  });
+
+  it('discards a pending poll failure after recovery and when disabled', async () => {
+    const poll = deferred<PerformanceStoreHealthV1>();
+    mocks.getHealth.mockReturnValueOnce(poll.promise);
+
+    await act(async () => root.render(<Probe enabled />));
+    await act(async () => {
+      container.querySelector('button')?.click();
+      await Promise.resolve();
+      root.render(<Probe enabled={false} />);
+    });
+    await act(async () => {
+      poll.reject(new Error('stale raw database failure'));
+      await poll.promise.catch(() => undefined);
+    });
+
+    expect(container.textContent).toContain('available||');
+    expect(container.textContent).not.toContain('could not verify');
+  });
+
+  it('never forwards raw backend failures to presentation state', async () => {
+    mocks.getHealth.mockRejectedValue(new Error('SQLITE_IOERR /Users/private/performance.sqlite3'));
+    mocks.recover.mockRejectedValue(new Error('SQLITE_CORRUPT at /Users/private'));
+
+    await act(async () => {
+      root.render(<Probe enabled />);
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('Murmur could not verify the local diagnostics store.');
+    expect(container.textContent).not.toContain('SQLITE');
+    expect(container.textContent).not.toContain('/Users');
+
+    await act(async () => {
+      container.querySelector('button')?.click();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('Diagnostics recovery did not complete.');
+    expect(container.textContent).not.toContain('CORRUPT');
+  });
+});

--- a/app/src/lib/hooks/usePerformanceStoreHealth.ts
+++ b/app/src/lib/hooks/usePerformanceStoreHealth.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getPerformanceStoreHealth,
+  recoverPerformanceStore,
+  type PerformanceStoreHealthV1,
+} from '../performance';
+
+const HEALTH_REFRESH_MS = 2_000;
+const HEALTH_ERROR = 'Murmur could not verify the local diagnostics store.';
+const RECOVERY_ERROR = 'Diagnostics recovery did not complete. Dictation remains available.';
+
+export interface PerformanceStoreHealthState {
+  health: PerformanceStoreHealthV1 | null;
+  loading: boolean;
+  error: string | null;
+  recovering: boolean;
+  recoveryError: string | null;
+  refresh: () => Promise<void>;
+  recover: () => Promise<void>;
+}
+
+export function usePerformanceStoreHealth(enabled: boolean): PerformanceStoreHealthState {
+  const [health, setHealth] = useState<PerformanceStoreHealthV1 | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [recovering, setRecovering] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
+  const enabledRef = useRef(enabled);
+  const mountedRef = useRef(true);
+  const requestSequenceRef = useRef(0);
+  const refreshRequestRef = useRef<number | null>(null);
+  const recoveryInFlightRef = useRef(false);
+  enabledRef.current = enabled;
+
+  const refresh = useCallback(async () => {
+    if (!enabledRef.current
+      || recoveryInFlightRef.current
+      || refreshRequestRef.current !== null) return;
+    const request = ++requestSequenceRef.current;
+    refreshRequestRef.current = request;
+    setLoading(true);
+    try {
+      const nextHealth = await getPerformanceStoreHealth();
+      if (!mountedRef.current
+        || !enabledRef.current
+        || requestSequenceRef.current !== request) return;
+      setHealth(nextHealth);
+      setError(null);
+    } catch {
+      if (!mountedRef.current
+        || !enabledRef.current
+        || requestSequenceRef.current !== request) return;
+      setError(HEALTH_ERROR);
+    } finally {
+      if (refreshRequestRef.current === request) {
+        refreshRequestRef.current = null;
+        if (mountedRef.current) setLoading(false);
+      }
+    }
+  }, []);
+
+  const recover = useCallback(async () => {
+    if (!enabledRef.current || recoveryInFlightRef.current) return;
+    recoveryInFlightRef.current = true;
+    refreshRequestRef.current = null;
+    const request = ++requestSequenceRef.current;
+    const allowReinitialize = health?.recommendedAction === 'reinitializeStore';
+    setRecovering(true);
+    setLoading(false);
+    setRecoveryError(null);
+    try {
+      const nextHealth = await recoverPerformanceStore(allowReinitialize);
+      if (!mountedRef.current
+        || !enabledRef.current
+        || requestSequenceRef.current !== request) return;
+      setHealth(nextHealth);
+      setError(null);
+    } catch {
+      if (!mountedRef.current
+        || !enabledRef.current
+        || requestSequenceRef.current !== request) return;
+      setRecoveryError(RECOVERY_ERROR);
+    } finally {
+      recoveryInFlightRef.current = false;
+      if (mountedRef.current) setRecovering(false);
+    }
+  }, [health?.recommendedAction]);
+
+  useEffect(() => {
+    if (!enabled) {
+      requestSequenceRef.current += 1;
+      refreshRequestRef.current = null;
+      setLoading(false);
+      return;
+    }
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), HEALTH_REFRESH_MS);
+    return () => {
+      window.clearInterval(interval);
+      requestSequenceRef.current += 1;
+      refreshRequestRef.current = null;
+    };
+  }, [enabled, refresh]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestSequenceRef.current += 1;
+      refreshRequestRef.current = null;
+    };
+  }, []);
+
+  return {
+    health,
+    loading,
+    error,
+    recovering,
+    recoveryError,
+    refresh,
+    recover,
+  };
+}

--- a/app/src/lib/performance.test.ts
+++ b/app/src/lib/performance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isMeasurementV1,
   isPerformanceRunV1,
+  isPerformanceStoreHealthV1,
   isResourceSampleV1,
   measuredValue,
   PERFORMANCE_STAGES_V1,
@@ -9,6 +10,76 @@ import {
 } from './performance';
 
 describe('performance contracts', () => {
+  it('accepts only the bounded, content-free diagnostics-health schema', () => {
+    const health = {
+      schemaVersion: 1,
+      status: 'available',
+      skippedRunCount: 2,
+      recommendedAction: 'retry',
+      lastFailure: {
+        operation: 'begin',
+        errorClass: 'busyLocked',
+        attemptCount: 3,
+        retryExhausted: true,
+        atMs: 1_786_720_000_000,
+        recordingId: 35,
+      },
+      lastRecovery: {
+        action: 'quarantinedAndReinitialized',
+        atMs: 1_786_719_000_000,
+      },
+    };
+
+    expect(isPerformanceStoreHealthV1(health)).toBe(true);
+    expect(isPerformanceStoreHealthV1({
+      schemaVersion: 1,
+      status: 'unavailable',
+      skippedRunCount: 0,
+      recommendedAction: 'reinitializeStore',
+    })).toBe(true);
+    expect(isPerformanceStoreHealthV1({ ...health, schemaVersion: 2 })).toBe(false);
+    expect(isPerformanceStoreHealthV1({ ...health, status: 'disabled' })).toBe(false);
+    expect(isPerformanceStoreHealthV1({ ...health, skippedRunCount: -1 })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, attemptCount: 0, retryExhausted: false },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, attemptCount: 4, retryExhausted: false },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, attemptCount: 2, retryExhausted: true },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, errorClass: 'io', retryExhausted: true },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, retryExhausted: false },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: {
+        ...health.lastFailure,
+        errorClass: 'io',
+        attemptCount: 1,
+        retryExhausted: false,
+      },
+    })).toBe(true);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, errorClass: 'rawSqliteError' },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({
+      ...health,
+      lastFailure: { ...health.lastFailure, path: '/private/data' },
+    })).toBe(false);
+    expect(isPerformanceStoreHealthV1({ ...health, message: 'database is locked' })).toBe(false);
+  });
+
   it('keeps measured zero distinct from unavailable and not-applicable', () => {
     const measured: MeasurementV1<number> = { status: 'measured', value: 0 };
     expect(isMeasurementV1(measured, (value): value is number => typeof value === 'number')).toBe(true);

--- a/app/src/lib/performance.ts
+++ b/app/src/lib/performance.ts
@@ -176,6 +176,54 @@ export interface PerformanceRunListV1 {
   runs: PerformanceRunV1[];
 }
 
+export type PerformanceStoreErrorClassV1 =
+  | 'busyLocked'
+  | 'storageFull'
+  | 'readOnly'
+  | 'io'
+  | 'corruptIntegrity'
+  | 'schemaMigration'
+  | 'invalidRecord'
+  | 'unavailable';
+
+export type PerformanceStoreOperationV1 =
+  | 'initialize'
+  | 'begin'
+  | 'update'
+  | 'complete'
+  | 'read'
+  | 'write'
+  | 'clear';
+
+export type PerformanceStoreRecommendedActionV1 =
+  | 'none'
+  | 'retry'
+  | 'freeDisk'
+  | 'checkPermissions'
+  | 'reinitializeStore'
+  | 'restartApp';
+
+export interface PerformanceStoreFailureV1 {
+  operation: PerformanceStoreOperationV1;
+  errorClass: PerformanceStoreErrorClassV1;
+  attemptCount: number;
+  retryExhausted: boolean;
+  atMs: number;
+  recordingId?: number;
+}
+
+export interface PerformanceStoreHealthV1 {
+  schemaVersion: 1;
+  status: 'available' | 'unavailable';
+  skippedRunCount: number;
+  lastFailure?: PerformanceStoreFailureV1;
+  recommendedAction: PerformanceStoreRecommendedActionV1;
+  lastRecovery?: {
+    action: 'quarantinedAndReinitialized';
+    atMs: number;
+  };
+}
+
 const unavailableReasons = new Set<UnavailableReasonV1>([
   'unsupportedPlatform',
   'sampleFailed',
@@ -203,6 +251,16 @@ const stableErrors = new Set([
   'inferenceFailed', 'transformStageFailed', 'deliveryFailed',
   'queryFailed', 'internalEarlyExit', 'interruptedByRestart',
 ]);
+const performanceStoreErrorClasses = new Set<PerformanceStoreErrorClassV1>([
+  'busyLocked', 'storageFull', 'readOnly', 'io', 'corruptIntegrity',
+  'schemaMigration', 'invalidRecord', 'unavailable',
+]);
+const performanceStoreOperations = new Set<PerformanceStoreOperationV1>([
+  'initialize', 'begin', 'update', 'complete', 'read', 'write', 'clear',
+]);
+const performanceStoreRecommendedActions = new Set<PerformanceStoreRecommendedActionV1>([
+  'none', 'retry', 'freeDisk', 'checkPermissions', 'reinitializeStore', 'restartApp',
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -223,6 +281,70 @@ function isPositiveSafeInteger(value: unknown): value is number {
   return typeof value === 'number'
     && Number.isSafeInteger(value)
     && value > 0;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+export function isPerformanceStoreHealthV1(
+  value: unknown,
+): value is PerformanceStoreHealthV1 {
+  if (!isRecord(value)) return false;
+  const expectedKeys = [
+    'schemaVersion', 'status', 'skippedRunCount', 'recommendedAction',
+  ];
+  if ('lastFailure' in value) expectedKeys.push('lastFailure');
+  if ('lastRecovery' in value) expectedKeys.push('lastRecovery');
+  if (!hasExactKeys(value, expectedKeys)
+    || value.schemaVersion !== 1
+    || (value.status !== 'available' && value.status !== 'unavailable')
+    || !isNonNegativeSafeInteger(value.skippedRunCount)
+    || typeof value.recommendedAction !== 'string'
+    || !performanceStoreRecommendedActions.has(
+      value.recommendedAction as PerformanceStoreRecommendedActionV1,
+    )) {
+    return false;
+  }
+  if ('lastFailure' in value) {
+    if (!isRecord(value.lastFailure)) return false;
+    const failureKeys = [
+      'operation', 'errorClass', 'attemptCount', 'retryExhausted', 'atMs',
+    ];
+    if ('recordingId' in value.lastFailure) failureKeys.push('recordingId');
+    if (!hasExactKeys(value.lastFailure, failureKeys)
+      || typeof value.lastFailure.operation !== 'string'
+      || !performanceStoreOperations.has(
+        value.lastFailure.operation as PerformanceStoreOperationV1,
+      )
+      || typeof value.lastFailure.errorClass !== 'string'
+      || !performanceStoreErrorClasses.has(
+        value.lastFailure.errorClass as PerformanceStoreErrorClassV1,
+      )
+      || !isPositiveSafeInteger(value.lastFailure.attemptCount)
+      || value.lastFailure.attemptCount > 3
+      || typeof value.lastFailure.retryExhausted !== 'boolean'
+      || value.lastFailure.retryExhausted !== (
+        value.lastFailure.errorClass === 'busyLocked'
+        && value.lastFailure.attemptCount === 3
+      )
+      || !isNonNegativeSafeInteger(value.lastFailure.atMs)
+      || ('recordingId' in value.lastFailure
+        && !isPositiveSafeInteger(value.lastFailure.recordingId))) {
+      return false;
+    }
+  }
+  if ('lastRecovery' in value) {
+    if (!isRecord(value.lastRecovery)
+      || !hasExactKeys(value.lastRecovery, ['action', 'atMs'])
+      || value.lastRecovery.action !== 'quarantinedAndReinitialized'
+      || !isNonNegativeSafeInteger(value.lastRecovery.atMs)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function isMeasurementV1<T>(
@@ -465,6 +587,24 @@ export async function getPerformanceResourceWindow(): Promise<ResourceSampleV1[]
 
 export async function clearPerformanceDiagnostics(): Promise<void> {
   await invoke('clear_performance_diagnostics');
+}
+
+export async function getPerformanceStoreHealth(): Promise<PerformanceStoreHealthV1> {
+  const value = await invoke<unknown>('get_performance_store_health');
+  if (!isPerformanceStoreHealthV1(value)) {
+    throw new Error('Murmur returned an unsupported diagnostics-health schema.');
+  }
+  return value;
+}
+
+export async function recoverPerformanceStore(
+  allowReinitialize: boolean,
+): Promise<PerformanceStoreHealthV1> {
+  const value = await invoke<unknown>('recover_performance_store', { allowReinitialize });
+  if (!isPerformanceStoreHealthV1(value)) {
+    throw new Error('Murmur returned an unsupported diagnostics-health schema.');
+  }
+  return value;
 }
 
 export function onPerformanceRunCompleted(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ available for packaging and callback-boundary validation. See the
 
 | Module | Purpose |
 |--------|---------|
-| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 158 registered commands, setup, tray, run loop |
+| `lib.rs` | App wiring: module declarations, `State`, `MutexExt`, 160 registered commands, setup, tray, run loop |
 | `alloc.rs` | Custom macOS malloc zone ("RustHeapZone") so Rust heap is accounted separately from whisper.cpp's FFI heap |
 | `audio.rs` | CPAL 0.18 capture worker, stable device-ID selection, typed error/phase telemetry, first-buffer readiness, mono mix, 16kHz resample, `audio-level` emission |
 | `audio_lifecycle.rs` | App-lifetime single-owner supervisor; async start, generation cancellation, deadlines, generation-gated publication, and strict worker ownership through exit |
@@ -345,7 +345,7 @@ tracing event
 
 Seven streams (tracing targets): `pipeline`, `audio`, `keyboard`, `transform`, `meeting`, `query`, `system`.
 
-**Privacy stripping.** In release builds, all string fields on `pipeline` events are removed from the data object; only numerics survive. `transform`, `meeting`, and `query` events are stricter still and stripped in *all* builds: every key, type, and stable string value must satisfy that stream's exact allowlist. Anything else is dropped at the layer, independent of the call site. Query questions, answers, context, stderr, and provider detail therefore cannot enter events even when local query history is enabled. The fleet shipper also rejects the entire `meeting` stream and malformed JSONL, so meeting content and lifecycle never leave the Mac.
+**Privacy stripping.** In release builds, all string fields on `pipeline` events are removed from the data object; only numerics survive. `transform`, `meeting`, and `query` events are stricter still and stripped in *all* builds: every key, type, and stable string value must satisfy that stream's exact allowlist. The `performance.store_operation_failed` system event is likewise reduced in every build to its stable code, operation, safe SQLite class, attempt count, and recording ID. Anything else is dropped at the layer, independent of the call site. Query questions, answers, context, stderr, SQL, database paths, and provider detail therefore cannot enter those events. The fleet shipper also rejects the entire `meeting` stream and malformed JSONL, so meeting content and lifecycle never leave the Mac.
 
 ### Local storage
 
@@ -385,7 +385,7 @@ Two rules keep the multi-window state coherent:
 
 ## Tauri Commands
 
-158 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
+160 commands are registered in `lib.rs`. See [reference/commands.md](reference/commands.md) for the full signature-level list, grouped by module.
 
 ## Events
 

--- a/docs/features/log-viewer.md
+++ b/docs/features/log-viewer.md
@@ -53,6 +53,10 @@ The pipeline string exceptions are exact allowlisted `event_code` values and
 the bounded terminal `outcome` / `error_code` vocabularies. Event codes are
 fixed identifiers such as `pipeline.dictation_terminal`; arbitrary values are
 removed. Transform event codes pass through the same exact-value allowlist.
+The `performance.store_operation_failed` system event is treated as its own
+all-build schema: only its code, bounded operation/error class, attempt count,
+and recording ID survive. SQLite text, SQL, paths, and unknown fields are
+dropped.
 Frontend-originated codes are validated by Rust before entering the structured
 event. This gives local and fleet presentation layers stable semantic keys
 without permitting user content or arbitrary labels.

--- a/docs/features/performance-diagnostics.md
+++ b/docs/features/performance-diagnostics.md
@@ -35,6 +35,25 @@ remain backward-compatible at `schemaVersion: 1`. A database created by a newer 
 build is preserved and treated as unavailable rather than rewritten. Unknown
 record versions are not decoded as V1.
 
+SQLite failures use a bounded taxonomy: `busyLocked`, `storageFull`,
+`readOnly`, `io`, `corruptIntegrity`, `schemaMigration`, `invalidRecord`, or
+`unavailable`. Only `busyLocked` is retried, for at most three total attempts
+with short bounded backoff. The retry happens in diagnostics persistence after
+the capture transition; it never delays microphone ownership or prevents
+ordinary dictation. A run that still cannot begin is explicitly skipped.
+
+Initialization validates integrity and supported-version records after opening
+the database and before the store is used. On automatic startup, only proven
+physical corruption quarantines the database and its SQLite sidecars inside the
+diagnostics directory before creating a fresh store once. An undecodable
+supported-version record stays unavailable until the user explicitly confirms
+**Reinitialize Store**. Unsupported/newer schemas and other persistent failures
+also leave the store unavailable with a bounded local action; the health banner
+distinguishes that state from a single skipped run. Explicit recovery reopens
+and rechecks the store, and never quarantines without both confirmed caller
+intent and fresh corruption or invalid-record evidence. It does not delete
+quarantined evidence, and a healthy database is never quarantined.
+
 ## Run contract
 
 `PerformanceRunV1` contains:
@@ -143,7 +162,12 @@ selected/proposed/replaced text, clipboard contents, paths or filenames, bundle
 IDs, window titles, selected context, project/profile names, raw stderr, or
 free-form native error messages. Voice Query records retain stderr presence
 only. Errors are stable enums. Text-related sizes are bounded buckets.
-There is no network upload or remote telemetry.
+Database contents are never uploaded. When a dictation diagnostics row still
+cannot begin after its bounded retry, one content-free structured event reports
+only `operation`, the safe error class, attempt count, and `recording_id`. The
+telemetry layer independently rejects every other key and unknown string in
+both debug and release builds; SQL, database paths, transcript, and audio can
+never enter this event.
 
 ## Commands and events
 
@@ -152,6 +176,8 @@ There is no network upload or remote telemetry.
 | `list_performance_runs` | Read newest supported V1 runs, bounded to 200 |
 | `get_performance_run` | Read one V1 run by opaque ID |
 | `get_performance_resource_window` | Read the persistent ten-minute sample window |
+| `get_performance_store_health` | Read available/unavailable state and bounded recovery evidence |
+| `recover_performance_store` | Explicitly retry initialization without restarting Murmur; destructive reinitialization requires confirmed caller intent |
 | `clear_performance_diagnostics` | Clear only the diagnostics database |
 | `show_diagnostics_window` | Show the persistent pop-out on an exact allowlisted tab |
 | `performance-run-completed` | Live typed completion event |
@@ -170,6 +196,12 @@ Diagnostics window on the currently selected tab, allowing the main window to
 remain navigable while events, resource samples, and UI latency samples update.
 Closing the pop-out hides it so opening it again avoids another WebView cold
 start.
+
+The production regression watch counts exhausted
+`performance.store_operation_failed` events by install, app version,
+operation, and safe error class. It consumes only the already privacy-stripped
+JSONL stream and collapses unrecognized labels to `unknown` before producing a
+report or dashboard alert.
 
 ## Capture startup health
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Tauri Commands Reference
 
-The 158 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
+The 160 commands registered in `lib.rs` and exposed to the frontend via `invoke()`, grouped by source module under `app/src-tauri/src/`.
 
 Parameters are listed with their Rust names; the frontend passes them camelCased (`model_name` → `modelName`). `app_handle` / `state` / `window` injections are omitted — they are supplied by Tauri, not by the caller.
 
@@ -230,6 +230,8 @@ frontend.
 | `list_performance_runs` | `limit: Option<u32>` | `Result<PerformanceRunListV1, String>` | Completed runs, newest first (cap 200). |
 | `get_performance_run` | `run_id: String` | `Result<Option<PerformanceRunV1>, String>` | One run with stage timings, warm state, RSS deltas, and transform follow-ups. |
 | `get_performance_resource_window` | — | `Result<Vec<ResourceSampleV1>, String>` | The rolling CPU/memory sample window (cap 600). |
+| `get_performance_store_health` | — | `Result<PerformanceStoreHealthV1, String>` | Main/Diagnostics-window-only content-free store availability, skipped-run count, last bounded failure/recovery evidence, and recommended local action. |
+| `recover_performance_store` | `allow_reinitialize: bool` | `Result<PerformanceStoreHealthV1, String>` | Main/Diagnostics-window-only explicit reopen/check. Quarantine/reinitialize additionally requires confirmed caller intent plus fresh corruption or invalid-record evidence; a healthy database is never deleted. |
 | `get_capture_health_history` | — | `CaptureHealthHistoryV1` | The 20 newest finalized dictation startup observations. Each contains only `startupMs`, `usedFallback`, and an optional allowlisted fallback backend enum. |
 | `clear_performance_diagnostics` | — | `Result<(), String>` | Deletes local run history, samples, and capture-startup observations; emits `performance-diagnostics-cleared`. |
 | `show_diagnostics_window` | `tab: String` | `Result<(), String>` | Shows and focuses the persistent Diagnostics window, selecting one of its exact allowlisted tabs. |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -132,6 +132,13 @@ vocabularies while dropping arbitrary string values. See
 [Transcription Pipeline](../features/transcription.md#per-recording-lifecycle-telemetry)
 for stage denominators and terminal semantics.
 
+An exhausted dictation diagnostics-row start emits the stable structured code
+`performance.store_operation_failed`. Its all-build allowlist admits only
+`operation`, `error_class`, numeric `attempts`, and numeric `recording_id`.
+SQL, SQLite messages, database paths, transcripts, and audio are rejected at
+the telemetry layer. The Fleet watch groups this event by ingested app version
+and safe error class.
+
 ## Updater
 
 | Event | Payload | Source | When it fires | Listeners |

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -157,6 +157,13 @@ Live pipeline/model state plus capture-startup health with an explicit `refresh`
 Its two-second refresh reads the dedicated bounded `get_capture_health_history`
 payload rather than polling the general event history.
 
+### `usePerformanceStoreHealth`
+Diagnostics-store availability and recovery controller. It polls only while
+its surface is enabled, keeps a single recovery request in flight, and exposes
+the typed skipped-run/failure evidence plus **Retry Store**. A failed
+refresh preserves the last valid bounded health value and surfaces a local UI
+error; it never changes dictation state.
+
 ### `useResourceMonitor`
 CPU/memory polling with a rolling 60-reading buffer. Only polls while the panel is expanded.
 

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -141,6 +141,8 @@ cohorts per install. Further versions collapse into a non-comparable
 - dictation `startup_ms` p50 and p95;
 - active-budget timeouts split by stable backend and native setup step;
 - fallback and both-backends-failed counts;
+- exhausted diagnostics-store operations split by stable operation and safe
+  SQLite error class for each app-version cohort;
 - a histogram of ready recordings for the five most recent completed,
   attempted dictation sessions in each cohort;
 - a stable-code dictation funnel with terminal outcome counts, per-stage
@@ -152,6 +154,13 @@ contained a dictation `audio initialization accepted`; idle launches, transform
 captures, and the currently open session are excluded. Per-session ready counts
 at or above 20 share one capped tail bucket, bounding both memory and report
 cardinality.
+
+`performance.store_operation_failed` contains only the operation, bounded
+error class, attempt count, and recording ID. The watch independently
+allowlists the operation and class, collapsing unknown labels before they can
+enter its report. The newest affected app-version cohort produces a dashboard
+alert; the versioned cohort rows retain the counts needed to distinguish a
+one-off skipped run from recurrence.
 
 An alert is created when the newest comparable version has at least five
 dictation readiness samples and its p50 is more than twice the best retained

--- a/infra/log-receiver/murmur-capture-watch.py
+++ b/infra/log-receiver/murmur-capture-watch.py
@@ -34,6 +34,25 @@ REPEATED_ZERO_READY_SESSIONS = 2
 RECENT_ATTEMPTED_SESSION_WINDOW = 5
 MAX_READY_RECORDINGS_PER_SESSION = 20
 CAPTURE_HEALTH_OWNER_KIND = "dictation"
+PERFORMANCE_STORE_OPERATIONS = {
+    "initialize",
+    "begin",
+    "update",
+    "complete",
+    "read",
+    "write",
+    "clear",
+}
+PERFORMANCE_STORE_ERROR_CLASSES = {
+    "busyLocked",
+    "storageFull",
+    "readOnly",
+    "io",
+    "corruptIntegrity",
+    "schemaMigration",
+    "invalidRecord",
+    "unavailable",
+}
 
 VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,39}$")
 INSTALL_RE = re.compile(r"^[0-9a-fA-F-]{8,64}$")
@@ -99,6 +118,14 @@ def bounded_setup_step(value):
     return value if value in SETUP_STEPS else "unknown"
 
 
+def bounded_performance_store_operation(value):
+    return value if value in PERFORMANCE_STORE_OPERATIONS else "unknown"
+
+
+def bounded_performance_store_error_class(value):
+    return value if value in PERFORMANCE_STORE_ERROR_CLASSES else "unknown"
+
+
 def numeric_startup(event):
     value = event_data(event).get("startup_ms")
     if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -126,6 +153,7 @@ def new_cohort(install_id, version):
         "timeouts": Counter(),
         "fallback_count": 0,
         "both_backends_failed_count": 0,
+        "performance_store_failures": Counter(),
         "attempted_sessions": 0,
         "recent_session_ready_counts": deque(maxlen=RECENT_ATTEMPTED_SESSION_WINDOW),
         "last_attempted_session_at": "",
@@ -245,6 +273,13 @@ def scan_install(path, install_id, cohorts):
                 continue
             if code == "audio.capture_failed":
                 cohort["both_backends_failed_count"] += 1
+                continue
+            if code == "performance.store_operation_failed":
+                key = (
+                    bounded_performance_store_operation(data.get("operation")),
+                    bounded_performance_store_error_class(data.get("error_class")),
+                )
+                cohort["performance_store_failures"][key] += 1
 
     # An open app session is deliberately not classified as zero-ready. A later
     # startup boundary proves that the preceding session ended and makes the
@@ -267,6 +302,17 @@ def serialize_cohort(cohort):
             key=lambda item: (-item[1], item[0]),
         )
     ]
+    performance_store_failure_rows = [
+        {
+            "operation": operation,
+            "error_class": error_class,
+            "count": count,
+        }
+        for (operation, error_class), count in sorted(
+            cohort["performance_store_failures"].items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
     return {
         "install_id": cohort["install_id"],
         "app_version": cohort["app_version"],
@@ -280,6 +326,10 @@ def serialize_cohort(cohort):
         "capture_backend_timeouts": timeout_rows,
         "fallback_count": cohort["fallback_count"],
         "both_backends_failed_count": cohort["both_backends_failed_count"],
+        "performance_store_failure_total": sum(
+            cohort["performance_store_failures"].values()
+        ),
+        "performance_store_failures": performance_store_failure_rows,
         "attempted_sessions": cohort["attempted_sessions"],
         "evaluated_attempted_sessions": len(recent_session_ready_counts),
         "attempted_sessions_truncated": (
@@ -314,6 +364,21 @@ def regression_alerts(cohort_rows):
         by_install.setdefault(row["install_id"], []).append(row)
 
     for install_id, rows in by_install.items():
+        latest = max(
+            rows,
+            key=lambda row: (row["last_event_at"], row["app_version"]),
+        )
+        for failure in latest["performance_store_failures"]:
+            alerts.append(
+                {
+                    "kind": "performance_store_failure",
+                    "install_id": install_id,
+                    "app_version": latest["app_version"],
+                    "operation": failure["operation"],
+                    "error_class": failure["error_class"],
+                    "count": failure["count"],
+                }
+            )
         lifecycle_rows = [
             row
             for row in rows

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -216,6 +216,18 @@ def render_capture_watch(report):
                     label,
                 )
             )
+        elif alert.get("kind") == "performance_store_failure":
+            rows.append(
+                "<li><code>%s</code> v%s: Diagnostics store %s failed %s time(s) "
+                "(%s)</li>"
+                % (
+                    install,
+                    html.escape(str(alert.get("app_version", ""))[:40]),
+                    html.escape(str(alert.get("operation", "unknown"))[:24]),
+                    html.escape(str(alert.get("count", ""))[:20]),
+                    html.escape(str(alert.get("error_class", "unknown"))[:32]),
+                )
+            )
     return (
         "<div class='watch-banner alert'><strong>Capture regression watch · "
         "%d alert%s</strong><span>Last run %s</span><ul>%s</ul></div>"

--- a/tests/test_capture_regression_watch.py
+++ b/tests/test_capture_regression_watch.py
@@ -110,6 +110,96 @@ class CaptureRegressionWatchTests(unittest.TestCase):
             [{"backend": "auhal", "last_setup_step": "stream_start", "count": 1}],
         )
 
+    def test_performance_store_failures_are_counted_by_version_and_safe_class(self) -> None:
+        events = [
+            event(
+                "untrusted diagnostic text",
+                "2026-08-01T00:00:00Z",
+                version="1.2.3",
+                data={
+                    "event_code": "performance.store_operation_failed",
+                    "operation": "begin",
+                    "error_class": "busyLocked",
+                    "attempts": 3,
+                    "recording_id": 35,
+                },
+            ),
+            event(
+                "another untrusted summary",
+                "2026-08-01T00:00:01Z",
+                version="1.2.3",
+                data={
+                    "event_code": "performance.store_operation_failed",
+                    "operation": "begin",
+                    "error_class": "busyLocked",
+                    "attempts": 3,
+                    "recording_id": 36,
+                },
+            ),
+            event(
+                "ignored",
+                "2026-08-02T00:00:00Z",
+                version="1.2.4",
+                data={
+                    "event_code": "performance.store_operation_failed",
+                    "operation": "begin",
+                    "error_class": "readOnly",
+                    "attempts": 1,
+                    "recording_id": 1,
+                },
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        cohorts = {row["app_version"]: row for row in report["cohorts"]}
+        self.assertEqual(cohorts["1.2.3"]["performance_store_failure_total"], 2)
+        self.assertEqual(
+            cohorts["1.2.3"]["performance_store_failures"],
+            [{"operation": "begin", "error_class": "busyLocked", "count": 2}],
+        )
+        self.assertEqual(cohorts["1.2.4"]["performance_store_failure_total"], 1)
+        self.assertEqual(report["status"], "alert")
+        self.assertEqual(
+            report["alerts"],
+            [
+                {
+                    "kind": "performance_store_failure",
+                    "install_id": "12345678-abcd",
+                    "app_version": "1.2.4",
+                    "operation": "begin",
+                    "error_class": "readOnly",
+                    "count": 1,
+                }
+            ],
+        )
+
+    def test_performance_store_watch_collapses_untrusted_labels(self) -> None:
+        events = [
+            event(
+                "ignored",
+                "2026-08-01T00:00:00Z",
+                version="1.2.3",
+                data={
+                    "event_code": "performance.store_operation_failed",
+                    "operation": "SELECT private_path",
+                    "error_class": "/Users/private/diagnostics.sqlite3",
+                },
+            )
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(root)
+
+        self.assertEqual(
+            report["cohorts"][0]["performance_store_failures"],
+            [{"operation": "unknown", "error_class": "unknown", "count": 1}],
+        )
+        encoded = json.dumps(report)
+        self.assertNotIn("private_path", encoded)
+        self.assertNotIn("/Users/private", encoded)
+
     def test_alerts_when_newest_version_p50_is_more_than_twice_baseline(self) -> None:
         events = self.ready_events("1.0.0", "01", [180, 190, 200, 210, 220])
         events += self.ready_events("1.1.0", "02", [500, 520, 540, 560, 580])

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -98,6 +98,36 @@ class LogReceiverHealthTests(unittest.TestCase):
         self.assertIn("v1.0.0 → v1.1.0", page)
         self.assertIn("p50 200 ms → 520 ms (2.6x)", page)
 
+    def test_dashboard_surfaces_performance_store_failure_watch(self) -> None:
+        report = {
+            "schema_version": 1,
+            "generated_at": "2026-08-14T00:00:00Z",
+            "status": "alert",
+            "alerts": [
+                {
+                    "kind": "performance_store_failure",
+                    "install_id": "12345678-abcd",
+                    "app_version": "1.2.3",
+                    "operation": "begin",
+                    "error_class": "busyLocked",
+                    "count": 2,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = receiver.ROOT
+            receiver.ROOT = directory
+            try:
+                (Path(directory) / receiver.CAPTURE_WATCH_REPORT).write_text(
+                    json.dumps(report),
+                    encoding="utf-8",
+                )
+                page = receiver.render_dashboard()
+            finally:
+                receiver.ROOT = original_root
+
+        self.assertIn("Diagnostics store begin failed 2 time(s) (busyLocked)", page)
+
     def test_stable_event_code_takes_precedence_over_compatibility_summary(self) -> None:
         item = event(
             "listener heartbeat — no rdev callbacks observed",

--- a/tests/test_reference_docs.py
+++ b/tests/test_reference_docs.py
@@ -28,7 +28,7 @@ def copy_reference_fixture(root: Path) -> None:
 
 class ReferenceDocsTests(unittest.TestCase):
     def test_repository_reference_docs_match_registered_commands(self) -> None:
-        self.assertEqual(validate_reference_docs(), 158)
+        self.assertEqual(validate_reference_docs(), 160)
 
     def test_missing_command_row_fails_even_when_prose_count_is_current(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -54,7 +54,7 @@ class ReferenceDocsTests(unittest.TestCase):
             architecture = root / "docs/ARCHITECTURE.md"
             architecture.write_text(
                 architecture.read_text().replace(
-                    "158 registered commands", "157 registered commands", 1
+                    "160 registered commands", "159 registered commands", 1
                 )
             )
 


### PR DESCRIPTION
Closes #536

## Summary
- classify performance-store failures with a stable, privacy-safe taxonomy and retry only bounded SQLite contention
- move dictation diagnostics persistence off capture ownership, preserve exact recording lifecycle ordering, and expose durable store health plus confirmed recovery actions
- add Diagnostics UI health states and Fleet recurrence counts by app version, operation, and safe error class
- document recovery, telemetry, command, and hook contracts

## Privacy and safety
- telemetry uses exact allowlisted fields and never includes SQLite errors, SQL, paths, transcript, or audio
- non-destructive retry cannot quarantine data; reinitialization requires explicit confirmation and fresh corruption/invalid-record evidence
- ordinary dictation continues when diagnostics persistence is unavailable

## Validation
- Ubuntu: `npx tsc --noEmit`
- Ubuntu: `npm test` — 96 files / 886 tests
- Ubuntu: Fleet watcher/reference suite — 48 tests
- exact-SHA Fleet Mac (`de470310d4c8e6ce7780a73dad4d7bc8fb58dc9b`): fmt, check, strict clippy, and full Rust tests — 959 passed / 5 ignored plus all integration suites
- GitHub CI: typecheck, visual regression, dependency audit, macOS Rust, and required aggregate gate passed
- independent concurrency/privacy/frontend reviews completed; final stale-cancellation ordering finding fixed and re-reviewed

## Murmur Bench
PASS — quick preset against baseline `cf22bd154ab069fc4e6f7ba34b748a3fb902dda6`, candidate `de470310d4c8e6ce7780a73dad4d7bc8fb58dc9b`, all 7 installed models. Thresholds: latency +10% and +25 ms; WER/delivered WER +0.01; memory +128 MB. Aggregate deltas: model load -2.0%, first inference -0.9%, warm median -1.0%, warm p95 +0.3%, RTF -0.5%, WER and delivered WER 0.000, memory -48 MB total. Worst latency increase +4.4% / +6.072 ms; no threshold exceeded. Raw reports remained on the trusted Mac.

## Native macOS smoke
PASS at exact candidate SHA in an isolated bundle/home. Debug app built and launched, onboarding completed, main UI reached Ready, Diagnostics > Runs showed `Diagnostics store available`, SQLite `quick_check` returned `ok` at schema v2 with expected tables, and logs had no store failure/panic/fatal. No production data was touched and no release/signing was attempted. The Fleet Mac exposes no input channels, so real microphone capture was not available; focused recording lifecycle tests passed 37/37.