### PR TITLE
Evaluate weekly dictation reliability SLOs

### DIFF
--- a/app/src-tauri/src/audio_lifecycle.rs
+++ b/app/src-tauri/src/audio_lifecycle.rs
@@ -822,25 +822,50 @@ fn handle_worker_event(
         AudioWorkerEvent::PermissionPromptPending { .. } => {
             if current.phase == AttemptPhase::Starting && current.tcc_pending_since.is_none() {
                 current.tcc_pending_since = Some(Instant::now());
-                tracing::info!(
-                    target: "audio",
-                    owner = owner.telemetry_id(),
-                    owner_kind = owner.kind(),
-                    "microphone permission prompt pending; initialization deadlines suspended"
-                );
+                if let Some(recording_id) = owner.dictation_id() {
+                    tracing::info!(
+                        target: "audio",
+                        event_code = "audio.permission_prompt_changed",
+                        recording_id,
+                        owner = owner.telemetry_id(),
+                        owner_kind = owner.kind(),
+                        state = "pending",
+                        "microphone permission prompt pending; initialization deadlines suspended"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "audio",
+                        owner = owner.telemetry_id(),
+                        owner_kind = owner.kind(),
+                        "microphone permission prompt pending; initialization deadlines suspended"
+                    );
+                }
             }
         }
         AudioWorkerEvent::PermissionPromptResolved { .. } => {
             if let Some(started) = current.tcc_pending_since.take() {
                 let paused = started.elapsed();
                 current.tcc_paused_total += paused;
-                tracing::info!(
-                    target: "audio",
-                    owner = owner.telemetry_id(),
-                    owner_kind = owner.kind(),
-                    prompt_pending_ms = paused.as_millis() as u64,
-                    "microphone permission prompt resolved; initialization deadlines resumed"
-                );
+                if let Some(recording_id) = owner.dictation_id() {
+                    tracing::info!(
+                        target: "audio",
+                        event_code = "audio.permission_prompt_changed",
+                        recording_id,
+                        owner = owner.telemetry_id(),
+                        owner_kind = owner.kind(),
+                        state = "resolved",
+                        prompt_pending_ms = paused.as_millis() as u64,
+                        "microphone permission prompt resolved; initialization deadlines resumed"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "audio",
+                        owner = owner.telemetry_id(),
+                        owner_kind = owner.kind(),
+                        prompt_pending_ms = paused.as_millis() as u64,
+                        "microphone permission prompt resolved; initialization deadlines resumed"
+                    );
+                }
             }
         }
         AudioWorkerEvent::TerminationUnconfirmed { failure, .. } => {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -3341,8 +3341,8 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
             }
         }
         AudioLifecycleEvent::RecoveryStalled => {
-            if is_current() {
-                if app_handle
+            if is_current()
+                && app_handle
                     .emit("recording-recovery-stalled", {
                         let (status_code, action_code) =
                             DictationPresentation::CleanupStalled.codes();
@@ -3353,12 +3353,8 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                         })
                     })
                     .is_ok()
-                {
-                    emit_dictation_presentation(
-                        recording_id,
-                        DictationPresentation::CleanupStalled,
-                    );
-                }
+            {
+                emit_dictation_presentation(recording_id, DictationPresentation::CleanupStalled);
             }
         }
         AudioLifecycleEvent::Interrupted {

--- a/app/src-tauri/src/commands/recording.rs
+++ b/app/src-tauri/src/commands/recording.rs
@@ -31,6 +31,110 @@ const WHISPER_PROMPT_TERMS: usize = 96;
 /// [`WHISPER_PROMPT_TERMS`] (a rank-prefix of them) feed Whisper.
 const CORRECTION_TERMS: usize = 500;
 
+/// Version of the stable fleet reliability contract attached to every eligible
+/// live-dictation request. Historical attempts without this marker remain
+/// visible to the legacy funnel but cannot be treated as SLO evidence.
+const DICTATION_SLO_CONTRACT: u64 = 1;
+
+fn dictation_status_code(status: DictationStatus) -> &'static str {
+    match status {
+        DictationStatus::Idle => "idle",
+        DictationStatus::Starting => "starting",
+        DictationStatus::Recording => "recording",
+        DictationStatus::Recovering => "recovering",
+        DictationStatus::Processing => "processing",
+    }
+}
+
+fn emit_dictation_state_changed(recording_id: u64, from: DictationStatus, to: DictationStatus) {
+    if recording_id == 0 || from == to {
+        return;
+    }
+    tracing::info!(
+        target: "pipeline",
+        event_code = "pipeline.dictation_state_changed",
+        recording_id,
+        from = dictation_status_code(from),
+        to = dictation_status_code(to),
+        "dictation state changed"
+    );
+}
+
+/// Mutate the live dictation state and publish its bounded, content-free
+/// transition evidence as one operation. Keep production status writes on this
+/// seam so early returns cannot silently create gaps in the SLO timeline.
+fn transition_dictation_status(
+    recording_id: u64,
+    dictation: &mut crate::state::DictationState,
+    to: DictationStatus,
+) -> DictationStatus {
+    let from = dictation.status;
+    dictation.status = to;
+    emit_dictation_state_changed(recording_id, from, to);
+    from
+}
+
+/// Mark an eligible live request at the exact Idle -> Starting boundary.
+/// Capture the performance origin and publish the denominator before the
+/// state-transition trace so diagnostic I/O cannot disappear from measured
+/// request-to-first-PCM latency.
+fn accept_live_dictation_request(
+    recording_id: u64,
+    dictation: &mut crate::state::DictationState,
+    emit_requested: impl FnOnce(DictationStatus),
+) -> i64 {
+    let performance_started_at_ms = chrono::Utc::now().timestamp_millis();
+    emit_requested(dictation.status);
+    transition_dictation_status(recording_id, dictation, DictationStatus::Starting);
+    performance_started_at_ms
+}
+
+#[derive(Clone, Copy)]
+enum DictationPresentation {
+    CleanupInProgress,
+    InitializationFailed(audio::AudioFailureKind),
+    CleanupStalled,
+    Interrupted { partial_transcription: bool },
+}
+
+impl DictationPresentation {
+    fn codes(self) -> (&'static str, &'static str) {
+        match self {
+            Self::CleanupInProgress => ("microphone_cleanup_in_progress", "wait"),
+            Self::InitializationFailed(audio::AudioFailureKind::PermissionDenied) => (
+                "microphone_initialization_failed",
+                "open_microphone_settings",
+            ),
+            Self::InitializationFailed(audio::AudioFailureKind::DeviceUnavailable) => {
+                ("microphone_initialization_failed", "choose_microphone")
+            }
+            Self::InitializationFailed(_) => ("microphone_initialization_failed", "retry"),
+            Self::CleanupStalled => ("microphone_cleanup_stalled", "restart_app"),
+            Self::Interrupted {
+                partial_transcription: true,
+            } => ("microphone_interrupted", "wait_for_partial_transcription"),
+            Self::Interrupted {
+                partial_transcription: false,
+            } => ("microphone_interrupted", "retry"),
+        }
+    }
+}
+
+fn emit_dictation_presentation(recording_id: u64, presentation: DictationPresentation) {
+    if recording_id == 0 {
+        return;
+    }
+    let (status_code, action_code) = presentation.codes();
+    tracing::info!(
+        target: "pipeline",
+        event_code = "pipeline.dictation_presentation",
+        recording_id,
+        status_code,
+        action_code,
+        "dictation status presented"
+    );
+}
+
 /// Scan `folder` for code identifiers and build the cached folder-scan prompt
 /// string, ranked by descending frequency and capped at [`CORRECTION_TERMS`].
 /// The cache holds the larger (top-500) list; the Whisper path takes its
@@ -343,7 +447,7 @@ impl Drop for IdleGuard<'_> {
             if current_rid != self.recording_id {
                 return;
             }
-            dictation.status = DictationStatus::Idle;
+            transition_dictation_status(self.recording_id, &mut dictation, DictationStatus::Idle);
             keyboard::set_processing(false);
         }
     }
@@ -1866,8 +1970,9 @@ pub async fn process_audio(
         if dictation.status != DictationStatus::Idle {
             return Err("Cannot process audio while live dictation is active.".to_string());
         }
-        dictation.status = DictationStatus::Processing;
-        state.app_state.next_recording_id()
+        let recording_id = state.app_state.next_recording_id();
+        transition_dictation_status(recording_id, &mut dictation, DictationStatus::Processing);
+        recording_id
     };
     drop(transition);
     keyboard::set_processing(true);
@@ -3070,7 +3175,7 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 );
                 return;
             }
-            dictation.status = DictationStatus::Recording;
+            transition_dictation_status(recording_id, &mut dictation, DictationStatus::Recording);
             *state.app_state.last_transcription_at.lock_or_recover() =
                 Some(std::time::Instant::now());
             let _ = app_handle.emit("recording-status-changed", "recording");
@@ -3106,13 +3211,21 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                     );
                     return;
                 }
-                previous_status = dictation.status;
-                dictation.status = DictationStatus::Recovering;
+                previous_status = transition_dictation_status(
+                    recording_id,
+                    &mut dictation,
+                    DictationStatus::Recovering,
+                );
             }
             if reason != AudioCancelReason::RuntimeFailure {
                 state.app_state.clear_active_context(recording_id);
             }
-            let _ = app_handle.emit("recording-status-changed", "recovering");
+            if app_handle
+                .emit("recording-status-changed", "recovering")
+                .is_ok()
+            {
+                emit_dictation_presentation(recording_id, DictationPresentation::CleanupInProgress);
+            }
             let _ = app_handle.emit(
                 "audio-recovery-started",
                 serde_json::json!({
@@ -3207,21 +3320,45 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 None,
                 None,
             );
-            let _ = app_handle.emit(
-                "recording-initialization-failed",
-                serde_json::json!({
-                    "recordingId": recording_id,
-                    "error": error,
-                    "errorKind": kind.as_str(),
-                }),
-            );
+            if app_handle
+                .emit("recording-initialization-failed", {
+                    let presentation = DictationPresentation::InitializationFailed(kind);
+                    let (status_code, action_code) = presentation.codes();
+                    serde_json::json!({
+                        "recordingId": recording_id,
+                        "error": error,
+                        "errorKind": kind.as_str(),
+                        "statusCode": status_code,
+                        "actionCode": action_code,
+                    })
+                })
+                .is_ok()
+            {
+                emit_dictation_presentation(
+                    recording_id,
+                    DictationPresentation::InitializationFailed(kind),
+                );
+            }
         }
         AudioLifecycleEvent::RecoveryStalled => {
             if is_current() {
-                let _ = app_handle.emit(
-                    "recording-recovery-stalled",
-                    serde_json::json!({ "recordingId": recording_id }),
-                );
+                if app_handle
+                    .emit("recording-recovery-stalled", {
+                        let (status_code, action_code) =
+                            DictationPresentation::CleanupStalled.codes();
+                        serde_json::json!({
+                            "recordingId": recording_id,
+                            "statusCode": status_code,
+                            "actionCode": action_code,
+                        })
+                    })
+                    .is_ok()
+                {
+                    emit_dictation_presentation(
+                        recording_id,
+                        DictationPresentation::CleanupStalled,
+                    );
+                }
             }
         }
         AudioLifecycleEvent::Interrupted {
@@ -3250,16 +3387,31 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 return;
             }
             let auto_transcribe = delivered_samples >= 8_000;
-            let _ = app_handle.emit(
-                "recording-interrupted",
-                serde_json::json!({
-                    "recordingId": recording_id,
-                    "reason": reason.as_str(),
-                    "deliveredSamples": delivered_samples,
-                    "durationMs": duration_ms,
-                    "autoTranscribe": auto_transcribe,
-                }),
-            );
+            if app_handle
+                .emit("recording-interrupted", {
+                    let presentation = DictationPresentation::Interrupted {
+                        partial_transcription: auto_transcribe,
+                    };
+                    let (status_code, action_code) = presentation.codes();
+                    serde_json::json!({
+                        "recordingId": recording_id,
+                        "reason": reason.as_str(),
+                        "deliveredSamples": delivered_samples,
+                        "durationMs": duration_ms,
+                        "autoTranscribe": auto_transcribe,
+                        "statusCode": status_code,
+                        "actionCode": action_code,
+                    })
+                })
+                .is_ok()
+            {
+                emit_dictation_presentation(
+                    recording_id,
+                    DictationPresentation::Interrupted {
+                        partial_transcription: auto_transcribe,
+                    },
+                );
+            }
             if auto_transcribe {
                 transcribe_interruption(app_handle.clone(), recording_id);
             } else {
@@ -3281,7 +3433,9 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                     Some(ContentFreeInputSummaryV1::audio(duration_ms)),
                     None,
                 );
-                state.app_state.dictation.lock_or_recover().status = DictationStatus::Idle;
+                let mut dictation = state.app_state.dictation.lock_or_recover();
+                transition_dictation_status(recording_id, &mut dictation, DictationStatus::Idle);
+                drop(dictation);
                 keyboard::set_processing(false);
                 let _ = app_handle.emit("recording-status-changed", "idle");
             }
@@ -3320,7 +3474,7 @@ fn handle_audio_lifecycle_with<R: tauri::Runtime>(
                 None,
                 None,
             );
-            dictation.status = DictationStatus::Idle;
+            transition_dictation_status(recording_id, &mut dictation, DictationStatus::Idle);
             state.app_state.clear_active_context(recording_id);
             keyboard::set_processing(false);
             let _ = app_handle.emit("recording-status-changed", "idle");
@@ -3345,7 +3499,7 @@ fn publish_recording_ready_if_audio_ready<R: tauri::Runtime>(
         return false;
     }
 
-    dictation.status = DictationStatus::Recording;
+    transition_dictation_status(recording_id, &mut dictation, DictationStatus::Recording);
     *state.app_state.last_transcription_at.lock_or_recover() = Some(std::time::Instant::now());
     let _ = app_handle.emit("recording-status-changed", "recording");
     tracing::info!(
@@ -3407,9 +3561,18 @@ pub async fn start_native_recording(
     // while a transform is in flight; the is_transform_busy guard below then
     // refuses this recording).
     state.transform_runtime.shutdown();
+    let origin = match origin.as_deref() {
+        Some("hold") => "hold",
+        _ => "toggle",
+    };
+    let device_selection = if device_name.is_some() {
+        "explicit"
+    } else {
+        "system_default"
+    };
     // Check and update status in one lock; assign recording ID in the same
     // critical section so no concurrent cancel/start can slip between them.
-    let rid = {
+    let (rid, performance_started_at_ms) = {
         let mut dictation = state.app_state.dictation.lock_or_recover();
         if state.app_state.meeting_blocks_asr() {
             tracing::warn!(target: "pipeline", "start_native_recording: blocked — meeting capture in progress");
@@ -3509,24 +3672,23 @@ pub async fn start_native_recording(
                 // pending undo still needs.
                 crate::transform_apply::clear_session(&state.app_state);
                 let rid = state.app_state.next_recording_id();
-                dictation.status = DictationStatus::Starting;
-                rid
+                let performance_started_at_ms =
+                    accept_live_dictation_request(rid, &mut dictation, |status_at_acceptance| {
+                        debug_assert_eq!(status_at_acceptance, DictationStatus::Idle);
+                        tracing::info!(
+                            target: "pipeline",
+                            event_code = "pipeline.dictation_requested",
+                            slo_contract = DICTATION_SLO_CONTRACT,
+                            device_selection,
+                            recording_id = rid,
+                            origin,
+                            "start_native_recording"
+                        );
+                    });
+                (rid, performance_started_at_ms)
             }
         }
     };
-    let performance_started_at_ms = chrono::Utc::now().timestamp_millis();
-    let origin = match origin.as_deref() {
-        Some("hold") => "hold",
-        _ => "toggle",
-    };
-    tracing::info!(
-        target: "pipeline",
-        event_code = "pipeline.dictation_requested",
-        device_selection = if device_name.is_some() { "explicit" } else { "system_default" },
-        recording_id = rid,
-        origin,
-        "start_native_recording"
-    );
     // Publish Starting before the worker can report Ready. Otherwise a very
     // fast device open could emit Recording first and this command would then
     // overwrite the frontend with a stale Starting event.
@@ -3547,7 +3709,7 @@ pub async fn start_native_recording(
         state.app_state.clear_active_context(rid);
         let mut dictation = state.app_state.dictation.lock_or_recover();
         if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
-            dictation.status = DictationStatus::Idle;
+            transition_dictation_status(rid, &mut dictation, DictationStatus::Idle);
         }
         let _ = app_handle.emit("recording-status-changed", "idle");
         return match error {
@@ -3738,7 +3900,7 @@ async fn stop_native_recording_for(
             DictationStatus::Starting => (DictationStatus::Starting, rid, None),
             DictationStatus::Recovering => {
                 if let Some(capture) = audio_lifecycle::take_interrupted_dictation(rid) {
-                    dictation.status = DictationStatus::Processing;
+                    transition_dictation_status(rid, &mut dictation, DictationStatus::Processing);
                     (DictationStatus::Processing, rid, Some(capture))
                 } else {
                     return Ok(serde_json::json!({
@@ -3748,7 +3910,7 @@ async fn stop_native_recording_for(
                 }
             }
             DictationStatus::Recording => {
-                dictation.status = DictationStatus::Processing;
+                transition_dictation_status(rid, &mut dictation, DictationStatus::Processing);
                 (DictationStatus::Recording, rid, None)
             }
         }
@@ -3775,7 +3937,7 @@ async fn stop_native_recording_for(
             );
             let mut dictation = state.app_state.dictation.lock_or_recover();
             if state.app_state.recording_id.load(Ordering::SeqCst) == rid {
-                dictation.status = DictationStatus::Idle;
+                transition_dictation_status(rid, &mut dictation, DictationStatus::Idle);
             }
             keyboard::set_processing(false);
             let _ = app_handle.emit("recording-status-changed", "idle");
@@ -4096,7 +4258,7 @@ pub async fn cancel_native_recording(
             DictationStatus::Starting | DictationStatus::Recording => {}
             DictationStatus::Recovering => return Ok(()),
             DictationStatus::Processing => {
-                dictation.status = DictationStatus::Idle;
+                transition_dictation_status(rid, &mut dictation, DictationStatus::Idle);
             }
         }
         (prev, rid)
@@ -4826,6 +4988,101 @@ mod tests {
         assert!(!status_allows_model_preparation(
             DictationStatus::Processing
         ));
+    }
+
+    #[test]
+    fn reliability_codes_are_bounded_and_actions_follow_existing_presentations() {
+        assert_eq!(DICTATION_SLO_CONTRACT, 1);
+        assert_eq!(dictation_status_code(DictationStatus::Idle), "idle");
+        assert_eq!(dictation_status_code(DictationStatus::Starting), "starting");
+        assert_eq!(
+            dictation_status_code(DictationStatus::Recording),
+            "recording"
+        );
+        assert_eq!(
+            dictation_status_code(DictationStatus::Recovering),
+            "recovering"
+        );
+        assert_eq!(
+            dictation_status_code(DictationStatus::Processing),
+            "processing"
+        );
+        assert_eq!(
+            DictationPresentation::CleanupInProgress.codes(),
+            ("microphone_cleanup_in_progress", "wait")
+        );
+        assert_eq!(
+            DictationPresentation::InitializationFailed(audio::AudioFailureKind::PermissionDenied)
+                .codes(),
+            (
+                "microphone_initialization_failed",
+                "open_microphone_settings"
+            )
+        );
+        assert_eq!(
+            DictationPresentation::InitializationFailed(audio::AudioFailureKind::BackendError)
+                .codes(),
+            ("microphone_initialization_failed", "retry")
+        );
+        assert_eq!(
+            DictationPresentation::InitializationFailed(audio::AudioFailureKind::DeviceUnavailable)
+                .codes(),
+            ("microphone_initialization_failed", "choose_microphone")
+        );
+        assert_eq!(
+            DictationPresentation::CleanupStalled.codes(),
+            ("microphone_cleanup_stalled", "restart_app")
+        );
+        assert_eq!(
+            DictationPresentation::Interrupted {
+                partial_transcription: false,
+            }
+            .codes(),
+            ("microphone_interrupted", "retry")
+        );
+        assert_eq!(
+            DictationPresentation::Interrupted {
+                partial_transcription: true,
+            }
+            .codes(),
+            ("microphone_interrupted", "wait_for_partial_transcription")
+        );
+    }
+
+    #[test]
+    fn reliability_transition_seam_mutates_once_and_returns_prior_state() {
+        let mut dictation = crate::state::DictationState::default();
+        assert_eq!(
+            transition_dictation_status(71, &mut dictation, DictationStatus::Starting),
+            DictationStatus::Idle
+        );
+        assert_eq!(dictation.status, DictationStatus::Starting);
+        assert_eq!(
+            transition_dictation_status(71, &mut dictation, DictationStatus::Recovering),
+            DictationStatus::Starting
+        );
+        assert_eq!(dictation.status, DictationStatus::Recovering);
+        assert_eq!(
+            transition_dictation_status(71, &mut dictation, DictationStatus::Idle),
+            DictationStatus::Recovering
+        );
+        assert_eq!(dictation.status, DictationStatus::Idle);
+    }
+
+    #[test]
+    fn accepted_request_is_published_before_the_starting_transition() {
+        let mut dictation = crate::state::DictationState::default();
+        let mut requested = false;
+
+        let performance_started_at_ms =
+            accept_live_dictation_request(72, &mut dictation, |status_at_acceptance| {
+                assert_eq!(status_at_acceptance, DictationStatus::Idle);
+                requested = true;
+            });
+
+        assert!(requested);
+        assert!(performance_started_at_ms > 0);
+        assert_eq!(dictation.status, DictationStatus::Starting);
     }
 
     #[test]

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -558,10 +558,10 @@ fn is_safe_dictation_slo_field(event_code: &str, key: &str, value: &serde_json::
 }
 
 fn valid_dictation_slo_shape(data: &serde_json::Map<String, serde_json::Value>) -> bool {
-    if !data
+    if data
         .get("recording_id")
         .and_then(serde_json::Value::as_u64)
-        .is_some_and(|value| value > 0)
+        .is_none_or(|value| value == 0)
     {
         return false;
     }

--- a/app/src-tauri/src/telemetry.rs
+++ b/app/src-tauri/src/telemetry.rs
@@ -219,7 +219,10 @@ pub(crate) fn canonical_event_code(value: &str) -> Option<&'static str> {
         "audio.capture_ready" => Some("audio.capture_ready"),
         "audio.capture_failed" => Some("audio.capture_failed"),
         "audio.lifecycle_failed" => Some("audio.lifecycle_failed"),
+        "audio.permission_prompt_changed" => Some("audio.permission_prompt_changed"),
         "pipeline.dictation_requested" => Some("pipeline.dictation_requested"),
+        "pipeline.dictation_state_changed" => Some("pipeline.dictation_state_changed"),
+        "pipeline.dictation_presentation" => Some("pipeline.dictation_presentation"),
         "pipeline.dictation_stop_handoff" => Some("pipeline.dictation_stop_handoff"),
         "pipeline.dictation_terminal" => Some("pipeline.dictation_terminal"),
         "pipeline.dictation_completed" => Some("pipeline.dictation_completed"),
@@ -399,6 +402,200 @@ fn sanitize_audio_device_reresolution_event(data: &mut serde_json::Map<String, s
     }
 }
 
+fn is_audio_permission_prompt_event(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    data.get("event_code").and_then(serde_json::Value::as_str)
+        == Some("audio.permission_prompt_changed")
+}
+
+fn is_safe_audio_permission_prompt_field(key: &str, value: &serde_json::Value) -> bool {
+    match key {
+        "event_code" => value.as_str() == Some("audio.permission_prompt_changed"),
+        "recording_id" | "owner" => value.as_u64().is_some_and(|value| value > 0),
+        "owner_kind" => value.as_str() == Some("dictation"),
+        "state" => value
+            .as_str()
+            .is_some_and(|value| matches!(value, "pending" | "resolved")),
+        "prompt_pending_ms" => value.as_u64().is_some_and(|value| value <= 300_000),
+        _ => false,
+    }
+}
+
+fn valid_audio_permission_prompt_shape(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    let recording_id = data.get("recording_id").and_then(serde_json::Value::as_u64);
+    let owner = data.get("owner").and_then(serde_json::Value::as_u64);
+    if recording_id.is_none() || owner != recording_id {
+        return false;
+    }
+    if data.get("owner_kind").and_then(serde_json::Value::as_str) != Some("dictation") {
+        return false;
+    }
+    match data.get("state").and_then(serde_json::Value::as_str) {
+        Some("pending") => data.get("prompt_pending_ms").is_none(),
+        Some("resolved") => data
+            .get("prompt_pending_ms")
+            .and_then(serde_json::Value::as_u64)
+            .is_some(),
+        _ => false,
+    }
+}
+
+fn sanitize_audio_permission_prompt_event(data: &mut serde_json::Map<String, serde_json::Value>) {
+    let has_invalid_known_field = data.iter().any(|(key, value)| {
+        matches!(
+            key.as_str(),
+            "event_code" | "recording_id" | "owner" | "owner_kind" | "state" | "prompt_pending_ms"
+        ) && !is_safe_audio_permission_prompt_field(key, value)
+    });
+    data.retain(|key, value| is_safe_audio_permission_prompt_field(key, value));
+    if has_invalid_known_field || !valid_audio_permission_prompt_shape(data) {
+        data.retain(|key, _| key == "event_code");
+    }
+}
+
+fn is_dictation_requested_event(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    data.get("event_code").and_then(serde_json::Value::as_str)
+        == Some("pipeline.dictation_requested")
+}
+
+fn is_safe_dictation_requested_field(key: &str, value: &serde_json::Value) -> bool {
+    match key {
+        "event_code" => value.as_str() == Some("pipeline.dictation_requested"),
+        "recording_id" => value.as_u64().is_some_and(|value| value > 0),
+        "slo_contract" => value.as_u64() == Some(1),
+        "origin" => value
+            .as_str()
+            .is_some_and(|value| matches!(value, "hold" | "toggle")),
+        "device_selection" => value
+            .as_str()
+            .is_some_and(|value| matches!(value, "explicit" | "system_default")),
+        _ => false,
+    }
+}
+
+fn valid_dictation_requested_shape(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    data.len() == 5
+        && data
+            .iter()
+            .all(|(key, value)| is_safe_dictation_requested_field(key, value))
+}
+
+fn sanitize_dictation_requested_event(data: &mut serde_json::Map<String, serde_json::Value>) {
+    let has_invalid_known_field = data.iter().any(|(key, value)| {
+        matches!(
+            key.as_str(),
+            "event_code" | "recording_id" | "slo_contract" | "origin" | "device_selection"
+        ) && !is_safe_dictation_requested_field(key, value)
+    });
+    data.retain(|key, value| is_safe_dictation_requested_field(key, value));
+    if has_invalid_known_field || !valid_dictation_requested_shape(data) {
+        data.retain(|key, _| key == "event_code");
+    }
+}
+
+fn is_dictation_slo_event(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    matches!(
+        data.get("event_code").and_then(serde_json::Value::as_str),
+        Some("pipeline.dictation_state_changed" | "pipeline.dictation_presentation")
+    )
+}
+
+fn is_safe_dictation_state(value: &str) -> bool {
+    matches!(
+        value,
+        "idle" | "starting" | "recording" | "recovering" | "processing"
+    )
+}
+
+fn valid_dictation_presentation_pair(status_code: &str, action_code: &str) -> bool {
+    matches!(
+        (status_code, action_code),
+        ("microphone_cleanup_in_progress", "wait")
+            | ("microphone_initialization_failed", "retry")
+            | (
+                "microphone_initialization_failed",
+                "open_microphone_settings"
+            )
+            | ("microphone_initialization_failed", "choose_microphone")
+            | ("microphone_cleanup_stalled", "restart_app")
+            | ("microphone_interrupted", "retry")
+            | ("microphone_interrupted", "wait_for_partial_transcription")
+    )
+}
+
+fn is_safe_dictation_slo_field(event_code: &str, key: &str, value: &serde_json::Value) -> bool {
+    match key {
+        "event_code" => value.as_str() == Some(event_code),
+        "recording_id" => value.as_u64().is_some_and(|value| value > 0),
+        "from" | "to" if event_code == "pipeline.dictation_state_changed" => {
+            value.as_str().is_some_and(is_safe_dictation_state)
+        }
+        "status_code" if event_code == "pipeline.dictation_presentation" => {
+            value.as_str().is_some_and(|value| {
+                matches!(
+                    value,
+                    "microphone_cleanup_in_progress"
+                        | "microphone_initialization_failed"
+                        | "microphone_cleanup_stalled"
+                        | "microphone_interrupted"
+                )
+            })
+        }
+        "action_code" if event_code == "pipeline.dictation_presentation" => {
+            value.as_str().is_some_and(|value| {
+                matches!(
+                    value,
+                    "wait"
+                        | "retry"
+                        | "open_microphone_settings"
+                        | "choose_microphone"
+                        | "restart_app"
+                        | "wait_for_partial_transcription"
+                )
+            })
+        }
+        _ => false,
+    }
+}
+
+fn valid_dictation_slo_shape(data: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if !data
+        .get("recording_id")
+        .and_then(serde_json::Value::as_u64)
+        .is_some_and(|value| value > 0)
+    {
+        return false;
+    }
+    match data.get("event_code").and_then(serde_json::Value::as_str) {
+        Some("pipeline.dictation_state_changed") => {
+            let from = data.get("from").and_then(serde_json::Value::as_str);
+            let to = data.get("to").and_then(serde_json::Value::as_str);
+            from.is_some() && to.is_some() && from != to
+        }
+        Some("pipeline.dictation_presentation") => {
+            let status_code = data.get("status_code").and_then(serde_json::Value::as_str);
+            let action_code = data.get("action_code").and_then(serde_json::Value::as_str);
+            status_code
+                .zip(action_code)
+                .is_some_and(|(status, action)| valid_dictation_presentation_pair(status, action))
+        }
+        _ => false,
+    }
+}
+
+fn sanitize_dictation_slo_event(data: &mut serde_json::Map<String, serde_json::Value>) {
+    let Some(event_code) = data
+        .get("event_code")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    data.retain(|key, value| is_safe_dictation_slo_field(&event_code, key, value));
+    if !valid_dictation_slo_shape(data) {
+        data.retain(|key, _| key == "event_code");
+    }
+}
+
 fn is_performance_store_event(data: &serde_json::Map<String, serde_json::Value>) -> bool {
     data.get("event_code").and_then(serde_json::Value::as_str)
         == Some("performance.store_operation_failed")
@@ -503,6 +700,19 @@ fn sanitized_summary(
         == Some("audio.device_reresolution_started")
     {
         "Microphone device re-resolution started".to_string()
+    } else if data.get("event_code").and_then(serde_json::Value::as_str)
+        == Some("audio.permission_prompt_changed")
+    {
+        "Microphone permission prompt state changed".to_string()
+    } else if matches!(
+        data.get("event_code").and_then(serde_json::Value::as_str),
+        Some(
+            "pipeline.dictation_requested"
+                | "pipeline.dictation_state_changed"
+                | "pipeline.dictation_presentation"
+        )
+    ) {
+        "Dictation reliability event".to_string()
     } else if stream == "meeting" {
         // Event codes carry the useful lifecycle meaning. Keep the JSONL/UI
         // summary constant so formatted content cannot leak from a call site.
@@ -760,6 +970,18 @@ fn sanitize_event_data(stream: &str, data: &mut serde_json::Value, debug_build: 
     }
     if is_audio_device_reresolution_event(obj) {
         sanitize_audio_device_reresolution_event(obj);
+        return;
+    }
+    if is_audio_permission_prompt_event(obj) {
+        sanitize_audio_permission_prompt_event(obj);
+        return;
+    }
+    if is_dictation_requested_event(obj) {
+        sanitize_dictation_requested_event(obj);
+        return;
+    }
+    if is_dictation_slo_event(obj) {
+        sanitize_dictation_slo_event(obj);
         return;
     }
     if is_performance_store_event(obj) {
@@ -1742,6 +1964,226 @@ mod tests {
         assert_eq!(data["attempts"], 3);
         assert_eq!(data["recording_id"], 35);
         assert_eq!(data.as_object().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn permission_prompt_schema_is_exact_and_content_free_in_every_build() {
+        for debug_build in [true, false] {
+            for (state, prompt_pending_ms, expected_len) in
+                [("pending", None, 5), ("resolved", Some(42_000), 6)]
+            {
+                let mut data = serde_json::json!({
+                    "event_code": "audio.permission_prompt_changed",
+                    "recording_id": 17,
+                    "owner": 17,
+                    "owner_kind": "dictation",
+                    "state": state,
+                    "device_name": "SENTINEL_PRIVATE_MICROPHONE",
+                    "device_id": "SENTINEL_PRIVATE_UID",
+                    "error": "/Users/private/CoreAudio",
+                    "transcript": "SENTINEL_PRIVATE_TRANSCRIPT"
+                });
+                if let Some(prompt_pending_ms) = prompt_pending_ms {
+                    data["prompt_pending_ms"] = prompt_pending_ms.into();
+                }
+
+                sanitize_event_data("audio", &mut data, debug_build);
+
+                assert_eq!(data["event_code"], "audio.permission_prompt_changed");
+                assert_eq!(data["recording_id"], 17);
+                assert_eq!(data["owner"], 17);
+                assert_eq!(data["owner_kind"], "dictation");
+                assert_eq!(data["state"], state);
+                assert_eq!(data.as_object().unwrap().len(), expected_len);
+                let encoded = serde_json::to_string(&data).unwrap();
+                assert!(!encoded.contains("SENTINEL"));
+                assert!(!encoded.contains("Users"));
+                assert_eq!(
+                    sanitized_summary(
+                        "audio",
+                        Some("SENTINEL /Users/private".to_string()),
+                        &data,
+                        debug_build,
+                    ),
+                    "Microphone permission prompt state changed"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn permission_prompt_schema_rejects_cross_field_contradictions() {
+        for mut data in [
+            serde_json::json!({
+                "event_code": "audio.permission_prompt_changed",
+                "recording_id": 17,
+                "owner": 18,
+                "owner_kind": "dictation",
+                "state": "pending"
+            }),
+            serde_json::json!({
+                "event_code": "audio.permission_prompt_changed",
+                "recording_id": 17,
+                "owner": 17,
+                "owner_kind": "transform",
+                "state": "pending"
+            }),
+            serde_json::json!({
+                "event_code": "audio.permission_prompt_changed",
+                "recording_id": 17,
+                "owner": 17,
+                "owner_kind": "dictation",
+                "state": "pending",
+                "prompt_pending_ms": 1
+            }),
+            serde_json::json!({
+                "event_code": "audio.permission_prompt_changed",
+                "recording_id": 17,
+                "owner": 17,
+                "owner_kind": "dictation",
+                "state": "resolved"
+            }),
+            serde_json::json!({
+                "event_code": "audio.permission_prompt_changed",
+                "recording_id": 17,
+                "owner": 17,
+                "owner_kind": "dictation",
+                "state": "pending",
+                "prompt_pending_ms": 300_001
+            }),
+        ] {
+            sanitize_event_data("audio", &mut data, true);
+            assert_eq!(data["event_code"], "audio.permission_prompt_changed");
+            assert_eq!(data.as_object().unwrap().len(), 1);
+        }
+    }
+
+    #[test]
+    fn dictation_slo_schemas_are_exact_and_content_free_in_every_build() {
+        for debug_build in [true, false] {
+            for mut data in [
+                serde_json::json!({
+                    "event_code": "pipeline.dictation_requested",
+                    "recording_id": 31,
+                    "slo_contract": 1,
+                    "origin": "hold",
+                    "device_selection": "explicit",
+                    "content": "SENTINEL_PRIVATE_TRANSCRIPT",
+                    "device_id": "/Users/private/device",
+                    "nested": {"raw_error": "SENTINEL"}
+                }),
+                serde_json::json!({
+                    "event_code": "pipeline.dictation_state_changed",
+                    "recording_id": 31,
+                    "from": "recording",
+                    "to": "processing",
+                    "error": "/Users/private/error",
+                    "content": "SENTINEL_PRIVATE_TRANSCRIPT"
+                }),
+                serde_json::json!({
+                    "event_code": "pipeline.dictation_presentation",
+                    "recording_id": 31,
+                    "status_code": "microphone_initialization_failed",
+                    "action_code": "choose_microphone",
+                    "device_id": "/Users/private/device",
+                    "message": "SENTINEL_PRIVATE_TRANSCRIPT"
+                }),
+                serde_json::json!({
+                    "event_code": "pipeline.dictation_presentation",
+                    "recording_id": 31,
+                    "status_code": "microphone_interrupted",
+                    "action_code": "wait_for_partial_transcription",
+                    "message": "SENTINEL_PRIVATE_TRANSCRIPT",
+                    "path": "/Users/private/project"
+                }),
+            ] {
+                sanitize_event_data("pipeline", &mut data, debug_build);
+                assert_eq!(data["recording_id"], 31);
+                assert_eq!(
+                    data.as_object().unwrap().len(),
+                    if data["event_code"] == "pipeline.dictation_requested" {
+                        5
+                    } else {
+                        4
+                    }
+                );
+                let encoded = serde_json::to_string(&data).unwrap();
+                assert!(!encoded.contains("SENTINEL"));
+                assert!(!encoded.contains("Users"));
+                assert_eq!(
+                    sanitized_summary(
+                        "pipeline",
+                        Some("SENTINEL /Users/private".to_string()),
+                        &data,
+                        debug_build,
+                    ),
+                    "Dictation reliability event"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dictation_slo_schemas_reject_invalid_states_and_presentations() {
+        for mut data in [
+            serde_json::json!({
+                "event_code": "pipeline.dictation_requested",
+                "recording_id": 31,
+                "slo_contract": 2,
+                "origin": "hold",
+                "device_selection": "explicit"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_requested",
+                "recording_id": 31,
+                "slo_contract": 1,
+                "origin": "SENTINEL_PRIVATE_ORIGIN",
+                "device_selection": "system_default"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_requested",
+                "recording_id": 31,
+                "slo_contract": 1,
+                "origin": "toggle",
+                "device_selection": "SENTINEL_PRIVATE_DEVICE"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_state_changed",
+                "recording_id": 31,
+                "from": "processing",
+                "to": "processing"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_state_changed",
+                "recording_id": 0,
+                "from": "SENTINEL_PRIVATE_STATE",
+                "to": "idle"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_presentation",
+                "recording_id": 31,
+                "status_code": "microphone_cleanup_stalled",
+                "action_code": "retry"
+            }),
+            serde_json::json!({
+                "event_code": "pipeline.dictation_presentation",
+                "recording_id": 31,
+                "status_code": "SENTINEL_PRIVATE_STATUS",
+                "action_code": "restart_app"
+            }),
+        ] {
+            sanitize_event_data("pipeline", &mut data, true);
+            assert!(matches!(
+                data["event_code"].as_str(),
+                Some(
+                    "pipeline.dictation_requested"
+                        | "pipeline.dictation_state_changed"
+                        | "pipeline.dictation_presentation"
+                )
+            ));
+            assert_eq!(data.as_object().unwrap().len(), 1);
+            assert!(!serde_json::to_string(&data).unwrap().contains("SENTINEL"));
+        }
     }
 
     #[test]

--- a/app/src/components/overlay/OverlayPill.test.tsx
+++ b/app/src/components/overlay/OverlayPill.test.tsx
@@ -60,7 +60,7 @@ describe('OverlayPill transient cues', () => {
 
   it('renders an actionable, non-interactive mic-off status for an unavailable device', async () => {
     await act(async () => root.render(
-      <CuePill indicator={{ kind: 'microphoneFailure', failure: 'deviceUnavailable' }} />,
+      <CuePill indicator={{ kind: 'microphoneFailure', failure: 'chooseMicrophone' }} />,
     ));
 
     const status = container.querySelector<HTMLElement>('[role="status"]');
@@ -75,7 +75,7 @@ describe('OverlayPill transient cues', () => {
 
   it('keeps other microphone failures generic and truthful', async () => {
     await act(async () => root.render(
-      <CuePill indicator={{ kind: 'microphoneFailure', failure: 'generic' }} />,
+      <CuePill indicator={{ kind: 'microphoneFailure', failure: 'retry' }} />,
     ));
 
     const status = container.querySelector<HTMLElement>('[role="status"]');
@@ -83,5 +83,22 @@ describe('OverlayPill transient cues', () => {
     expect(status?.getAttribute('aria-label')).toBe(
       'Microphone capture failed. Try recording again.',
     );
+  });
+
+  it('renders the exact permission and partial-transcription actions', async () => {
+    await act(async () => root.render(
+      <CuePill indicator={{ kind: 'microphoneFailure', failure: 'openMicrophoneSettings' }} />,
+    ));
+    expect(container.querySelector<HTMLElement>('[role="status"]')?.getAttribute('aria-label'))
+      .toBe('Microphone access denied. Open System Settings to grant access.');
+
+    await act(async () => root.render(
+      <CuePill indicator={{
+        kind: 'microphoneFailure',
+        failure: 'waitForPartialTranscription',
+      }} />,
+    ));
+    expect(container.querySelector<HTMLElement>('[role="status"]')?.getAttribute('aria-label'))
+      .toBe('Microphone capture was interrupted. Waiting for the partial transcription.');
   });
 });

--- a/app/src/components/overlay/OverlayPill.tsx
+++ b/app/src/components/overlay/OverlayPill.tsx
@@ -55,11 +55,14 @@ export function OverlayPill({
               !
             </span>
           ) : indicator.kind === 'microphoneFailure' ? (
-            indicator.failure === 'deviceUnavailable' ? (
+            indicator.failure === 'chooseMicrophone'
+              || indicator.failure === 'openMicrophoneSettings' ? (
               <span
                 role="status"
                 aria-live="assertive"
-                aria-label="Selected microphone unavailable. Open Settings to choose another."
+                aria-label={indicator.failure === 'chooseMicrophone'
+                  ? 'Selected microphone unavailable. Open Settings to choose another.'
+                  : 'Microphone access denied. Open System Settings to grant access.'}
                 className="flex h-4 w-4 items-center justify-center text-red-300"
               >
                 <svg
@@ -86,7 +89,9 @@ export function OverlayPill({
               <span
                 role="status"
                 aria-live="assertive"
-                aria-label="Microphone capture failed. Try recording again."
+                aria-label={indicator.failure === 'waitForPartialTranscription'
+                  ? 'Microphone capture was interrupted. Waiting for the partial transcription.'
+                  : 'Microphone capture failed. Try recording again.'}
                 className="w-3 h-3 rounded-full border border-red-400 text-red-300 text-[8px] leading-none flex items-center justify-center font-bold"
               >
                 !

--- a/app/src/components/overlay/deriveVisual.test.ts
+++ b/app/src/components/overlay/deriveVisual.test.ts
@@ -93,26 +93,26 @@ describe('deriveVisual', () => {
   it('microphone failure flash beats active lifecycle indicators', () => {
     expect(
       deriveVisual(
-        'recovering', false, false, false, false, false, false, 'deviceUnavailable',
+        'recovering', false, false, false, false, false, false, 'chooseMicrophone',
       ).indicator,
-    ).toEqual({ kind: 'microphoneFailure', failure: 'deviceUnavailable' });
+    ).toEqual({ kind: 'microphoneFailure', failure: 'chooseMicrophone' });
 
     expect(
       deriveVisual(
-        'recording', false, false, false, false, false, false, 'generic',
+        'recording', false, false, false, false, false, false, 'retry',
       ).indicator,
-    ).toEqual({ kind: 'microphoneFailure', failure: 'generic' });
+    ).toEqual({ kind: 'microphoneFailure', failure: 'retry' });
   });
 
   it('cancelled and secure-field cues retain priority over microphone failures', () => {
     expect(
       deriveVisual(
-        'idle', true, false, false, false, false, false, 'deviceUnavailable',
+        'idle', true, false, false, false, false, false, 'chooseMicrophone',
       ).indicator,
     ).toEqual({ kind: 'cancelled' });
     expect(
       deriveVisual(
-        'idle', false, false, false, false, true, false, 'deviceUnavailable',
+        'idle', false, false, false, false, true, false, 'chooseMicrophone',
       ).indicator,
     ).toEqual({ kind: 'secureField' });
   });
@@ -173,7 +173,7 @@ describe('deriveVisual', () => {
       true,
       true,
       true,
-      'generic',
+      'retry',
       true,
       true,
     );
@@ -211,10 +211,10 @@ describe('deriveVisual', () => {
     ).toEqual({ kind: 'cancelled' });
     expect(
       deriveVisual(
-        'idle', false, false, false, false, false, false, 'deviceUnavailable',
+        'idle', false, false, false, false, false, false, 'chooseMicrophone',
         false, false, 'idle', true,
       ).indicator,
-    ).toEqual({ kind: 'microphoneFailure', failure: 'deviceUnavailable' });
+    ).toEqual({ kind: 'microphoneFailure', failure: 'chooseMicrophone' });
     expect(
       deriveVisual('idle', false, true, false, false, false, false, false, false, false, 'idle', true).indicator,
     ).toEqual({ kind: 'hotkeyMiss' });

--- a/app/src/lib/dictationPresentation.test.ts
+++ b/app/src/lib/dictationPresentation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cleanupStalledPresentationFromPayload,
+  dictationPresentationFromPayload,
+  initializationPresentationFromPayload,
+  interruptedPresentationFromPayload,
+} from './dictationPresentation';
+
+describe('dictation presentation payload contract', () => {
+  it('accepts every bounded status/action pair', () => {
+    for (const [statusCode, actionCode] of [
+      ['microphone_cleanup_in_progress', 'wait'],
+      ['microphone_initialization_failed', 'retry'],
+      ['microphone_initialization_failed', 'open_microphone_settings'],
+      ['microphone_initialization_failed', 'choose_microphone'],
+      ['microphone_cleanup_stalled', 'restart_app'],
+      ['microphone_interrupted', 'retry'],
+      ['microphone_interrupted', 'wait_for_partial_transcription'],
+    ]) {
+      expect(dictationPresentationFromPayload({ recordingId: 7, statusCode, actionCode }))
+        .toEqual({ recordingId: 7, statusCode, actionCode });
+    }
+  });
+
+  it('rejects unknown, contradictory, and unowned payloads', () => {
+    for (const payload of [
+      null,
+      { recordingId: 0, statusCode: 'microphone_interrupted', actionCode: 'retry' },
+      { recordingId: 7, statusCode: 'microphone_interrupted', actionCode: 'restart_app' },
+      { recordingId: 7, statusCode: 'private', actionCode: 'retry' },
+    ]) {
+      expect(dictationPresentationFromPayload(payload)).toBeNull();
+    }
+  });
+
+  it('ties initialization actions to the bounded failure kind', () => {
+    expect(initializationPresentationFromPayload({
+      recordingId: 1,
+      errorKind: 'permission_denied',
+      statusCode: 'microphone_initialization_failed',
+      actionCode: 'open_microphone_settings',
+    })?.actionCode).toBe('open_microphone_settings');
+    expect(initializationPresentationFromPayload({
+      recordingId: 2,
+      errorKind: 'device_unavailable',
+      statusCode: 'microphone_initialization_failed',
+      actionCode: 'choose_microphone',
+    })?.actionCode).toBe('choose_microphone');
+    expect(initializationPresentationFromPayload({
+      recordingId: 3,
+      errorKind: 'backend_error',
+      statusCode: 'microphone_initialization_failed',
+      actionCode: 'retry',
+    })?.actionCode).toBe('retry');
+    expect(initializationPresentationFromPayload({
+      recordingId: 4,
+      errorKind: 'permission_denied',
+      statusCode: 'microphone_initialization_failed',
+      actionCode: 'retry',
+    })).toBeNull();
+  });
+
+  it('ties interruption actions to actual partial-transcription behavior', () => {
+    expect(interruptedPresentationFromPayload({
+      recordingId: 5,
+      autoTranscribe: true,
+      statusCode: 'microphone_interrupted',
+      actionCode: 'wait_for_partial_transcription',
+    })?.actionCode).toBe('wait_for_partial_transcription');
+    expect(interruptedPresentationFromPayload({
+      recordingId: 5,
+      autoTranscribe: false,
+      statusCode: 'microphone_interrupted',
+      actionCode: 'retry',
+    })?.actionCode).toBe('retry');
+    expect(interruptedPresentationFromPayload({
+      recordingId: 5,
+      autoTranscribe: true,
+      statusCode: 'microphone_interrupted',
+      actionCode: 'retry',
+    })).toBeNull();
+  });
+
+  it('accepts only the restart action for stalled cleanup', () => {
+    expect(cleanupStalledPresentationFromPayload({
+      recordingId: 6,
+      statusCode: 'microphone_cleanup_stalled',
+      actionCode: 'restart_app',
+    })?.recordingId).toBe(6);
+  });
+});

--- a/app/src/lib/dictationPresentation.ts
+++ b/app/src/lib/dictationPresentation.ts
@@ -1,0 +1,102 @@
+export type DictationPresentationStatusCode =
+  | 'microphone_cleanup_in_progress'
+  | 'microphone_initialization_failed'
+  | 'microphone_cleanup_stalled'
+  | 'microphone_interrupted';
+
+export type DictationPresentationActionCode =
+  | 'wait'
+  | 'retry'
+  | 'open_microphone_settings'
+  | 'choose_microphone'
+  | 'restart_app'
+  | 'wait_for_partial_transcription';
+
+export interface DictationPresentationPayload {
+  recordingId: number;
+  statusCode: DictationPresentationStatusCode;
+  actionCode: DictationPresentationActionCode;
+}
+
+const PRESENTATION_PAIRS = new Set([
+  'microphone_cleanup_in_progress:wait',
+  'microphone_initialization_failed:retry',
+  'microphone_initialization_failed:open_microphone_settings',
+  'microphone_initialization_failed:choose_microphone',
+  'microphone_cleanup_stalled:restart_app',
+  'microphone_interrupted:retry',
+  'microphone_interrupted:wait_for_partial_transcription',
+]);
+
+const AUDIO_FAILURE_KINDS = new Set([
+  'permission_denied',
+  'device_unavailable',
+  'host_unavailable',
+  'invalid_input',
+  'resource_exhausted',
+  'stream_invalidated',
+  'unsupported_config',
+  'backend_error',
+  'protocol_error',
+  'first_buffer_timeout',
+  'initialization_timeout',
+  'permission_prompt_timeout',
+  'termination_unconfirmed',
+  'worker_panicked',
+  'signature_invalid',
+]);
+
+export function dictationPresentationFromPayload(
+  value: unknown,
+): DictationPresentationPayload | null {
+  if (!value || typeof value !== 'object') return null;
+  const payload = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(payload.recordingId) || (payload.recordingId as number) <= 0) {
+    return null;
+  }
+  if (typeof payload.statusCode !== 'string' || typeof payload.actionCode !== 'string') {
+    return null;
+  }
+  if (!PRESENTATION_PAIRS.has(`${payload.statusCode}:${payload.actionCode}`)) return null;
+  return payload as unknown as DictationPresentationPayload;
+}
+
+export function initializationPresentationFromPayload(
+  value: unknown,
+): DictationPresentationPayload | null {
+  const presentation = dictationPresentationFromPayload(value);
+  if (!presentation || presentation.statusCode !== 'microphone_initialization_failed') {
+    return null;
+  }
+  const payload = value as Record<string, unknown>;
+  if (typeof payload.errorKind !== 'string' || !AUDIO_FAILURE_KINDS.has(payload.errorKind)) {
+    return null;
+  }
+  const expectedAction = payload.errorKind === 'permission_denied'
+    ? 'open_microphone_settings'
+    : payload.errorKind === 'device_unavailable'
+      ? 'choose_microphone'
+      : 'retry';
+  return presentation.actionCode === expectedAction ? presentation : null;
+}
+
+export function cleanupStalledPresentationFromPayload(
+  value: unknown,
+): DictationPresentationPayload | null {
+  const presentation = dictationPresentationFromPayload(value);
+  return presentation?.statusCode === 'microphone_cleanup_stalled'
+    && presentation.actionCode === 'restart_app'
+    ? presentation
+    : null;
+}
+
+export function interruptedPresentationFromPayload(
+  value: unknown,
+): DictationPresentationPayload | null {
+  const presentation = dictationPresentationFromPayload(value);
+  if (!presentation || presentation.statusCode !== 'microphone_interrupted') return null;
+  const autoTranscribe = (value as Record<string, unknown>).autoTranscribe;
+  if (typeof autoTranscribe !== 'boolean') return null;
+  const expectedAction = autoTranscribe ? 'wait_for_partial_transcription' : 'retry';
+  return presentation.actionCode === expectedAction ? presentation : null;
+}

--- a/app/src/lib/hooks/useOverlayRuntime.test.tsx
+++ b/app/src/lib/hooks/useOverlayRuntime.test.tsx
@@ -105,9 +105,32 @@ describe('useOverlayRuntime transient cues', () => {
   }
 
   async function emitInitializationFailure(errorKind: unknown, recordingId = 1) {
+    const actionCode = errorKind === 'permission_denied'
+      ? 'open_microphone_settings'
+      : errorKind === 'device_unavailable'
+        ? 'choose_microphone'
+        : 'retry';
     await act(async () => {
       mocks.handlers.get('recording-initialization-failed')?.({
-        payload: { recordingId, errorKind },
+        payload: {
+          recordingId,
+          errorKind,
+          statusCode: 'microphone_initialization_failed',
+          actionCode,
+        },
+      });
+    });
+  }
+
+  async function emitInterruption(recordingId: number, autoTranscribe: boolean) {
+    await act(async () => {
+      mocks.handlers.get('recording-interrupted')?.({
+        payload: {
+          recordingId,
+          autoTranscribe,
+          statusCode: 'microphone_interrupted',
+          actionCode: autoTranscribe ? 'wait_for_partial_transcription' : 'retry',
+        },
       });
     });
   }
@@ -116,18 +139,18 @@ describe('useOverlayRuntime transient cues', () => {
     expect(current?.showMicrophoneFailure).toBeNull();
 
     await emitInitializationFailure('device_unavailable');
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
 
     await act(async () => vi.advanceTimersByTime(MICROPHONE_FAILURE_FLASH_MS - 1));
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
 
     await act(async () => vi.advanceTimersByTime(1));
     expect(current?.showMicrophoneFailure).toBeNull();
   });
 
-  it('keeps unknown and interrupted failures generic and ignores malformed payloads', async () => {
+  it('uses exact permission and interruption actions and ignores malformed payloads', async () => {
     await emitInitializationFailure('permission_denied');
-    expect(current?.showMicrophoneFailure).toBe('generic');
+    expect(current?.showMicrophoneFailure).toBe('openMicrophoneSettings');
 
     await emitGeneration(2);
     await act(async () => {
@@ -138,7 +161,13 @@ describe('useOverlayRuntime transient cues', () => {
     await act(async () => {
       mocks.handlers.get('recording-interrupted')?.({ payload: { recordingId: 2 } });
     });
-    expect(current?.showMicrophoneFailure).toBe('generic');
+    expect(current?.showMicrophoneFailure).toBeNull();
+
+    await emitInterruption(2, false);
+    expect(current?.showMicrophoneFailure).toBe('retry');
+
+    await emitInterruption(2, true);
+    expect(current?.showMicrophoneFailure).toBe('waitForPartialTranscription');
   });
 
   it('restarts the full failure timeout and adopts the latest typed cue', async () => {
@@ -146,10 +175,10 @@ describe('useOverlayRuntime transient cues', () => {
     await act(async () => vi.advanceTimersByTime(MICROPHONE_FAILURE_FLASH_MS - 1000));
 
     await emitInitializationFailure('backend_error');
-    expect(current?.showMicrophoneFailure).toBe('generic');
+    expect(current?.showMicrophoneFailure).toBe('retry');
 
     await act(async () => vi.advanceTimersByTime(1000));
-    expect(current?.showMicrophoneFailure).toBe('generic');
+    expect(current?.showMicrophoneFailure).toBe('retry');
 
     await act(async () => vi.advanceTimersByTime(MICROPHONE_FAILURE_FLASH_MS - 1000));
     expect(current?.showMicrophoneFailure).toBeNull();
@@ -157,7 +186,7 @@ describe('useOverlayRuntime transient cues', () => {
 
   it('clears an older failure cue when a newer recording generation starts', async () => {
     await emitInitializationFailure('device_unavailable');
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
 
     await emitGeneration(2);
     expect(current?.showMicrophoneFailure).toBeNull();
@@ -168,7 +197,14 @@ describe('useOverlayRuntime transient cues', () => {
     await emitGeneration(3);
     await emitInitializationFailure('device_unavailable', 2);
     await act(async () => {
-      mocks.handlers.get('recording-interrupted')?.({ payload: { recordingId: 2 } });
+      mocks.handlers.get('recording-interrupted')?.({
+        payload: {
+          recordingId: 2,
+          autoTranscribe: false,
+          statusCode: 'microphone_interrupted',
+          actionCode: 'retry',
+        },
+      });
     });
     expect(current?.showMicrophoneFailure).toBeNull();
     expect(vi.getTimerCount()).toBe(0);
@@ -183,7 +219,7 @@ describe('useOverlayRuntime transient cues', () => {
 
   it('clears an older microphone failure when a newer delivery arrives first', async () => {
     await emitInitializationFailure('device_unavailable', 8);
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
 
     await emitDelivery(9);
     await emitGeneration(9);
@@ -205,7 +241,7 @@ describe('useOverlayRuntime transient cues', () => {
     });
 
     await emitInitializationFailure('device_unavailable', 5);
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
     await emitGeneration(6);
     expect(current?.showMicrophoneFailure).toBeNull();
   });
@@ -223,7 +259,7 @@ describe('useOverlayRuntime transient cues', () => {
     });
 
     await emitInitializationFailure('device_unavailable', 10);
-    expect(current?.showMicrophoneFailure).toBe('deviceUnavailable');
+    expect(current?.showMicrophoneFailure).toBe('chooseMicrophone');
     await act(async () => root.render(<Harness status="starting" />));
     expect(current?.showMicrophoneFailure).toBeNull();
     expect(vi.getTimerCount()).toBe(0);
@@ -243,7 +279,14 @@ describe('useOverlayRuntime transient cues', () => {
 
     await act(async () => root.unmount());
     await act(async () => {
-      delayedHandler?.({ payload: { recordingId: 7, errorKind: 'device_unavailable' } });
+      delayedHandler?.({
+        payload: {
+          recordingId: 7,
+          errorKind: 'device_unavailable',
+          statusCode: 'microphone_initialization_failed',
+          actionCode: 'choose_microphone',
+        },
+      });
     });
     expect(vi.getTimerCount()).toBe(0);
     await act(async () => {

--- a/app/src/lib/hooks/useOverlayRuntime.ts
+++ b/app/src/lib/hooks/useOverlayRuntime.ts
@@ -8,6 +8,11 @@ import {
   isHotkeyTapRejectedPayload,
   shouldShowHotkeyMissFeedback,
 } from '../hotkeyFeedback';
+import {
+  initializationPresentationFromPayload,
+  interruptedPresentationFromPayload,
+  type DictationPresentationActionCode,
+} from '../dictationPresentation';
 
 const CANCELLED_FLASH_MS = 800;
 /** How long the secure-field refusal flash shows (issue #312 PR-C2). */
@@ -17,7 +22,11 @@ const TRANSFORM_BUSY_FLASH_MS = 800;
 export const MICROPHONE_FAILURE_FLASH_MS = 5000;
 export const CLIPBOARD_ONLY_FLASH_MS = 5000;
 
-export type MicrophoneFailureCue = 'deviceUnavailable' | 'generic';
+export type MicrophoneFailureCue =
+  | 'retry'
+  | 'openMicrophoneSettings'
+  | 'chooseMicrophone'
+  | 'waitForPartialTranscription';
 
 type DictationDeliveryOutcome =
   | 'clipboardOnly'
@@ -52,11 +61,16 @@ function isDictationDeliveryOutcomePayload(
     ].includes(payload.outcome as string);
 }
 
-function microphoneFailureCueFromPayload(value: unknown): MicrophoneFailureCue | null {
-  if (recordingIdFromPayload(value) == null) return null;
-  return (value as Record<string, unknown>).errorKind === 'device_unavailable'
-    ? 'deviceUnavailable'
-    : 'generic';
+function microphoneFailureCueFromAction(
+  actionCode: DictationPresentationActionCode,
+): MicrophoneFailureCue | null {
+  switch (actionCode) {
+    case 'retry': return 'retry';
+    case 'open_microphone_settings': return 'openMicrophoneSettings';
+    case 'choose_microphone': return 'chooseMicrophone';
+    case 'wait_for_partial_transcription': return 'waitForPartialTranscription';
+    default: return null;
+  }
 }
 
 export interface UseOverlayRuntimeArgs {
@@ -340,9 +354,11 @@ export function useOverlayRuntime({
     };
     const unlistens: (() => void)[] = [];
     listen<unknown>('recording-initialization-failed', (event) => {
-      const recordingId = recordingIdFromPayload(event.payload);
-      const cue = microphoneFailureCueFromPayload(event.payload);
-      if (recordingId != null && cue != null) flashFailure(recordingId, cue);
+      const presentation = initializationPresentationFromPayload(event.payload);
+      const cue = presentation
+        ? microphoneFailureCueFromAction(presentation.actionCode)
+        : null;
+      if (presentation && cue) flashFailure(presentation.recordingId, cue);
     }).then((fn) => {
       if (cancelled) fn(); else unlistens.push(fn);
     }).catch((cause: unknown) => {
@@ -353,8 +369,11 @@ export function useOverlayRuntime({
       }
     });
     listen<unknown>('recording-interrupted', (event) => {
-      const recordingId = recordingIdFromPayload(event.payload);
-      if (recordingId != null) flashFailure(recordingId, 'generic');
+      const presentation = interruptedPresentationFromPayload(event.payload);
+      const cue = presentation
+        ? microphoneFailureCueFromAction(presentation.actionCode)
+        : null;
+      if (presentation && cue) flashFailure(presentation.recordingId, cue);
     }).then((fn) => {
       if (cancelled) fn(); else unlistens.push(fn);
     }).catch((cause: unknown) => {

--- a/app/src/lib/hooks/useRecordingState.test.tsx
+++ b/app/src/lib/hooks/useRecordingState.test.tsx
@@ -205,4 +205,53 @@ describe('useRecordingState transition ordering', () => {
     expect(mocks.updateStats).toHaveBeenCalledWith('one final transcript', 12);
     expect(current.transcription).toBe('one final transcript');
   });
+
+  it('clears an older failure for a new generation and ignores delayed stale presentations', async () => {
+    const initializationFailure = (recordingId: number) => ({
+      recordingId,
+      error: 'Microphone capture failed.',
+      errorKind: 'backend_error',
+      statusCode: 'microphone_initialization_failed',
+      actionCode: 'retry',
+    });
+
+    await act(async () => {
+      mocks.listeners.get('dictation-generation-started')?.({
+        payload: { recordingId: 2 },
+      });
+      mocks.listeners.get('recording-initialization-failed')?.({
+        payload: initializationFailure(2),
+      });
+    });
+    expect(current.error).toBe('Microphone capture failed.');
+
+    await act(async () => {
+      mocks.listeners.get('dictation-generation-started')?.({
+        payload: { recordingId: 3 },
+      });
+    });
+    expect(current.error).toBe('');
+
+    await act(async () => {
+      mocks.listeners.get('recording-initialization-failed')?.({
+        payload: initializationFailure(2),
+      });
+      mocks.listeners.get('recording-recovery-stalled')?.({
+        payload: {
+          recordingId: 2,
+          statusCode: 'microphone_cleanup_stalled',
+          actionCode: 'restart_app',
+        },
+      });
+      mocks.listeners.get('recording-interrupted')?.({
+        payload: {
+          recordingId: 2,
+          autoTranscribe: false,
+          statusCode: 'microphone_interrupted',
+          actionCode: 'retry',
+        },
+      });
+    });
+    expect(current.error).toBe('');
+  });
 });

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -32,6 +32,7 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
   const statusRef = useRef(status);
   const microphoneRef = useRef(microphone);
   const recordingStartTimeRef = useRef(recordingStartTime);
+  const latestRecordingGenerationRef = useRef(0);
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { microphoneRef.current = microphone; }, [microphone]);
   const isStartingRef = useRef(false);
@@ -101,8 +102,31 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
   useEffect(() => {
     let cancelled = false;
     const unlistens: (() => void)[] = [];
+    const acceptPresentationGeneration = (recordingId: number) => {
+      if (recordingId < latestRecordingGenerationRef.current) return false;
+      if (recordingId > latestRecordingGenerationRef.current) {
+        latestRecordingGenerationRef.current = recordingId;
+        setError('');
+      }
+      return true;
+    };
+    listen<unknown>('dictation-generation-started', (event) => {
+      const payload = event.payload as Record<string, unknown> | null;
+      const recordingId = payload?.recordingId;
+      if (
+        typeof recordingId === 'number'
+        && Number.isSafeInteger(recordingId)
+        && recordingId > latestRecordingGenerationRef.current
+      ) {
+        latestRecordingGenerationRef.current = recordingId;
+        setError('');
+      }
+    }).then((fn) => {
+      if (cancelled) fn(); else unlistens.push(fn);
+    });
     listen<unknown>('recording-initialization-failed', (event) => {
-      if (!initializationPresentationFromPayload(event.payload)) return;
+      const presentation = initializationPresentationFromPayload(event.payload);
+      if (!presentation || !acceptPresentationGeneration(presentation.recordingId)) return;
       const payload = event.payload as Record<string, unknown>;
       const message = typeof payload.error === 'string'
         ? payload.error
@@ -112,7 +136,8 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
       if (cancelled) fn(); else unlistens.push(fn);
     });
     listen<unknown>('recording-recovery-stalled', (event) => {
-      if (!cleanupStalledPresentationFromPayload(event.payload)) return;
+      const presentation = cleanupStalledPresentationFromPayload(event.payload);
+      if (!presentation || !acceptPresentationGeneration(presentation.recordingId)) return;
       setError(
         'Murmur is still waiting for macOS audio to finish stopping the microphone. '
         + 'Restarting Murmur clears this stop, but macOS audio may still need time to recover.',
@@ -121,7 +146,8 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
       if (cancelled) fn(); else unlistens.push(fn);
     });
     listen<unknown>('recording-interrupted', (event) => {
-      if (!interruptedPresentationFromPayload(event.payload)) return;
+      const presentation = interruptedPresentationFromPayload(event.payload);
+      if (!presentation || !acceptPresentationGeneration(presentation.recordingId)) return;
       const payload = event.payload as Record<string, unknown>;
       setError(payload.autoTranscribe === true
         ? 'Microphone capture was interrupted. Murmur is transcribing the audio received so far.'

--- a/app/src/lib/hooks/useRecordingState.ts
+++ b/app/src/lib/hooks/useRecordingState.ts
@@ -7,6 +7,11 @@ import { updateStats } from '../stats';
 import { flog } from '../log';
 import type { TeachingContext } from '../correctAndTeach';
 import type { HistoryInterruption } from '../history';
+import {
+  cleanupStalledPresentationFromPayload,
+  initializationPresentationFromPayload,
+  interruptedPresentationFromPayload,
+} from '../dictationPresentation';
 
 interface UseRecordingStateProps {
   addEntry: (text: string, duration: number, source?: 'recording' | 'file', sourceName?: string, teachingContext?: TeachingContext, interruption?: HistoryInterruption) => void;
@@ -96,15 +101,18 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
   useEffect(() => {
     let cancelled = false;
     const unlistens: (() => void)[] = [];
-    listen<{ error?: unknown }>('recording-initialization-failed', (event) => {
-      const message = typeof event.payload?.error === 'string'
-        ? event.payload.error
+    listen<unknown>('recording-initialization-failed', (event) => {
+      if (!initializationPresentationFromPayload(event.payload)) return;
+      const payload = event.payload as Record<string, unknown>;
+      const message = typeof payload.error === 'string'
+        ? payload.error
         : 'Microphone initialization failed.';
       setError(message);
     }).then((fn) => {
       if (cancelled) fn(); else unlistens.push(fn);
     });
-    listen('recording-recovery-stalled', () => {
+    listen<unknown>('recording-recovery-stalled', (event) => {
+      if (!cleanupStalledPresentationFromPayload(event.payload)) return;
       setError(
         'Murmur is still waiting for macOS audio to finish stopping the microphone. '
         + 'Restarting Murmur clears this stop, but macOS audio may still need time to recover.',
@@ -112,8 +120,10 @@ export function useRecordingState({ addEntry, microphone }: UseRecordingStatePro
     }).then((fn) => {
       if (cancelled) fn(); else unlistens.push(fn);
     });
-    listen<{ autoTranscribe?: boolean }>('recording-interrupted', (event) => {
-      setError(event.payload?.autoTranscribe
+    listen<unknown>('recording-interrupted', (event) => {
+      if (!interruptedPresentationFromPayload(event.payload)) return;
+      const payload = event.payload as Record<string, unknown>;
+      setError(payload.autoTranscribe === true
         ? 'Microphone capture was interrupted. Murmur is transcribing the audio received so far.'
         : 'Microphone capture was interrupted before enough audio was received.');
     }).then((fn) => {

--- a/docs/features/log-shipping.md
+++ b/docs/features/log-shipping.md
@@ -191,12 +191,91 @@ replaced at `~/murmur-logs/capture-watch.json`; an alert also makes the one-shot
 exit nonzero for systemd/journal visibility and appears on the protected
 dashboard.
 
+The same line-by-line pass also evaluates the versioned
+`murmur-reliability-slo/v1` contract. Only native dictation requests with exact
+numeric `slo_contract: 1` are eligible. Historical requests without the marker
+remain useful to the legacy capture funnel but cannot enter a weekly SLO or
+make a pre-contract week pass.
+
+The evaluator recomputes the current partial ISO week and the previous eight
+complete Monday-to-Monday UTC weeks from the full retained log on every run.
+This deliberate full rescan lets a late-arriving event repair its original
+week; the atomically replaced `reliability_slo` subtree is the persisted rolling
+result. Its policy is:
+
+- at least 200 eligible requests are required for a complete week's sufficient
+  sample;
+- at least 99.5% of all eligible requests—including missing-ready and failed
+  attempts—must reach the first matching retained-PCM readiness event within
+  400 ms of the request timestamp;
+- a stable microphone-permission-prompt record excludes that attempt from the
+  startup denominator. It remains in requested/accepted/ready/terminal,
+  state, and actionable-presentation counts, so a prompt cannot hide a stuck
+  state or unpresented failure;
+- a `Recovering` or `Processing` interval that exits before the next startup is
+  `self_recovered`; one still open at the next `system.startup_baseline` is
+  `restart_required`; an interval still open at the end of the full scan, or
+  one with malformed/orphan transition evidence, is `indeterminate`. Durations
+  are reported for valid closed intervals, but there is no invented time
+  threshold that turns a slow self-recovery into a restart;
+- capture-initialization and runtime-interruption failures require their exact
+  actionable presentation pair. A stop failure is covered only by a correlated
+  cleanup-stalled/restart-app presentation; fast stop failures without that
+  real UI evidence and pipeline failures fail the presentation clause.
+
+An exact contract-v1 request whose timestamp is malformed or in the future
+cannot be assigned to an invented week. Valid history older than the retained
+weekly horizon expires normally and is not an integrity error.
+The report instead increments the bounded aggregate
+`integrity.unassigned_contract_requests` count, marks source integrity
+`indeterminate`, forces the two-week proof false, and raises the outer capture
+watch alert. Attempts or per-attempt event evidence beyond the evaluator's
+fixed memory/cardinality bounds increment the separate aggregate
+`integrity.overflowed_events` count and have the same fail-closed effect. These
+integrity counts have no install or event-content breakdown. Every malformed
+JSON or non-object line in the retained `events.jsonl` scan increments bounded
+`integrity.malformed_source_lines`; any nonzero count also makes integrity
+indeterminate and blocks the two-week proof. Because each run is a full scan,
+a concurrently partial final line self-heals after the writer completes it.
+
+A correlated accepted/ready/prompt/terminal/presentation/state record with a
+malformed timestamp or a timestamp later than the evaluation instant cannot
+supply healthy evidence early. The evaluator ignores that record's claimed
+lifecycle effect, increments the bounded weekly
+`invalid_evidence_timestamps` count, and makes the request week indeterminate.
+This prevents future evidence from curing an otherwise open or failed attempt.
+
+Every week carries `sample_status` (`partial`, `below_minimum`, or
+`sufficient`), a verdict, bounded reason codes, denominator/outcome/actionable
+counts, startup p50/p95/max, and aggregate state-interval counts/durations. A
+partial week is always `insufficient`. Complete weeks prefer
+`indeterminate`, then `fail`, then below-minimum `insufficient`; only a
+sufficient, contradiction-free week meeting every clause can `pass`. The
+two-week finish line becomes true only when the newest two complete weeks both
+pass. The newest non-insufficient complete verdict controls the outer watch: a
+failure or indeterminate result raises the status and the `--fail-on-alert`
+service exit until a later decisive pass supersedes it. Intervening
+insufficient weeks remain visible and cannot mask or clear that evidence.
+
+Per-install IDs remain internal join keys. The published
+`reliability_slo` subtree and dashboard are aggregate-only and contain no
+install UUID, device label/UID, app version, transcript/audio, path, bundle ID,
+raw event summary, or free-form error. The dashboard shows the current and two
+newest complete windows, their verdict/sample status, supporting counts,
+latency distribution, state evidence, bounded integrity/reason counts,
+actionable-presentation coverage, and whether two consecutive complete weeks
+pass. The renderer strictly validates the exact nested schema, window sequence,
+numeric bounds, and cross-field equations before displaying a verdict; a
+truncated or contradictory local report falls back to a diagnostic card.
+
 ### Operator event semantics
 
 High-value producers attach an allowlisted, privacy-safe `event_code` inside
 the structured `data` object. Examples include
 `audio.capture_backend_timeout`, `audio.fallback_started`,
 `audio.capture_ready`, `audio.capture_failed`,
+`audio.permission_prompt_changed`, `pipeline.dictation_state_changed`,
+`pipeline.dictation_presentation`,
 `audio.device_reresolution_started`, `audio.input_resolution_observed`,
 `keyboard.listener_silent`, `pipeline.dictation_terminal`,
 `transform.pass_outcome`, and `updater.install_failed`.

--- a/docs/features/overlay.md
+++ b/docs/features/overlay.md
@@ -175,7 +175,9 @@ returns to Idle only after the exclusively owned Core Audio thread exits.
 Terminal microphone failure gets a five-second, non-interactive red status cue
 without expanding, focusing, or resizing the overlay. `device_unavailable`
 uses a mic-off glyph whose accessibility label directs the user to Settings to
-choose another input; other failures use a generic capture warning. A newer
+choose another input; permission denial points to microphone settings, ordinary
+capture failures recommend retry, and an interrupted partial capture says to
+wait for transcription. A newer
 recording generation clears the prior cue immediately so successful retries
 cannot remain covered by stale failure feedback. A normal
 recording stop whose teardown remains blocked surfaces persistent guidance in

--- a/docs/features/transcription.md
+++ b/docs/features/transcription.md
@@ -176,8 +176,10 @@ Transcription processing is local. Network access occurs for model setup and may
   `recording-initialization-failed` event with `errorKind: device_unavailable`.
   The overlay shows a truthful mic-off status for five seconds with the exact
   accessible label “Selected microphone unavailable. Open Settings to choose
-  another.” Other capture failures use the generic failure cue. The cue neither
-  expands nor focuses the overlay and does not mutate native geometry.
+  another.” Permission denial points to microphone settings, ordinary capture
+  failures recommend retry, and interrupted retained audio says to wait for
+  partial transcription. The cue neither expands nor focuses the overlay and
+  does not mutate native geometry.
 - Recording duration begins at accepted readiness, not at the user's initial
   activation.
 - Multi-channel to mono conversion (averages channels) supports every PCM
@@ -199,6 +201,36 @@ capture cannot enter dictation reports.
 | Capture ready | `audio.capture_ready` | Accepted IDs that retained their first nonempty PCM buffer |
 | Stop handoff | `pipeline.dictation_stop_handoff` | Accepted IDs handed from capture to final processing |
 | Terminal | `pipeline.dictation_terminal` | Accepted IDs that emitted exactly one terminal event |
+
+The reliability SLO uses only native hotkey/input requests carrying
+`slo_contract: 1` on `pipeline.dictation_requested`. That marker defines the
+contract-v1 population and keeps historical records from being mistaken for
+complete evidence after the contract is deployed. Prompted requests are split
+out of the startup-latency denominator as described below. Historical requests
+remain available to the legacy funnel, but the weekly evaluator labels windows
+that contain only pre-contract data as insufficient.
+
+Three additional exact-schema records make the SLO clauses measurable:
+
+- `audio.permission_prompt_changed` marks a dictation-owned microphone prompt
+  as `pending` or `resolved`. A request with a valid prompt record is excluded
+  only from the start-to-first-PCM denominator; it still contributes to
+  lifecycle, terminal, state, and presentation coverage. The resolved event
+  includes only the bounded pending duration.
+- `pipeline.dictation_state_changed` records unequal transitions among
+  `idle`, `starting`, `recording`, `recovering`, and `processing`. The fleet
+  evaluator closes intervals only from matching recording generations and
+  treats unclosed intervals as unknown evidence, never as healthy recovery.
+- `pipeline.dictation_presentation` proves that a successfully emitted native
+  status carried one allowlisted action. Cleanup-in-progress maps to `wait`,
+  initialization failure maps to `retry`, `open_microphone_settings`, or
+  `choose_microphone`, a
+  cleanup stall maps to `restart_app`, and an interrupted capture maps to
+  `retry` or `wait_for_partial_transcription`.
+
+All three records are reduced to exact, content-free schemas in debug and
+release builds. They contain no microphone identity, app identity, transcript,
+audio, path, raw error, or free-form presentation text.
 
 The terminal `outcome` vocabulary is `success`, `no_speech`, `too_short`,
 `user_cancelled_starting`, `user_cancelled_recording`,

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -19,9 +19,9 @@ For commands see [commands.md](commands.md). For the hooks that consume these ev
 | `dictation-generation-started` | `{recordingId}` | `commands/recording.rs` | When a live or legacy in-memory dictation generation claims the pipeline. Content-free and monotonic. | Overlay (`useOverlayRuntime`): advances its stale-event floor and clears older clipboard-only and microphone-failure cues. |
 | `audio-initialization-stalled` | `{recordingId}` | `commands/recording.rs` | The current generation has spent 5 seconds in `Starting`; this is informational, not failure. | Overlay slow-connecting cue. |
 | `audio-recovery-started` | `{recordingId, reason}` | `commands/recording.rs` | A starting/recording owner was cancelled, including when the 30-second hard deadline begins recovery. The app reports `recovering` and retains exclusive logical ownership until its worker exits, then returns to `idle`. A hard deadline also emits the failure event below. | Overlay recovering cue and diagnostics. |
-| `recording-initialization-failed` | `{recordingId, error, errorKind}` | `commands/recording.rs` | Initialization/runtime capture failed or crossed the 30-second hard deadline. A hard deadline emits this after `audio-recovery-started`. `error` is a fixed user-facing message and `errorKind` is a stable content-free enum; raw backend messages are never emitted. Emitted exactly once per generation. | Main error surface. For exactly `errorKind: device_unavailable`, the overlay renders a five-second mic-off status with `aria-live="assertive"` and aria-label “Selected microphone unavailable. Open Settings to choose another.” All other kinds render the generic bounded failure cue; neither path expands, focuses, nor resizes the overlay. |
-| `recording-recovery-stalled` | `{recordingId}` | `commands/recording.rs` | A normal recording stop/teardown has remained blocked for the recovery grace period. | Main persistent, truthfully scoped restart guidance. |
-| `recording-interrupted` | `{recordingId, reason, deliveredSamples, durationMs, autoTranscribe}` | `commands/recording.rs` | The isolated capture worker ended unexpectedly after delivering zero or more samples. At least 8,000 delivered samples sets `autoTranscribe` and preserves a partial transcript; shorter captures fail without transcription. | Main window (`useRecordingState`) finalizes or discards the partial capture; overlay (`useOverlayRuntime`) flashes failure. |
+| `recording-initialization-failed` | `{recordingId, error, errorKind, statusCode, actionCode}` | `commands/recording.rs` | Initialization/runtime capture failed or crossed the 30-second hard deadline. A hard deadline emits this after `audio-recovery-started`. `error` is a fixed user-facing message; `errorKind` and the status/action pair are stable bounded enums validated together by consumers. Raw backend messages are never emitted. Emitted exactly once per generation. | Main error surface. A missing device renders the five-second mic-off/choose-microphone status; permission denial directs the user to microphone settings; other failures show bounded retry guidance. Neither path expands, focuses, nor resizes the overlay. |
+| `recording-recovery-stalled` | `{recordingId, statusCode, actionCode}` | `commands/recording.rs` | A normal recording stop/teardown has remained blocked for the recovery grace period. The exact pair is `microphone_cleanup_stalled`/`restart_app`. | Main persistent, truthfully scoped restart guidance. |
+| `recording-interrupted` | `{recordingId, reason, deliveredSamples, durationMs, autoTranscribe, statusCode, actionCode}` | `commands/recording.rs` | The isolated capture worker ended unexpectedly after delivering zero or more samples. At least 8,000 delivered samples sets `autoTranscribe` and pairs the status with `wait_for_partial_transcription`; shorter captures pair it with `retry`. | Main window (`useRecordingState`) finalizes or discards the partial capture; overlay (`useOverlayRuntime`) shows the same validated action. |
 | `transcription-complete` | `{recordingId, text, duration, teachingContext}` | `commands/recording.rs` | After a non-empty transcription is delivered. Broadcast to all windows. `teachingContext` seeds Correct and Teach. | Main window (`useRecordingState` → history, stats, display). |
 | `recording-cancelled` | `{recordingId}` | `commands/recording.rs` | A recording was discarded without transcription (speculative Both-mode hold, explicit cancel). | Main window, overlay (clears in-flight UI). |
 | `auto-paste-failed` | `string` (hint) | `commands/recording.rs` via `injector.rs` | Clipboard or automatic-paste delivery failed, a focus safety check refused paste, or completion could not be confirmed. Messages claim clipboard readiness only after a confirmed write. Disabled auto-paste and missing Accessibility permission do not emit this error event. | Main window (`useRecordingState`, detailed hint for 5s). |
@@ -133,6 +133,36 @@ only an allowlisted `outcome`, an allowlisted `error_code`, numeric
 vocabularies while dropping arbitrary string values. See
 [Transcription Pipeline](../features/transcription.md#per-recording-lifecycle-telemetry)
 for stage denominators and terminal semantics.
+
+The weekly reliability contract is opt-in per request through numeric
+`slo_contract: 1` on `pipeline.dictation_requested`; older requests never enter
+an SLO denominator. Its supporting records are exact-schema sanitized in every
+build:
+
+- `audio.permission_prompt_changed` carries positive matching
+  `recording_id`/`owner`, `owner_kind: "dictation"`, `state: "pending"` or
+  `"resolved"`, and `prompt_pending_ms` only for `resolved`. A pending prompt
+  excludes only startup latency; its attempt remains in every other reliability
+  count.
+- `pipeline.dictation_state_changed` carries a positive `recording_id` plus
+  unequal `from`/`to` values from `idle`, `starting`, `recording`,
+  `recovering`, and `processing`. The accepted request record is emitted
+  immediately before the `idle` to `starting` transition so telemetry work is
+  included in request-to-first-PCM latency. Fleet correlation still uses the
+  recording ID and app-session boundary rather than arrival order alone.
+- `pipeline.dictation_presentation` carries a positive `recording_id` and one
+  valid status/action pair: `microphone_cleanup_in_progress`/`wait`;
+  `microphone_initialization_failed`/(`retry` or
+  `open_microphone_settings` or `choose_microphone`);
+  `microphone_cleanup_stalled`/`restart_app`; or
+  `microphone_interrupted`/(`retry` or
+  `wait_for_partial_transcription`). It is emitted only after the corresponding
+  user-facing Tauri event succeeds.
+
+Unknown extra fields are stripped while a valid required core survives.
+Missing, invalid, or contradictory required/known fields collapse to the event
+code alone. Device/app identity, presentation text, transcript/audio, paths,
+and raw errors are never admitted.
 
 An exhausted dictation diagnostics-row start emits the stable structured code
 `performance.store_operation_failed`. Its all-build allowlist admits only

--- a/infra/log-receiver/README.md
+++ b/infra/log-receiver/README.md
@@ -24,6 +24,7 @@ of truth and redeploy from it.
 | `murmur-logs.service` | `/etc/systemd/system/` | runs the receiver as `george`, restart-always |
 | `murmur-capture-watch.py` | `/home/george/murmur-capture-watch.py` | bounded stdlib aggregation of shipped capture-startup metrics |
 | `dictation_lifecycle.py` | `/home/george/dictation_lifecycle.py` | deterministic per-session dictation funnel and terminal correlator |
+| `reliability_slo.py` | `/home/george/reliability_slo.py` | aggregate-only complete-week evaluator for the versioned dictation SLO contract |
 | `murmur-capture-watch.service` | `/etc/systemd/system/` | one-shot capture regression analysis |
 | `murmur-capture-watch.timer` | `/etc/systemd/system/` | runs the watch hourly with a randomized delay |
 | `nginx-murmur-ingest-opti.conf` | `/etc/nginx/sites-available/murmur-ingest` (+ symlink in sites-enabled; default site removed) | local-only proxy on `127.0.0.1:8601` for `/murmur/ingest`, `/murmur/state`, `/murmur/healthz` |
@@ -68,6 +69,7 @@ Instead:
 ```bash
 cat infra/log-receiver/murmur-logs-receiver.py | tailscale ssh george@opti "cat > /home/george/murmur-logs-receiver.py"
 cat infra/log-receiver/dictation_lifecycle.py | tailscale ssh george@opti "cat > /home/george/dictation_lifecycle.py"
+cat infra/log-receiver/reliability_slo.py | tailscale ssh george@opti "cat > /home/george/reliability_slo.py"
 cat infra/log-receiver/murmur-capture-watch.py | tailscale ssh george@opti "cat > /home/george/murmur-capture-watch.py"
 cat infra/log-receiver/murmur-capture-watch.service | tailscale ssh george@opti "cat > /tmp/murmur-capture-watch.service"
 cat infra/log-receiver/murmur-capture-watch.timer | tailscale ssh george@opti "cat > /tmp/murmur-capture-watch.timer"
@@ -127,9 +129,12 @@ Accepted production events are annotated with the bounded
 client-collected field. Pre-deployment retained lines remain unmodified and the
 watch groups them under `unknown`, which is never used for version comparisons.
 
-`capture-watch.json` is a versioned, atomically replaced derived report. It
-contains no source event text or device metadata: only install UUID, bounded app
-version/backend/setup-step/outcome labels, counts, and startup durations.
+`capture-watch.json` is a versioned, atomically replaced derived report. Its
+legacy cohort/alert rows contain no source event text or device metadata: only
+install UUID, bounded app version/backend/setup-step/outcome labels, counts,
+and startup durations. Its `reliability_slo` subtree is stricter and
+aggregate-only: install UUIDs and app versions are internal joins and never
+enter that subtree or its dashboard card.
 
 ## Capture regression watch
 
@@ -147,6 +152,37 @@ cohorts per install. Further versions collapse into a non-comparable
   attempted dictation sessions in each cohort;
 - a stable-code dictation funnel with terminal outcome counts, per-stage
   drop-off, and missing/duplicate terminal counts.
+
+The same full scan feeds `ReliabilitySloEvaluator` in source order. Production
+emits the accepted request immediately before `idle` → `starting`, keeping the
+transition telemetry cost inside request-to-first-PCM latency. The evaluator
+still tolerates late or reordered transport and joins internally by install,
+`startup_baseline` app session, and positive recording ID, then publishes only
+weekly aggregate counts. It recomputes one partial and eight complete UTC weeks
+every run so late arrivals update their original window. Only requests marked
+`slo_contract: 1` count; pre-contract data is always insufficient. A complete
+week needs 200 eligible requests and 99.5% at or below 400 ms, has explicit
+permission-prompt exclusion, restart-boundary state classification, and
+actionable-presentation coverage. The newest two complete sufficient passing
+weeks are the only path to the two-week finish-line flag.
+
+Contract requests with invalid or future timestamps are not assigned to guessed
+windows. Valid history older than the retained horizon simply expires. Invalid
+requests increment a bounded aggregate integrity count, force the two-week flag
+false, and make the one-shot watch alert. Evidence beyond fixed evaluator
+memory/cardinality bounds increments a separate aggregate overflow count and
+fails closed the same way. Malformed JSON and non-object lines in the retained
+`events.jsonl` input increment a bounded malformed-source count and fail closed;
+the next complete full scan clears a transient partial-tail error. The dashboard
+validates the exact report shape and cross-field arithmetic before rendering;
+malformed or contradictory derived reports are shown as unavailable rather
+than trusted.
+
+Correlated non-request lifecycle evidence with a malformed or future timestamp
+is ignored as proof and counted in its request week's
+`invalid_evidence_timestamps`. That week is indeterminate rather than allowing
+future accepted/ready/prompt/terminal/presentation/state records to manufacture
+a healthy result.
 
 `startup_baseline` begins an app session. A session contributes to the
 zero-ready signal only after a later baseline proves it ended and only when it
@@ -183,6 +219,7 @@ bounds, HTML escaping, and dictation lifecycle correlation are covered by:
 python3 -m unittest tests/test_log_receiver.py
 python3 -m unittest tests/test_capture_regression_watch.py
 python3 -m unittest tests/test_dictation_lifecycle.py
+python3 -m unittest tests/test_reliability_slo.py
 ```
 
 Install pages expose raw JSONL downloads for the latest 200, latest 500, or the

--- a/infra/log-receiver/murmur-capture-watch.py
+++ b/infra/log-receiver/murmur-capture-watch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Scheduled capture-startup regression watch for shipped Murmur logs.
+"""Scheduled capture-health and reliability-SLO watch for shipped Murmur logs.
 
 The watch reads the already privacy-stripped per-install JSONL retained by the
 log receiver. It never reads diagnostic bundles, transcript history, audio, or
@@ -22,6 +22,7 @@ if SCRIPT_DIR not in sys.path:
     sys.path.insert(0, SCRIPT_DIR)
 
 from dictation_lifecycle import DictationLifecycleCorrelator, STAGE_CODES
+from reliability_slo import ReliabilitySloEvaluator
 
 
 SCHEMA_VERSION = 1
@@ -199,7 +200,7 @@ def finish_session(session, cohorts, install_id, finished_at):
         cohort["last_attempted_session_at"] = finished_at
 
 
-def scan_install(path, install_id, cohorts):
+def scan_install(path, install_id, cohorts, reliability_slo):
     malformed = 0
     session = None
     session_id = 0
@@ -209,9 +210,11 @@ def scan_install(path, install_id, cohorts):
                 event = json.loads(line)
             except (ValueError, TypeError):
                 malformed += 1
+                reliability_slo.observe_malformed_source_line()
                 continue
             if not isinstance(event, dict):
                 malformed += 1
+                reliability_slo.observe_malformed_source_line()
                 continue
 
             code = event_code(event)
@@ -227,6 +230,14 @@ def scan_install(path, install_id, cohorts):
                 and owner_kind != CAPTURE_HEALTH_OWNER_KIND
             ):
                 continue
+
+            # Feed the exact same dictation-or-unscoped record into the
+            # aggregate SLO evaluator during this full scan. Install identity
+            # is an internal correlation key only;
+            # ReliabilitySloEvaluator.report() exposes no per-install rows or
+            # identifiers. Explicitly non-dictation owners are rejected before
+            # they can create even provisional request/state correlation.
+            reliability_slo.observe(install_id, event)
 
             version = event_version(event)
             timestamp = event_timestamp(event)
@@ -495,7 +506,9 @@ def regression_alerts(cohort_rows):
     return alerts
 
 
-def build_report(root):
+def build_report(root, now=None):
+    now = now or datetime.now(timezone.utc)
+    reliability_evaluator = ReliabilitySloEvaluator(now=now, complete_weeks=8)
     cohorts = {}
     malformed_lines = 0
     scanned_installs = 0
@@ -507,11 +520,34 @@ def build_report(root):
             if not os.path.isfile(path):
                 continue
             scanned_installs += 1
-            malformed_lines += scan_install(path, install_id, cohorts)
+            malformed_lines += scan_install(
+                path,
+                install_id,
+                cohorts,
+                reliability_evaluator,
+            )
 
     rows = [serialize_cohort(cohort) for cohort in cohorts.values()]
     rows.sort(key=lambda row: (row["install_id"], row["last_event_at"], row["app_version"]))
     alerts = regression_alerts(rows)
+    reliability_slo = reliability_evaluator.report()
+    newest_decisive_slo_week = next(
+        (
+            week
+            for week in reliability_slo.get("weeks", [])
+            if isinstance(week, dict)
+            and week.get("complete") is True
+            and week.get("verdict") != "insufficient"
+        ),
+        None,
+    )
+    reliability_alert = (
+        reliability_slo.get("integrity", {}).get("status") == "indeterminate"
+        or (
+            isinstance(newest_decisive_slo_week, dict)
+            and newest_decisive_slo_week.get("verdict") in ("fail", "indeterminate")
+        )
+    )
     known_rows = [
         row
         for row in rows
@@ -523,10 +559,16 @@ def build_report(root):
         if row["startup_sample_count"] >= MIN_COMPARISON_SAMPLES
         or row["attempted_sessions"] >= REPEATED_ZERO_READY_SESSIONS
     ]
-    status = "alert" if alerts else "healthy" if evaluable_rows else "insufficient_data"
+    status = (
+        "alert"
+        if alerts or reliability_alert
+        else "healthy"
+        if evaluable_rows
+        else "insufficient_data"
+    )
     return {
         "schema_version": SCHEMA_VERSION,
-        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
         "status": status,
         "scanned_installs": scanned_installs,
         "malformed_lines": malformed_lines,
@@ -544,6 +586,7 @@ def build_report(root):
         },
         "alerts": alerts,
         "cohorts": rows,
+        "reliability_slo": reliability_slo,
     }
 
 
@@ -579,22 +622,42 @@ def main(argv=None):
     parser.add_argument(
         "--fail-on-alert",
         action="store_true",
-        help="exit 2 after writing the report when alerts are present",
+        help="exit 2 after writing the report when its status is alert",
     )
     args = parser.parse_args(argv)
     output = args.output or os.path.join(args.root, REPORT_NAME)
     report = build_report(args.root)
     atomic_write_report(output, report)
+    decisive_slo_week = next(
+        (
+            week
+            for week in report["reliability_slo"].get("weeks", [])
+            if isinstance(week, dict)
+            and week.get("complete") is True
+            and week.get("verdict") != "insufficient"
+        ),
+        None,
+    )
+    slo_verdict = (
+        "indeterminate"
+        if report["reliability_slo"].get("integrity", {}).get("status")
+        == "indeterminate"
+        else decisive_slo_week.get("verdict")
+        if isinstance(decisive_slo_week, dict)
+        else "insufficient"
+    )
     print(
-        "capture watch: %s, %d install(s), %d cohort(s), %d alert(s)"
+        "capture watch: %s, %d install(s), %d cohort(s), "
+        "%d legacy alert(s), reliability SLO %s"
         % (
             report["status"],
             report["scanned_installs"],
             len(report["cohorts"]),
             len(report["alerts"]),
+            slo_verdict,
         )
     )
-    return 2 if args.fail_on_alert and report["alerts"] else 0
+    return 2 if args.fail_on_alert and report["status"] == "alert" else 0
 
 
 if __name__ == "__main__":

--- a/infra/log-receiver/murmur-capture-watch.py
+++ b/infra/log-receiver/murmur-capture-watch.py
@@ -208,7 +208,7 @@ def scan_install(path, install_id, cohorts, reliability_slo):
         for line in handle:
             try:
                 event = json.loads(line)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, RecursionError):
                 malformed += 1
                 reliability_slo.observe_malformed_source_line()
                 continue

--- a/infra/log-receiver/murmur-logs-receiver.py
+++ b/infra/log-receiver/murmur-logs-receiver.py
@@ -26,7 +26,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs
 from zoneinfo import ZoneInfo
@@ -44,6 +44,45 @@ MAX_ACTIVITY_EVENT_BYTES = 512 * 1024
 LLM_REPORT_FORMAT = "murmur-fleet-llm/v1"
 CAPTURE_WATCH_REPORT = "capture-watch.json"
 APP_VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,39}$")
+SLO_UTC_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+)
+SLO_COUNT_KEYS = {
+    "requested",
+    "eligible_requests",
+    "excluded_permission_prompts",
+    "accepted",
+    "ready",
+    "ready_without_accepted",
+    "within_400",
+    "failed",
+    "cancelled",
+    "missing_terminals",
+    "duplicate_terminals",
+    "unknown_terminals",
+    "failures_with_actionable_presentation",
+    "failures_without_actionable_presentation",
+    "duplicate_requests",
+    "invalid_startup_timings",
+    "invalid_state_transitions",
+    "invalid_evidence_timestamps",
+}
+SLO_REASON_CODES = {
+    "partial_week",
+    "missing_terminal",
+    "duplicate_terminal",
+    "unknown_terminal",
+    "duplicate_request",
+    "invalid_startup_timing",
+    "ready_without_accepted",
+    "invalid_state_transition",
+    "invalid_evidence_timestamp",
+    "state_interval_indeterminate",
+    "restart_required_state",
+    "startup_target_missed",
+    "failure_presentation_missing",
+    "eligible_requests_below_minimum",
+}
 DICTATION_TERMINAL_OUTCOMES = {
     "success",
     "no_speech",
@@ -236,6 +275,513 @@ def render_capture_watch(report):
             "" if len(alerts) == 1 else "s",
             generated or "unknown",
             "".join(rows) or "<li>Unrecognized bounded alert record</li>",
+        )
+    )
+
+
+def _slo_count(value):
+    if isinstance(value, bool) or not isinstance(value, int):
+        return "—"
+    return "{:,}".format(value) if 0 <= value <= 1_000_000_000 else "—"
+
+
+def _slo_milliseconds(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "—"
+    # The evaluator bounds state intervals to 31 days. Keep that evidence
+    # visible: a restart-required interval can legitimately be much longer
+    # than a capture-start latency sample.
+    maximum_duration_ms = 31 * 24 * 60 * 60 * 1_000
+    return ("%g ms" % value) if 0 <= value <= maximum_duration_ms else "—"
+
+
+def _slo_fraction(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "—"
+    return ("%.2f%%" % (value * 100)) if 0 <= value <= 1 else "—"
+
+
+def _slo_timestamp(value):
+    if not isinstance(value, str) or SLO_UTC_TIMESTAMP_RE.fullmatch(value) is None:
+        return "unknown"
+    return html.escape(value)
+
+
+def _parse_slo_timestamp(value):
+    if not isinstance(value, str) or SLO_UTC_TIMESTAMP_RE.fullmatch(value) is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def _valid_slo_count(value):
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and 0 <= value <= 1_000_000_000
+    )
+
+
+def _valid_slo_metric(value, *, nullable=False):
+    if value is None:
+        return nullable
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+        and 0 <= value <= 31 * 24 * 60 * 60 * 1_000
+    )
+
+
+def _valid_slo_distribution(value, expected_samples):
+    if not isinstance(value, dict) or set(value) != {"sample_count", "p50", "p95", "max"}:
+        return False
+    if value.get("sample_count") != expected_samples:
+        return False
+    p50, p95, maximum = value.get("p50"), value.get("p95"), value.get("max")
+    if expected_samples == 0:
+        return p50 is None and p95 is None and maximum is None
+    return (
+        _valid_slo_metric(p50)
+        and _valid_slo_metric(p95)
+        and _valid_slo_metric(maximum)
+        and p50 <= p95 <= maximum
+    )
+
+
+def _valid_slo_state(value):
+    if not isinstance(value, dict) or set(value) != {
+        "self_recovered",
+        "restart_required",
+        "indeterminate",
+        "duration_ms",
+    }:
+        return False
+    if not all(
+        _valid_slo_count(value.get(key))
+        for key in ("self_recovered", "restart_required", "indeterminate")
+    ):
+        return False
+    duration_samples = value["self_recovered"] + value["restart_required"]
+    return _valid_slo_distribution(value.get("duration_ms"), duration_samples)
+
+
+def _expected_slo_reasons(counts, startup, states, complete):
+    indeterminate = []
+    if counts["missing_terminals"]:
+        indeterminate.append("missing_terminal")
+    if counts["duplicate_terminals"]:
+        indeterminate.append("duplicate_terminal")
+    if counts["unknown_terminals"]:
+        indeterminate.append("unknown_terminal")
+    if counts["duplicate_requests"]:
+        indeterminate.append("duplicate_request")
+    if counts["invalid_startup_timings"]:
+        indeterminate.append("invalid_startup_timing")
+    if counts["ready_without_accepted"]:
+        indeterminate.append("ready_without_accepted")
+    if counts["invalid_state_transitions"]:
+        indeterminate.append("invalid_state_transition")
+    if counts["invalid_evidence_timestamps"]:
+        indeterminate.append("invalid_evidence_timestamp")
+    if any(states[name]["indeterminate"] for name in ("recovering", "processing")):
+        indeterminate.append("state_interval_indeterminate")
+
+    failures = []
+    if any(states[name]["restart_required"] for name in ("recovering", "processing")):
+        failures.append("restart_required_state")
+    fraction = startup["within_400_fraction"]
+    if fraction is not None and fraction < 0.995:
+        failures.append("startup_target_missed")
+    if counts["failures_without_actionable_presentation"]:
+        failures.append("failure_presentation_missing")
+
+    if not complete:
+        return "insufficient", ["partial_week", *indeterminate, *failures]
+    if indeterminate:
+        return "indeterminate", indeterminate
+    if failures:
+        return "fail", failures
+    if counts["eligible_requests"] < 200:
+        return "insufficient", ["eligible_requests_below_minimum"]
+    return "pass", []
+
+
+def _valid_slo_week(week, index, expected_start):
+    if not isinstance(week, dict) or set(week) != {
+        "week_start",
+        "week_end",
+        "complete",
+        "sample_status",
+        "verdict",
+        "reasons",
+        "counts",
+        "startup_ms",
+        "states",
+    }:
+        return False
+    start = _parse_slo_timestamp(week.get("week_start"))
+    end = _parse_slo_timestamp(week.get("week_end"))
+    complete = week.get("complete")
+    if (
+        start != expected_start
+        or end != expected_start + timedelta(weeks=1)
+        or not isinstance(complete, bool)
+        or complete != (index > 0)
+    ):
+        return False
+
+    counts = week.get("counts")
+    if (
+        not isinstance(counts, dict)
+        or set(counts) != SLO_COUNT_KEYS
+        or not all(_valid_slo_count(value) for value in counts.values())
+    ):
+        return False
+    if (
+        counts["requested"]
+        != counts["eligible_requests"] + counts["excluded_permission_prompts"]
+        or counts["accepted"] > counts["requested"]
+        or counts["ready"] > counts["requested"]
+        or counts["ready_without_accepted"] > counts["ready"]
+        or counts["ready"] - counts["ready_without_accepted"]
+        > counts["accepted"]
+        or counts["failed"] + counts["cancelled"] > counts["requested"]
+        or counts["failures_with_actionable_presentation"]
+        + counts["failures_without_actionable_presentation"]
+        != counts["failed"]
+        or any(
+            counts[key] > counts["requested"]
+            for key in (
+                "missing_terminals",
+                "duplicate_terminals",
+                "unknown_terminals",
+                "duplicate_requests",
+                "invalid_startup_timings",
+            )
+        )
+    ):
+        return False
+
+    startup = week.get("startup_ms")
+    if not isinstance(startup, dict) or set(startup) != {
+        "sample_count",
+        "p50",
+        "p95",
+        "max",
+        "within_400_fraction",
+    }:
+        return False
+    sample_count = startup.get("sample_count")
+    if (
+        not _valid_slo_count(sample_count)
+        or sample_count > counts["eligible_requests"]
+        or sample_count > counts["ready"]
+        or sample_count + counts["invalid_startup_timings"]
+        > counts["eligible_requests"]
+        or sample_count + counts["invalid_startup_timings"] > counts["ready"]
+        or counts["within_400"] > sample_count
+        or not _valid_slo_distribution(
+            {key: startup.get(key) for key in ("sample_count", "p50", "p95", "max")},
+            sample_count,
+        )
+    ):
+        return False
+    fraction = startup.get("within_400_fraction")
+    expected_fraction = (
+        counts["within_400"] / counts["eligible_requests"]
+        if counts["eligible_requests"]
+        else None
+    )
+    if expected_fraction is None:
+        if fraction is not None:
+            return False
+    elif (
+        isinstance(fraction, bool)
+        or not isinstance(fraction, (int, float))
+        or not math.isfinite(fraction)
+        or not math.isclose(fraction, expected_fraction, rel_tol=0, abs_tol=1e-12)
+    ):
+        return False
+
+    states = week.get("states")
+    if (
+        not isinstance(states, dict)
+        or set(states) != {"recovering", "processing"}
+        or not all(_valid_slo_state(states.get(name)) for name in states)
+    ):
+        return False
+    reasons = week.get("reasons")
+    if (
+        not isinstance(reasons, list)
+        or len(reasons) > len(SLO_REASON_CODES)
+        or not all(isinstance(reason, str) for reason in reasons)
+        or len(reasons) != len(set(reasons))
+        or any(reason not in SLO_REASON_CODES for reason in reasons)
+    ):
+        return False
+    expected_verdict, expected_reasons = _expected_slo_reasons(
+        counts, startup, states, complete
+    )
+    expected_sample_status = (
+        "partial"
+        if not complete
+        else "below_minimum"
+        if counts["eligible_requests"] < 200
+        else "sufficient"
+    )
+    return (
+        week.get("verdict") == expected_verdict
+        and reasons == expected_reasons
+        and week.get("sample_status") == expected_sample_status
+    )
+
+
+def _valid_reliability_slo(slo):
+    if (
+        not isinstance(slo, dict)
+        or set(slo) != {
+            "schema_version",
+            "report",
+            "generated_at",
+            "contract_version",
+            "privacy",
+            "thresholds",
+            "integrity",
+            "two_consecutive_complete_weeks_pass",
+            "weeks",
+        }
+        or slo.get("schema_version") != 1
+        or slo.get("report") != "murmur-reliability-slo/v1"
+        or slo.get("contract_version") != 1
+        or slo.get("privacy") != "aggregate_only"
+        or not isinstance(slo.get("two_consecutive_complete_weeks_pass"), bool)
+    ):
+        return False
+    thresholds = slo.get("thresholds")
+    if thresholds != {
+        "complete_weeks": 8,
+        "minimum_eligible_requests": 200,
+        "startup_target_ms": 400.0,
+        "startup_target_fraction": 0.995,
+    }:
+        return False
+    integrity = slo.get("integrity")
+    if (
+        not isinstance(integrity, dict)
+        or set(integrity)
+        != {
+            "status",
+            "unassigned_contract_requests",
+            "overflowed_events",
+            "malformed_source_lines",
+        }
+        or not _valid_slo_count(integrity.get("unassigned_contract_requests"))
+        or not _valid_slo_count(integrity.get("overflowed_events"))
+        or not _valid_slo_count(integrity.get("malformed_source_lines"))
+        or integrity.get("status")
+        != (
+            "complete"
+            if integrity.get("unassigned_contract_requests") == 0
+            and integrity.get("overflowed_events") == 0
+            and integrity.get("malformed_source_lines") == 0
+            else "indeterminate"
+        )
+    ):
+        return False
+    generated = _parse_slo_timestamp(slo.get("generated_at"))
+    weeks = slo.get("weeks")
+    if generated is None or not isinstance(weeks, list) or len(weeks) != 9:
+        return False
+    try:
+        current_start = (generated - timedelta(days=generated.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        valid_weeks = all(
+            _valid_slo_week(week, index, current_start - timedelta(weeks=index))
+            for index, week in enumerate(weeks)
+        )
+    except (OverflowError, ValueError):
+        return False
+    if not valid_weeks:
+        return False
+    expected_two_week = (
+        integrity["status"] == "complete"
+        and all(week["verdict"] == "pass" for week in weeks[1:3])
+    )
+    return slo["two_consecutive_complete_weeks_pass"] == expected_two_week
+
+
+def render_reliability_slo(report):
+    slo = report.get("reliability_slo") if isinstance(report, dict) else None
+    if not _valid_reliability_slo(slo):
+        return (
+            "<div class='watch-banner diagnostic'><strong>Dictation reliability SLO</strong>"
+            "<span>No aggregate contract report is available yet. Historical "
+            "pre-contract data is insufficient.</span></div>"
+        )
+
+    weeks = [week for week in slo["weeks"][:9] if isinstance(week, dict)]
+    complete_weeks = [week for week in weeks if week.get("complete") is True]
+    newest_complete = complete_weeks[0] if complete_weeks else None
+    newest_decisive = next(
+        (
+            week
+            for week in complete_weeks
+            if week.get("verdict") in ("pass", "fail", "indeterminate")
+        ),
+        None,
+    )
+    headline_week = newest_decisive or newest_complete
+    integrity = slo["integrity"]
+    verdict = (
+        "indeterminate"
+        if integrity["status"] == "indeterminate"
+        else headline_week.get("verdict")
+        if isinstance(headline_week, dict)
+        else "insufficient"
+    )
+    if verdict not in ("pass", "fail", "insufficient", "indeterminate"):
+        verdict = "indeterminate"
+    css_class = "healthy" if verdict == "pass" else (
+        "alert" if verdict in ("fail", "indeterminate") else "diagnostic"
+    )
+    # Treat the persisted convenience flag as an assertion, not authority.
+    # A truncated or manually corrupted local report must never make the
+    # dashboard claim the finish line unless the two newest complete rows
+    # independently prove sufficient passing samples.
+    derived_two_week_pass = (
+        len(complete_weeks) >= 2
+        and all(
+            week.get("verdict") == "pass"
+            and week.get("sample_status") == "sufficient"
+            for week in complete_weeks[:2]
+        )
+    )
+    two_week_pass = (
+        slo.get("two_consecutive_complete_weeks_pass") is True
+        and integrity["status"] == "complete"
+        and derived_two_week_pass
+    )
+    two_week_label = (
+        "Two consecutive complete weeks pass"
+        if two_week_pass
+        else "Two consecutive complete passing weeks not yet proven"
+    )
+
+    rows = []
+    for week in weeks[:3]:
+        week_verdict = week.get("verdict")
+        if week_verdict not in ("pass", "fail", "insufficient", "indeterminate"):
+            week_verdict = "indeterminate"
+        sample_status = week.get("sample_status")
+        if sample_status not in ("partial", "below_minimum", "sufficient"):
+            sample_status = "unknown_sample_status"
+        counts = week.get("counts") if isinstance(week.get("counts"), dict) else {}
+        startup = (
+            week.get("startup_ms")
+            if isinstance(week.get("startup_ms"), dict)
+            else {}
+        )
+        states = week.get("states") if isinstance(week.get("states"), dict) else {}
+        recovering = (
+            states.get("recovering")
+            if isinstance(states.get("recovering"), dict)
+            else {}
+        )
+        processing = (
+            states.get("processing")
+            if isinstance(states.get("processing"), dict)
+            else {}
+        )
+        recovering_duration = (
+            recovering.get("duration_ms")
+            if isinstance(recovering.get("duration_ms"), dict)
+            else {}
+        )
+        processing_duration = (
+            processing.get("duration_ms")
+            if isinstance(processing.get("duration_ms"), dict)
+            else {}
+        )
+        window = "%s → %s" % (
+            _slo_timestamp(week.get("week_start")),
+            _slo_timestamp(week.get("week_end")),
+        )
+        completeness = "complete" if week.get("complete") is True else "partial"
+        rows.append(
+            "<li><strong>%s · %s</strong> <span class='slo-window'>%s (%s; %s sample)</span>"
+            "<div class='slo-metrics'>requests %s total · latency denominator %s eligible / %s prompt-excluded · "
+            "accepted %s · ready %s · failed %s · cancelled %s · missing terminal %s · "
+            "startup ≤400 ms %s (%s samples; p50 %s, p95 %s, max %s) · "
+            "failure presentation %s covered / %s missing · "
+            "integrity duplicate request/terminal/unknown terminal/ready-without-accepted/"
+            "invalid-startup/invalid-state/invalid-evidence-time %s/%s/%s/%s/%s/%s/%s · reasons %s · "
+            "recovering self/restart/unknown %s/%s/%s (p95 %s, max %s) · "
+            "processing self/restart/unknown %s/%s/%s (p95 %s, max %s)</div></li>"
+            % (
+                html.escape(str(week_verdict).upper()),
+                completeness,
+                window,
+                completeness,
+                html.escape(sample_status.replace("_", " ")),
+                _slo_count(counts.get("requested")),
+                _slo_count(counts.get("eligible_requests")),
+                _slo_count(counts.get("excluded_permission_prompts")),
+                _slo_count(counts.get("accepted")),
+                _slo_count(counts.get("ready")),
+                _slo_count(counts.get("failed")),
+                _slo_count(counts.get("cancelled")),
+                _slo_count(counts.get("missing_terminals")),
+                _slo_fraction(startup.get("within_400_fraction")),
+                _slo_count(startup.get("sample_count")),
+                _slo_milliseconds(startup.get("p50")),
+                _slo_milliseconds(startup.get("p95")),
+                _slo_milliseconds(startup.get("max")),
+                _slo_count(counts.get("failures_with_actionable_presentation")),
+                _slo_count(counts.get("failures_without_actionable_presentation")),
+                _slo_count(counts.get("duplicate_requests")),
+                _slo_count(counts.get("duplicate_terminals")),
+                _slo_count(counts.get("unknown_terminals")),
+                _slo_count(counts.get("ready_without_accepted")),
+                _slo_count(counts.get("invalid_startup_timings")),
+                _slo_count(counts.get("invalid_state_transitions")),
+                _slo_count(counts.get("invalid_evidence_timestamps")),
+                html.escape(", ".join(week.get("reasons", [])) or "none"),
+                _slo_count(recovering.get("self_recovered")),
+                _slo_count(recovering.get("restart_required")),
+                _slo_count(recovering.get("indeterminate")),
+                _slo_milliseconds(recovering_duration.get("p95")),
+                _slo_milliseconds(recovering_duration.get("max")),
+                _slo_count(processing.get("self_recovered")),
+                _slo_count(processing.get("restart_required")),
+                _slo_count(processing.get("indeterminate")),
+                _slo_milliseconds(processing_duration.get("p95")),
+                _slo_milliseconds(processing_duration.get("max")),
+            )
+        )
+
+    return (
+        "<div class='watch-banner %s'><strong>Dictation reliability SLO · %s</strong>"
+        "<span>%s · source integrity %s (%s unassigned contract request%s; "
+        "%s bounded-correlation overflow event%s; %s malformed source line%s) · "
+        "aggregate-only contract v1</span><ul class='slo-weeks'>%s</ul></div>"
+        % (
+            css_class,
+            html.escape(str(verdict).upper()),
+            two_week_label,
+            html.escape(integrity["status"]),
+            _slo_count(integrity["unassigned_contract_requests"]),
+            "" if integrity["unassigned_contract_requests"] == 1 else "s",
+            _slo_count(integrity["overflowed_events"]),
+            "" if integrity["overflowed_events"] == 1 else "s",
+            _slo_count(integrity["malformed_source_lines"]),
+            "" if integrity["malformed_source_lines"] == 1 else "s",
+            "".join(rows) or "<li>No weekly windows are available.</li>",
         )
     )
 
@@ -1986,7 +2532,9 @@ def render_problem_group(item):
 
 def render_dashboard():
     installs = collect_installs()
-    capture_watch = render_capture_watch(load_capture_watch_report())
+    capture_report = load_capture_watch_report()
+    capture_watch = render_capture_watch(capture_report)
+    reliability_slo = render_reliability_slo(capture_report)
     now = time.time()
     rows = []
     for i in installs:
@@ -2025,7 +2573,7 @@ def render_dashboard():
     body = (
         "<h1>murmur fleet logs</h1>"
         "<p class='sub'>%d install stream%s · refreshes every 30s · %s</p>"
-        "%s"
+        "%s%s"
         "<table><thead><tr><th>device</th><th>version</th>"
         "<th>last event</th></tr></thead>"
         "<tbody>%s</tbody></table>"
@@ -2034,6 +2582,7 @@ def render_dashboard():
             "" if len(installs) == 1 else "s",
             datetime.now(EASTERN).strftime("%Y-%m-%d %-I:%M %p ET"),
             capture_watch,
+            reliability_slo,
             "".join(rows) or '<tr><td colspan="3">no installs yet</td></tr>',
         )
     )
@@ -2059,6 +2608,7 @@ code{color:#93c5fd;font-size:.85em}
 .meta{color:#64748b;font-size:.75rem;margin-top:.15rem}
 .watch-banner{border:1px solid #1e293b;border-radius:10px;display:grid;gap:.3rem;margin:0 0 1.2rem;padding:.7rem .85rem}
 .watch-banner span{color:#94a3b8;font-size:.78rem}.watch-banner ul{margin:.25rem 0 0;padding-left:1.25rem}
+.watch-banner .slo-weeks{display:grid;gap:.45rem}.slo-window{margin-left:.35rem}.slo-metrics{color:#94a3b8;font-size:.78rem;margin-top:.12rem}
 .watch-banner.healthy{border-color:#14532d}.watch-banner.diagnostic{border-color:#334155}
 .watch-banner.alert{background:#2a0f14;border-color:#7f1d1d}
 a{color:#e2e8f0;text-decoration:none}a:hover{text-decoration:underline}

--- a/infra/log-receiver/reliability_slo.py
+++ b/infra/log-receiver/reliability_slo.py
@@ -434,7 +434,13 @@ class ReliabilitySloEvaluator:
     def _observe_state(self, attempt, data, timestamp):
         previous = data.get("from")
         current = data.get("to")
-        if previous not in STATE_VALUES or current not in STATE_VALUES or previous == current:
+        if previous not in STATE_VALUES or current not in STATE_VALUES:
+            attempt["state_chain_anomalies"] = min(
+                attempt["state_chain_anomalies"] + 1,
+                MAX_AGGREGATE_COUNT,
+            )
+            return
+        if previous == current:
             return
         cursor = attempt["state_cursor"]
         if cursor is not None and previous != cursor:

--- a/infra/log-receiver/reliability_slo.py
+++ b/infra/log-receiver/reliability_slo.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""Deterministic, aggregate-only evaluator for Murmur recording SLOs.
+
+The evaluator consumes a full retained-log scan on every run. Install IDs are
+used only as an in-memory correlation boundary and never enter the report.
+Only dictation requests carrying the exact numeric ``slo_contract=1`` marker
+are eligible; older telemetry cannot accidentally improve or degrade an SLO.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timedelta, timezone
+
+
+SCHEMA_VERSION = 1
+REPORT_FORMAT = "murmur-reliability-slo/v1"
+CONTRACT_VERSION = 1
+MIN_COMPLETE_WEEKS = 8
+MIN_ELIGIBLE_REQUESTS = 200
+STARTUP_TARGET_MS = 400.0
+STARTUP_TARGET_FRACTION = 0.995
+MAX_AGGREGATE_COUNT = 1_000_000_000
+MAX_TRACKED_INSTALLS = 150
+MAX_TRACKED_ATTEMPTS = 250_000
+MAX_STATE_INTERVALS_PER_ATTEMPT = 8
+MAX_SESSION_NUMBER = 1_000_000
+
+STATE_NAMES = ("recovering", "processing")
+STATE_VALUES = {"idle", "starting", "recording", *STATE_NAMES}
+TERMINAL_OUTCOMES = {
+    "success",
+    "no_speech",
+    "too_short",
+    "user_cancelled_starting",
+    "user_cancelled_recording",
+    "user_cancelled_processing",
+    "capture_init_failure",
+    "runtime_interruption",
+    "stop_failure",
+    "pipeline_failure",
+    "superseded",
+}
+CANCELLED_OUTCOMES = {
+    "user_cancelled_starting",
+    "user_cancelled_recording",
+    "user_cancelled_processing",
+    "superseded",
+}
+FAILURE_OUTCOMES = {
+    "capture_init_failure",
+    "runtime_interruption",
+    "stop_failure",
+    "pipeline_failure",
+}
+
+# Only these presentation pairs prove that a failure terminal received a
+# useful action. Cleanup-in-progress is state guidance; a stop failure is
+# covered only when the real stalled-cleanup UI was emitted successfully.
+ACTIONABLE_PRESENTATIONS = {
+    "capture_init_failure": {
+        ("microphone_initialization_failed", "retry"),
+        ("microphone_initialization_failed", "open_microphone_settings"),
+        ("microphone_initialization_failed", "choose_microphone"),
+    },
+    "runtime_interruption": {
+        ("microphone_interrupted", "retry"),
+        ("microphone_interrupted", "wait_for_partial_transcription"),
+    },
+    "stop_failure": {
+        ("microphone_cleanup_stalled", "restart_app"),
+    },
+}
+KNOWN_PRESENTATIONS = {
+    ("microphone_cleanup_in_progress", "wait"),
+    ("microphone_initialization_failed", "retry"),
+    ("microphone_initialization_failed", "open_microphone_settings"),
+    ("microphone_initialization_failed", "choose_microphone"),
+    ("microphone_cleanup_stalled", "restart_app"),
+    ("microphone_interrupted", "retry"),
+    ("microphone_interrupted", "wait_for_partial_transcription"),
+}
+
+UTC_TIMESTAMP_RE = re.compile(
+    r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})"
+    r"(?:\.(\d{1,9}))?Z$"
+)
+
+
+def _event_code(event):
+    data = event.get("data") if isinstance(event, dict) else None
+    if not isinstance(data, dict):
+        return None
+    code = data.get("event_code")
+    return code if isinstance(code, str) else None
+
+
+def _event_data(event):
+    data = event.get("data") if isinstance(event, dict) else None
+    return data if isinstance(data, dict) else {}
+
+
+def _recording_id(data):
+    value = data.get("recording_id")
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 < value < 2**64 else None
+
+
+def parse_utc_timestamp(value):
+    """Parse the producer's strict UTC RFC3339 subset, never local offsets."""
+    if not isinstance(value, str) or len(value) > 40:
+        return None
+    match = UTC_TIMESTAMP_RE.fullmatch(value)
+    if match is None:
+        return None
+    year, month, day, hour, minute, second = map(int, match.groups()[:6])
+    fraction = match.group(7) or ""
+    microsecond = int((fraction + "000000")[:6])
+    try:
+        return datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            microsecond,
+            tzinfo=timezone.utc,
+        )
+    except ValueError:
+        return None
+
+
+def _strict_now(now):
+    if now is None:
+        return datetime.now(timezone.utc)
+    if not isinstance(now, datetime) or now.tzinfo is None:
+        raise ValueError("now must be an aware UTC datetime")
+    if now.utcoffset() != timedelta(0):
+        raise ValueError("now must use UTC")
+    return now.astimezone(timezone.utc)
+
+
+def _week_start(value):
+    value = value.astimezone(timezone.utc)
+    return (value - timedelta(days=value.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _format_timestamp(value):
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _nearest_rank(values, percentile):
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile / 100.0) * len(ordered)))
+    return ordered[min(rank - 1, len(ordered) - 1)]
+
+
+def _duration_ms(start, end):
+    if start is None or end is None or end < start:
+        return None
+    value = (end - start).total_seconds() * 1000.0
+    # A corrupt timestamp must not create an unbounded numeric report value.
+    return value if math.isfinite(value) and value <= 31 * 24 * 60 * 60 * 1000 else None
+
+
+def _new_attempt():
+    return {
+        "request_count": 0,
+        "requested_at": None,
+        "accepted": False,
+        "ready_at": None,
+        "permission_pending": False,
+        "terminal_count": 0,
+        "terminal_outcome": None,
+        "presentations": set(),
+        "state_open": {name: None for name in STATE_NAMES},
+        "state_intervals": {name: [] for name in STATE_NAMES},
+        "state_anomalies": {name: 0 for name in STATE_NAMES},
+        "state_cursor": None,
+        "state_chain_anomalies": 0,
+        "evidence_time_anomalies": 0,
+    }
+
+
+class ReliabilitySloEvaluator:
+    """Full-scan evaluator with internal install/session/recording joins."""
+
+    def __init__(self, now=None, complete_weeks=MIN_COMPLETE_WEEKS):
+        if (
+            isinstance(complete_weeks, bool)
+            or not isinstance(complete_weeks, int)
+            or complete_weeks != MIN_COMPLETE_WEEKS
+        ):
+            raise ValueError("complete_weeks must be exactly 8 for report contract v1")
+        self.now = _strict_now(now)
+        self.complete_weeks = complete_weeks
+        self._install_sessions = {}
+        self._attempts = {}
+        self._session_attempt_keys = {}
+        self._unassigned_contract_requests = 0
+        self._overflowed_events = 0
+        self._malformed_source_lines = 0
+
+    def _mark_overflow(self):
+        self._overflowed_events = min(
+            self._overflowed_events + 1,
+            MAX_AGGREGATE_COUNT,
+        )
+
+    def observe_malformed_source_line(self):
+        """Fail closed when a retained source row cannot be evaluated."""
+        self._malformed_source_lines = min(
+            self._malformed_source_lines + 1,
+            MAX_AGGREGATE_COUNT,
+        )
+
+    def _session(self, install_id):
+        session = self._install_sessions.get(install_id)
+        if session is not None:
+            return session
+        if len(self._install_sessions) >= MAX_TRACKED_INSTALLS:
+            self._mark_overflow()
+            return None
+        session = {"active": False, "number": 0}
+        self._install_sessions[install_id] = session
+        return session
+
+    def _attempt(self, install_id, session_number, recording_id):
+        key = (install_id, session_number, recording_id)
+        attempt = self._attempts.get(key)
+        if attempt is not None:
+            return attempt
+        if len(self._attempts) >= MAX_TRACKED_ATTEMPTS:
+            self._mark_overflow()
+            return None
+        attempt = _new_attempt()
+        self._attempts[key] = attempt
+        self._session_attempt_keys.setdefault(
+            (install_id, session_number), set()
+        ).add(key)
+        return attempt
+
+    def _append_state_interval(self, attempt, state, classification, duration):
+        intervals = attempt["state_intervals"][state]
+        if len(intervals) >= MAX_STATE_INTERVALS_PER_ATTEMPT:
+            self._mark_overflow()
+            attempt["state_anomalies"][state] = min(
+                attempt["state_anomalies"][state] + 1,
+                MAX_AGGREGATE_COUNT,
+            )
+            return
+        intervals.append((classification, duration))
+
+    def _close_for_restart(self, install_id, session_number, boundary_time):
+        session_key = (install_id, session_number)
+        for key in self._session_attempt_keys.get(session_key, ()):
+            attempt = self._attempts.get(key)
+            if attempt is None:
+                continue
+            for state in STATE_NAMES:
+                started = attempt["state_open"][state]
+                if started is not None:
+                    duration = _duration_ms(started, boundary_time)
+                    self._append_state_interval(
+                        attempt,
+                        state,
+                        "restart_required" if duration is not None else "indeterminate",
+                        duration,
+                    )
+                    attempt["state_open"][state] = None
+
+    def _prune_closed_session(self, install_id, session_number):
+        """Drop closed-session state that cannot enter the retained windows."""
+        session_key = (install_id, session_number)
+        keys = self._session_attempt_keys.pop(session_key, set())
+        for key in keys:
+            attempt = self._attempts.get(key)
+            if attempt is None or attempt["requested_at"] is None:
+                self._attempts.pop(key, None)
+
+    def observe(self, install_id, event):
+        """Observe one validated event in retained source order.
+
+        ``install_id`` is deliberately opaque and used only in internal keys.
+        Callers must perform a complete scan on every scheduled evaluation so
+        late-arriving events can revise their original request week.
+        """
+        if (
+            not isinstance(install_id, str)
+            or not (1 <= len(install_id) <= 64)
+            or not isinstance(event, dict)
+        ):
+            return
+        code = _event_code(event)
+        if code is None:
+            return
+        timestamp = parse_utc_timestamp(event.get("timestamp"))
+        session = self._session(install_id)
+        if session is None:
+            return
+
+        if code == "system.startup_baseline":
+            if session["active"]:
+                boundary_time = (
+                    timestamp
+                    if timestamp is not None and timestamp <= self.now
+                    else None
+                )
+                self._close_for_restart(
+                    install_id, session["number"], boundary_time
+                )
+                self._prune_closed_session(install_id, session["number"])
+            if session["number"] >= MAX_SESSION_NUMBER:
+                self._mark_overflow()
+                session["active"] = False
+                return
+            session["number"] += 1
+            session["active"] = True
+            return
+        if not session["active"]:
+            return
+
+        data = _event_data(event)
+        rid = _recording_id(data)
+        if rid is None:
+            return
+        relevant = {
+            "pipeline.dictation_requested",
+            "audio.capture_started",
+            "audio.capture_ready",
+            "audio.permission_prompt_changed",
+            "pipeline.dictation_terminal",
+            "pipeline.dictation_state_changed",
+            "pipeline.dictation_presentation",
+        }
+        if code not in relevant:
+            return
+
+        if code in {
+            "audio.capture_started",
+            "audio.capture_ready",
+            "audio.permission_prompt_changed",
+        }:
+            owner = data.get("owner")
+            if (
+                data.get("owner_kind") != "dictation"
+                or isinstance(owner, bool)
+                or not isinstance(owner, int)
+                or owner != rid
+            ):
+                return
+
+        earliest_retained = self._window_starts()[-1]
+        if code == "pipeline.dictation_requested":
+            contract = data.get("slo_contract")
+            if (
+                isinstance(contract, bool)
+                or not isinstance(contract, int)
+                or contract != CONTRACT_VERSION
+            ):
+                return
+            if timestamp is None or timestamp > self.now:
+                # There is no honest UTC week for this contract request. Keep
+                # it out of every denominator, but surface bounded global
+                # integrity evidence and refuse the two-week proof rather than
+                # silently making the request disappear.
+                self._unassigned_contract_requests = min(
+                    self._unassigned_contract_requests + 1,
+                    MAX_AGGREGATE_COUNT,
+                )
+                return
+            if timestamp < earliest_retained:
+                return
+        elif timestamp is not None and timestamp < earliest_retained:
+            # Events older than every published bucket cannot correlate to an
+            # in-window producer attempt. Skip them before allocating state.
+            return
+
+        attempt = self._attempt(install_id, session["number"], rid)
+        if attempt is None:
+            return
+        if code != "pipeline.dictation_requested" and (
+            timestamp is None or timestamp > self.now
+        ):
+            # Non-request lifecycle evidence cannot prove a healthy outcome
+            # before its own event time. Retain only a bounded contradiction
+            # marker so a later/out-of-order in-window request fails closed.
+            attempt["evidence_time_anomalies"] = min(
+                attempt["evidence_time_anomalies"] + 1,
+                MAX_AGGREGATE_COUNT,
+            )
+            return
+        if code == "pipeline.dictation_requested":
+            attempt["request_count"] = min(attempt["request_count"] + 1, 2)
+            if attempt["requested_at"] is None or timestamp < attempt["requested_at"]:
+                attempt["requested_at"] = timestamp
+        elif code == "audio.capture_started":
+            attempt["accepted"] = True
+        elif code == "audio.capture_ready":
+            if timestamp is not None and (
+                attempt["ready_at"] is None or timestamp < attempt["ready_at"]
+            ):
+                attempt["ready_at"] = timestamp
+        elif code == "audio.permission_prompt_changed":
+            # Either retained half of the exact producer pair proves that the
+            # attempt crossed the TCC prompt boundary. In particular, a
+            # resolved record carries a validated bounded pending duration and
+            # remains sufficient when retention or delivery omitted `pending`.
+            if data.get("state") in ("pending", "resolved"):
+                attempt["permission_pending"] = True
+        elif code == "pipeline.dictation_terminal":
+            outcome = data.get("outcome")
+            attempt["terminal_count"] = min(attempt["terminal_count"] + 1, 2)
+            if attempt["terminal_outcome"] is None:
+                attempt["terminal_outcome"] = (
+                    outcome if outcome in TERMINAL_OUTCOMES else "unknown"
+                )
+        elif code == "pipeline.dictation_presentation":
+            pair = (data.get("status_code"), data.get("action_code"))
+            if pair in KNOWN_PRESENTATIONS:
+                attempt["presentations"].add(pair)
+        elif code == "pipeline.dictation_state_changed":
+            self._observe_state(attempt, data, timestamp)
+
+    def _observe_state(self, attempt, data, timestamp):
+        previous = data.get("from")
+        current = data.get("to")
+        if previous not in STATE_VALUES or current not in STATE_VALUES or previous == current:
+            return
+        cursor = attempt["state_cursor"]
+        if cursor is not None and previous != cursor:
+            attempt["state_chain_anomalies"] = min(
+                attempt["state_chain_anomalies"] + 1,
+                MAX_AGGREGATE_COUNT,
+            )
+            # Re-establish a bounded source-order cursor, but do not invent an
+            # interval close/open from contradictory evidence.
+            attempt["state_cursor"] = current
+            return
+        attempt["state_cursor"] = current
+        for state in STATE_NAMES:
+            if previous == state:
+                started = attempt["state_open"][state]
+                if started is None:
+                    attempt["state_anomalies"][state] = min(
+                        attempt["state_anomalies"][state] + 1,
+                        MAX_AGGREGATE_COUNT,
+                    )
+                else:
+                    duration = _duration_ms(started, timestamp)
+                    if duration is None:
+                        self._append_state_interval(
+                            attempt, state, "indeterminate", None
+                        )
+                    else:
+                        self._append_state_interval(
+                            attempt, state, "self_recovered", duration
+                        )
+                    attempt["state_open"][state] = None
+            if current == state:
+                if attempt["state_open"][state] is not None:
+                    attempt["state_anomalies"][state] = min(
+                        attempt["state_anomalies"][state] + 1,
+                        MAX_AGGREGATE_COUNT,
+                    )
+                else:
+                    # ``None`` also represents an invalid timestamp. Count it
+                    # now so the interval cannot disappear as apparently idle.
+                    if timestamp is None:
+                        attempt["state_anomalies"][state] = min(
+                            attempt["state_anomalies"][state] + 1,
+                            MAX_AGGREGATE_COUNT,
+                        )
+                    else:
+                        attempt["state_open"][state] = timestamp
+
+    def _window_starts(self):
+        current = _week_start(self.now)
+        return [current - timedelta(weeks=index) for index in range(self.complete_weeks + 1)]
+
+    @staticmethod
+    def _blank_week(start, current_start):
+        return {
+            "start": start,
+            "end": start + timedelta(weeks=1),
+            "complete": start < current_start,
+            "attempts": [],
+        }
+
+    def _week_buckets(self):
+        starts = self._window_starts()
+        buckets = {
+            start: self._blank_week(start, starts[0]) for start in starts
+        }
+        for attempt in self._attempts.values():
+            if attempt["request_count"] <= 0 or attempt["requested_at"] is None:
+                continue
+            requested_at = attempt["requested_at"]
+            start = _week_start(requested_at)
+            if start in buckets:
+                buckets[start]["attempts"].append(attempt)
+        return [buckets[start] for start in starts]
+
+    @staticmethod
+    def _state_report(attempts, state):
+        counts = {
+            "self_recovered": 0,
+            "restart_required": 0,
+            "indeterminate": 0,
+        }
+        durations = []
+        for attempt in attempts:
+            for classification, duration in attempt["state_intervals"][state]:
+                counts[classification] = min(
+                    counts[classification] + 1,
+                    MAX_AGGREGATE_COUNT,
+                )
+                if duration is not None:
+                    durations.append(duration)
+            counts["indeterminate"] = min(
+                counts["indeterminate"] + attempt["state_anomalies"][state],
+                MAX_AGGREGATE_COUNT,
+            )
+            if attempt["state_open"][state] is not None:
+                counts["indeterminate"] = min(
+                    counts["indeterminate"] + 1,
+                    MAX_AGGREGATE_COUNT,
+                )
+        return {
+            **counts,
+            "duration_ms": {
+                "sample_count": len(durations),
+                "p50": _nearest_rank(durations, 50),
+                "p95": _nearest_rank(durations, 95),
+                "max": max(durations) if durations else None,
+            },
+        }
+
+    @staticmethod
+    def _actionable(attempt, outcome):
+        allowed = ACTIONABLE_PRESENTATIONS.get(outcome, set())
+        return bool(allowed.intersection(attempt["presentations"]))
+
+    def _render_week(self, bucket):
+        attempts = bucket["attempts"]
+        excluded = [item for item in attempts if item["permission_pending"]]
+        eligible = [item for item in attempts if not item["permission_pending"]]
+        counts = {
+            "requested": len(attempts),
+            "eligible_requests": len(eligible),
+            "excluded_permission_prompts": len(excluded),
+            "accepted": 0,
+            "ready": 0,
+            "ready_without_accepted": 0,
+            "within_400": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "missing_terminals": 0,
+            "duplicate_terminals": 0,
+            "unknown_terminals": 0,
+            "failures_with_actionable_presentation": 0,
+            "failures_without_actionable_presentation": 0,
+            "duplicate_requests": 0,
+            "invalid_startup_timings": 0,
+            "invalid_state_transitions": min(
+                sum(item["state_chain_anomalies"] for item in attempts),
+                MAX_AGGREGATE_COUNT,
+            ),
+            "invalid_evidence_timestamps": min(
+                sum(item["evidence_time_anomalies"] for item in attempts),
+                MAX_AGGREGATE_COUNT,
+            ),
+        }
+        startup_samples = []
+        # Funnel, terminal-integrity, state, and presentation evidence cover
+        # every v1 request. Permission-pending excludes only the latency SLO.
+        for attempt in attempts:
+            counts["accepted"] += bool(attempt["accepted"])
+            counts["duplicate_requests"] += attempt["request_count"] > 1
+            terminal_count = attempt["terminal_count"]
+            if terminal_count == 0:
+                counts["missing_terminals"] += 1
+            if terminal_count > 1:
+                counts["duplicate_terminals"] += 1
+            outcome = attempt["terminal_outcome"]
+            if outcome == "unknown":
+                counts["unknown_terminals"] += 1
+            elif outcome in CANCELLED_OUTCOMES:
+                counts["cancelled"] += 1
+            elif outcome in FAILURE_OUTCOMES:
+                counts["failed"] += 1
+                if self._actionable(attempt, outcome):
+                    counts["failures_with_actionable_presentation"] += 1
+                else:
+                    counts["failures_without_actionable_presentation"] += 1
+
+            if attempt["ready_at"] is not None:
+                counts["ready"] += 1
+                if not attempt["accepted"]:
+                    counts["ready_without_accepted"] += 1
+
+        for attempt in eligible:
+            if attempt["ready_at"] is not None:
+                requested_at = attempt["requested_at"]
+                ready_at = attempt["ready_at"]
+                latency = _duration_ms(requested_at, ready_at)
+                if latency is None:
+                    counts["invalid_startup_timings"] += 1
+                else:
+                    startup_samples.append(latency)
+                    counts["within_400"] += latency <= STARTUP_TARGET_MS
+
+        state_report = {
+            state: self._state_report(attempts, state) for state in STATE_NAMES
+        }
+        indeterminate = []
+        if counts["missing_terminals"]:
+            indeterminate.append("missing_terminal")
+        if counts["duplicate_terminals"]:
+            indeterminate.append("duplicate_terminal")
+        if counts["unknown_terminals"]:
+            indeterminate.append("unknown_terminal")
+        if counts["duplicate_requests"]:
+            indeterminate.append("duplicate_request")
+        if counts["invalid_startup_timings"]:
+            indeterminate.append("invalid_startup_timing")
+        if counts["ready_without_accepted"]:
+            indeterminate.append("ready_without_accepted")
+        if counts["invalid_state_transitions"]:
+            indeterminate.append("invalid_state_transition")
+        if counts["invalid_evidence_timestamps"]:
+            indeterminate.append("invalid_evidence_timestamp")
+        if any(value["indeterminate"] for value in state_report.values()):
+            indeterminate.append("state_interval_indeterminate")
+
+        failures = []
+        if any(value["restart_required"] for value in state_report.values()):
+            failures.append("restart_required_state")
+        fraction = (
+            counts["within_400"] / counts["eligible_requests"]
+            if counts["eligible_requests"]
+            else None
+        )
+        if fraction is not None and fraction < STARTUP_TARGET_FRACTION:
+            failures.append("startup_target_missed")
+        if counts["failures_without_actionable_presentation"]:
+            failures.append("failure_presentation_missing")
+
+        sample_status = (
+            "partial"
+            if not bucket["complete"]
+            else (
+                "below_minimum"
+                if counts["eligible_requests"] < MIN_ELIGIBLE_REQUESTS
+                else "sufficient"
+            )
+        )
+        if not bucket["complete"]:
+            verdict = "insufficient"
+            # Keep bounded evidence visible without allowing a partial window
+            # to claim a definitive weekly SLO result.
+            reasons = ["partial_week", *indeterminate, *failures]
+        elif indeterminate:
+            verdict = "indeterminate"
+            reasons = indeterminate
+        elif failures:
+            verdict = "fail"
+            reasons = failures
+        elif counts["eligible_requests"] < MIN_ELIGIBLE_REQUESTS:
+            verdict = "insufficient"
+            reasons = ["eligible_requests_below_minimum"]
+        else:
+            verdict = "pass"
+            reasons = []
+
+        return {
+            "week_start": _format_timestamp(bucket["start"]),
+            "week_end": _format_timestamp(bucket["end"]),
+            "complete": bucket["complete"],
+            "sample_status": sample_status,
+            "verdict": verdict,
+            "reasons": reasons,
+            "counts": counts,
+            "startup_ms": {
+                "sample_count": len(startup_samples),
+                "p50": _nearest_rank(startup_samples, 50),
+                "p95": _nearest_rank(startup_samples, 95),
+                "max": max(startup_samples) if startup_samples else None,
+                "within_400_fraction": fraction,
+            },
+            "states": state_report,
+        }
+
+    def report(self):
+        weeks = [self._render_week(bucket) for bucket in self._week_buckets()]
+        latest_complete = [week for week in weeks if week["complete"]][:2]
+        consecutive_pass = (
+            len(latest_complete) == 2
+            and all(week["verdict"] == "pass" for week in latest_complete)
+            and self._unassigned_contract_requests == 0
+            and self._overflowed_events == 0
+            and self._malformed_source_lines == 0
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "report": REPORT_FORMAT,
+            "generated_at": _format_timestamp(self.now),
+            "contract_version": CONTRACT_VERSION,
+            "privacy": "aggregate_only",
+            "integrity": {
+                "status": (
+                    "complete"
+                    if self._unassigned_contract_requests == 0
+                    and self._overflowed_events == 0
+                    and self._malformed_source_lines == 0
+                    else "indeterminate"
+                ),
+                "unassigned_contract_requests": self._unassigned_contract_requests,
+                "overflowed_events": self._overflowed_events,
+                "malformed_source_lines": self._malformed_source_lines,
+            },
+            "thresholds": {
+                "complete_weeks": self.complete_weeks,
+                "minimum_eligible_requests": MIN_ELIGIBLE_REQUESTS,
+                "startup_target_ms": STARTUP_TARGET_MS,
+                "startup_target_fraction": STARTUP_TARGET_FRACTION,
+            },
+            "two_consecutive_complete_weeks_pass": consecutive_pass,
+            "weeks": weeks,
+        }
+
+
+def evaluate_fleet(event_feed, now=None, complete_weeks=MIN_COMPLETE_WEEKS):
+    """Convenience API for an iterable of ``(install_id, event)`` records."""
+    evaluator = ReliabilitySloEvaluator(now=now, complete_weeks=complete_weeks)
+    for install_id, event in event_feed:
+        evaluator.observe(install_id, event)
+    return evaluator.report()

--- a/tests/test_capture_regression_watch.py
+++ b/tests/test_capture_regression_watch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import tempfile
 import unittest
@@ -583,10 +584,41 @@ class CaptureRegressionWatchTests(unittest.TestCase):
             self.write_install(root, "12345678-abcd", items)
             path = Path(root) / "12345678-abcd" / "events.jsonl"
             with path.open("a", encoding="utf-8") as handle:
-                handle.write("{broken\n")
+                handle.write("{broken\n[]\n")
+            (Path(root) / "12345678-abcd" / "ignored.jsonl").write_text(
+                "{also broken\n",
+                encoding="utf-8",
+            )
             report = watch.build_report(root)
 
-        self.assertEqual(report["malformed_lines"], 1)
+            # The hourly evaluator is a full rescan. Replacing a concurrently
+            # partial tail with the next complete scan must self-heal instead
+            # of persisting an integrity failure forever.
+            path.write_text(
+                "\n".join(json.dumps(item) for item in items) + "\n",
+                encoding="utf-8",
+            )
+            healed = watch.build_report(root)
+
+        self.assertEqual(report["malformed_lines"], 2)
+        self.assertEqual(report["status"], "alert")
+        self.assertEqual(
+            report["reliability_slo"]["integrity"]["malformed_source_lines"],
+            2,
+        )
+        self.assertEqual(
+            report["reliability_slo"]["integrity"]["status"],
+            "indeterminate",
+        )
+        self.assertFalse(
+            report["reliability_slo"]["two_consecutive_complete_weeks_pass"]
+        )
+        self.assertEqual(healed["malformed_lines"], 0)
+        self.assertEqual(
+            healed["reliability_slo"]["integrity"]["malformed_source_lines"],
+            0,
+        )
+        self.assertEqual(healed["reliability_slo"]["integrity"]["status"], "complete")
         timeouts = report["cohorts"][0]["capture_backend_timeouts"]
         self.assertIn(
             {"backend": "unknown", "last_setup_step": "unknown", "count": 1},
@@ -809,6 +841,212 @@ class CaptureRegressionWatchTests(unittest.TestCase):
         self.assertEqual(len(versions), watch.MAX_VERSIONS_PER_INSTALL + 1)
         self.assertIn("overflow", versions)
 
+    def test_full_scan_adds_aggregate_slo_and_precontract_data_stays_insufficient(self) -> None:
+        private_sentinel = "SENTINEL_PRIVATE_INSTALL_DEVICE_TRANSCRIPT"
+        events = [
+            event(
+                private_sentinel,
+                "2026-08-04T00:00:00Z",
+                version="1.2.3",
+                data={
+                    "event_code": "pipeline.dictation_requested",
+                    "recording_id": 1,
+                    # No slo_contract: historical records are deliberately
+                    # ineligible even if all later lifecycle stages exist.
+                    "transcript": private_sentinel,
+                    "device_id": private_sentinel,
+                },
+            ),
+            event(
+                private_sentinel,
+                "2026-08-04T00:00:00.100Z",
+                version="1.2.3",
+                data={
+                    "event_code": "audio.capture_ready",
+                    "recording_id": 1,
+                    "owner": 1,
+                    "owner_kind": "dictation",
+                    "startup_ms": 100,
+                    "raw_error": private_sentinel,
+                },
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(
+                root,
+                now=datetime(2026, 8, 17, tzinfo=timezone.utc),
+            )
+
+        slo = report["reliability_slo"]
+        self.assertEqual(slo["report"], "murmur-reliability-slo/v1")
+        self.assertEqual(slo["privacy"], "aggregate_only")
+        self.assertFalse(slo["two_consecutive_complete_weeks_pass"])
+        self.assertTrue(all(week["verdict"] == "insufficient" for week in slo["weeks"]))
+        encoded = json.dumps(slo, sort_keys=True)
+        self.assertNotIn("12345678-abcd", encoded)
+        self.assertNotIn("1.2.3", encoded)
+        self.assertNotIn(private_sentinel, encoded)
+
+    def test_complete_contract_week_can_alert_without_per_install_slo_output(self) -> None:
+        baseline = datetime(2026, 8, 11, tzinfo=timezone.utc)
+        events = [
+            event(
+                "startup_baseline",
+                "2026-08-10T00:00:00Z",
+                version="1.2.3",
+                data={"event_code": "system.startup_baseline"},
+            )
+        ]
+        for index in range(200):
+            recording_id = index + 1
+            requested_at = baseline + timedelta(seconds=index)
+            ready_at = requested_at + timedelta(milliseconds=100)
+            requested = requested_at.isoformat(timespec="milliseconds").replace(
+                "+00:00", "Z"
+            )
+            ready = ready_at.isoformat(timespec="milliseconds").replace(
+                "+00:00", "Z"
+            )
+            events.extend(
+                [
+                    # Production ordering intentionally permits state evidence
+                    # immediately before the request marker.
+                    event(
+                        "ignored",
+                        requested,
+                        version="1.2.3",
+                        data={
+                            "event_code": "pipeline.dictation_state_changed",
+                            "recording_id": recording_id,
+                            "from": "idle",
+                            "to": "starting",
+                        },
+                    ),
+                    event(
+                        "ignored",
+                        requested,
+                        version="1.2.3",
+                        data={
+                            "event_code": "pipeline.dictation_requested",
+                            "recording_id": recording_id,
+                            "slo_contract": 1,
+                        },
+                    ),
+                    event(
+                        "ignored",
+                        requested,
+                        version="1.2.3",
+                        data={
+                            "event_code": "audio.capture_started",
+                            "recording_id": recording_id,
+                            "owner": recording_id,
+                            "owner_kind": "dictation",
+                        },
+                    ),
+                ]
+            )
+            # One accepted request deliberately fails before first PCM and has
+            # no actionable presentation. The other 199 are within 400 ms, so
+            # the startup fraction is exactly 99.5% and the presentation clause
+            # alone makes the complete week fail.
+            if index < 199:
+                events.append(
+                    event(
+                        "ignored",
+                        ready,
+                        version="1.2.3",
+                        data={
+                            "event_code": "audio.capture_ready",
+                            "recording_id": recording_id,
+                            "owner": recording_id,
+                            "owner_kind": "dictation",
+                            "startup_ms": 100,
+                        },
+                    )
+                )
+                outcome = "success"
+            else:
+                outcome = "pipeline_failure"
+            events.append(
+                event(
+                    "ignored",
+                    ready,
+                    version="1.2.3",
+                    data={
+                        "event_code": "pipeline.dictation_terminal",
+                        "recording_id": recording_id,
+                        "outcome": outcome,
+                    },
+                )
+            )
+
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(
+                root,
+                now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            )
+
+        complete = next(
+            week
+            for week in report["reliability_slo"]["weeks"]
+            if week["week_start"] == "2026-08-10T00:00:00Z"
+        )
+        self.assertEqual(complete["sample_status"], "sufficient")
+        self.assertEqual(complete["verdict"], "fail")
+        self.assertEqual(complete["counts"]["eligible_requests"], 200)
+        self.assertEqual(complete["counts"]["within_400"], 199)
+        self.assertEqual(complete["startup_ms"]["within_400_fraction"], 0.995)
+        self.assertEqual(
+            complete["counts"]["failures_without_actionable_presentation"],
+            1,
+        )
+        self.assertEqual(report["status"], "alert")
+        self.assertEqual(report["alerts"], [])
+        self.assertNotIn("install_id", json.dumps(report["reliability_slo"]))
+
+    def test_unassigned_contract_request_forces_outer_watch_alert(self) -> None:
+        events = [
+            event(
+                "startup_baseline",
+                "2026-08-10T00:00:00Z",
+                version="1.2.3",
+                data={"event_code": "system.startup_baseline"},
+            ),
+            event(
+                "ignored",
+                "not-a-time",
+                version="1.2.3",
+                data={
+                    "event_code": "pipeline.dictation_requested",
+                    "recording_id": 1,
+                    "slo_contract": 1,
+                },
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            self.write_install(root, "12345678-abcd", events)
+            report = watch.build_report(
+                root,
+                now=datetime(2026, 8, 17, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(report["status"], "alert")
+        self.assertEqual(report["alerts"], [])
+        self.assertEqual(
+            report["reliability_slo"]["integrity"],
+            {
+                "status": "indeterminate",
+                "unassigned_contract_requests": 1,
+                "overflowed_events": 0,
+                "malformed_source_lines": 0,
+            },
+        )
+        self.assertFalse(
+            report["reliability_slo"]["two_consecutive_complete_weeks_pass"]
+        )
+
     def test_cli_writes_report_before_returning_alert_exit(self) -> None:
         events = self.ready_events("1.0.0", "01", [100] * 5)
         events += self.ready_events("1.1.0", "02", [300] * 5)
@@ -829,6 +1067,35 @@ class CaptureRegressionWatchTests(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertEqual(saved["schema_version"], 1)
         self.assertEqual(saved["status"], "alert")
+
+    def test_cli_malformed_source_persists_integrity_and_returns_alert(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            directory = Path(root) / "12345678-abcd"
+            directory.mkdir()
+            (directory / "events.jsonl").write_text("{partial", encoding="utf-8")
+            output = Path(root) / "watch.json"
+
+            result = watch.main(
+                [
+                    "--root",
+                    root,
+                    "--output",
+                    str(output),
+                    "--fail-on-alert",
+                ]
+            )
+            saved = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 2)
+        self.assertEqual(saved["status"], "alert")
+        self.assertEqual(saved["malformed_lines"], 1)
+        self.assertEqual(
+            saved["reliability_slo"]["integrity"]["malformed_source_lines"],
+            1,
+        )
+        self.assertFalse(
+            saved["reliability_slo"]["two_consecutive_complete_weeks_pass"]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_capture_regression_watch.py
+++ b/tests/test_capture_regression_watch.py
@@ -584,7 +584,8 @@ class CaptureRegressionWatchTests(unittest.TestCase):
             self.write_install(root, "12345678-abcd", items)
             path = Path(root) / "12345678-abcd" / "events.jsonl"
             with path.open("a", encoding="utf-8") as handle:
-                handle.write("{broken\n[]\n")
+                deeply_nested = "[" * 2_000 + "0" + "]" * 2_000
+                handle.write("{broken\n[]\n" + deeply_nested + "\n")
             (Path(root) / "12345678-abcd" / "ignored.jsonl").write_text(
                 "{also broken\n",
                 encoding="utf-8",
@@ -600,11 +601,11 @@ class CaptureRegressionWatchTests(unittest.TestCase):
             )
             healed = watch.build_report(root)
 
-        self.assertEqual(report["malformed_lines"], 2)
+        self.assertEqual(report["malformed_lines"], 3)
         self.assertEqual(report["status"], "alert")
         self.assertEqual(
             report["reliability_slo"]["integrity"]["malformed_source_lines"],
-            2,
+            3,
         )
         self.assertEqual(
             report["reliability_slo"]["integrity"]["status"],

--- a/tests/test_log_receiver.py
+++ b/tests/test_log_receiver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import http.client
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import tempfile
 import threading
@@ -20,6 +21,12 @@ SPEC = importlib.util.spec_from_file_location("murmur_logs_receiver", RECEIVER_P
 assert SPEC and SPEC.loader
 receiver = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(receiver)
+
+SLO_PATH = RECEIVER_PATH.with_name("reliability_slo.py")
+SLO_SPEC = importlib.util.spec_from_file_location("reliability_slo_for_dashboard", SLO_PATH)
+assert SLO_SPEC and SLO_SPEC.loader
+reliability_slo = importlib.util.module_from_spec(SLO_SPEC)
+SLO_SPEC.loader.exec_module(reliability_slo)
 
 
 def event(
@@ -127,6 +134,239 @@ class LogReceiverHealthTests(unittest.TestCase):
                 receiver.ROOT = original_root
 
         self.assertIn("Diagnostics store begin failed 2 time(s) (busyLocked)", page)
+
+    def test_dashboard_surfaces_aggregate_reliability_slo_without_identity(self) -> None:
+        private_sentinel = "SENTINEL_PRIVATE_INSTALL_OR_CONTENT"
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+
+        def observe(code, when, recording_id=None, **data):
+            fields = {"event_code": code, **data}
+            if recording_id is not None:
+                fields["recording_id"] = recording_id
+            evaluator.observe(
+                private_sentinel,
+                {
+                    "timestamp": when.isoformat(timespec="milliseconds").replace(
+                        "+00:00", "Z"
+                    ),
+                    "data": fields,
+                },
+            )
+
+        week_start = datetime(2026, 8, 3, tzinfo=timezone.utc)
+        observe("system.startup_baseline", week_start)
+        for offset in range(200):
+            recording_id = offset + 1
+            requested = week_start + timedelta(seconds=offset * 10 + 1)
+            observe(
+                "pipeline.dictation_requested",
+                requested,
+                recording_id,
+                slo_contract=1,
+            )
+            observe(
+                "audio.capture_started",
+                requested + timedelta(milliseconds=10),
+                recording_id,
+                owner=recording_id,
+                owner_kind="dictation",
+            )
+            if offset < 199:
+                observe(
+                    "audio.capture_ready",
+                    requested + timedelta(milliseconds=100),
+                    recording_id,
+                    owner=recording_id,
+                    owner_kind="dictation",
+                )
+                outcome = "success"
+            else:
+                outcome = "pipeline_failure"
+            observe(
+                "pipeline.dictation_terminal",
+                requested + timedelta(seconds=1),
+                recording_id,
+                outcome=outcome,
+            )
+
+        report = {
+            "schema_version": 1,
+            "generated_at": "2026-08-17T00:00:00Z",
+            "status": "alert",
+            "alerts": [],
+            "reliability_slo": evaluator.report(),
+            "ignored_private_outer_field": private_sentinel,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = receiver.ROOT
+            receiver.ROOT = directory
+            try:
+                (Path(directory) / receiver.CAPTURE_WATCH_REPORT).write_text(
+                    json.dumps(report),
+                    encoding="utf-8",
+                )
+                page = receiver.render_dashboard()
+            finally:
+                receiver.ROOT = original_root
+
+        self.assertIn("Dictation reliability SLO · FAIL", page)
+        self.assertIn("Two consecutive complete passing weeks not yet proven", page)
+        self.assertIn("2026-08-03T00:00:00Z → 2026-08-10T00:00:00Z", page)
+        self.assertIn("(complete; sufficient sample)", page)
+        self.assertIn(
+            "requests 200 total · latency denominator 200 eligible / 0 prompt-excluded",
+            page,
+        )
+        self.assertIn("startup ≤400 ms 99.50%", page)
+        self.assertIn("failure presentation 0 covered / 1 missing", page)
+        self.assertIn("processing self/restart/unknown 0/0/0", page)
+        self.assertNotIn(private_sentinel, page)
+
+    def test_dashboard_labels_precontract_capture_report_insufficient_for_slo(self) -> None:
+        report = {
+            "schema_version": 1,
+            "generated_at": "2026-08-17T00:00:00Z",
+            "status": "healthy",
+            "alerts": [],
+        }
+        rendered = receiver.render_reliability_slo(report)
+
+        self.assertIn("No aggregate contract report is available yet", rendered)
+        self.assertIn("Historical pre-contract data is insufficient", rendered)
+
+    def test_dashboard_never_trusts_a_contradictory_two_week_pass_flag(self) -> None:
+        report = {
+            "reliability_slo": {
+                "schema_version": 1,
+                "report": "murmur-reliability-slo/v1",
+                "contract_version": 1,
+                "privacy": "aggregate_only",
+                "two_consecutive_complete_weeks_pass": True,
+                "weeks": [],
+            }
+        }
+
+        rendered = receiver.render_reliability_slo(report)
+
+        self.assertNotIn("Two consecutive complete weeks pass", rendered)
+        self.assertIn("No aggregate contract report is available yet", rendered)
+
+    def test_dashboard_rejects_cross_field_or_extra_nested_slo_data(self) -> None:
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+        contradictory = evaluator.report()
+        contradictory["weeks"][0]["counts"]["requested"] = 1
+        contradictory["weeks"][0]["counts"]["eligible_requests"] = 0
+        contradictory["weeks"][0]["counts"]["excluded_permission_prompts"] = 0
+        rendered = receiver.render_reliability_slo(
+            {"reliability_slo": contradictory}
+        )
+        self.assertIn("No aggregate contract report is available yet", rendered)
+
+        private_sentinel = "SENTINEL_PRIVATE_NESTED_VALUE"
+        extra = evaluator.report()
+        extra["raw_error"] = private_sentinel
+        rendered = receiver.render_reliability_slo({"reliability_slo": extra})
+        self.assertIn("No aggregate contract report is available yet", rendered)
+        self.assertNotIn(private_sentinel, rendered)
+
+    def test_dashboard_corrupt_slo_boundaries_never_raise(self) -> None:
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+        cases = []
+
+        minimum_year = evaluator.report()
+        minimum_year["generated_at"] = "0001-01-01T00:00:00Z"
+        cases.append(minimum_year)
+
+        maximum_year = evaluator.report()
+        maximum_year["generated_at"] = "9999-12-31T00:00:00Z"
+        maximum_year["weeks"][0]["week_start"] = "9999-12-27T00:00:00Z"
+        maximum_year["weeks"][0]["week_end"] = "9999-12-31T00:00:00Z"
+        cases.append(maximum_year)
+
+        unhashable_reason = evaluator.report()
+        unhashable_reason["weeks"][0]["reasons"] = [{}]
+        cases.append(unhashable_reason)
+
+        for slo in cases:
+            with self.subTest(generated_at=slo["generated_at"]):
+                rendered = receiver.render_reliability_slo(
+                    {"reliability_slo": slo}
+                )
+                self.assertIn("No aggregate contract report is available yet", rendered)
+
+    def test_dashboard_surfaces_unassigned_contract_requests_as_indeterminate(self) -> None:
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+        evaluator.observe(
+            "internal-install-only",
+            {
+                "timestamp": "2026-08-10T00:00:00Z",
+                "data": {"event_code": "system.startup_baseline"},
+            },
+        )
+        evaluator.observe(
+            "internal-install-only",
+            {
+                "timestamp": "not-a-time",
+                "data": {
+                    "event_code": "pipeline.dictation_requested",
+                    "recording_id": 1,
+                    "slo_contract": 1,
+                },
+            },
+        )
+
+        rendered = receiver.render_reliability_slo(
+            {"reliability_slo": evaluator.report()}
+        )
+
+        self.assertIn("Dictation reliability SLO · INDETERMINATE", rendered)
+        self.assertIn(
+            "source integrity indeterminate (1 unassigned contract request; "
+            "0 bounded-correlation overflow events; 0 malformed source lines)",
+            rendered,
+        )
+        self.assertNotIn("Two consecutive complete weeks pass", rendered)
+
+    def test_dashboard_surfaces_bounded_correlation_overflow_as_indeterminate(self) -> None:
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+        report = evaluator.report()
+        report["integrity"] = {
+            "status": "indeterminate",
+            "unassigned_contract_requests": 0,
+            "overflowed_events": 1,
+            "malformed_source_lines": 0,
+        }
+        report["two_consecutive_complete_weeks_pass"] = False
+
+        rendered = receiver.render_reliability_slo({"reliability_slo": report})
+
+        self.assertIn("Dictation reliability SLO · INDETERMINATE", rendered)
+        self.assertIn("1 bounded-correlation overflow event", rendered)
+        self.assertNotIn("Two consecutive complete weeks pass", rendered)
+
+    def test_dashboard_surfaces_malformed_source_integrity_as_indeterminate(self) -> None:
+        evaluator = reliability_slo.ReliabilitySloEvaluator(
+            now=datetime(2026, 8, 17, tzinfo=timezone.utc)
+        )
+        evaluator.observe_malformed_source_line()
+
+        rendered = receiver.render_reliability_slo(
+            {"reliability_slo": evaluator.report()}
+        )
+
+        self.assertIn("Dictation reliability SLO · INDETERMINATE", rendered)
+        self.assertIn("1 malformed source line", rendered)
+        self.assertNotIn("Two consecutive complete weeks pass", rendered)
 
     def test_stable_event_code_takes_precedence_over_compatibility_summary(self) -> None:
         item = event(

--- a/tests/test_reliability_slo.py
+++ b/tests/test_reliability_slo.py
@@ -1,0 +1,1014 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "infra"
+    / "log-receiver"
+    / "reliability_slo.py"
+)
+SPEC = importlib.util.spec_from_file_location("reliability_slo", MODULE_PATH)
+assert SPEC and SPEC.loader
+slo = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(slo)
+
+NOW = datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)  # Wednesday
+INSTALL = "internal-install-sentinel"
+
+
+def stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def event(code: str, when: datetime | str, recording_id: int | None = None, **data: object) -> dict:
+    fields = {"event_code": code, **data}
+    if recording_id is not None:
+        fields["recording_id"] = recording_id
+    return {
+        "timestamp": stamp(when) if isinstance(when, datetime) else when,
+        "stream": "pipeline",
+        "level": "info",
+        "summary": "untrusted summary",
+        "data": fields,
+    }
+
+
+def audio(code: str, when: datetime, recording_id: int, **data: object) -> dict:
+    item = event(
+        code,
+        when,
+        recording_id,
+        owner=recording_id,
+        owner_kind="dictation",
+        **data,
+    )
+    item["stream"] = "audio"
+    return item
+
+
+def request(when: datetime, recording_id: int, contract: object = 1) -> dict:
+    return event(
+        "pipeline.dictation_requested",
+        when,
+        recording_id,
+        slo_contract=contract,
+    )
+
+
+def terminal(when: datetime, recording_id: int, outcome: str = "success") -> dict:
+    return event(
+        "pipeline.dictation_terminal",
+        when,
+        recording_id,
+        outcome=outcome,
+        error_code="none",
+    )
+
+
+def baseline(when: datetime) -> dict:
+    return event("system.startup_baseline", when)
+
+
+def complete_attempt(
+    when: datetime,
+    recording_id: int,
+    latency_ms: float = 200,
+    outcome: str = "success",
+) -> list[dict]:
+    return [
+        request(when, recording_id),
+        audio("audio.capture_started", when + timedelta(milliseconds=10), recording_id),
+        audio(
+            "audio.capture_ready",
+            when + timedelta(milliseconds=latency_ms),
+            recording_id,
+        ),
+        terminal(when + timedelta(seconds=2), recording_id, outcome),
+    ]
+
+
+def feed(items: list[dict], now: datetime = NOW, install: str = INSTALL) -> dict:
+    evaluator = slo.ReliabilitySloEvaluator(now=now)
+    for item in items:
+        evaluator.observe(install, item)
+    return evaluator.report()
+
+
+def week(report: dict, index: int = 0) -> dict:
+    return report["weeks"][index]
+
+
+class ReliabilitySloContractTests(unittest.TestCase):
+    def test_only_exact_numeric_contract_v1_requests_enter_the_denominator(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+        for recording_id, contract in enumerate((None, 0, 2, True, 1.0, "1"), start=1):
+            items.extend(complete_attempt(start + timedelta(minutes=recording_id), recording_id))
+            items[-4]["data"]["slo_contract"] = contract
+        items.extend(complete_attempt(start + timedelta(hours=1), 20))
+
+        current = week(feed(items))
+
+        self.assertEqual(current["counts"]["eligible_requests"], 1)
+        self.assertEqual(current["counts"]["ready"], 1)
+
+    def test_permission_pending_excludes_only_the_latency_denominator(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+        items.extend(complete_attempt(start, 1, latency_ms=900, outcome="capture_init_failure"))
+        items.insert(
+            2,
+            audio(
+                "audio.permission_prompt_changed",
+                start + timedelta(milliseconds=5),
+                1,
+                state="pending",
+            ),
+        )
+        items.append(
+            audio(
+                "audio.permission_prompt_changed",
+                start + timedelta(seconds=1),
+                1,
+                state="resolved",
+                prompt_pending_ms=995,
+            )
+        )
+
+        current = week(feed(items))
+
+        self.assertEqual(current["counts"]["excluded_permission_prompts"], 1)
+        self.assertEqual(current["counts"]["requested"], 1)
+        self.assertEqual(current["counts"]["eligible_requests"], 0)
+        self.assertEqual(current["counts"]["accepted"], 1)
+        self.assertEqual(current["counts"]["ready"], 1)
+        self.assertEqual(current["counts"]["failed"], 1)
+        self.assertEqual(current["counts"]["within_400"], 0)
+        self.assertEqual(current["startup_ms"]["sample_count"], 0)
+
+    def test_retained_prompt_resolution_alone_proves_permission_exclusion(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+        items.extend(complete_attempt(start, 1, latency_ms=900))
+        items.append(
+            audio(
+                "audio.permission_prompt_changed",
+                start + timedelta(seconds=1),
+                1,
+                state="resolved",
+                prompt_pending_ms=500,
+            )
+        )
+
+        current = week(feed(items))
+
+        self.assertEqual(current["counts"]["requested"], 1)
+        self.assertEqual(current["counts"]["excluded_permission_prompts"], 1)
+        self.assertEqual(current["counts"]["eligible_requests"], 0)
+        self.assertEqual(current["startup_ms"]["sample_count"], 0)
+
+    def test_prompted_stuck_failure_still_fails_state_and_presentation_slos(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [
+            baseline(start - timedelta(minutes=1)),
+            request(start, 1),
+            audio(
+                "audio.permission_prompt_changed",
+                start + timedelta(milliseconds=1),
+                1,
+                state="pending",
+            ),
+            event(
+                "pipeline.dictation_state_changed",
+                start + timedelta(seconds=1),
+                1,
+                **{"from": "starting", "to": "processing"},
+            ),
+            terminal(start + timedelta(seconds=2), 1, "capture_init_failure"),
+            baseline(start + timedelta(minutes=1)),
+        ]
+
+        previous = week(feed(items), 1)
+        self.assertEqual(previous["counts"]["eligible_requests"], 0)
+        self.assertEqual(previous["counts"]["excluded_permission_prompts"], 1)
+        self.assertEqual(previous["counts"]["failed"], 1)
+        self.assertEqual(
+            previous["counts"]["failures_without_actionable_presentation"], 1
+        )
+        self.assertEqual(previous["states"]["processing"]["restart_required"], 1)
+        self.assertEqual(previous["sample_status"], "below_minimum")
+        self.assertEqual(previous["verdict"], "fail")
+        self.assertIn("restart_required_state", previous["reasons"])
+        self.assertIn("failure_presentation_missing", previous["reasons"])
+
+    def test_audio_ownership_must_match_dictation_and_recording_id(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1)), request(start, 1)]
+        wrong_owner = audio("audio.capture_ready", start + timedelta(milliseconds=100), 1)
+        wrong_owner["data"]["owner"] = 2
+        transform = audio("audio.capture_started", start, 1)
+        transform["data"]["owner_kind"] = "transform"
+        items.extend([wrong_owner, transform, terminal(start + timedelta(seconds=1), 1)])
+
+        current = week(feed(items))
+
+        self.assertEqual(current["counts"]["accepted"], 0)
+        self.assertEqual(current["counts"]["ready"], 0)
+        self.assertEqual(current["startup_ms"]["within_400_fraction"], 0.0)
+
+    def test_events_before_a_proven_startup_session_are_ignored(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = complete_attempt(start, 1)
+        items.extend([baseline(start + timedelta(hours=1)), *complete_attempt(start + timedelta(hours=2), 2)])
+
+        self.assertEqual(week(feed(items))["counts"]["eligible_requests"], 1)
+
+    def test_recording_ids_are_isolated_by_install_and_startup_session(self) -> None:
+        start = NOW - timedelta(days=1)
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        first_session = [
+            baseline(start - timedelta(minutes=2)),
+            *complete_attempt(start, 1, outcome="pipeline_failure"),
+        ]
+        second_session = [
+            baseline(start + timedelta(minutes=1)),
+            *complete_attempt(start + timedelta(minutes=2), 1),
+        ]
+        other_install = [
+            baseline(start - timedelta(minutes=1)),
+            *complete_attempt(start + timedelta(minutes=3), 1),
+        ]
+        for item in [*first_session, *second_session]:
+            evaluator.observe("install-a", item)
+        for item in other_install:
+            evaluator.observe("install-b", item)
+
+        current = week(evaluator.report())
+        self.assertEqual(current["counts"]["requested"], 3)
+        self.assertEqual(current["counts"]["failed"], 1)
+        self.assertEqual(current["counts"]["ready"], 3)
+
+
+class ReliabilitySloTimingTests(unittest.TestCase):
+    def test_four_hundred_milliseconds_is_inclusive_and_uses_request_time(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+        items.extend(complete_attempt(start, 1, latency_ms=400))
+        items.extend(complete_attempt(start + timedelta(minutes=1), 2, latency_ms=401))
+
+        current = week(feed(items))
+
+        self.assertEqual(current["counts"]["ready"], 2)
+        self.assertEqual(current["counts"]["within_400"], 1)
+        self.assertEqual(current["startup_ms"]["within_400_fraction"], 0.5)
+
+    def test_nearest_rank_percentiles_and_maximum_are_exact(self) -> None:
+        start = NOW - timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+        for recording_id, latency in enumerate(range(10, 210, 10), start=1):
+            items.extend(
+                complete_attempt(
+                    start + timedelta(minutes=recording_id),
+                    recording_id,
+                    latency_ms=latency,
+                )
+            )
+
+        metrics = week(feed(items))["startup_ms"]
+
+        self.assertEqual(metrics["sample_count"], 20)
+        self.assertEqual(metrics["p50"], 100.0)
+        self.assertEqual(metrics["p95"], 190.0)
+        self.assertEqual(metrics["max"], 200.0)
+
+    def test_invalid_or_reversed_startup_timing_is_indeterminate(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        report = feed(
+            [
+                baseline(start - timedelta(minutes=1)),
+                request(start, 1),
+                audio("audio.capture_ready", start - timedelta(milliseconds=1), 1),
+                terminal(start + timedelta(seconds=1), 1),
+            ]
+        )
+
+        previous = week(report, 1)
+        self.assertEqual(previous["counts"]["ready"], 1)
+        self.assertEqual(previous["counts"]["invalid_startup_timings"], 1)
+        self.assertEqual(previous["verdict"], "indeterminate")
+        self.assertIn("invalid_startup_timing", previous["reasons"])
+
+    def test_strict_utc_parser_rejects_offsets_and_invalid_calendar_values(self) -> None:
+        self.assertIsNotNone(slo.parse_utc_timestamp("2026-08-17T00:00:00.123456789Z"))
+        self.assertIsNone(slo.parse_utc_timestamp("2026-08-17T00:00:00+00:00"))
+        self.assertIsNone(slo.parse_utc_timestamp("2026-02-30T00:00:00Z"))
+        self.assertIsNone(slo.parse_utc_timestamp("not-a-time"))
+
+    def test_unassignable_contract_request_is_visible_and_blocks_two_week_proof(self) -> None:
+        newest = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        older = newest - timedelta(weeks=1)
+        events = ReliabilitySloVerdictTests.completed_week_events(
+            older,
+            200,
+            first_id=1,
+        )
+        events.extend(
+            ReliabilitySloVerdictTests.completed_week_events(
+                newest,
+                200,
+                first_id=1_000,
+            )
+        )
+        events.append(request(newest, 9_999))
+        events[-1]["timestamp"] = "not-a-timestamp"
+
+        report = feed(events)
+
+        self.assertEqual(
+            report["integrity"],
+            {
+                "status": "indeterminate",
+                "unassigned_contract_requests": 1,
+                "overflowed_events": 0,
+                "malformed_source_lines": 0,
+            },
+        )
+        self.assertFalse(report["two_consecutive_complete_weeks_pass"])
+
+    def test_future_contract_request_is_unassigned_but_expired_history_is_not(self) -> None:
+        oldest_retained = datetime(2026, 6, 22, 0, 0, tzinfo=timezone.utc)
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        evaluator.observe(INSTALL, baseline(oldest_retained - timedelta(weeks=2)))
+        evaluator.observe(INSTALL, request(oldest_retained - timedelta(microseconds=1), 1))
+        evaluator.observe(INSTALL, request(NOW + timedelta(seconds=1), 2))
+
+        report = evaluator.report()
+
+        self.assertEqual(report["integrity"]["unassigned_contract_requests"], 1)
+        self.assertEqual(report["integrity"]["status"], "indeterminate")
+        self.assertTrue(
+            all(item["counts"]["requested"] == 0 for item in report["weeks"])
+        )
+
+    def test_malformed_retained_source_line_blocks_two_week_proof(self) -> None:
+        newest = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        older = newest - timedelta(weeks=1)
+        events = ReliabilitySloVerdictTests.completed_week_events(older, 200)
+        events.extend(
+            ReliabilitySloVerdictTests.completed_week_events(
+                newest,
+                200,
+                first_id=1_000,
+            )
+        )
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        for item in events:
+            evaluator.observe(INSTALL, item)
+        with mock.patch.object(slo, "MAX_AGGREGATE_COUNT", 1):
+            evaluator.observe_malformed_source_line()
+            evaluator.observe_malformed_source_line()
+
+        report = evaluator.report()
+
+        self.assertEqual(report["integrity"]["malformed_source_lines"], 1)
+        self.assertEqual(report["integrity"]["status"], "indeterminate")
+        self.assertFalse(report["two_consecutive_complete_weeks_pass"])
+
+    def test_weeks_are_monday_utc_half_open_and_include_eight_complete_weeks(self) -> None:
+        current_start = datetime(2026, 8, 17, tzinfo=timezone.utc)
+        previous_start = current_start - timedelta(weeks=1)
+        items = [baseline(previous_start - timedelta(minutes=1))]
+        items.extend(complete_attempt(previous_start, 1))
+        items.extend(
+            complete_attempt(
+                current_start - timedelta(microseconds=1),
+                2,
+            )
+        )
+        items.extend(complete_attempt(current_start, 3))
+
+        report = feed(items)
+
+        self.assertEqual(len(report["weeks"]), 9)
+        self.assertEqual(report["weeks"][0]["week_start"], "2026-08-17T00:00:00Z")
+        self.assertFalse(report["weeks"][0]["complete"])
+        self.assertEqual(report["weeks"][0]["counts"]["eligible_requests"], 1)
+        self.assertEqual(report["weeks"][1]["counts"]["eligible_requests"], 2)
+
+
+class ReliabilitySloLifecycleTests(unittest.TestCase):
+    def test_out_of_order_terminal_still_joins_by_session_and_recording(self) -> None:
+        start = NOW - timedelta(days=1)
+        report = feed(
+            [
+                baseline(start - timedelta(minutes=1)),
+                terminal(start + timedelta(seconds=1), 9),
+                audio("audio.capture_ready", start + timedelta(milliseconds=300), 9),
+                request(start, 9),
+                audio("audio.capture_started", start + timedelta(milliseconds=10), 9),
+            ]
+        )
+
+        current = week(report)
+        self.assertEqual(current["counts"]["eligible_requests"], 1)
+        self.assertEqual(current["counts"]["missing_terminals"], 0)
+        self.assertEqual(current["counts"]["ready"], 1)
+        self.assertEqual(current["counts"]["ready_without_accepted"], 0)
+
+    def test_pre_request_state_evidence_is_retained_until_contract_request_arrives(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [
+            baseline(start - timedelta(minutes=1)),
+            event(
+                "pipeline.dictation_state_changed",
+                start - timedelta(milliseconds=1),
+                8,
+                **{"from": "starting", "to": "recovering"},
+            ),
+            request(start, 8),
+            event(
+                "pipeline.dictation_state_changed",
+                start + timedelta(seconds=2),
+                8,
+                **{"from": "recovering", "to": "idle"},
+            ),
+            terminal(start + timedelta(seconds=3), 8),
+        ]
+
+        previous = week(feed(items), 1)
+        self.assertEqual(previous["states"]["recovering"]["self_recovered"], 1)
+        self.assertEqual(
+            previous["states"]["recovering"]["duration_ms"]["max"],
+            2001.0,
+        )
+
+    def test_ready_without_eventually_correlated_acceptance_is_indeterminate(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        previous = week(
+            feed(
+                [
+                    baseline(start - timedelta(minutes=1)),
+                    request(start, 1),
+                    audio("audio.capture_ready", start + timedelta(milliseconds=200), 1),
+                    terminal(start + timedelta(seconds=1), 1),
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(previous["counts"]["ready_without_accepted"], 1)
+        self.assertEqual(previous["verdict"], "indeterminate")
+        self.assertIn("ready_without_accepted", previous["reasons"])
+
+    def test_missing_duplicate_unknown_terminals_are_indeterminate(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1))]
+        items.append(request(start, 1))
+        items.extend([request(start, 2), terminal(start, 2), terminal(start, 2)])
+        items.extend([request(start, 3), terminal(start, 3, "private-outcome")])
+
+        current = week(feed(items), 1)
+
+        self.assertEqual(current["counts"]["missing_terminals"], 1)
+        self.assertEqual(current["counts"]["duplicate_terminals"], 1)
+        self.assertEqual(current["counts"]["unknown_terminals"], 1)
+        self.assertEqual(current["verdict"], "indeterminate")
+        self.assertEqual(
+            current["reasons"][:3],
+            ["missing_terminal", "duplicate_terminal", "unknown_terminal"],
+        )
+        self.assertNotIn("private-outcome", json.dumps(current))
+
+    def test_state_intervals_distinguish_recovery_restart_and_open_unknown(self) -> None:
+        complete_week = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        session_start = complete_week - timedelta(hours=1)
+        items = [baseline(session_start)]
+        items.extend(complete_attempt(complete_week, 1))
+        items.extend(
+            [
+                event(
+                    "pipeline.dictation_state_changed",
+                    complete_week + timedelta(seconds=3),
+                    1,
+                    **{"from": "recording", "to": "recovering"},
+                ),
+                event(
+                    "pipeline.dictation_state_changed",
+                    complete_week + timedelta(seconds=5),
+                    1,
+                    **{"from": "recovering", "to": "idle"},
+                ),
+            ]
+        )
+        items.extend(complete_attempt(complete_week + timedelta(minutes=1), 2))
+        items.append(
+            event(
+                "pipeline.dictation_state_changed",
+                complete_week + timedelta(minutes=1, seconds=3),
+                2,
+                **{"from": "recording", "to": "processing"},
+            )
+        )
+        items.append(baseline(complete_week + timedelta(minutes=3)))
+        items.extend(complete_attempt(complete_week + timedelta(minutes=4), 3))
+        items.append(
+            event(
+                "pipeline.dictation_state_changed",
+                complete_week + timedelta(minutes=4, seconds=3),
+                3,
+                **{"from": "recording", "to": "recovering"},
+            )
+        )
+
+        previous = week(feed(items), 1)
+
+        self.assertEqual(previous["states"]["recovering"]["self_recovered"], 1)
+        self.assertEqual(previous["states"]["recovering"]["indeterminate"], 1)
+        self.assertEqual(previous["states"]["recovering"]["duration_ms"]["p50"], 2000.0)
+        self.assertEqual(previous["states"]["processing"]["restart_required"], 1)
+        self.assertEqual(previous["states"]["processing"]["duration_ms"]["max"], 117000.0)
+        self.assertEqual(previous["verdict"], "indeterminate")
+
+    def test_orphan_state_exit_is_never_silently_healthy(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        items.append(
+            event(
+                "pipeline.dictation_state_changed",
+                start + timedelta(seconds=3),
+                1,
+                **{"from": "processing", "to": "idle"},
+            )
+        )
+
+        current = week(feed(items), 1)
+        self.assertEqual(current["states"]["processing"]["indeterminate"], 1)
+        self.assertEqual(current["verdict"], "indeterminate")
+
+    def test_valid_state_chain_uses_the_prior_target_as_the_next_source(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        for offset, previous, current in [
+            (3, "idle", "starting"),
+            (4, "starting", "recording"),
+            (5, "recording", "processing"),
+            (7, "processing", "idle"),
+        ]:
+            items.append(
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=offset),
+                    1,
+                    **{"from": previous, "to": current},
+                )
+            )
+
+        current = week(feed(items), 1)
+
+        self.assertEqual(current["counts"]["invalid_state_transitions"], 0)
+        self.assertEqual(current["states"]["processing"]["self_recovered"], 1)
+
+    def test_overlapping_out_of_order_state_chain_is_indeterminate(self) -> None:
+        start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        items = ReliabilitySloVerdictTests.completed_week_events(start, 200)
+        for offset, previous, current in [
+            (3, "recording", "recovering"),
+            (4, "recording", "processing"),
+            (5, "recovering", "idle"),
+            (6, "processing", "idle"),
+        ]:
+            items.append(
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=offset),
+                    1,
+                    **{"from": previous, "to": current},
+                )
+            )
+
+        current = week(feed(items), 1)
+
+        self.assertGreater(current["counts"]["invalid_state_transitions"], 0)
+        self.assertIn("invalid_state_transition", current["reasons"])
+        self.assertEqual(current["verdict"], "indeterminate")
+
+    def test_future_state_exit_cannot_turn_a_complete_week_healthy(self) -> None:
+        start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        items = ReliabilitySloVerdictTests.completed_week_events(start, 200)
+        items.extend(
+            [
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=3),
+                    1,
+                    **{"from": "recording", "to": "recovering"},
+                ),
+                event(
+                    "pipeline.dictation_state_changed",
+                    NOW + timedelta(days=1),
+                    1,
+                    **{"from": "recovering", "to": "idle"},
+                ),
+            ]
+        )
+
+        previous = week(feed(items), 1)
+
+        self.assertEqual(previous["verdict"], "indeterminate")
+        self.assertEqual(previous["counts"]["invalid_evidence_timestamps"], 1)
+        self.assertEqual(previous["states"]["recovering"]["self_recovered"], 0)
+        self.assertEqual(previous["states"]["recovering"]["indeterminate"], 1)
+        self.assertIn("invalid_evidence_timestamp", previous["reasons"])
+
+    def test_future_or_invalid_evidence_cannot_cure_any_attempt_clause(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        future = NOW + timedelta(days=1)
+        items = [baseline(start - timedelta(minutes=1))]
+
+        items.extend([request(start, 1), audio("audio.capture_started", future, 1), terminal(start + timedelta(seconds=2), 1)])
+        items.extend([request(start + timedelta(minutes=1), 2), audio("audio.capture_started", start + timedelta(minutes=1, milliseconds=10), 2), audio("audio.capture_ready", future, 2), terminal(start + timedelta(minutes=1, seconds=2), 2)])
+        items.extend(complete_attempt(start + timedelta(minutes=2), 3, latency_ms=900))
+        items.append(audio("audio.permission_prompt_changed", future, 3, state="resolved", prompt_pending_ms=500))
+        items.extend([request(start + timedelta(minutes=3), 4), audio("audio.capture_started", start + timedelta(minutes=3, milliseconds=10), 4), audio("audio.capture_ready", start + timedelta(minutes=3, milliseconds=200), 4), terminal(future, 4)])
+        items.extend(complete_attempt(start + timedelta(minutes=4), 5, outcome="capture_init_failure"))
+        items.append(event("pipeline.dictation_presentation", future, 5, status_code="microphone_initialization_failed", action_code="retry"))
+        items.extend(complete_attempt(start + timedelta(minutes=5), 6))
+        items.extend([
+            event("pipeline.dictation_state_changed", start + timedelta(minutes=5, seconds=3), 6, **{"from": "recording", "to": "recovering"}),
+            event("pipeline.dictation_state_changed", future, 6, **{"from": "recovering", "to": "idle"}),
+        ])
+        items.append(request(start + timedelta(minutes=6), 7))
+        items.append(event("pipeline.dictation_terminal", "not-a-time", 7, outcome="success"))
+
+        previous = week(feed(items), 1)
+
+        self.assertEqual(previous["counts"]["invalid_evidence_timestamps"], 7)
+        self.assertEqual(previous["counts"]["accepted"], 5)
+        self.assertEqual(previous["counts"]["ready"], 4)
+        self.assertEqual(previous["counts"]["excluded_permission_prompts"], 0)
+        self.assertEqual(previous["counts"]["missing_terminals"], 2)
+        self.assertEqual(
+            previous["counts"]["failures_without_actionable_presentation"],
+            1,
+        )
+        self.assertEqual(previous["states"]["recovering"]["self_recovered"], 0)
+        self.assertEqual(previous["verdict"], "indeterminate")
+
+    def test_invalid_restart_boundary_makes_open_state_indeterminate(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        items.extend(
+            [
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=3),
+                    1,
+                    **{"from": "recording", "to": "recovering"},
+                ),
+                event("system.startup_baseline", "not-a-timestamp"),
+            ]
+        )
+        previous = week(feed(items), 1)
+        self.assertEqual(previous["states"]["recovering"]["restart_required"], 0)
+        self.assertEqual(previous["states"]["recovering"]["indeterminate"], 1)
+        self.assertEqual(previous["verdict"], "indeterminate")
+
+    def test_future_restart_boundary_cannot_fabricate_restart_duration(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        items.extend(
+            [
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=3),
+                    1,
+                    **{"from": "recording", "to": "recovering"},
+                ),
+                baseline(NOW + timedelta(days=1)),
+            ]
+        )
+
+        previous = week(feed(items), 1)
+
+        self.assertEqual(previous["states"]["recovering"]["restart_required"], 0)
+        self.assertEqual(previous["states"]["recovering"]["indeterminate"], 1)
+        self.assertEqual(
+            previous["states"]["recovering"]["duration_ms"]["sample_count"],
+            0,
+        )
+        self.assertEqual(previous["verdict"], "indeterminate")
+
+    def test_actionable_failure_coverage_uses_exact_outcome_pairs(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1))]
+        failures = [
+            (1, "capture_init_failure", "microphone_initialization_failed", "retry"),
+            (2, "runtime_interruption", "microphone_interrupted", "wait_for_partial_transcription"),
+            (3, "stop_failure", "microphone_cleanup_stalled", "restart_app"),
+            (4, "pipeline_failure", "private-status", "private-action"),
+        ]
+        for rid, outcome, status, action in failures:
+            items.extend(complete_attempt(start + timedelta(minutes=rid), rid, outcome=outcome))
+            items.append(
+                event(
+                    "pipeline.dictation_presentation",
+                    start + timedelta(minutes=rid, seconds=3),
+                    rid,
+                    status_code=status,
+                    action_code=action,
+                )
+            )
+        # An immediate stop failure may have no correlated stalled-cleanup UI;
+        # it must remain visible as missing presentation evidence.
+        items.extend(
+            complete_attempt(
+                start + timedelta(minutes=5),
+                5,
+                outcome="stop_failure",
+            )
+        )
+        items.extend(
+            complete_attempt(
+                start + timedelta(minutes=6),
+                6,
+                outcome="capture_init_failure",
+            )
+        )
+        items.append(
+            event(
+                "pipeline.dictation_presentation",
+                start + timedelta(minutes=6, seconds=3),
+                6,
+                status_code="microphone_initialization_failed",
+                action_code="choose_microphone",
+            )
+        )
+
+        current = week(feed(items), 1)
+
+        self.assertEqual(current["counts"]["failed"], 6)
+        self.assertEqual(current["counts"]["failures_with_actionable_presentation"], 4)
+        self.assertEqual(current["counts"]["failures_without_actionable_presentation"], 2)
+        self.assertEqual(current["verdict"], "fail")
+        rendered = json.dumps(current)
+        self.assertNotIn("private-status", rendered)
+        self.assertNotIn("private-action", rendered)
+
+    def test_cancelled_and_neutral_terminals_have_stable_bounded_counts(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1))]
+        outcomes = [
+            "user_cancelled_starting",
+            "user_cancelled_recording",
+            "user_cancelled_processing",
+            "superseded",
+            "no_speech",
+            "too_short",
+        ]
+        for rid, outcome in enumerate(outcomes, start=1):
+            items.extend(
+                complete_attempt(
+                    start + timedelta(minutes=rid),
+                    rid,
+                    outcome=outcome,
+                )
+            )
+
+        previous = week(feed(items), 1)
+        self.assertEqual(previous["counts"]["cancelled"], 4)
+        self.assertEqual(previous["counts"]["failed"], 0)
+        self.assertEqual(previous["counts"]["missing_terminals"], 0)
+
+
+class ReliabilitySloVerdictTests(unittest.TestCase):
+    @staticmethod
+    def completed_week_events(
+        start: datetime,
+        count: int,
+        misses: int = 0,
+        first_id: int = 1,
+    ) -> list[dict]:
+        items = [baseline(start - timedelta(minutes=1))]
+        for offset in range(count):
+            latency = 401 if offset < misses else 200
+            items.extend(
+                complete_attempt(
+                    start + timedelta(seconds=offset * 10),
+                    first_id + offset,
+                    latency_ms=latency,
+                )
+            )
+        return items
+
+    def test_exact_minimum_and_995_percent_threshold_pass(self) -> None:
+        start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        report = feed(self.completed_week_events(start, 200, misses=1))
+
+        previous = week(report, 1)
+        self.assertEqual(previous["counts"]["eligible_requests"], 200)
+        self.assertEqual(previous["startup_ms"]["within_400_fraction"], 0.995)
+        self.assertEqual(previous["verdict"], "pass")
+
+    def test_verdict_precedence_is_indeterminate_fail_insufficient_pass(self) -> None:
+        start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+
+        indeterminate_items = self.completed_week_events(start, 1, misses=1)
+        indeterminate_items[-1] = request(start + timedelta(minutes=1), 999)
+        self.assertEqual(week(feed(indeterminate_items), 1)["verdict"], "indeterminate")
+
+        failed = week(feed(self.completed_week_events(start, 1, misses=1)), 1)
+        self.assertEqual(failed["verdict"], "fail")
+
+        insufficient = week(feed(self.completed_week_events(start, 199)), 1)
+        self.assertEqual(insufficient["verdict"], "insufficient")
+
+        passed = week(feed(self.completed_week_events(start, 200)), 1)
+        self.assertEqual(passed["verdict"], "pass")
+
+    def test_current_partial_week_can_never_pass(self) -> None:
+        start = datetime(2026, 8, 17, 0, 0, tzinfo=timezone.utc)
+        current = week(feed(self.completed_week_events(start, 200)))
+        self.assertEqual(current["verdict"], "insufficient")
+        self.assertEqual(current["reasons"], ["partial_week"])
+
+    def test_two_consecutive_complete_weeks_requires_the_newest_two(self) -> None:
+        newest = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        older = newest - timedelta(weeks=1)
+        events = self.completed_week_events(older, 200, first_id=1)
+        # A startup boundary separates reused recording IDs and also proves no
+        # state interval leaked between application sessions.
+        events.extend(self.completed_week_events(newest, 200, first_id=1000))
+        report = feed(events)
+        self.assertTrue(report["two_consecutive_complete_weeks_pass"])
+
+        not_enough = self.completed_week_events(older, 200)
+        not_enough.extend(self.completed_week_events(newest, 199, first_id=1000))
+        self.assertFalse(feed(not_enough)["two_consecutive_complete_weeks_pass"])
+
+    def test_full_rescan_late_arrival_revises_a_closed_week(self) -> None:
+        start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+        first_scan = [baseline(start - timedelta(minutes=1)), request(start, 1)]
+        self.assertEqual(week(feed(first_scan), 1)["verdict"], "indeterminate")
+
+        second_scan = [
+            baseline(start - timedelta(minutes=1)),
+            request(start, 1),
+            audio("audio.capture_started", start + timedelta(milliseconds=10), 1),
+            audio("audio.capture_ready", start + timedelta(milliseconds=200), 1),
+            terminal(start + timedelta(seconds=1), 1),
+        ]
+        revised = week(feed(second_scan), 1)
+        self.assertEqual(revised["counts"]["missing_terminals"], 0)
+        self.assertEqual(revised["verdict"], "insufficient")
+
+
+class ReliabilitySloPrivacyAndApiTests(unittest.TestCase):
+    def test_attempt_cap_fails_closed_with_bounded_overflow_evidence(self) -> None:
+        start = NOW - timedelta(days=1)
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        evaluator.observe(INSTALL, baseline(start - timedelta(minutes=1)))
+        with mock.patch.object(slo, "MAX_TRACKED_ATTEMPTS", 2):
+            for recording_id in range(1, 4):
+                evaluator.observe(
+                    INSTALL,
+                    request(start + timedelta(minutes=recording_id), recording_id),
+                )
+
+        report = evaluator.report()
+
+        self.assertEqual(week(report)["counts"]["requested"], 2)
+        self.assertEqual(report["integrity"]["overflowed_events"], 1)
+        self.assertEqual(report["integrity"]["status"], "indeterminate")
+        self.assertFalse(report["two_consecutive_complete_weeks_pass"])
+
+    def test_install_cap_fails_closed_without_allocating_unbounded_sessions(self) -> None:
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        with mock.patch.object(slo, "MAX_TRACKED_INSTALLS", 1):
+            evaluator.observe("install-a", baseline(NOW - timedelta(minutes=2)))
+            evaluator.observe("install-b", baseline(NOW - timedelta(minutes=1)))
+
+        report = evaluator.report()
+
+        self.assertEqual(len(evaluator._install_sessions), 1)
+        self.assertEqual(report["integrity"]["overflowed_events"], 1)
+        self.assertEqual(report["integrity"]["status"], "indeterminate")
+
+    def test_repeated_evidence_and_state_intervals_have_fixed_caps(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        evaluator.observe(INSTALL, baseline(start - timedelta(minutes=1)))
+        for _ in range(20):
+            evaluator.observe(INSTALL, request(start, 1))
+            evaluator.observe(
+                INSTALL,
+                audio("audio.capture_ready", start + timedelta(milliseconds=200), 1),
+            )
+            evaluator.observe(INSTALL, terminal(start + timedelta(seconds=1), 1))
+        transitions = [
+            ("idle", "starting"),
+            ("starting", "recording"),
+            ("recording", "processing"),
+            ("processing", "idle"),
+            ("idle", "starting"),
+            ("starting", "recording"),
+            ("recording", "processing"),
+            ("processing", "idle"),
+        ]
+        with mock.patch.object(slo, "MAX_STATE_INTERVALS_PER_ATTEMPT", 1):
+            for offset, (previous, current) in enumerate(transitions, start=2):
+                evaluator.observe(
+                    INSTALL,
+                    event(
+                        "pipeline.dictation_state_changed",
+                        start + timedelta(seconds=offset),
+                        1,
+                        **{"from": previous, "to": current},
+                    ),
+                )
+
+        attempt = next(iter(evaluator._attempts.values()))
+        report = evaluator.report()
+
+        self.assertEqual(attempt["request_count"], 2)
+        self.assertEqual(attempt["terminal_count"], 2)
+        self.assertIsInstance(attempt["requested_at"], datetime)
+        self.assertIsInstance(attempt["ready_at"], datetime)
+        self.assertEqual(len(attempt["state_intervals"]["processing"]), 1)
+        self.assertEqual(report["integrity"]["overflowed_events"], 1)
+        self.assertEqual(report["integrity"]["status"], "indeterminate")
+
+    def test_old_events_skip_allocation_and_restart_index_is_session_local(self) -> None:
+        retained = NOW - timedelta(weeks=7)
+        expired = NOW - timedelta(weeks=10)
+        evaluator = slo.ReliabilitySloEvaluator(now=NOW)
+        evaluator.observe("install-a", baseline(expired - timedelta(minutes=1)))
+        evaluator.observe("install-a", request(expired, 99))
+        self.assertEqual(evaluator._attempts, {})
+
+        evaluator.observe("install-a", request(retained, 1))
+        evaluator.observe("install-b", baseline(retained - timedelta(minutes=1)))
+        evaluator.observe("install-b", request(retained, 1))
+        self.assertIn(("install-a", 1), evaluator._session_attempt_keys)
+        self.assertIn(("install-b", 1), evaluator._session_attempt_keys)
+
+        evaluator.observe("install-a", baseline(retained + timedelta(minutes=1)))
+
+        self.assertNotIn(("install-a", 1), evaluator._session_attempt_keys)
+        self.assertIn(("install-b", 1), evaluator._session_attempt_keys)
+        self.assertEqual(len(evaluator._attempts), 2)
+
+    def test_convenience_feed_api_and_report_shape_are_aggregate_only(self) -> None:
+        start = NOW - timedelta(days=1)
+        secret_install = "PRIVATE-INSTALL-UUID"
+        secret_summary = "PRIVATE TRANSCRIPT CONTENT"
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        for item in items:
+            item["summary"] = secret_summary
+            item["ingest_app_version"] = "99.99-private"
+            item["data"]["device_path"] = "/private/device/path"
+        report = slo.evaluate_fleet(
+            [(secret_install, item) for item in items],
+            now=NOW,
+        )
+        rendered = json.dumps(report, sort_keys=True)
+
+        self.assertEqual(report["schema_version"], 1)
+        self.assertEqual(report["report"], "murmur-reliability-slo/v1")
+        self.assertEqual(report["privacy"], "aggregate_only")
+        self.assertNotIn(secret_install, rendered)
+        self.assertNotIn(secret_summary, rendered)
+        self.assertNotIn("99.99-private", rendered)
+        self.assertNotIn("/private/device/path", rendered)
+        for forbidden_key in (
+            "install_id",
+            "app_version",
+            "device",
+            "content",
+            "path",
+            "raw",
+        ):
+            self.assertNotIn('"%s"' % forbidden_key, rendered)
+
+    def test_constructor_requires_utc_and_at_least_eight_complete_weeks(self) -> None:
+        with self.assertRaises(ValueError):
+            slo.ReliabilitySloEvaluator(now=datetime(2026, 8, 19))
+        with self.assertRaises(ValueError):
+            slo.ReliabilitySloEvaluator(
+                now=datetime(2026, 8, 19, tzinfo=timezone(timedelta(hours=1)))
+            )
+        with self.assertRaises(ValueError):
+            slo.ReliabilitySloEvaluator(now=NOW, complete_weeks=7)
+        with self.assertRaises(ValueError):
+            slo.ReliabilitySloEvaluator(now=NOW, complete_weeks=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reliability_slo.py
+++ b/tests/test_reliability_slo.py
@@ -600,6 +600,32 @@ class ReliabilitySloLifecycleTests(unittest.TestCase):
         self.assertIn("invalid_state_transition", current["reasons"])
         self.assertEqual(current["verdict"], "indeterminate")
 
+    def test_unknown_state_is_indeterminate_but_unchanged_known_state_is_a_noop(self) -> None:
+        start = datetime(2026, 8, 11, 12, tzinfo=timezone.utc)
+        items = [baseline(start - timedelta(minutes=1)), *complete_attempt(start, 1)]
+        items.extend(
+            [
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=3),
+                    1,
+                    **{"from": "recording", "to": "private_state"},
+                ),
+                event(
+                    "pipeline.dictation_state_changed",
+                    start + timedelta(seconds=4),
+                    1,
+                    **{"from": "recording", "to": "recording"},
+                ),
+            ]
+        )
+
+        current = week(feed(items), 1)
+
+        self.assertEqual(current["counts"]["invalid_state_transitions"], 1)
+        self.assertIn("invalid_state_transition", current["reasons"])
+        self.assertEqual(current["verdict"], "indeterminate")
+
     def test_future_state_exit_cannot_turn_a_complete_week_healthy(self) -> None:
         start = datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
         items = ReliabilitySloVerdictTests.completed_week_events(start, 200)


### PR DESCRIPTION
Closes #537.

## What changed

- emit exact, content-free request, permission-prompt, dictation-state, and user-presentation evidence for contract-v1 live dictations
- carry bounded status/action codes through the existing Tauri failure events so the fleet evidence matches what the main window and overlay actually show
- evaluate the current partial week plus eight complete UTC weeks over the full retained fleet log, including the request denominator, permission exclusion, first-PCM distribution, terminal integrity, Recovering/Processing intervals, restart evidence, and actionable failure coverage
- persist an aggregate-only rolling SLO report and render its supporting counts and two-week proof in the fleet dashboard
- fail closed on malformed/future evidence, malformed retained JSONL, contradictory state chains, corrupt derived reports, and bounded-correlation overflow

## Why

#486 cannot be evaluated from successful capture samples alone. The previous watch lacked a stable request denominator, prompt exclusions, state-interval evidence, presentation correlation, complete weekly verdicts, and a two-week proof.

## Privacy and safety

- install/session/recording identities remain internal join keys and never enter the report
- telemetry is reduced through exact schemas in debug and release builds
- report/dashboard output contains no device identity, app identity, transcript/audio, path, bundle ID, raw error, or free-form event text
- malformed or unverifiable evidence produces an indeterminate alert; it can never manufacture a pass

## Validation

Exact head: `8e8f2f4c669407e5a23a8d732b8e61eafd9c0663`

- GitHub Actions: changes, dependency audit, TypeScript/frontend, visual regression, macOS Rust, capture-worker/integration suites, deterministic evaluation, and aggregate CI all passed; one unrelated 250 ms AppleScript timing test flaked once and passed on the unchanged-head failed-job rerun
- trusted arm64 Mac: helper prerequisite, `cargo fmt --all -- --check`, `cargo check --tests`, strict all-target/all-feature Clippy, and full Rust suites passed (1,019 unit tests plus integration targets; one capture-helper timing test passed its workflow-permitted exact retry)
- frontend: `npx tsc --noEmit`; 101 files / 964 tests passed
- focused evaluator/watch/lifecycle/receiver/reference and adversarial privacy/corruption tests passed
- isolated unsigned debug bundle, real default microphone: request to first PCM/Recording in 130 ms; Stop accepted at 158.5 ms; exact states `idle -> starting -> recording -> processing -> idle`
- strict audit of 107 relevant isolated JSONL records found no device/app identity, transcript/audio/content, user path, raw error, or free-form presentation data
- isolated app and every helper were reaped; production namespaces were unchanged; worktree and temporary files were removed
- both CodeRabbit findings are addressed and resolved; no unresolved review threads
- `git diff --check`

Murmur Bench: N/A — telemetry, local presentation metadata, and fleet reporting only; no recognition, transform, delivery, dependency, or benchmarked execution path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Microphone errors now provide clearer actions: choose another microphone, open settings, retry, or wait for partial transcription.
  - Improved accessibility labels distinguish permission problems, unavailable devices, interrupted captures, and recovery states.
  - Added validation for recording recovery and interruption guidance.

- **Reliability**
  - Added privacy-safe dictation reliability monitoring and aggregate reporting to track startup, recovery, and presentation outcomes.

- **Documentation**
  - Updated microphone troubleshooting guidance, event references, and reliability reporting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
